### PR TITLE
fixed that onEnter/onLeave would not handle piles correctly (fixes #82)

### DIFF
--- a/client/js/widgets/holder.js
+++ b/client/js/widgets/holder.js
@@ -42,9 +42,13 @@ class Holder extends Widget {
   }
 
   dispenseCard(card) {
-    if(!card.p('ignoreOnLeave'))
-      for(const property in this.p('onLeave'))
-        card.p(property, this.p('onLeave')[property]);
+    let toProcess = [ card ];
+    if(card.p('type') == 'pile')
+      toProcess = card.children();
+    for(const w of toProcess)
+      if(!w.p('ignoreOnLeave'))
+        for(const property in this.p('onLeave'))
+          w.p(property, this.p('onLeave')[property]);
     if(this.p('alignChildren'))
       this.receiveCard(null);
   }
@@ -57,9 +61,13 @@ class Holder extends Widget {
     if(this.p('childrenPerOwner'))
       child.p('owner', playerName);
 
-    if(this != child.currentParent) // FIXME: this isn't exactly pretty
+    if(this != child.currentParent) { // FIXME: this isn't exactly pretty
+      let toProcess = [ child ];
+      if(child.p('type') == 'pile')
+        toProcess = child.children();
       for(const property in this.p('onEnter'))
-        child.p(property, this.p('onEnter')[property]);
+        toProcess.forEach(w=>w.p(property, this.p('onEnter')[property]));
+    }
   }
 
   onChildAddAlign(child, oldParentID) {

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -93,6 +93,9 @@ class Pile extends Widget {
 
       removeWidgetLocal(this.p('id'));
     }
+
+    if(this.parent && this.parent.p('type') == 'holder')
+      this.parent.dispenseCard(child);
   }
 
   supportsPiles() {


### PR DESCRIPTION
I hope I didn't forget an edge case but now onEnter and onLeave should be applied to all children of piles.

Please test this a bit.