### PR TITLE
User input checkbox defaults and Go button focus

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# See https://editorconfig.org
+
+# top-most editorconfig file
+root = true
+
+# Apply these settings to all files
+[*]
+end_of_line              = lf
+indent_size              = 2
+indent_style             = space
+insert_final_newline     = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length          = 70

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 save
+*.tgz

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -54,6 +54,11 @@ function showOverlay(id) {
     style.display = style.display === 'flex' ? 'none' : 'flex';
     $('#roomArea').className = style.display === 'flex' ? 'hasOverlay' : '';
     overlayActive = style.display === 'flex';
+
+    //Hack to focus on the Go button for the input overlay
+    if (id == 'buttonInputOverlay') {
+      $('#buttonInputGo').focus();
+    }
   } else {
     $('#roomArea').className = '';
     overlayActive = false;

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -231,13 +231,14 @@ class Button extends Widget {
         const dom = document.createElement('div');
 
         if(field.type == 'checkbox') {
-          const checkbox = document.createElement('input');
-          const label    = document.createElement('label');
-          checkbox.type = 'checkbox';
+          const input = document.createElement('input');
+          const label = document.createElement('label');
+          input.type = 'checkbox';
+          input.checked = field.value || false;
           label.textContent = field.label;
-          dom.appendChild(checkbox);
+          dom.appendChild(input);
           dom.appendChild(label);
-          label.htmlFor = checkbox.id = this.p('id') + ';' + field.variable;
+          label.htmlFor = input.id = this.p('id') + ';' + field.variable;
         }
 
         if(field.type == 'color') {


### PR DESCRIPTION
1. Put focus on the Go button when user input overlay is presented. This enables the user to press the enter key without having to move their mouse.
2. Support a default value for INPUT type `checkbox`.

These changes also:
* establish an editorconfig file
* git ignore tgz files created by `npm pack`

Corresponding updates for the wiki (see [this gist](https://gist.github.com/larrybotha/10650410) for how to bring in the changes using git cli):
* [ ] Button.md: [INPUT checkbox defaults to unchecked; Have example demonstrate checking](https://github.com/UltimateGeek/virtualtabletop/wiki/Buttons/_compare/8d42ec9b5356b3edd5566eb63e27e0999e9992f7...ab9d491f7276d4864673949e31d657b385cabd72)