### PR TITLE
Improvements to skip

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -339,7 +339,8 @@ function jeAddButtonOperationCommands(command, defaults) {
     }
   });
 
-  defaults.skip = false;
+  defaults.skipIF = false;
+  defaults.doIF = false;
   for(const property in defaults) {
     jeCommands.push({
       name: property,

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -84,7 +84,7 @@ export class Button extends Widget {
         }
       }
       if(a.onlyif) {
-        if (!variables[a.if]) {
+        if (!variables[a.onlyif]) {
           $('#debugButtonOutput').textContent += '\n\n\nOPERATION SKIPPED (' + a.onlyif + ' != true): \n' + JSON.stringify(a, null, '  ');
           continue;
         }

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -78,11 +78,17 @@ export class Button extends Widget {
         }
       }
       if(a.skip) {
-        $('#debugButtonOutput').textContent += '\n\n\nOPERATION SKIPPED: \n' + JSON.stringify(a, null, '  ');
-        continue;
+        if (variables[a.skip]) {
+          $('#debugButtonOutput').textContent += '\n\n\nOPERATION SKIPPED (' + a.skip + ' == true): \n' + JSON.stringify(a, null, '  ');
+          continue;
+        }
       }
-
-
+      if(a.onlyif) {
+        if (!variables[a.if]) {
+          $('#debugButtonOutput').textContent += '\n\n\nOPERATION SKIPPED (' + a.onlyif + ' != true): \n' + JSON.stringify(a, null, '  ');
+          continue;
+        }
+      }
 
       if(a.func == 'CLICK') {
         setDefaults(a, { collection: 'DEFAULT', count: 1 });

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -77,15 +77,15 @@ export class Button extends Widget {
           problems.push('Parameter applyVariables is not an array.');
         }
       }
-      if(a.skip) {
-        if (variables[a.skip]) {
-          $('#debugButtonOutput').textContent += '\n\n\nOPERATION SKIPPED (' + a.skip + ' == true): \n' + JSON.stringify(a, null, '  ');
+      if(a.skipIF) {
+        if (variables[a.skipIF]) {
+          $('#debugButtonOutput').textContent += '\n\n\nOPERATION SKIPPED (' + a.skipIF + ' == true): \n' + JSON.stringify(a, null, '  ');
           continue;
         }
       }
-      if(a.onlyif) {
-        if (!variables[a.onlyif]) {
-          $('#debugButtonOutput').textContent += '\n\n\nOPERATION SKIPPED (' + a.onlyif + ' != true): \n' + JSON.stringify(a, null, '  ');
+      if(a.doIF) {
+        if (!variables[a.doIF]) {
+          $('#debugButtonOutput').textContent += '\n\n\nOPERATION SKIPPED (' + a.doIF + ' != true): \n' + JSON.stringify(a, null, '  ');
           continue;
         }
       }


### PR DESCRIPTION
- Skip now references a variable name directly, rather than having to use applyVariables.
- Introduced `onlyif` parameter as the opposite of `skip`
- Added further details to the debug output