### PR TITLE
autosave rooms once per minute

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -44,6 +44,13 @@ function downloadState(res, roomID, stateID, variantID) {
   }
 }
 
+function autosaveRooms() {
+  setInterval(function() {
+    for(const [ _, room ] of activeRooms)
+      room.writeToFilesystem();
+  }, 60*1000);
+}
+
 MinifyRoom().then(function(result) {
   app.use('/', express.static(path.resolve() + '/client'));
   app.use('/i', express.static(path.resolve() + '/assets'));
@@ -174,6 +181,8 @@ const ws = new WebSocket(server, function(connection, { playerName, roomID }) {
   if(ensureRoomIsLoaded(roomID))
     activeRooms.get(roomID).addPlayer(new Player(connection, playerName, activeRooms.get(roomID)));
 });
+
+autosaveRooms();
 
 ['exit', 'SIGINT', 'SIGUSR1', 'SIGUSR2', 'SIGTERM'].forEach((eventType) => {
   process.on(eventType, function() {

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -287,6 +287,10 @@ export default class Room {
 
   unload() {
     console.log(new Date().toISOString(), `unloading room ${this.id}`);
+    this.writeToFilesystem();
+  }
+
+  writeToFilesystem() {
     const json = JSON.stringify(this.state);
     fs.writeFileSync(path.resolve() + '/save/rooms/' + this.id + '.json', json);
   }


### PR DESCRIPTION
Issue #157 shows that server crashes can happen that don't trigger the error handler that takes care of saving rooms to the filesystem.

While the goal is obviously that the server never crashes, this PR adds a failsafe that saves any active rooms once per minute.