### PR TITLE
fixed pile alignment after RECALL

### DIFF
--- a/client/js/widgets/holder.js
+++ b/client/js/widgets/holder.js
@@ -49,7 +49,7 @@ class Holder extends Widget {
       if(!w.p('ignoreOnLeave'))
         for(const property in this.p('onLeave'))
           w.p(property, this.p('onLeave')[property]);
-    if(this.p('alignChildren'))
+    if(this.p('alignChildren') && (this.p('stackOffsetX') || this.p('stackOffsetY')))
       this.receiveCard(null);
   }
 


### PR DESCRIPTION
The fix of onEnter/onLeave broke the alignement of cards inside piles. This happens pretty much every time a reset button is pressed.

I only did very basic tests where the problem seems to be fixed. Please test some more stuff in tutorials and games.