### PR TITLE
added the possibility to get memory dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage
 node_modules
 save
 *.tgz
+*.heapsnapshot

--- a/server.mjs
+++ b/server.mjs
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import v8 from 'v8';
 
 import express from 'express';
 import bodyParser from 'body-parser';
@@ -74,6 +75,10 @@ MinifyRoom().then(function(result) {
 
       res.send(content);
     });
+  });
+
+  app.post('/heapsnapshot', function(req, res) {
+    v8.getHeapSnapshot().pipe(fs.createWriteStream('memory.heapsnapshot'));
   });
 
   app.post('/quit', function(req, res) {


### PR DESCRIPTION
Issue #157 is caused by the server process running out of memory. This PR adds a new URL /heapsnapshot that generates a memory snapshot so I can look at the internals.

The snapshot is stored on the server filesystem as to not leak sensitive information.