### PR TITLE
added empty click method to widget.js

### DIFF
--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -48,7 +48,7 @@ function inputHandler(name, e) {
       if(ms.status == 'initial' || timeSinceStart < 250 && pixelsMoved < 10) {
         if(edit)
           editClick(widgets.get(target.id));
-        else if(widgets.get(target.id).click)
+        else
           widgets.get(target.id).click();
       }
       delete mouseStatus[target.id];

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -168,6 +168,9 @@ export class Widget extends StateManaged {
   classesProperties() {
     return [ 'classes', 'owner', 'typeClasses' ];
   }
+  
+  click() {
+  }
 
   css() {
     let css = this.p('css');


### PR DESCRIPTION
Widgets without a click method can trigger an error in click routines.