### PR TITLE
handle property missing in GET first

### DIFF
--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -265,7 +265,7 @@ export class Button extends Widget {
                 variables[a.variable] = JSON.parse(JSON.stringify(collections[a.collection][0].p(a.property)));
               else {
                 variables[a.variable] = null;
-                problems.push("Property ${a.property} missing from first item of collection, setting ${a.variable} to null");
+                problems.push(`Property ${a.property} missing from first item of collection, setting ${a.variable} to null`);
               }
             else
               problems.push(`Collection ${a.collection} is empty.`);

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -260,8 +260,12 @@ export class Button extends Widget {
           switch(a.aggregation) {
           case 'first':
             if(collections[a.collection].length)
-              // always get a deep copy and not object references
-              variables[a.variable] = JSON.parse(JSON.stringify(collections[a.collection][0].p(a.property)));
+              if(collections[a.collection][0].(a.property) !== undefined)
+                // always get a deep copy and not object references
+                variables[a.variable] = JSON.parse(JSON.stringify(collections[a.collection][0].p(a.property)));
+              else
+                variables[a.variable] = null;
+                problems.push('Property ${a.property} missing from first item of collection, setting ${a.variable} to null");
             else
               problems.push(`Collection ${a.collection} is empty.`);
             break;

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -263,9 +263,10 @@ export class Button extends Widget {
               if(collections[a.collection][0].p(a.property) !== undefined)
                 // always get a deep copy and not object references
                 variables[a.variable] = JSON.parse(JSON.stringify(collections[a.collection][0].p(a.property)));
-              else
+              else {
                 variables[a.variable] = null;
                 problems.push("Property ${a.property} missing from first item of collection, setting ${a.variable} to null");
+              }
             else
               problems.push(`Collection ${a.collection} is empty.`);
             break;

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -260,12 +260,12 @@ export class Button extends Widget {
           switch(a.aggregation) {
           case 'first':
             if(collections[a.collection].length)
-              if(collections[a.collection][0].p(a.property) !== undefined)
+              if(collections[a.collection][0].p(a.property) !== undefined) {
                 // always get a deep copy and not object references
                 variables[a.variable] = JSON.parse(JSON.stringify(collections[a.collection][0].p(a.property)));
-              else {
+              } else {
                 variables[a.variable] = null;
-                problems.push(`Property ${a.property} missing from first item of collection, setting ${a.variable} to null`);
+                problems.push(`Property ${a.property} missing from first item of collection, setting ${a.variable} to null.`);
               }
             else
               problems.push(`Collection ${a.collection} is empty.`);

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -265,7 +265,7 @@ export class Button extends Widget {
                 variables[a.variable] = JSON.parse(JSON.stringify(collections[a.collection][0].p(a.property)));
               else
                 variables[a.variable] = null;
-                problems.push('Property ${a.property} missing from first item of collection, setting ${a.variable} to null");
+                problems.push("Property ${a.property} missing from first item of collection, setting ${a.variable} to null");
             else
               problems.push(`Collection ${a.collection} is empty.`);
             break;

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -260,7 +260,7 @@ export class Button extends Widget {
           switch(a.aggregation) {
           case 'first':
             if(collections[a.collection].length)
-              if(collections[a.collection][0].(a.property) !== undefined)
+              if(collections[a.collection][0].p(a.property) !== undefined)
                 // always get a deep copy and not object references
                 variables[a.variable] = JSON.parse(JSON.stringify(collections[a.collection][0].p(a.property)));
               else


### PR DESCRIPTION
fixes #162 

Test case loaded to room. To reset the test case, choose "GET missing property bug" from the "Development" game in the games list.

Clicking button updates label to "Success!" after adding/incrementing a "clickCount" property.