### PR TITLE
prevent button "All -1" in deck editor to set card counts below 0 (fixes #100)

### DIFF
--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -428,7 +428,7 @@ onLoad(function() {
   });
 
   on('#decrementAllCardTypes', 'click', function() {
-    $a('#cardTypesList .count').forEach(i=>--i.value);
+    $a('#cardTypesList .count').forEach(i=>i.value=Math.max(0, i.value-1));
   });
 
   on('#incrementAllCardTypes', 'click', function() {


### PR DESCRIPTION
See title.