### PR TITLE
piles are no longer widgets but simply UI elements

### DIFF
--- a/client/css/widgets/pile.css
+++ b/client/css/widgets/pile.css
@@ -1,10 +1,6 @@
 .pile.handle {
   cursor: default;
   position: absolute;
-  left: -15px;
-  top: -15px;
-  width: 40px;
-  height: 40px;
   font-size: 20px;
   background: #e4e4e4;
   color: #6d6d6d;

--- a/client/css/widgets/pile.css
+++ b/client/css/widgets/pile.css
@@ -1,4 +1,5 @@
 .pile.handle {
+  cursor: default;
   position: absolute;
   left: -15px;
   top: -15px;

--- a/client/css/widgets/pile.css
+++ b/client/css/widgets/pile.css
@@ -22,16 +22,6 @@
   font-size: 10px;
 }
 
-.pile.handle.right {
-  left: unset;
-  right: -15px;
-}
-
-.pile.handle.bottom {
-  top: unset;
-  bottom: -15px;
-}
-
 body.edit .pile {
   display: none;
 }

--- a/client/css/widgets/pile.css
+++ b/client/css/widgets/pile.css
@@ -1,4 +1,4 @@
-.pile .handle {
+.pile.handle {
   position: absolute;
   left: -15px;
   top: -15px;
@@ -15,18 +15,18 @@
   z-index: 9999999;
 }
 
-.pile .handle.small {
+.pile.handle.small {
   width: 20px;
   height: 20px;
   font-size: 10px;
 }
 
-.pile .handle.right {
+.pile.handle.right {
   left: unset;
   right: -15px;
 }
 
-.pile .handle.bottom {
+.pile.handle.bottom {
   top: unset;
   bottom: -15px;
 }

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -5,6 +5,8 @@ function addWidgetLocal(widget) {
     widget.id = Math.random().toString(36).substring(3, 7);
   sendPropertyUpdate(widget.id, widget);
   sendDelta(true);
+  if(widget.parent)
+    widgets.get(widget.parent).onChildAdd(widgets.get(widget.id));
 }
 
 function populateEditOptionsDeck(widget) {
@@ -129,7 +131,6 @@ function editClick(widget) {
 function generateCardDeckWidgets(id, x, y) {
   const widgets = [
     { type:'holder', id, x, y, dropTarget: { type: 'card' } },
-    { type:'pile', id: id+'P', parent: id, width:103, height:160 },
     {
       id: id+'B',
       parent: id,
@@ -156,7 +157,7 @@ function generateCardDeckWidgets(id, x, y) {
   [ {label:'C', color: "♣", alternating:"1♣"}, {label:'D', color: "♦", alternating:"4♦"}, {label:'H', color: "♥", alternating:"2♥"}, {label:'S', color: "♠", alternating:"3♠"} ].forEach(function(s) {
     [ {label:'A', rank: "01", rankA:"5A"}, {label:'2', rank: "02", rankA:"02"},{label:'3', rank: "03", rankA:"03"},{label:'4', rank: "04", rankA:"04"},{label:'5', rank: "05", rankA:"05"},{label:'6', rank: "06", rankA:"06"},{label:'7', rank: "07", rankA:"07"},{label:'8', rank: "08", rankA:"08"},{label:'9', rank: "09", rankA:"09"},{label:'T', rank: "10", rankA:"10"},{label:'J', rank: "2J", rankA:"2J"},{label:'Q', rank: "3Q", rankA:"3Q"},{label:'K', rank: "4K", rankA:"4K"}].forEach(function(n) {
       types[s.label+" "+n.rank] = { image:`/i/cards-default/${n.label}${s.label}.svg`, suit:s.label, suitColor:s.color, suitAlt:s.alternating, rank:n.rank,rankA:n.rankA, rankFixed:n.rank+" "+s.label};
-      cards.push({ id:id+"_"+n.label+"_"+s.label, parent:id+'P', deck:id+'D', type:'card', cardType:s.label+" "+n.rank });
+      cards.push({ id:id+"_"+n.label+"_"+s.label, parent:id, pile:id+'P', deck:id+'D', type:'card', cardType:s.label+" "+n.rank });
     });
   });
 
@@ -217,7 +218,6 @@ function addCompositeWidgetToAddWidgetOverlay(widgetsToAdd, onClick) {
     if(wi.type == 'deck')   w = new Deck(wi.id);
     if(wi.type == 'holder') w = new Holder(wi.id);
     if(wi.type == 'label')  w = new Label(wi.id);
-    if(wi.type == 'pile')   w = new Pile(wi.id);
     widgets.set(wi.id, w);
     w.applyDelta(wi);
     if(!wi.parent) {
@@ -243,6 +243,7 @@ function addWidgetToAddWidgetOverlay(w, wi) {
 }
 
 function populateAddWidgetOverlay() {
+  return; // FIXME: re-enable
   const x = 20+140-111/2;
   addWidgetToAddWidgetOverlay(new Holder('add-holder'), {
     type: 'holder',

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -243,7 +243,6 @@ function addWidgetToAddWidgetOverlay(w, wi) {
 }
 
 function populateAddWidgetOverlay() {
-  return; // FIXME: re-enable
   const x = 20+140-111/2;
   addWidgetToAddWidgetOverlay(new Holder('add-holder'), {
     type: 'holder',
@@ -255,6 +254,12 @@ function populateAddWidgetOverlay() {
     for(const w of generateCardDeckWidgets(Math.random().toString(36).substring(3, 7), x, 500))
       addWidgetLocal(w);
   });
+  // add a dummy pile handle to the card deck because the real one doesn't work
+  const dummyHandle = document.createElement('div');
+  dummyHandle.className = 'pile handle';
+  dummyHandle.style = `width:40px;height:40px;transform:translate(190px, 490px)`;
+  dummyHandle.textContent = 52;
+  $('#addOverlay').appendChild(dummyHandle);
 
   let y = 100;
   for(const color of [ '#000000','#4a4a4a','#4c5fea','#bc5bee','#e84242','#e0cb0b','#23ca5b','#e2a633','#ffffff' ]) {

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -9,6 +9,7 @@ let urlProperties = {};
 
 let maxZ = {};
 export const dropTargets = new Map();
+const piles = new Map();
 
 function getValidDropTargets(widget) {
   const targets = [];

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -21,7 +21,7 @@ function inputHandler(name, e) {
   e.preventDefault();
 
   let target = e.target;
-  while(target && (!target.id || !widgets.has(target.id)))
+  while(target && (!target.id || !widgets.has(target.id) && !piles.has(target.id)))
     target = target.parentNode;
 
   const coords = eventCoords(name, e);
@@ -46,7 +46,9 @@ function inputHandler(name, e) {
       if(ms.status != 'initial' && ms.widget.p(edit ? 'movableInEdit' : 'movable'))
         ms.widget.moveEnd();
       if(ms.status == 'initial' || timeSinceStart < 250 && pixelsMoved < 10) {
-        if(edit)
+        if(piles.has(target.id))
+          piles.get(target.id).click();
+        else if(edit)
           editClick(widgets.get(target.id));
         else if(widgets.get(target.id).click)
           widgets.get(target.id).click();
@@ -61,7 +63,7 @@ function inputHandler(name, e) {
         Object.assign(mouseStatus[target.id], {
           status: 'moving',
           offset: [ downCoords[0] - (targetRect.left + targetRect.width/2), downCoords[1] - (targetRect.top + targetRect.height/2) ],
-          widget: widgets.get(target.id)
+          widget: piles.has(target.id) ? piles.get(target.id) : widgets.get(target.id)
         });
         if(mouseStatus[target.id].widget.p(edit ? 'movableInEdit' : 'movable'))
           mouseStatus[target.id].widget.moveStart();

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -44,8 +44,6 @@ export function addWidget(widget, instance) {
       deferredCards[widget.deck].push(widget);
       return;
     }
-  } else if(widget.type == 'pile') {
-    w = new Pile(id);
   } else if(widget.type == 'deck') {
     w = new Deck(id);
   } else if(widget.type == 'holder') {
@@ -155,6 +153,8 @@ onLoad(function() {
     for(const widget of $a('#room .widget'))
       if(widget.id != 'enlarged')
         widgets.get(widget.id).applyRemove();
+    for(const pile of piles.values())
+      pile.destroy();
     widgets.clear();
     dropTargets.clear();
     maxZ = {};

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -300,24 +300,17 @@ export class Button extends Widget {
         const count = a.count || 999999;
 
         if(isValidID(a.from) && isValidID(a.to)) {
-          if(a.face === null && typeof a.from == 'string' && typeof a.to == 'string' && !widgets.get(a.to).children().length && widgets.get(a.from).children().length <= count) {
-            // this is a hacky shortcut to avoid removing and creating card piles when moving all children to an empty holder
-            Widget.prototype.children.call(widgets.get(a.from)).filter(
-              w => w.p('type') != 'label' && w.p('type') != 'button' && w.p('type') != 'deck'
-            ).forEach(c=>c.p('parent', a.to));
-          } else {
-            this.w(a.from, source=>this.w(a.to, target=>source.children().slice(0, count).reverse().forEach(c=> {
-              if(a.face !== null && c.flip)
-                c.flip(a.face);
-              if(source == target) {
-                c.bringToFront();
-              } else {
-                c.movedByButton = true;
-                c.moveToHolder(target);
-                delete c.movedByButton;
-              }
-            })));
-          }
+          this.w(a.from, source=>this.w(a.to, target=>source.children().slice(0, count).reverse().forEach(c=> {
+            if(a.face !== null && c.flip)
+              c.flip(a.face);
+            if(source == target) {
+              c.bringToFront();
+            } else {
+              c.movedByButton = true;
+              c.moveToHolder(target);
+              delete c.movedByButton;
+            }
+          })));
         }
       }
 
@@ -371,7 +364,7 @@ export class Button extends Widget {
         if(a.source == 'all' || isValidCollection(a.source)) {
           if([ 'add', 'set' ].indexOf(a.mode) == -1)
             problems.push(`Warning: Mode ${a.mode} interpreted as set.`);
-          let c = (a.source == 'all' ? Array.from(widgets.values()) : collections[a.source]).filter(function(w) {
+          collections[a.collection] = (a.source == 'all' ? Array.from(widgets.values()) : collections[a.source]).filter(function(w) {
             if(a.relation === '<')
               return w.p(a.property) < a.value;
             else if(a.relation === '<=')
@@ -386,11 +379,6 @@ export class Button extends Widget {
               problems.push(`Warning: Relation ${a.relation} interpreted as ==.`);
             return w.p(a.property) === a.value;
           }).slice(0, a.max).concat(a.mode == 'add' ? collections[a.collection] || [] : []);
-
-          // resolve piles
-          c.filter(w=>w.p('type')=='pile').forEach(w=>c.push(...w.children()));
-          c = c.filter(w=>w.p('type')!='pile');
-          collections[a.collection] = c;
         }
       }
 

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -3,6 +3,8 @@ class Card extends Widget {
     super(id);
 
     this.addDefaults({
+      x: 4,
+      y: 4,
       width: 103,
       height: 160,
       typeClasses: 'widget card',
@@ -11,7 +13,8 @@ class Card extends Widget {
       activeFace: 0,
 
       deck: null,
-      cardType: null
+      cardType: null,
+      pilesWith: { type: 'card' }
     });
 
     this.deck = null;

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -76,7 +76,6 @@ class Pile {
   }
 
   move(x, y) {
-    // FIXME: pile with "0" stays if dropped into a hand (at least that happened once :( )
     for(const widget of this.movingWidgets)
       if(widget.p('movable'))
         widget.move(x - this.o('width')/2 - this.movingOffset[0] + widget.p('width')/2, y - this.o('height')/2 - this.movingOffset[1] + widget.p('height')/2);

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -12,7 +12,6 @@ class Pile {
     this.handle.id = id;
 
     $('#topSurface').appendChild(this.handle);
-    this.handle.textContent = 0;
   }
 
   addWidget(child) {
@@ -20,7 +19,7 @@ class Pile {
 
     this.widgets.set(child.p('id'), child);
     this.setPosition(child.absoluteCoord('x'), child.absoluteCoord('y'));
-    ++this.handle.textContent;
+    this.updateHandleText();
   }
 
   children() {
@@ -69,13 +68,14 @@ class Pile {
   }
 
   moveStart() {
-    this.movingWidgets = Array.from(this.widgets.values());
+    this.movingWidgets = this.children().sort((v,w)=>v.p('z')-w.p('z'));
     for(const widget of this.movingWidgets)
       widget.moveStart(true);
   }
 
   move(x, y) {
     // FIXME: pile shows "0" while being dragged
+    // FIXME: pile with "0" stays if dropped into a hand (at least that happened once :( )
     // FIXME: a new pile handle shows up when dragging out of a holder
     this.setPosition(x - 20 + 15, y - 20 + 15);
     for(const widget of this.movingWidgets)
@@ -86,6 +86,7 @@ class Pile {
     for(const widget of this.movingWidgets)
       widget.moveEnd();
     delete this.movingWidgets;
+    this.updateHandleText();
     if(this.destroyAfterMove)
       this.destroy();
   }
@@ -96,8 +97,8 @@ class Pile {
 
   removeWidget(child) {
     this.widgets.delete(child.p('id'));
-    --this.handle.textContent;
-    if(this.handle.textContent == 1)
+    this.updateHandleText();
+    if(this.widgets.size == 1)
       this.destroy();
   }
 
@@ -120,7 +121,7 @@ class Pile {
     }
   }
 
-  validDropTargets() {
-    return getValidDropTargets(this.children()[0]);
+  updateHandleText() {
+    this.handle.textContent = this.movingWidgets ? this.movingWidgets.length : this.widgets.size;
   }
 }

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -15,11 +15,15 @@ class Pile {
   }
 
   addWidget(child) {
-    this.rectangle = child.domElement.getBoundingClientRect();
-
     this.widgets.set(child.p('id'), child);
-    this.setPosition(child.absoluteCoord('x'), child.absoluteCoord('y'));
+    this.applyRenderLocationChanged;
     this.updateHandleText();
+  }
+
+  applyRenderLocationChanged() {
+    const rectangle = this.children()[0].domElement.getBoundingClientRect();
+
+    this.setPosition((rectangle.left-roomRectangle.left)/scale, (rectangle.top-roomRectangle.top)/scale, rectangle.width/scale, rectangle.height/scale);
   }
 
   children() {
@@ -71,7 +75,6 @@ class Pile {
 
   move(x, y) {
     // FIXME: pile with "0" stays if dropped into a hand (at least that happened once :( )
-    this.setPosition(x - 20 + 15, y - 20 + 15);
     for(const widget of this.movingWidgets)
       widget.move(x - 5 + widget.p('width')/2, y - 5 + widget.p('height')/2);
   }
@@ -94,23 +97,18 @@ class Pile {
       this.destroy();
   }
 
-  setPosition(x, y) {
+  setPosition(x, y, width, height) {
+    /*if(x < 1600-width-20)
+      x += width-10;
+    if(y < 20)
+      y += height-10;*/
+
     this.handle.style.transform = `translate(${x}px, ${y}px)`;
 
-    if(this.handle && (delta.width !== undefined || delta.height !== undefined)) {
-      if(this.p('width') < 50 || this.p('height') < 50)
-        this.handle.classList.add('small');
-      else
-        this.handle.classList.remove('small');
-    }
-    for(const e of [ [ 'x', 'right', 1600-this.p('width')-20 ], [ 'y', 'bottom', 20 ] ]) {
-      if(this.handle && (delta[e[0]] !== undefined || delta.parent !== undefined)) {
-        if(this.absoluteCoord(e[0]) < e[2])
-          this.handle.classList.add(e[1]);
-        else
-          this.handle.classList.remove(e[1]);
-      }
-    }
+    if(width < 50 || height < 50)
+      this.handle.classList.add('small');
+    else
+      this.handle.classList.remove('small');
   }
 
   updateHandleText() {

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -58,13 +58,9 @@ class Pile {
   }
 
   destroy() {
-    if(this.movingWidgets) {
-      this.destroyAfterMove = true;
-    } else {
-      console.log('destroying pile', this.id);
-      piles.delete(this.id);
-      removeFromDOM(this.handle);
-    }
+    console.log('destroying pile', this.id);
+    piles.delete(this.id);
+    removeFromDOM(this.handle);
   }
 
   moveStart() {
@@ -74,9 +70,7 @@ class Pile {
   }
 
   move(x, y) {
-    // FIXME: pile shows "0" while being dragged
     // FIXME: pile with "0" stays if dropped into a hand (at least that happened once :( )
-    // FIXME: a new pile handle shows up when dragging out of a holder
     this.setPosition(x - 20 + 15, y - 20 + 15);
     for(const widget of this.movingWidgets)
       widget.move(x - 5 + widget.p('width')/2, y - 5 + widget.p('height')/2);
@@ -87,8 +81,6 @@ class Pile {
       widget.moveEnd();
     delete this.movingWidgets;
     this.updateHandleText();
-    if(this.destroyAfterMove)
-      this.destroy();
   }
 
   p(property) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -127,6 +127,9 @@ export class Widget extends StateManaged {
       }
     }
 
+    if(delta.x !== undefined || delta.y !== undefined || delta.parent !== undefined || delta.scale !== undefined || delta.rotation !== undefined)
+      this.applyRenderLocationChanged();
+
     if($('#enlarged').dataset.id == this.p('id') && !$('#enlarged').className.match(/hidden/))
       this.showEnlarged();
   }
@@ -135,6 +138,13 @@ export class Widget extends StateManaged {
     if(this.p('parent'))
       widgets.get(this.p('parent')).applyChildRemove(this);
     removeFromDOM(this.domElement);
+  }
+
+  applyRenderLocationChanged() {
+    if(this.pile)
+      this.pile.applyRenderLocationChanged();
+    for(const child of this.children())
+      child.applyRenderLocationChanged();
   }
 
   applyZ(force) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -340,8 +340,8 @@ export class Widget extends StateManaged {
     }
     if(property == 'pile' && piles.has(oldValue)) {
       const pileChildren = piles.get(oldValue).children();
-      if(pileChildren.length == 1)
-        pileChildren[0].p('pile', null);
+      if(pileChildren.length == 2)
+        pileChildren.forEach(w=>w!=this&&w.p('pile', null));
     }
   }
 
@@ -447,23 +447,17 @@ export class Widget extends StateManaged {
       }
 
       // if a pile gets dropped onto a pile, all children of one pile are moved to the other (the empty one destroys itself)
-      if(widget.p('pile') && this.p('pile')) {
+      if(widget.p('pile') && this.p('pile'))
         // FIXME: does this catch all of them?
-        // FIXME: Z-order
         widget.p('pile', this.p('pile'));
-      }
 
       // if a pile gets dropped onto a card, the card is added to the pile but the pile is moved to the original position of the card
-      if(!widget.p('pile') && this.p('pile')) {
-        // FIXME: Z-order
+      if(!widget.p('pile') && this.p('pile'))
         widget.p('pile', this.p('pile'));
-      }
 
       // if a card gets dropped onto a pile, it simply gets added to the pile
-      if(widget.p('pile') && !this.p('pile')) {
-        // FIXME: Z-order
+      if(widget.p('pile') && !this.p('pile'))
         this.p('pile', widget.p('pile'));
-      }
     }
   }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -355,7 +355,7 @@ export class Widget extends StateManaged {
     if(property == 'pile' && piles.has(oldValue)) {
       const pileChildren = piles.get(oldValue).children();
       if(pileChildren.length == 2)
-        pileChildren.forEach(w=>w!=this&&w.p('pile', null));
+        pileChildren.forEach(w=>w.p('pile')==oldValue&&w.p('pile', null));
     }
   }
 
@@ -449,31 +449,22 @@ export class Widget extends StateManaged {
     }
 
     const siblings = parent ? widgets.get(this.p('parent')).children() : Array.from(widgets.values()); // FIXME: this.parent
-    // FIXME: merging piles doesn't change all positions
     for(const widget of siblings.filter(canPileWith)) {
+      if(widget.p('pile') && widget.p('pile') == this.p('pile'))
+        continue;
+
       this.p('x', widget.p('x'));
       this.p('y', widget.p('y'));
 
       // if a card gets dropped onto a card, they create a new pile and are added to it
-      if(!widget.p('pile') && !this.p('pile')) {
+      if(!widget.p('pile')) {
         const pileID = Math.random().toString(36).substring(3, 7);
         this.p('pile', pileID);
         widget.p('pile', pileID);
-        break;
-      }
-
-      // if a pile gets dropped onto a pile, all children of one pile are moved to the other (the empty one destroys itself)
-      if(widget.p('pile') && this.p('pile') && widget.p('pile') != this.p('pile'))
-        // FIXME: does this catch all of them?
-        widget.p('pile', this.p('pile'));
-
-      // if a pile gets dropped onto a card, the card is added to the pile but the pile is moved to the original position of the card
-      if(!widget.p('pile') && this.p('pile'))
-        widget.p('pile', this.p('pile'));
-
-      // if a card gets dropped onto a pile, it simply gets added to the pile
-      if(widget.p('pile') && !this.p('pile'))
+      } else {
         this.p('pile', widget.p('pile'));
+      }
+      break;
     }
   }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -41,8 +41,8 @@ export class Widget extends StateManaged {
       pile: null,
       pilesWith: null,
       pileOptions: {
-        xOffset: 10,
-        yOffset: 10
+        snapX: 10,
+        snapY: 10
       }
     });
 
@@ -351,9 +351,6 @@ export class Widget extends StateManaged {
         widgets.get(oldValue).onChildRemove(this);
       if(newValue)
         widgets.get(newValue).onChildAdd(this, oldValue);
-      if(!this.movedByPile)
-        this.p('pile', null);
-      this.updatePiles();
     }
     if(property == 'pile' && piles.has(oldValue)) {
       const pileChildren = piles.get(oldValue).children();
@@ -433,7 +430,7 @@ export class Widget extends StateManaged {
     const pilesWith = JSON.stringify(this.p('pilesWith'));
     const pileOptions = JSON.stringify(this.p('pileOptions'));
 
-    const canPileWith = (widget) => { // FIXME: rotation? scale? movable?
+    const canPileWith = (widget) => { // FIXME: rotation? scale?
       if(widget.p('parent') !== parent)
         return false;
       if(JSON.stringify(widget.p('pilesWith')) !== pilesWith)
@@ -444,9 +441,9 @@ export class Widget extends StateManaged {
         return false;
       if(JSON.stringify(widget.p('owner')) !== owner)
         return false;
-      if(Math.abs(widget.p('x')-this.p('x')) > (this.p('pileOptions').xOffset || 10))
+      if(Math.abs(widget.p('x')-this.p('x')) > (this.p('pileOptions').snapX || 10))
         return false;
-      if(Math.abs(widget.p('y')-this.p('y')) > (this.p('pileOptions').yOffset || 10))
+      if(Math.abs(widget.p('y')-this.p('y')) > (this.p('pileOptions').snapY || 10))
         return false;
       return true;
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean": "rm -rf coverage",
     "clobber": "npm clean && rm -rf save",
-    "debug": "NOCOMPRESS=1 npm start",
+    "debug": "env NOCOMPRESS=1 npm start",
     "start": "nodemon -e js,mjs,css,html --ignore save --ignore coverage --ignore tests server.mjs",
     "test": "node --experimental-vm-modules node_modules/.bin/jest --coverage",
     "test-cont": "nodemon -e js,mjs,css,html --ignore save --ignore coverage --experimental-vm-modules node_modules/.bin/jest"

--- a/server/fileloader.mjs
+++ b/server/fileloader.mjs
@@ -90,8 +90,8 @@ async function readVariantsFromBuffer(buffer) {
         if(zip.files[filename]._data.uncompressedSize >= 2097152)
           throw `${filename} is bigger than 2 MiB.`;
         const variant = JSON.parse(await zip.files[filename].async('string'));
-        if(variant._meta.version !== 1)
-          throw `Found a valid JSON file but version ${variant._meta.version} is not supported.`;
+        if(!variant._meta.version)
+          throw 'Found a valid JSON file with invalid version information.';
         variants[filename] = variant;
       }
 

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -1,0 +1,35 @@
+const VERSION = 2;
+
+export default function FileUpdater(state) {
+  const v = state._meta.version;
+  if(v == VERSION)
+    return state;
+
+  const widgetsArray = Array.from(Object.values(state));
+  const pileIDs = widgetsArray.filter(w=>w.type=='pile').map(w=>w.id);
+
+  for(const id in state) {
+    const w = state[id];
+
+    if(v == 1 && w.parent && pileIDs.indexOf(w.parent) != -1) {
+
+      const pile = widgetsArray.filter(x=>x.id==w.parent)[0];
+      w.pile = pile.id;
+      w.parent = pile.parent;
+      w.x = (w.x || 0) + (pile.x || 4);
+      w.y = (w.y || 0) + (pile.y || 4);
+      if(w.x == 4)
+        delete w.x;
+      if(w.y == 4)
+        delete w.y;
+
+    }
+
+  }
+
+  for(const pile of pileIDs)
+    delete state[pile];
+
+  state._meta.version = VERSION;
+  return state;
+}

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -150,6 +150,7 @@ export default class Room {
         state = await FileLoader.readVariantFromLink(v.link);
       else
         state = JSON.parse(fs.readFileSync(filename));
+      state = FileUpdater(state);
       state._meta = { version: this.state._meta.version, info: { ...this.state._meta.states[stateID] } };
       Object.assign(state._meta.info, state._meta.info.variants[vID]);
       delete state._meta.info.variants;


### PR DESCRIPTION
I already posted an issue about this earlier. Having piles as widgets seemed like a good idea at the time but leads to a lot of headaches.

This PR removes piles from the widget hierarchy and instead puts a property `pile` with the same value to each widget within a pile. The client then simply displays a UI element on top of the pile that looks and feels like the old pile handle.

This introduces these new widget properties (and the default values):

```
      allowPiles: true, // set to false on a holder would prevent piles inside the holder
      pile: null,       // the reference to the pile
      pilesWith: null,  // cards have this set to { type: 'card' } and it can be used to make other things pileable
      pileOptions: {    // also "css" to customize the handle
        xOffset: 10,
        yOffset: 10
      }
```

I didn't really test those properties yet though because the main code still needs work.

I'll add my generic test room to the PR test server. It's fun to play around with and might be a good tutorial/demo somewhere?

Stuff I'm still aware of:
- [x] Dropping a pile onto a pile doesn't move all widgets to the other pile's location.
- [x] The _add widgets_ overlay is disabled because its pile handle messes things up.
- [x] Pile handles don't move if its widgets (or their parents) move for any reason.
- [x] The handle is currently _always_ at the top left.
- [x] The handle doesn't scale down yet for very small widgets.
- [ ] Changing `pileOptions` (or anything else affecting the creation of piles) doesn't take effect immediately.
- [ ] Dropping a pile into a hand doesn't remove the pile handle when the cards get spread out.
- [ ] Adding a new card deck makes the shuffle button (and deck) go to 0,0 in the holder (counters are also broken).
- [ ] Cards with different `pileOptions` in one holder form multiple piles. Probably only direct neighbors (on the Z axis) should form a pile?