### PR TITLE
rooms cleanup unused files on the server

### DIFF
--- a/server/room.mjs
+++ b/server/room.mjs
@@ -124,8 +124,8 @@ export default class Room {
 
   deleteUnusedVariantFiles(stateID, oldState, newState) {
     for(const oldVariantID in oldState.variants) {
-      if(!newState.variants[oldVariantID] && stateID.match(/^[a-z0-9]+$/) && oldVariantID.match(/^[a-z0-9]+$/)) {
-        const savefile = path.resolve() + '/save/states/' + this.id + '-' + stateID + '-' + oldVariantID + '.json';
+      if(!newState.variants[oldVariantID]) {
+        const savefile = this.variantFilename(stateID, oldVariantID);
         if(fs.existsSync(savefile))
           fs.unlinkSync(savefile);
       }

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -123,7 +123,7 @@ export default class Room {
   }
 
   deleteUnusedVariantFiles(stateID, oldState, newState) {
-    for(const oldVariantID of Object.keys(oldState.variants)) {
+    for(const oldVariantID in oldState.variants) {
       if(!newState.variants[oldVariantID] && stateID.match(/^[a-z0-9]+$/) && oldVariantID.match(/^[a-z0-9]+$/)) {
         const savefile = path.resolve() + '/save/states/' + this.id + '-' + stateID + '-' + oldVariantID + '.json';
         if(fs.existsSync(savefile))


### PR DESCRIPTION
When deleting states and/or variants from a room, it now actually removes the files from the save directory. And when unloading a room, it also removes the room file itself if it doesn't contain any states or widgets.

You can't see if the test server actually deletes stuff but please do a few tests that it doesn't delete stuff it shouldn't.

Note that the variant can be visible in the game overlay but the file might be gone. You'll only know when you try to actually load it.