### PR TITLE
Major Tutorial Reorganization (plus add COMPUTE and SORT)

### DIFF
--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -91,6 +91,155 @@ export class Button extends Widget {
             w.click();
       }
 
+      if(a.func == 'COMPUTE') {
+        setDefaults(a, { operation: '+', operand1: 1, operand2: 1, operand3: 1, variable: 'COMPUTE' });
+        const toNum = s=>typeof s == 'string' && s.match(/^[-+]?[0-9]+(\.[0-9]+)?$/) ? +s : s;
+        const x = toNum(a.operand1);
+        const y = toNum(a.operand2);
+        const z = toNum(a.operand3);
+        const v = a.variable;
+
+        try {
+          switch(a.operation) {
+          case '+':  variables[v] = x + y;  break;
+          case '-':  variables[v] = x - y;  break;
+          case '*':  variables[v] = x * y;  break;
+          case '**': variables[v] = x ** y; break;
+          case '/':  variables[v] = x / y;  break;
+          case '%':  variables[v] = x % y;  break;
+          case '<':  variables[v] = x < y;  break;
+          case '<=': variables[v] = x <= y; break;
+          case '==': variables[v] = x == y; break;
+          case '!=': variables[v] = x != y; break;
+          case '>=': variables[v] = x >= y; break;
+          case '>':  variables[v] = x > y;  break;
+          case '&&': variables[v] = x && y; break;
+          case '||': variables[v] = x || y; break;
+          case '!':  variables[v] = !x;     break;
+
+          // Math operations
+          case 'hypot':
+          case 'max':
+          case 'min':
+          case 'pow':
+            variables[v] = Math[a.operation](x, y);
+            break;
+          case 'sin':
+          case 'cos':
+          case 'tan':
+            variables[v] = Math[a.operation](x * Math.PI/180);
+            break;
+          case 'abs':
+          case 'cbrt':
+          case 'ceil':
+          case 'exp':
+          case 'floor':
+          case 'log':
+          case 'log10':
+          case 'log2':
+          case 'round':
+          case 'sign':
+          case 'sqrt':
+          case 'trunc':
+            variables[v] = Math[a.operation](x);
+            break;
+          case 'E':
+          case 'LN2':
+          case 'LN10':
+          case 'LOG2E':
+          case 'LOG10E':
+          case 'PI':
+          case 'SQRT1_2':
+          case 'SQRT2':
+            variables[v] = Math[a.operation];
+            break;
+
+          // String operations
+          case 'length':
+            variables[v] = x.length;
+            break;
+          case 'toLowerCase':
+          case 'toUpperCase':
+          case 'trim':
+          case 'trimStart':
+          case 'trimEnd':
+            variables[v] = x[a.operation]();
+            break;
+          case 'charAt':
+          case 'charCodeAt':
+          case 'codePointAt':
+          case 'concat':
+          case 'includes':
+          case 'endsWith':
+          case 'indexOf':
+          case 'lastIndexOf':
+          case 'localeCompare':
+          case 'match':
+          case 'padEnd':
+          case 'padStart':
+          case 'repeat':
+          case 'search':
+          case 'split':
+          case 'startsWith':
+          case 'toLocaleLowerCase':
+          case 'toLocaleUpperCase':
+            variables[v] = x[a.operation](y);
+            break;
+          case 'replace':
+          case 'replaceAll':
+          case 'substr':
+            variables[v] = x[a.operation](y, z);
+            break;
+
+          // Array operations
+          // 'length' should work the same as for strings
+          case 'getIndex':
+            variables[v] = x[y];
+            break;
+          case 'setIndex':
+            variables[v][x] = y;
+            break;
+          case 'from':
+          case 'isArray':
+            variables[v] = Array[a.operation](x);
+            break;
+          case 'concatArray':
+            variables[v] = x.concat(y);
+            break;
+          case 'pop':
+          case 'reverse':
+          case 'shift':
+          case 'sort':
+            variables[v] = x[a.operation]();
+            break;
+          case 'findIndex':
+          case 'includes':
+          case 'indexOf':
+          case 'join':
+          case 'lastIndexOf':
+            variables[v] = x[a.operation](y);
+            break;
+          case 'slice':
+            variables[v] = x[a.operation](y, z);
+            break;
+          case 'push':
+          case 'unshift':
+            variables[v][a.operation](x);
+            break;
+          default:
+            problems.push(`Operation ${a.operation} is unsupported.`);
+          }
+        } catch(e) {
+          variables[v] = 0;
+          problems.push(`Exception: ${e.toString()}`);
+        }
+
+        if(variables[v] === null || typeof variables[v] === 'number' && !isFinite(variables[v])) {
+          variables[v] = 0;
+          problems.push(`The operation evaluated to null, Infinity or NaN. Setting the variable to 0.`);
+        }
+      }
+
       if(a.func == 'COUNT') {
         setDefaults(a, { collection: 'DEFAULT', variable: 'COUNT' });
         if(isValidCollection(a.collection))

--- a/client/js/widgets/label.js
+++ b/client/js/widgets/label.js
@@ -42,9 +42,13 @@ export class Label extends Widget {
   }
 
   setText(text, mode) {
-    if(!mode || mode == 'set')
-      this.p('text', typeof text != 'string' || text.match(/^[-+]?[0-9.]+$/) ? +text : text);
-    else
+    if(mode == 'inc' || mode == 'dec')
       this.p('text', (parseInt(this.p('text')) || 0) + (mode == 'dec' ? -1 : 1) * text);
+    else if(Array.isArray(text))
+      this.p('text', text.join(', '));
+    else if(typeof text == 'string' && text.match(/^[-+]?[0-9]+(\.[0-9]+)?$/))
+      this.p('text', +text);
+    else
+      this.p('text', text);
   }
 }


### PR DESCRIPTION
Created consistency in the library image.  Unlike games, creative images don’t help.  I think just seeing the names is best.

Created consistency at the top of most tutorial variants with the name of the tutorial and the variant in large letters.

Eliminated copyright notices.  Tutorials use generic assets.  Have updated the README.md file to indicate CC0 for all tutorials and to link to the new https://virtualtabletop.io/Tutorials room.

Reorganized some of the existing tutorial structure.  Buttons as a category really doesn’t make sense.  Broke all of those out into Functions – xyz tutorials.  Combined some other tutorials that were spread out into the Holders one.

File naming structure is mostly intact.  Only a couple of wiki entries directly reference the existing files and those should work.  This new structure should make wiki linkage easier.  But I have deleted all tutorial files and added them back with this PR.

New content includes a basic tutorial on Hands before the more advanced tutorial on custom visibility.  First version of COMPUTE tutorial is on here.  First version of SORT tutorial is as well.  Other tutorials which have been on hold in the #tutorials channel have mostly been added as well.  A few are still missing and I will get to those soon (text bearer and sorting spinners by value).

Future needs:  additional Skip examples.  COMPUTE string and array examples.  Other functions that could use a little attention: COUNT and SET).  UltimateGeek has a draft tutorial for MOVE and MOVEXY that should be publishable after the PR dealing with those changes is committed.
