### PR TITLE
prevent SET from setting a non-existent parent (fixes #110)

### DIFF
--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -399,7 +399,9 @@ export class Button extends Widget {
 
       if(a.func == 'SET') {
         setDefaults(a, { collection: 'DEFAULT', property: 'parent', relation: '=', value: null });
-        if(isValidCollection(a.collection)) {
+        if((a.property == 'parent' || a.property == 'deck') && a.value !== null && !widgets.has(a.value)) {
+          problems.push(`Tried setting ${a.property} to ${a.value} which doesn't exist.`);
+        } else if(isValidCollection(a.collection)) {
           if([ '+', '-', '=' ].indexOf(a.relation) == -1)
             problems.push(`Warning: Relation ${a.relation} interpreted as =.`);
           for(const w of collections[a.collection]) {


### PR DESCRIPTION
Using SET with a parent that doesn't exist throws a Javascript error. This catches the attempt in SET.

There are still many ways to set an invalid parent but I think this covers 90% of real life use cases.