### PR TITLE
changed duplicate button to offset to the left at the edge (fixes #52)

### DIFF
--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -479,6 +479,11 @@ onLoad(function() {
     if(widget.y)
       widget.y += 20;
     addWidgetLocal(widget);
+    const w = widgets.get(widget.id);
+    if(widget.x && w.absoluteCoord('x') > 1500)
+      w.p('x', w.p('x')-40);
+    if(widget.y && w.absoluteCoord('y') > 900)
+      w.p('y', w.p('y')-40);
     showOverlay();
   });
 


### PR DESCRIPTION
This is not as easy as it sounds because of parents but I think this solution should work in most cases.

After adding the new widget it checks if the widget has an explicit position set and if it does and its absolute coordinate is `x>1500` or `y>900`, it gets moved 40px to the left/top.