### PR TITLE
SELECT now resolves piles

### DIFF
--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -374,7 +374,7 @@ export class Button extends Widget {
         if(a.source == 'all' || isValidCollection(a.source)) {
           if([ 'add', 'set' ].indexOf(a.mode) == -1)
             problems.push(`Warning: Mode ${a.mode} interpreted as set.`);
-          collections[a.collection] = (a.source == 'all' ? Array.from(widgets.values()) : collections[a.source]).filter(function(w) {
+          let c = (a.source == 'all' ? Array.from(widgets.values()) : collections[a.source]).filter(function(w) {
             if(a.relation === '<')
               return w.p(a.property) < a.value;
             else if(a.relation === '<=')
@@ -389,6 +389,11 @@ export class Button extends Widget {
               problems.push(`Warning: Relation ${a.relation} interpreted as ==.`);
             return w.p(a.property) === a.value;
           }).slice(0, a.max).concat(a.mode == 'add' ? collections[a.collection] || [] : []);
+
+          // resolve piles
+          c.filter(w=>w.p('type')=='pile').forEach(w=>c.push(...w.children()));
+          c = c.filter(w=>w.p('type')!='pile');
+          collections[a.collection] = c;
         }
       }
 


### PR DESCRIPTION
After each `SELECT` operation every pile in the resulting collection will be replaced by all its children.

This will probably break a few rooms out there but I'm pretty sure everyone affected will love the change.