### PR TITLE
added a new keyboard focused JSON editor

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -52,6 +52,7 @@ i.default { color: #606060; }
 i.error   { color: red; font-weight: bold; }
 
 #jeCommands {
+  white-space: pre-wrap;
   height: 100%;
   width: 350px;
   right: 0;

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -6,8 +6,11 @@
   width: 100%;
 }
 
+#jsonEditor > *, .jsonEdit {
+  background: #08090a;
+}
 #jsonEditor > * {
-  background: white;
+  color: #f8f8f2;
   padding: 5px;
   margin: 0;
   position: fixed;
@@ -31,7 +34,7 @@
   outline: none;
 }
 #jeText::selection {
-  background-color: black;
+  background-color: #808080;
   -webkit-text-fill-color: white;
 }
 
@@ -39,9 +42,10 @@
   font-style: normal;
 }
 
-i.curl {
-  color: grey;
-}
+i.key    { color: yellow;  }
+i.string { color: #7ed07e; }
+i.number { color: #dda0dd; }
+i.null   { color: blue;    }
 
 #jeCommands {
   height: 100%;

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -1,0 +1,42 @@
+#jsonEditor {
+  display: none;
+  height: 100%;
+  width: 100%;
+}
+
+#jeText {
+  height: 100%;
+  width: 25%;
+  position: fixed;
+  right: 25%;
+  border: none;
+  resize: none;
+  box-sizing: border-box;
+}
+
+#jeCommands {
+  padding: 5px;
+  font-family: monospace;
+  background: white;
+  white-space: pre-line;
+  height: 100%;
+  width: 25%;
+  position: fixed;
+  right: 0;
+  border: none;
+  resize: none;
+  box-sizing: border-box;
+}
+
+body.jsonEdit #jsonEditor {
+  display: block;
+}
+
+body.jsonEdit #toolbar {
+  display: none;
+}
+
+body.jsonEdit #roomArea {
+  top: calc((100vh - var(--roomHeight) * var(--scale)) / 2 - var(--toolbarSize) / 2);
+  left: 0;
+}

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -38,7 +38,7 @@
   -webkit-text-fill-color: white;
 }
 
-#jeTextHighlight i {
+#jsonEditor i {
   font-style: normal;
 }
 
@@ -48,6 +48,7 @@ i.string  { color: #7ed07e; }
 i.number  { color: #dda0dd; }
 i.null    { color: blue;    }
 i.default { color: #606060; }
+i.error   { color: red; font-weight: bold; }
 
 #jeCommands {
   height: 100%;
@@ -58,7 +59,7 @@ i.default { color: #606060; }
 
 #jeWidgetLayers {
   height: 10%;
-  width: 50%;
+  width: calc(100%-700px);
   white-space: pre;
   overflow: hidden;
 }

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -23,8 +23,8 @@
   white-space: pre-wrap;
   overflow-y: auto;
   height: 100%;
-  width: 25%;
-  right: 25%;
+  width: 350px;
+  right: 350px;
 }
 
 #jeText {
@@ -49,7 +49,7 @@ i.null   { color: blue;    }
 
 #jeCommands {
   height: 100%;
-  width: 25%;
+  width: 350px;
   right: 0;
   overflow: auto;
 }

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -40,3 +40,13 @@ body.jsonEdit #roomArea {
   top: calc((100vh - var(--roomHeight) * var(--scale)) / 2 - var(--toolbarSize) / 2);
   left: 0;
 }
+
+body.jsonEdit.jeZoomOut #roomArea {
+  top: calc((100vh - var(--roomHeight) * var(--scale)) / 2 - var(--toolbarSize) / 2);
+  left: 12.5%;
+  overflow: visible;
+}
+
+body.jsonEdit.jeZoomOut #topSurface {
+  overflow: visible;
+}

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -1,31 +1,42 @@
 #jsonEditor {
+  white-space: pre-line;
+  font-family: monospace;
   display: none;
   height: 100%;
   width: 100%;
 }
 
-#jeText {
-  height: 100%;
-  width: 25%;
+#jsonEditor > * {
+  background: white;
+  padding: 5px;
+  margin: 0;
   position: fixed;
-  right: 25%;
   border: none;
   resize: none;
   box-sizing: border-box;
 }
 
-#jeCommands {
-  padding: 5px;
-  font-family: monospace;
-  background: white;
-  white-space: pre-line;
+#jeText {
   height: 100%;
   width: 25%;
-  position: fixed;
+  right: 25%;
+}
+
+#jeCommands {
+  height: 100%;
+  width: 25%;
   right: 0;
-  border: none;
-  resize: none;
-  box-sizing: border-box;
+}
+
+#jeWidgetLayers {
+  height: 10%;
+  width: 50%;
+}
+
+#jeWidgetLayers > div {
+  display: inline-block;
+  width: 125px;
+  margin-bottom: 10px;
 }
 
 body.jsonEdit #jsonEditor {

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -26,11 +26,14 @@
   height: 100%;
   width: 25%;
   right: 0;
+  overflow: auto;
 }
 
 #jeWidgetLayers {
   height: 10%;
   width: 50%;
+  white-space: pre;
+  overflow: hidden;
 }
 
 #jeWidgetLayers > div {

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -42,10 +42,12 @@
   font-style: normal;
 }
 
-i.key    { color: yellow;  }
-i.string { color: #7ed07e; }
-i.number { color: #dda0dd; }
-i.null   { color: blue;    }
+i.key     { color: yellow;  }
+i.custom  { color: orange;  }
+i.string  { color: #7ed07e; }
+i.number  { color: #dda0dd; }
+i.null    { color: blue;    }
+i.default { color: #606060; }
 
 #jeCommands {
   height: 100%;

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -16,10 +16,31 @@
   box-sizing: border-box;
 }
 
-#jeText {
+#jeText, #jeTextHighlight {
+  white-space: pre-wrap;
+  overflow-y: auto;
   height: 100%;
   width: 25%;
   right: 25%;
+}
+
+#jeText {
+  background: none;
+  -webkit-text-fill-color: transparent;
+  text-fill-color: transparent;
+  outline: none;
+}
+#jeText::selection {
+  background-color: black;
+  -webkit-text-fill-color: white;
+}
+
+#jeTextHighlight i {
+  font-style: normal;
+}
+
+i.curl {
+  color: grey;
 }
 
 #jeCommands {

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -44,6 +44,7 @@
 
 i.key     { color: yellow;  }
 i.custom  { color: orange;  }
+i.extern  { color: red;     }
 i.string  { color: #7ed07e; }
 i.number  { color: #dda0dd; }
 i.null    { color: blue;    }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -124,6 +124,24 @@ const jeCommands = [
     }
   },
   {
+    name: 'css',
+    context: '^deck ↦ faceTemplates ↦ [0-9]+ ↦ objects ↦ [0-9]+',
+    show: _=>!jeStateNow.faceTemplates[+jeContext[2]].objects[+jeContext[4]].css,
+    call: function() {
+      jeStateNow.faceTemplates[+jeContext[2]].objects[+jeContext[4]].css = '###SELECT ME###';
+      jeSetAndSelect('');
+    }
+  },
+  {
+    name: 'rotation',
+    context: '^deck ↦ faceTemplates ↦ [0-9]+ ↦ objects ↦ [0-9]+',
+    show: _=>!jeStateNow.faceTemplates[+jeContext[2]].objects[+jeContext[4]].rotation,
+    call: function() {
+      jeStateNow.faceTemplates[+jeContext[2]].objects[+jeContext[4]].rotation = '###SELECT ME###';
+      jeSetAndSelect(0);
+    }
+  },
+  {
     name: _=>jeStateNow.faceTemplates[+jeContext[2]].objects[+jeContext[4]].valueType == 'dynamic' ? 'static' : 'dynamic',
     context: '^deck ↦ faceTemplates ↦ [0-9]+ ↦ objects ↦ [0-9]+',
     call: function() {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1,0 +1,230 @@
+let jeEnabled = false;
+let jeWidget = null;
+let jeStateBefore = null;
+let jeStateNow = null;
+let jeJSONerror = null;
+let jeContext = null;
+const jeState = {
+  ctrl: false,
+  shift: false,
+  mouseX: 0,
+  mouseY: 0,
+  widget: null
+};
+
+const jeCommands = [
+  {
+    name: 'toggle boolean',
+    context: '"(true|false)"',
+    call: function() {
+      jeInsert(jeContext.slice(1), jeContext[jeContext.length-2], jeContext[jeContext.length-1]=='"false"');
+    }
+  },
+  {
+    name: _=>`remove property ${jeContext && jeContext[jeContext.length-1]}`,
+    forceKey: 'd',
+    context: ' ↦ (?=[^"]+$)',
+    call: function() {
+      let pointer = jeStateNow;
+      for(const key of jeContext.slice(1))
+        if(typeof pointer[key] == 'object')
+          pointer = pointer[key];
+      delete pointer[jeContext[jeContext.length-1]];
+
+      const oldStart = $('#jeText').selectionStart;
+      const oldEnd   = $('#jeText').selectionEnd;
+      $('#jeText').value = JSON.stringify(jeStateNow, null, '  ');
+      $('#jeText').selectionStart = oldStart;
+      $('#jeText').selectionEnd   = oldEnd;
+    },
+    show: function() {
+      return jeStateNow && jeStateNow[jeContext && jeContext[jeContext.length-1]] !== undefined;
+    }
+  },
+  {
+    name: _=>jeJSONerror?'go to error':'apply changes',
+    forceKey: ' ',
+    call: function() {
+      if(jeJSONerror) {
+        const location = String(jeJSONerror).match(/line ([0-9]+) column ([0-9]+)/);
+        if(location)
+          $('#jeText').selectionStart = $('#jeText').selectionEnd = $('#jeText').value.split('\n').slice(0, location[1]-1).join('\n').length + +location[2];
+      } else {
+        $('#editWidgetJSON').dataset.previousState = jeStateBefore;
+        $('#editWidgetJSON').value = $('#jeText').value;
+        $('#updateWidgetJSON').click();
+      }
+    }
+  }
+];
+
+function jeAddCommands() {
+  jeAddWidgetPropertyCommands(new BasicWidget());
+  jeAddWidgetPropertyCommands(new Button());
+  jeAddWidgetPropertyCommands(new Card());
+  jeAddWidgetPropertyCommands(new Deck());
+  jeAddWidgetPropertyCommands(new Holder());
+  jeAddWidgetPropertyCommands(new Label());
+  jeAddWidgetPropertyCommands(new Pile());
+  jeAddWidgetPropertyCommands(new Spinner());
+}
+
+function jeAddWidgetPropertyCommands(object) {
+  for(const property in object.defaults)
+    if(property != 'typeClasses')
+      jeAddWidgetPropertyCommand(object.defaults, property);
+  object.applyRemove();
+}
+
+function jeAddWidgetPropertyCommand(defaults, property) {
+  jeCommands.push({
+    name: property,
+    context: `^${defaults.typeClasses.replace('widget ', '')}`,
+    call: function() {
+      jeInsert([], property, defaults[property]);
+    },
+    show: function() {
+      return jeStateNow && jeStateNow[property] === undefined;
+    }
+  });
+}
+
+function jeClick(widget, e) {
+  if(jeState.ctrl) {
+    jeWidget = widget;
+    $('#jeText').value = jeStateBefore = JSON.stringify(widget.state, null, '  ');
+    $('#jeText').focus();
+  } else if(widget.click) {
+    widget.click();
+  }
+}
+
+function jeGetContext() {
+  if(!jeWidget)
+    return [];
+
+  const s = $('#jeText').selectionStart;
+  const e = $('#jeText').selectionEnd;
+  const v = $('#jeText').value;
+  const t = jeWidget.p('type') || 'basic';
+
+  const select = v.substr(s, e-s);
+  const line = v.substr(0, s).split('\n').pop();
+
+  let keys = [ t ];
+  for(const line of v.substr(0, s).split('\n')) {
+    const m = line.match(/^( +)(["{])([^"]*)/);
+    if(m) {
+      const depth = m[1].length/2;
+      keys[depth] = m[2]=='{' ? (keys[depth] === undefined ? -1 : keys[depth]) + 1 : m[3];
+      keys = keys.slice(0, depth+1);
+    }
+  }
+  if(select)
+    keys.push(`"${select}"`);
+
+  try {
+    jeStateNow = JSON.parse(v);
+    jeJSONerror = null;
+  } catch(e) {
+    jeStateNow = null;
+    jeJSONerror = e;
+  }
+
+  jeContext = keys;
+
+  const context = keys.join(' ↦ ');
+  const usedKeys = { c: 1, x: 1, v: 1, w: 1, n: 1, t: 1, q: 1, j: 1, z: 1 };
+  let commandText = '';
+  for(const command of jeCommands) {
+    delete command.currentKey;
+    if(context.match(new RegExp(command.context)) && (!command.show || command.show())) {
+      const name = typeof command.name == 'function' ? command.name() : command.name;
+      if(command.forceKey)
+        command.currentKey = command.forceKey;
+      for(const key of name.split(''))
+        if(!command.currentKey && !usedKeys[key.toLowerCase()])
+          command.currentKey = key.toLowerCase();
+      for(const key of 'abcdefghijklmnopqrstuvwxyz1234567890'.split(''))
+        if(!command.currentKey && !usedKeys[key])
+          command.currentKey = key;
+      usedKeys[command.currentKey] = true;
+      commandText += `Ctrl-${command.currentKey}: ${name}\n`;
+    }
+  }
+  if(jeJSONerror)
+    commandText += `\n${String(jeJSONerror)}\n`;
+  $('#jeCommands').textContent = commandText;
+
+  return jeContext;
+}
+
+function jeInsert(context, key, value) {
+  if(!jeJSONerror) {
+    let pointer = jeStateNow;
+    for(const key of context)
+      if(typeof pointer[key] == 'object')
+        pointer = pointer[key];
+    pointer[key] = "###SELECT ME###";
+    let jsonString = JSON.stringify(jeStateNow, null, '  ');
+    const startIndex = jsonString.indexOf("\"###SELECT ME###\"");
+    let length = jsonString.length-pointer[key].length-2;
+
+    pointer[key] = value;
+    jsonString = JSON.stringify(jeStateNow, null, '  ');
+
+    $('#jeText').value = jsonString;
+    $('#jeText').selectionStart = startIndex;
+    $('#jeText').selectionEnd = startIndex+jsonString.length-length;
+    $('#jeText').focus();
+  }
+}
+
+window.addEventListener('mousemove', function(e) {
+  jeState.mouseX = Math.floor((e.clientX - roomRectangle.left) / scale);
+  jeState.mouseY = Math.floor((e.clientY - roomRectangle.top ) / scale);
+});
+
+window.addEventListener('mouseup', function(e) {
+  if(e.target == $('#jeText'))
+    jeGetContext();
+});
+
+window.addEventListener('keydown', function(e) {
+  if(e.key == 'Control')
+    jeState.ctrl = true;
+  if(e.key == 'Shift')
+    jeState.shift = true;
+
+  if(jeState.ctrl) {
+    if(e.key == 'j') {
+      e.preventDefault();
+      jeEnabled = !jeEnabled;
+      if(jeEnabled) {
+        $('body').classList.add('jsonEdit');
+        jeAddCommands();
+        $('#jeText').focus();
+      } else {
+        $('body').classList.remove('jsonEdit');
+      }
+      setScale();
+    } else {
+      for(const command of jeCommands) {
+        if(command.currentKey == e.key) {
+          e.preventDefault();
+          command.call();
+        }
+      }
+    }
+  }
+});
+
+window.addEventListener('keyup', function(e) {
+  if(e.key == 'Control')
+    jeState.ctrl = false;
+  if(e.key == 'Shift')
+    jeState.shift = false;
+
+  if(e.target == $('#jeText'))
+    jeGetContext();
+});

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -133,6 +133,9 @@ function jeAddButtonOperationCommands(command, defaults) {
 }
 
 function jeAddCommands() {
+  if(jeCommands.length > 100)
+    return;
+
   jeAddWidgetPropertyCommands(new BasicWidget());
   jeAddWidgetPropertyCommands(new Button());
   jeAddWidgetPropertyCommands(new Card());
@@ -205,6 +208,25 @@ function jeClick(widget, e) {
   } else if(widget.click) {
     widget.click();
   }
+}
+
+function jeDisplayTree() {
+  const allWidgets = Array.from(widgets.values());
+  let result = 'CTRL-click a widget on the left to edit it.\n\nRoom\n';
+  result += jeDisplayTreeAddWidgets(allWidgets, null, '  ');
+  console.log(allWidgets);
+  $('#jeText').value = jeStateBefore = result;
+  $('#jeText').focus();
+}
+
+function jeDisplayTreeAddWidgets(allWidgets, parent, indent) {
+  let result = '';
+  for(const widget of allWidgets.filter(w=>w.p('parent')==parent)) {
+    result += `${indent}${widget.p('id')} (${widget.p('type') || 'basic'} - ${Math.floor(widget.p('x'))},${Math.floor(widget.p('y'))})\n`;
+    result += jeDisplayTreeAddWidgets(allWidgets, widget.p('id'), indent+'  ');
+    delete allWidgets[allWidgets.indexOf(widget)];
+  }
+  return result;
 }
 
 function jeGetContext() {
@@ -380,8 +402,7 @@ window.addEventListener('keydown', function(e) {
       if(jeEnabled) {
         $('body').classList.add('jsonEdit');
         jeAddCommands();
-        $('#jeText').value = 'CTRL-click a widget';
-        $('#jeText').focus();
+        jeDisplayTree();
       } else {
         $('body').classList.remove('jsonEdit');
       }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -243,6 +243,16 @@ function jeInsert(context, key, value) {
   }
 }
 
+function jePasteText(text) {
+  const s = $('#jeText').selectionStart;
+  const e = $('#jeText').selectionEnd;
+  const v = $('#jeText').value;
+
+  $('#jeText').value = v.substr(0, s) + text + v.substr(e);
+  $('#jeText').selectionStart = s;
+  $('#jeText').selectionEnd   = s + text.length;
+}
+
 function jeSetAndSelect(replaceBy) {
   let jsonString = JSON.stringify(jeStateNow, null, '  ');
   const startIndex = jsonString.indexOf('"###SELECT ME###"');
@@ -359,10 +369,14 @@ window.addEventListener('keydown', function(e) {
         }
       }
     }
-  } else {
-    const functionKey = e.key.match(/F([0-9]+)/);
-    if(functionKey && jeWidgetLayers[+functionKey[1]]) {
-      e.preventDefault();
+  }
+
+  const functionKey = e.key.match(/F([0-9]+)/);
+  if(functionKey && jeWidgetLayers[+functionKey[1]]) {
+    e.preventDefault();
+    if(jeState.ctrl) {
+      jePasteText(jeWidgetLayers[+functionKey[1]].p('id'));
+    } else {
       jeState.ctrl = true;
       jeClick(jeWidgetLayers[+functionKey[1]]);
       jeState.ctrl = false;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -323,30 +323,34 @@ function jePasteText(text) {
 
 function jeSelect(start, end) {
   const t = $('#jeText');
-  t.focus();
-
-  const scroll = t.scrollTop;
   const text = t.textContent;
-  t.textContent = text.substring(0, end);
-  const height = t.scrollHeight;
-  t.scrollTop = 50000;
-  t.textContent = text;
+  try {
+    t.focus();
 
-  if(t.scrollTop) {
-    if(Math.abs(t.scrollTop + t.clientHeight/2 - scroll) < t.clientHeight*.25)
-      t.scrollTop = scroll;
-    else
-      t.scrollTop += t.clientHeight/2;
+    const scroll = t.scrollTop;
+    t.textContent = text.substring(0, end);
+    const height = t.scrollHeight;
+    t.scrollTop = 50000;
+    t.textContent = text;
+
+    if(t.scrollTop) {
+      if(Math.abs(t.scrollTop + t.clientHeight/2 - scroll) < t.clientHeight*.25)
+        t.scrollTop = scroll;
+      else
+        t.scrollTop += t.clientHeight/2;
+    }
+
+    const node = t.firstChild;
+    const range = document.createRange();
+    range.setStart(node, start);
+    range.setEnd(node, end);
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+
+    selection.addRange(range);
+  } catch(e) {
+    t.textContent = text;
   }
-
-  const node = t.firstChild;
-  const range = document.createRange();
-  range.setStart(node, start);
-  range.setEnd(node, end);
-  const selection = window.getSelection();
-  selection.removeAllRanges();
-
-  selection.addRange(range);
 }
 
 function jeSet(text) {
@@ -450,13 +454,18 @@ window.addEventListener('keydown', function(e) {
   if(e.key == 'Shift')
     jeState.shift = true;
 
+  if(e.key == 'Enter' && jeEnabled) {
+    document.execCommand('insertHTML', false, '\n');
+    e.preventDefault();
+  }
+
   if(jeState.ctrl) {
     if(e.key == 'j') {
       e.preventDefault();
       if(jeEnabled === null) {
         jeAddCommands();
         jeDisplayTree();
-        $('#jeText').addEventListener("input", jeColorize);
+        $('#jeText').addEventListener('input', jeColorize);
         $('#jeText').onscroll = e=>$('#jeTextHighlight').scrollTop = e.target.scrollTop;
         jeColorize();
       }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -85,6 +85,18 @@ const jeCommands = [
 ];
 
 function jeAddButtonOperationCommands(command, defaults) {
+  jeCommands.push({
+    name: command,
+    context: `^button ↦ clickRoutine`,
+    call: function() {
+      if(jeContext.length == 2)
+        jeStateNow.clickRoutine.push({func: command});
+      else
+        jeStateNow.clickRoutine.splice(jeContext[2]+1, 0, {func: '###SELECT ME###'});
+      jeSetAndSelect(command);
+    }
+  });
+
   defaults.skip = false;
   for(const property in defaults) {
     jeCommands.push({
@@ -167,7 +179,7 @@ function jeGetContext() {
   const v = $('#jeText').value;
   const t = jeWidget.p('type') || 'basic';
 
-  const select = v.substr(s, e-s);
+  const select = v.substr(s, e-s).replace(/\n/g, '\\n');
   const line = v.substr(0, s).split('\n').pop();
 
   try {
@@ -205,7 +217,7 @@ function jeGetContext() {
 function jeGetValue(context, all) {
   let pointer = jeStateNow;
   for(const key of context || jeContext)
-    if(all && typeof pointer[key] !== undefined || typeof pointer[key] == 'object')
+    if(all && typeof pointer[key] !== undefined || typeof pointer[key] == 'object' && pointer[key] !== null)
       pointer = pointer[key];
   return pointer
 }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -80,7 +80,7 @@ const jeCommands = [
   {
     name: 'remove card',
     context: '^deck ↦ cardTypes ↦ .*? ↦',
-    show: _=>widgetFilter(w=>w.p('deck')==jeStateNow.id&&w.p('cardType')==jeContext[2]).length,
+    show: _=>jeStateNow&&widgetFilter(w=>w.p('deck')==jeStateNow.id&&w.p('cardType')==jeContext[2]).length,
     call: function() {
       const card = widgetFilter(w=>w.p('deck')==jeStateNow.id&&w.p('cardType')==jeContext[2])[0];
       removeWidgetLocal(card.p('id'));

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -276,6 +276,23 @@ const jeCommands = [
     }
   },
   {
+    name: 'open deck',
+    forceKey: 'D',
+    context: '^card',
+    show: _=>jeStateNow&&widgets.has(jeStateNow.deck),
+    call: function() {
+      jeClick(widgets.get(jeStateNow.deck), true);
+    }
+  },
+  {
+    name: 'open parent',
+    forceKey: 'ArrowUp',
+    show: _=>jeStateNow&&widgets.has(jeStateNow.parent),
+    call: function() {
+      jeClick(widgets.get(jeStateNow.parent), true);
+    }
+  },
+  {
     name: _=>jeJSONerror?'go to error':'apply changes',
     forceKey: ' ',
     show: _=>jeWidget,

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -52,10 +52,17 @@ const jeCommands = [
     context: '^deck ↦ cardTypes',
     call: function() {
       const cardType = {};
-      for(const face of jeStateNow.faceTemplates)
-        for(const object of face.objects)
+      const cssVariables = {};
+      for(const face of jeStateNow.faceTemplates) {
+        for(const object of face.objects) {
           if(object.valueType == 'dynamic')
             cardType[object.value] = '';
+          ((object.css || '').match(/--[a-zA-Z]+/g) || []).forEach(m=>cssVariables[`${m}: black`]=true);
+        }
+      }
+      const css = Object.keys(cssVariables).join('; ');
+      if(css)
+        cardType.css = css;
       jeStateNow.cardTypes['###SELECT ME###'] = cardType;
       jeSetAndSelect(Math.random().toString(36).substring(3, 7));
     }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -92,6 +92,18 @@ const jeCommands = [
     }
   },
   {
+    name: _=>jeStateNow.faceTemplates[+jeContext[2]].objects[+jeContext[4]].valueType == 'dynamic' ? 'static' : 'dynamic',
+    context: '^deck ↦ faceTemplates ↦ [0-9]+ ↦ objects ↦ [0-9]+',
+    call: function() {
+      const o = jeStateNow.faceTemplates[+jeContext[2]].objects[+jeContext[4]];
+      const d = o.valueType == 'dynamic';
+      const v = o.value;
+      o.valueType = d ? 'static' : 'dynamic';
+      o.value = '###SELECT ME###';
+      jeSetAndSelect(v);
+    }
+  },
+  {
     name: 'toggle zoom out',
     forceKey: 'Z',
     call: function() {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -6,6 +6,7 @@ let jeStateBeforeRaw = null;
 let jeStateNow = null;
 let jeJSONerror = null;
 let jeContext = null;
+let jeSecondaryWidget = null;
 let jeDeltaIsOurs = false;
 const jeWidgetLayers = {};
 const jeState = {
@@ -89,6 +90,14 @@ const jeCommands = [
           jeJSONerror = e;
         }
       }
+      jeShowCommands();
+    }
+  },
+  {
+    name: 'show this widget below',
+    forceKey: 'S',
+    call: function() {
+      jeSecondaryWidget = jeWidget && JSON.stringify(jeWidget.state, null, '  ');
       jeShowCommands();
     }
   },
@@ -560,6 +569,8 @@ function jeShowCommands() {
   commandText += `\n${context}\n`;
   if(jeJSONerror)
     commandText += `\n<i class=error>${String(jeJSONerror)}</i>\n`;
+  if(jeSecondaryWidget)
+    commandText += `\n\n${jeSecondaryWidget}\n`;
   $('#jeCommands').innerHTML = commandText;
 }
 

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -48,6 +48,16 @@ const jeCommands = [
     }
   },
   {
+    name: 'face template',
+    context: '^deck ↦ faceTemplates',
+    call: function() {
+      jeStateNow.faceTemplates.push({
+        objects: '###SELECT ME###'
+      });
+      jeSetAndSelect([]);
+    }
+  },
+  {
     name: 'image template',
     context: '^deck ↦ faceTemplates ↦ [0-9]+ ↦ objects',
     call: function() {
@@ -72,11 +82,10 @@ const jeCommands = [
         type: 'text',
         x: 0,
         y: 0,
-        fontSize: '20',
+        fontSize: 20,
         valueType: 'dynamic',
         value: '###SELECT ME###',
         textAlign: 'center',
-        textFont: null,
         width: jeStateNow.cardDefaults && jeStateNow.cardDefaults.width  || 103
       });
       jeSetAndSelect('text');
@@ -243,6 +252,10 @@ function jeAddCommands() {
   jeAddButtonOperationCommands('SHUFFLE', { holder: null });
 
   jeAddCSScommands();
+
+  jeAddFaceCommand('border', '', 1);
+  jeAddFaceCommand('css', '', '');
+  jeAddFaceCommand('radius', ' (rounded corners)', 1);
 }
 
 function jeAddCSScommands() {
@@ -258,6 +271,18 @@ function jeAddCSScommands() {
       }
     });
   }
+}
+
+function jeAddFaceCommand(key, description, value) {
+  jeCommands.push({
+    name: key+description,
+    context: '^deck ↦ faceTemplates ↦ [0-9]+',
+    show: _=>!jeStateNow.faceTemplates[+jeContext[2]][key],
+    call: function() {
+      jeStateNow.faceTemplates[+jeContext[2]][key] = '###SELECT ME###';
+      jeSetAndSelect(value);
+    }
+  });
 }
 
 function jeAddWidgetPropertyCommands(object) {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -35,6 +35,13 @@ const jeCommands = [
     }
   },
   {
+    name: 'upload a different asset',
+    context: '"(/assets/[0-9_-]+)"',
+    call: function() {
+      uploadAsset().then(a=>jePasteText(a));
+    }
+  },
+  {
     name: 'toggle zoom out',
     forceKey: 'Z',
     call: function() {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -22,6 +22,18 @@ const jeCommands = [
     }
   },
   {
+    name: 'open widget by ID',
+    context: '"([^"]+)"',
+    call: function() {
+      const m = jeContext.join('').match(/"([^"]+)"/);
+      jeClick(widgets.get(m[1]));
+    },
+    show: function() {
+      const m = jeContext.join('').match(/"([^"]+)"/);
+      return widgets.has(m[1]);
+    }
+  },
+  {
     name: 'toggle zoom out',
     forceKey: 'Z',
     call: function() {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -61,6 +61,25 @@ const jeCommands = [
     }
   },
   {
+    name: 'add card',
+    context: '^deck ↦ cardTypes ↦ .*? ↦',
+    call: function() {
+      const card = { deck:jeStateNow.id, type:'card', cardType:jeContext[2] };
+      addWidgetLocal(card);
+      if(jeStateNow.parent)
+        widgets.get(card.id).moveToHolder(widgets.get(jeStateNow.parent));
+    }
+  },
+  {
+    name: 'remove card',
+    context: '^deck ↦ cardTypes ↦ .*? ↦',
+    show: _=>widgetFilter(w=>w.p('deck')==jeStateNow.id&&w.p('cardType')==jeContext[2]).length,
+    call: function() {
+      const card = widgetFilter(w=>w.p('deck')==jeStateNow.id&&w.p('cardType')==jeContext[2])[0];
+      removeWidgetLocal(card.p('id'));
+    }
+  },
+  {
     name: 'face template',
     context: '^deck ↦ faceTemplates',
     call: function() {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -208,14 +208,30 @@ function jeClick(widget, e) {
 }
 
 function jeColorize() {
-  const langObj = {
-    curl: /([{}":,\[\]])/g,
-  };
-  let html = $('#jeText').textContent;
-  for(const l in langObj) {
-    html = html.replace(langObj[l], `<i class=${l}>$1</i>`);
-  };
-  $('#jeTextHighlight').innerHTML = html;
+  const langObj = [
+    [ /^ +"(.*)": "(.*)",?$/, 'key', 'string' ],
+    [ /^ +"(.*)": (-?[0-9.]+),?$/, 'key', 'number' ],
+    [ /^ +"(.*)": (null|true|false),?$/, 'key', 'null' ],
+    [ /^ +"(.*)":/, 'key' ]
+  ];
+  let out = [];
+  for(const line of $('#jeText').textContent.split('\n')) {
+    let foundMatch = false;
+    for(const l of langObj) {
+      const match = line.match(l[0]);
+      if(match) {
+        let outLine = line;
+        for(let i=1; i<l.length; ++i)
+          outLine = outLine.replace(match[i], `<i class=${l[i]}>${match[i]}</i>`);
+        out.push(outLine);
+        foundMatch = true;
+        break;
+      }
+    }
+    if(!foundMatch)
+      out.push(line);
+  }
+  $('#jeTextHighlight').innerHTML = out.join('\n');
 }
 
 function jeDisplayTree() {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -25,7 +25,6 @@ const jeCommands = [
     name: 'toggle zoom out',
     forceKey: 'Z',
     call: function() {
-      console.log("yes");
       jeZoomOut = !jeZoomOut;
       if(jeZoomOut) {
         $('body').classList.add('jeZoomOut');
@@ -37,13 +36,10 @@ const jeCommands = [
   },
   {
     name: _=>`remove property ${jeContext && jeContext[jeContext.length-1]}`,
-    forceKey: 'd',
+    forceKey: 'D',
     context: ' ↦ (?=[^"]+$)',
     call: function() {
-      let pointer = jeStateNow;
-      for(const key of jeContext.slice(1))
-        if(typeof pointer[key] == 'object')
-          pointer = pointer[key];
+      let pointer = jeGetValue();
       delete pointer[jeContext[jeContext.length-1]];
 
       const oldStart = $('#jeText').selectionStart;
@@ -53,7 +49,7 @@ const jeCommands = [
       $('#jeText').selectionEnd   = oldEnd;
     },
     show: function() {
-      return jeStateNow && jeStateNow[jeContext && jeContext[jeContext.length-1]] !== undefined;
+      return jeStateNow && jeGetValue()[jeContext[jeContext.length-1]] !== undefined;
     }
   },
   {
@@ -70,8 +66,39 @@ const jeCommands = [
         $('#updateWidgetJSON').click();
       }
     }
+  },
+  {
+    name: _=>`change ${jeContext && jeContext[4]} to applyVariables`,
+    context: '^button.*\\) ↦ [a-zA-Z]+',
+    call: function() {
+      const operation = jeGetValue(jeContext.slice(1, 3));
+      delete operation[jeContext[4]];
+      if(!operation.applyVariables)
+        operation.applyVariables = [];
+      operation.applyVariables.push({ parameter: jeContext[4], variable: '###SELECT ME###' });
+      jeSetAndSelect('');
+    },
+    show: function() {
+      return jeContext && jeContext[4] != 'applyVariables';
+    }
   }
 ];
+
+function jeAddButtonOperationCommands(command, defaults) {
+  defaults.skip = false;
+  for(const property in defaults) {
+    jeCommands.push({
+      name: property,
+      context: `^button.* ↦ \\(${command}\\) ↦ `,
+      call: function() {
+        jeInsert(jeContext.slice(1, 3), property, defaults[property]);
+      },
+      show: function() {
+        return jeStateNow && jeGetValue()[property] === undefined;
+      }
+    });
+  }
+}
 
 function jeAddCommands() {
   jeAddWidgetPropertyCommands(new BasicWidget());
@@ -82,6 +109,23 @@ function jeAddCommands() {
   jeAddWidgetPropertyCommands(new Label());
   jeAddWidgetPropertyCommands(new Pile());
   jeAddWidgetPropertyCommands(new Spinner());
+
+  jeAddButtonOperationCommands('CLICK', { collection: 'DEFAULT', count: 1 });
+  jeAddButtonOperationCommands('COMPUTE', { operation: '+', operand1: 1, operand2: 1, operand3: 1, variable: 'COMPUTE' });
+  jeAddButtonOperationCommands('COUNT', { collection: 'DEFAULT', variable: 'COUNT' });
+  jeAddButtonOperationCommands('FLIP', { count: 0, face: null });
+  jeAddButtonOperationCommands('GET', { variable: 'id', collection: 'DEFAULT', property: 'id', aggregation: 'first' });
+  // INPUT is missing
+  jeAddButtonOperationCommands('LABEL', { value: 0, mode: 'set', label: null });
+  jeAddButtonOperationCommands('MOVE', { count: 1, face: null, from: null, to: null });
+  jeAddButtonOperationCommands('MOVEXY', { count: 1, face: null, from: null, x: 0, y: 0 });
+  jeAddButtonOperationCommands('RANDOM', { min: 1, max: 10, variable: 'RANDOM' });
+  jeAddButtonOperationCommands('RECALL', { owned: true, holder: null });
+  jeAddButtonOperationCommands('ROTATE', { count: 1, angle: 90, mode: 'add', holder: null });
+  jeAddButtonOperationCommands('SELECT', { type: 'all', property: 'parent', relation: '==', value: null, max: 999999, collection: 'DEFAULT', mode: 'add', source: 'all' });
+  jeAddButtonOperationCommands('SET', { collection: 'DEFAULT', property: 'parent', relation: '=', value: null });
+  jeAddButtonOperationCommands('SORT', { key: 'value', reverse: false, holder: null });
+  jeAddButtonOperationCommands('SHUFFLE', { holder: null });
 }
 
 function jeAddWidgetPropertyCommands(object) {
@@ -126,6 +170,14 @@ function jeGetContext() {
   const select = v.substr(s, e-s);
   const line = v.substr(0, s).split('\n').pop();
 
+  try {
+    jeStateNow = JSON.parse(v);
+    jeJSONerror = null;
+  } catch(e) {
+    jeStateNow = null;
+    jeJSONerror = e;
+  }
+
   let keys = [ t ];
   for(const line of v.substr(0, s).split('\n')) {
     const m = line.match(/^( +)(["{])([^"]*)/);
@@ -135,64 +187,95 @@ function jeGetContext() {
       keys = keys.slice(0, depth+1);
     }
   }
+  try {
+    if(keys[1] == 'clickRoutine' && typeof keys[2] == 'number' && !jeJSONerror)
+      keys.splice(3, 0, '(' + jeStateNow.clickRoutine[keys[2]].func + ')');
+  } catch(e) {}
+
   if(select)
     keys.push(`"${select}"`);
 
-  try {
-    jeStateNow = JSON.parse(v);
-    jeJSONerror = null;
-  } catch(e) {
-    jeStateNow = null;
-    jeJSONerror = e;
-  }
-
   jeContext = keys;
 
-  const context = keys.join(' ↦ ');
-  const usedKeys = { c: 1, x: 1, v: 1, w: 1, n: 1, t: 1, q: 1, j: 1, z: 1 };
-  let commandText = '';
-  for(const command of jeCommands) {
-    delete command.currentKey;
-    if(context.match(new RegExp(command.context)) && (!command.show || command.show())) {
-      const name = typeof command.name == 'function' ? command.name() : command.name;
-      if(command.forceKey)
-        command.currentKey = command.forceKey;
-      for(const key of name.split(''))
-        if(!command.currentKey && !usedKeys[key.toLowerCase()])
-          command.currentKey = key.toLowerCase();
-      for(const key of 'abcdefghijklmnopqrstuvwxyz1234567890'.split(''))
-        if(!command.currentKey && !usedKeys[key])
-          command.currentKey = key;
-      usedKeys[command.currentKey] = true;
-      commandText += `Ctrl-${command.currentKey}: ${name}\n`;
-    }
-  }
-  if(jeJSONerror)
-    commandText += `\n${String(jeJSONerror)}\n`;
-  $('#jeCommands').textContent = commandText;
+  jeShowCommands();
 
   return jeContext;
 }
 
+function jeGetValue(context, all) {
+  let pointer = jeStateNow;
+  for(const key of context || jeContext)
+    if(all && typeof pointer[key] !== undefined || typeof pointer[key] == 'object')
+      pointer = pointer[key];
+  return pointer
+}
+
 function jeInsert(context, key, value) {
   if(!jeJSONerror) {
-    let pointer = jeStateNow;
-    for(const key of context)
-      if(typeof pointer[key] == 'object')
-        pointer = pointer[key];
-    pointer[key] = "###SELECT ME###";
-    let jsonString = JSON.stringify(jeStateNow, null, '  ');
-    const startIndex = jsonString.indexOf("\"###SELECT ME###\"");
-    let length = jsonString.length-pointer[key].length-2;
-
-    pointer[key] = value;
-    jsonString = JSON.stringify(jeStateNow, null, '  ');
-
-    $('#jeText').value = jsonString;
-    $('#jeText').selectionStart = startIndex;
-    $('#jeText').selectionEnd = startIndex+jsonString.length-length;
-    $('#jeText').focus();
+    let pointer = jeGetValue(context);
+    pointer[key] = '###SELECT ME###';
+    jeSetAndSelect(value);
   }
+}
+
+function jeSetAndSelect(replaceBy) {
+  let jsonString = JSON.stringify(jeStateNow, null, '  ');
+  const startIndex = jsonString.indexOf('"###SELECT ME###"');
+  let length = jsonString.length-17;
+
+  jsonString = JSON.stringify(jeStateNow, null, '  ').replace(/"###SELECT ME###"/, JSON.stringify(replaceBy));
+
+  $('#jeText').value = jsonString;
+  $('#jeText').selectionStart = startIndex + (typeof replaceBy == 'string' ? 1 : 0);
+  $('#jeText').selectionEnd = startIndex+jsonString.length-length - (typeof replaceBy == 'string' ? 1 : 0);
+  $('#jeText').focus();
+}
+
+function jeShowCommands() {
+  const activeCommands = {};
+
+  const context = jeContext.join(' ↦ ');
+  for(const command of jeCommands) {
+    delete command.currentKey;
+    const contextMatch = context.match(new RegExp(command.context));
+    if(contextMatch && (!command.show || command.show())) {
+      if(activeCommands[contextMatch[0]] === undefined)
+        activeCommands[contextMatch[0]] = [];
+      activeCommands[contextMatch[0]].push(command);
+    }
+  }
+
+  const usedKeys = { c: 1, x: 1, v: 1, w: 1, n: 1, t: 1, q: 1, j: 1, z: 1 };
+  let commandText = '';
+
+  const sortByName = function(a, b) {
+    const nameA = typeof a.name == 'function' ? a.name() : a.name;
+    const nameB = typeof b.name == 'function' ? b.name() : b.name;
+    return nameA.localeCompare(nameB);
+  }
+
+  for(const contextMatch of (Object.keys(activeCommands).sort((a,b)=>b.length-a.length))) {
+    commandText += `\n  <b>${contextMatch}</b>\n`;
+    for(const command of activeCommands[contextMatch].sort(sortByName)) {
+      if(context.match(new RegExp(command.context)) && (!command.show || command.show())) {
+        const name = typeof command.name == 'function' ? command.name() : command.name;
+        if(command.forceKey && !usedKeys[command.forceKey])
+          command.currentKey = command.forceKey;
+        for(const key of name.split(''))
+          if(key != ' ' && !command.currentKey && !usedKeys[key.toLowerCase()])
+            command.currentKey = key.toLowerCase();
+        for(const key of 'abcdefghijklmnopqrstuvwxyz1234567890'.split(''))
+          if(!command.currentKey && !usedKeys[key])
+            command.currentKey = key;
+        usedKeys[command.currentKey] = true;
+        commandText += `Ctrl-${command.currentKey}: ${name.replace(command.currentKey, '<b>' + command.currentKey + '</b>')}\n`;
+      }
+    }
+  }
+  commandText += `\n${context}\n`;
+  if(jeJSONerror)
+    commandText += `\n${String(jeJSONerror)}\n`;
+  $('#jeCommands').innerHTML = commandText;
 }
 
 window.addEventListener('mousemove', function(e) {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -59,7 +59,7 @@ const jeCommands = [
     forceKey: 'D',
     context: ' ↦ (?=[^"]+$)',
     call: function() {
-      let pointer = jeGetValue();
+      let pointer = jeGetValue(jeContext.slice(0, -1));
       delete pointer[jeContext[jeContext.length-1]];
 
       const oldStart = $('#jeText').selectionStart;
@@ -69,7 +69,7 @@ const jeCommands = [
       $('#jeText').selectionEnd   = oldEnd;
     },
     show: function() {
-      return jeStateNow && jeGetValue()[jeContext[jeContext.length-1]] !== undefined;
+      return jeStateNow && jeGetValue(jeContext.slice(0, -1))[jeContext[jeContext.length-1]] !== undefined;
     }
   },
   {
@@ -163,7 +163,7 @@ function jeAddCommands() {
 }
 
 function jeAddCSScommands() {
-  for(const css of [ 'border: 1px solid black', 'background: black', 'font-size: 30px' ]) {
+  for(const css of [ 'border: 1px solid black', 'background: black', 'font-size: 30px', 'color: black' ]) {
     jeCommands.push({
       name: css,
       context: ' ↦ css',
@@ -380,6 +380,7 @@ window.addEventListener('keydown', function(e) {
       if(jeEnabled) {
         $('body').classList.add('jsonEdit');
         jeAddCommands();
+        $('#jeText').value = 'CTRL-click a widget';
         $('#jeText').focus();
       } else {
         $('body').classList.remove('jsonEdit');

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1,4 +1,5 @@
 let jeEnabled = false;
+let jeZoomOut = false;
 let jeWidget = null;
 let jeStateBefore = null;
 let jeStateNow = null;
@@ -18,6 +19,20 @@ const jeCommands = [
     context: '"(true|false)"',
     call: function() {
       jeInsert(jeContext.slice(1), jeContext[jeContext.length-2], jeContext[jeContext.length-1]=='"false"');
+    }
+  },
+  {
+    name: 'toggle zoom out',
+    forceKey: 'Z',
+    call: function() {
+      console.log("yes");
+      jeZoomOut = !jeZoomOut;
+      if(jeZoomOut) {
+        $('body').classList.add('jeZoomOut');
+      } else {
+        $('body').classList.remove('jeZoomOut');
+      }
+      setScale();
     }
   },
   {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -158,6 +158,23 @@ function jeAddCommands() {
   jeAddButtonOperationCommands('SET', { collection: 'DEFAULT', property: 'parent', relation: '=', value: null });
   jeAddButtonOperationCommands('SORT', { key: 'value', reverse: false, holder: null });
   jeAddButtonOperationCommands('SHUFFLE', { holder: null });
+
+  jeAddCSScommands();
+}
+
+function jeAddCSScommands() {
+  for(const css of [ 'border: 1px solid black', 'background: black', 'font-size: 30px' ]) {
+    jeCommands.push({
+      name: css,
+      context: ' ↦ css',
+      call: function() {
+        jePasteText(css + '; ');
+      },
+      show: function() {
+        return !jeJSONerror && !jeGetValue().css.match(css.split(':')[0]);
+      }
+    });
+  }
 }
 
 function jeAddWidgetPropertyCommands(object) {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -48,6 +48,19 @@ const jeCommands = [
     }
   },
   {
+    name: 'card type template',
+    context: '^deck ↦ cardTypes',
+    call: function() {
+      const cardType = {};
+      for(const face of jeStateNow.faceTemplates)
+        for(const object of face.objects)
+          if(object.valueType == 'dynamic')
+            cardType[object.value] = '';
+      jeStateNow.cardTypes['###SELECT ME###'] = cardType;
+      jeSetAndSelect(Math.random().toString(36).substring(3, 7));
+    }
+  },
+  {
     name: 'face template',
     context: '^deck ↦ faceTemplates',
     call: function() {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -152,7 +152,10 @@ const jeCommands = [
     context: ' ↦ (?=[^"]+$)',
     call: function() {
       let pointer = jeGetValue(jeContext.slice(0, -1));
-      delete pointer[jeContext[jeContext.length-1]];
+      if(Array.isArray(pointer))
+        pointer.splice(jeContext[jeContext.length-1], 1);
+      else
+        delete pointer[jeContext[jeContext.length-1]];
 
       const oldStart = getSelection().anchorOffset;
       const oldEnd   = getSelection().focusOffset;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -216,6 +216,13 @@ const jeCommands = [
     }
   },
   {
+    name: 'tree',
+    forceKey: 'T',
+    call: function() {
+      jeDisplayTree();
+    }
+  },
+  {
     name: _=>`remove property ${jeContext && jeContext[jeContext.length-1]}`,
     forceKey: 'D',
     context: ' ↦ (?=[^"]+$)',
@@ -361,18 +368,44 @@ function jeAddCommands() {
   jeAddFaceCommand('border', '', 1);
   jeAddFaceCommand('css', '', '');
   jeAddFaceCommand('radius', ' (rounded corners)', 1);
+
+  jeAddEnumCommands('^[a-z]+ ↦ type', [ null, 'button', 'card', 'deck', 'holder', 'label', 'spinner' ]);
+  jeAddEnumCommands('^deck ↦ faceTemplates ↦ [0-9]+ ↦ objects ↦ [0-9]+ ↦ textAlign', [ 'left', 'center', 'right' ]);
+  jeAddEnumCommands('^.*\\(GET\\) ↦ aggregation', [ 'first', 'sum' ]);
+  jeAddEnumCommands('^.*\\(LABEL\\) ↦ mode', [ 'set', 'dec', 'inc' ]);
+  jeAddEnumCommands('^.*\\(ROTATE\\) ↦ mode', [ 'set', 'add' ]);
+  jeAddEnumCommands('^.*\\(SELECT\\) ↦ mode', [ 'set', 'add' ]);
+  jeAddEnumCommands('^.*\\(SELECT\\) ↦ relation', [ '<', '<=', '==', '!=', '>', '>=', 'in' ]);
+  jeAddEnumCommands('^.*\\(SELECT\\) ↦ type', [ 'all', null, 'button', 'card', 'deck', 'holder', 'label', 'spinner' ]);
+  jeAddEnumCommands('^.*\\(SET\\) ↦ relation', [ '+', '-', '=' ]);
 }
 
 function jeAddCSScommands() {
   for(const css of [ 'border: 1px solid black', 'background: black', 'font-size: 30px', 'color: black' ]) {
     jeCommands.push({
       name: css,
-      context: ' ↦ css',
+      context: '^.* ↦ (css|[a-z]+CSS)',
       call: function() {
         jePasteText(css + '; ');
       },
       show: function() {
-        return !jeJSONerror && !jeGetValue().css.match(css.split(':')[0]);
+        return !jeJSONerror && !jeGetValue()[jeGetLastKey()].match(css.split(':')[0]);
+      }
+    });
+  }
+}
+
+function jeAddEnumCommands(context, values) {
+  for(const v of values) {
+    jeCommands.push({
+      name: String(v),
+      context: context,
+      call: function() {
+        jeInsert(null, jeGetLastKey(), v);
+      },
+      show: function() {
+        let pointer = jeGetValue();
+        return pointer[jeGetValue()] !== v;
       }
     });
   }
@@ -583,6 +616,10 @@ function jeGetContext() {
   jeShowCommands();
 
   return jeContext;
+}
+
+function jeGetLastKey() {
+  return jeContext[jeContext.length-1].match(/^"/) ? jeContext[jeContext.length-2] : jeContext[jeContext.length-1];
 }
 
 function jeGetValue(context, all) {

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -104,10 +104,12 @@ function checkURLproperties() {
 function setScale() {
   const w = window.innerWidth;
   const h = window.innerHeight;
-  if(jeEnabled)
-    scale = jeZoomOut ? w/6400 : w/3200;
-  else
+  if(jeEnabled) {
+    const targetWidth = jeZoomOut ? 3200 : 1600;
+    scale = (w-700)/targetWidth;
+  } else {
     scale = w/h < 1600/1000 ? w/1600 : h/1000;
+  }
   document.documentElement.style.setProperty('--scale', scale);
   roomRectangle = $('#roomArea').getBoundingClientRect();
 }

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -105,7 +105,7 @@ function setScale() {
   const w = window.innerWidth;
   const h = window.innerHeight;
   if(jeEnabled)
-    scale = w/3200;
+    scale = jeZoomOut ? w/6400 : w/3200;
   else
     scale = w/h < 1600/1000 ? w/1600 : h/1000;
   document.documentElement.style.setProperty('--scale', scale);

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -104,7 +104,10 @@ function checkURLproperties() {
 function setScale() {
   const w = window.innerWidth;
   const h = window.innerHeight;
-  scale = w/h < 1600/1000 ? w/1600 : h/1000;
+  if(jeEnabled)
+    scale = w/3200;
+  else
+    scale = w/h < 1600/1000 ? w/1600 : h/1000;
   document.documentElement.style.setProperty('--scale', scale);
   roomRectangle = $('#roomArea').getBoundingClientRect();
 }

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -46,7 +46,9 @@ function inputHandler(name, e) {
       if(ms.status != 'initial' && ms.widget.p(edit ? 'movableInEdit' : 'movable'))
         ms.widget.moveEnd();
       if(ms.status == 'initial' || timeSinceStart < 250 && pixelsMoved < 10) {
-        if(edit)
+        if(jeEnabled)
+          jeClick(widgets.get(target.id), e);
+        else if(edit)
           editClick(widgets.get(target.id));
         else if(widgets.get(target.id).click)
           widgets.get(target.id).click();

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -46,8 +46,8 @@ function inputHandler(name, e) {
       if(ms.status != 'initial' && (jeEnabled || ms.widget.p(edit ? 'movableInEdit' : 'movable')))
         ms.widget.moveEnd();
       if(ms.status == 'initial' || timeSinceStart < 250 && pixelsMoved < 10) {
-        if(jeEnabled)
-          jeClick(widgets.get(target.id), e);
+        if(typeof jeEnabled == 'boolean' && jeEnabled)
+          jeClick(widgets.get(target.id));
         else if(edit)
           editClick(widgets.get(target.id));
         else if(widgets.get(target.id).click)

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -13,7 +13,7 @@ function eventCoords(name, e) {
 }
 
 function inputHandler(name, e) {
-  if(overlayActive)
+  if(overlayActive || e.target.id == 'jeText')
     return;
   if(!mouseTarget && [ "TEXTAREA", "INPUT", "BUTTON", "OPTION", "LABEL" ].indexOf(e.target.tagName) != -1)
     if(!edit || !e.target.parentNode || !e.target.parentNode.className.match(/label/))

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -43,7 +43,7 @@ function inputHandler(name, e) {
       const ms = mouseStatus[target.id];
       const timeSinceStart = +new Date() - ms.start;
       const pixelsMoved = ms.coords ? Math.abs(ms.coords[0] - ms.downCoords[0]) + Math.abs(ms.coords[1] - ms.downCoords[1]) : 0;
-      if(ms.status != 'initial' && ms.widget.p(edit ? 'movableInEdit' : 'movable'))
+      if(ms.status != 'initial' && (jeEnabled || ms.widget.p(edit ? 'movableInEdit' : 'movable')))
         ms.widget.moveEnd();
       if(ms.status == 'initial' || timeSinceStart < 250 && pixelsMoved < 10) {
         if(jeEnabled)
@@ -65,13 +65,13 @@ function inputHandler(name, e) {
           offset: [ downCoords[0] - (targetRect.left + targetRect.width/2), downCoords[1] - (targetRect.top + targetRect.height/2) ],
           widget: widgets.get(target.id)
         });
-        if(mouseStatus[target.id].widget.p(edit ? 'movableInEdit' : 'movable'))
+        if(jeEnabled || mouseStatus[target.id].widget.p(edit ? 'movableInEdit' : 'movable'))
           mouseStatus[target.id].widget.moveStart();
       }
       mouseStatus[target.id].coords = coords;
       const x = Math.floor((coords[0] - roomRectangle.left - mouseStatus[target.id].offset[0]) / scale);
       const y = Math.floor((coords[1] - roomRectangle.top  - mouseStatus[target.id].offset[1]) / scale);
-      if(mouseStatus[target.id].widget.p(edit ? 'movableInEdit' : 'movable'))
+      if(jeEnabled || mouseStatus[target.id].widget.p(edit ? 'movableInEdit' : 'movable'))
         mouseStatus[target.id].widget.move(x, y);
       batchEnd();
     }

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -13,7 +13,7 @@ function eventCoords(name, e) {
 }
 
 function inputHandler(name, e) {
-  if(overlayActive || e.target.id == 'jeText')
+  if(overlayActive || e.target.id == 'jeText' || e.target.id == 'jeCommands')
     return;
   if(!mouseTarget && [ "TEXTAREA", "INPUT", "BUTTON", "OPTION", "LABEL" ].indexOf(e.target.tagName) != -1)
     if(!edit || !e.target.parentNode || !e.target.parentNode.className.match(/label/))

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -105,7 +105,7 @@ function receiveDelta(delta) {
       widgets.get(widgetID).applyDelta(delta.s[widgetID]);
     }
   }
-  if(jeApplyDelta)
+  if(typeof jeApplyDelta == 'function')
     jeApplyDelta(delta);
 }
 

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -105,6 +105,8 @@ function receiveDelta(delta) {
       widgets.get(widgetID).applyDelta(delta.s[widgetID]);
     }
   }
+  if(jeApplyDelta)
+    jeApplyDelta(delta);
 }
 
 function receiveDeltaFromServer(delta) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -228,8 +228,8 @@ export class Widget extends StateManaged {
   }
 
   move(x, y) {
-    const newX = Math.max(0-this.p('width' )*0.25, Math.min(1600+this.p('width' )*0.25, x)) - this.p('width' )/2;
-    const newY = Math.max(0-this.p('height')*0.25, Math.min(1000+this.p('height')*0.25, y)) - this.p('height')/2;
+    const newX = (jeEnabled ? x : Math.max(0-this.p('width' )*0.25, Math.min(1600+this.p('width' )*0.25, x))) - this.p('width' )/2;
+    const newY = (jeEnabled ? y : Math.max(0-this.p('height')*0.25, Math.min(1000+this.p('height')*0.25, y))) - this.p('height')/2;
 
     this.setPosition(newX, newY, this.p('z'));
     const myCenter = center(this.domElement);

--- a/client/room.html
+++ b/client/room.html
@@ -226,7 +226,20 @@
   </div>
 
   <div id="jsonEditor">
-    <div id="jeWidgetLayers"></div>
+    <div id="jeWidgetLayers">
+      <div id="jeWidgetLayer1"></div>
+      <div id="jeWidgetLayer2"></div>
+      <div id="jeWidgetLayer3"></div>
+      <div id="jeWidgetLayer4"></div>
+      <div id="jeWidgetLayer5"></div>
+      <div id="jeWidgetLayer6"></div>
+      <div id="jeWidgetLayer7"></div>
+      <div id="jeWidgetLayer8"></div>
+      <div id="jeWidgetLayer9"></div>
+      <div id="jeWidgetLayer10"></div>
+      <div id="jeWidgetLayer11"></div>
+      <div id="jeWidgetLayer12"></div>
+    </div>
     <textarea id="jeText"></textarea>
     <div id="jeCommands"></div>
   </div>

--- a/client/room.html
+++ b/client/room.html
@@ -226,6 +226,7 @@
   </div>
 
   <div id="jsonEditor">
+    <div id="jeWidgetLayers"></div>
     <textarea id="jeText"></textarea>
     <div id="jeCommands"></div>
   </div>

--- a/client/room.html
+++ b/client/room.html
@@ -240,7 +240,8 @@
       <div id="jeWidgetLayer11"></div>
       <div id="jeWidgetLayer12"></div>
     </div>
-    <textarea id="jeText"></textarea>
+    <div id="jeTextHighlight"></div>
+    <div id="jeText" contenteditable="true"></div>
     <div id="jeCommands"></div>
   </div>
 

--- a/client/room.html
+++ b/client/room.html
@@ -225,6 +225,11 @@
     </div>
   </div>
 
+  <div id="jsonEditor">
+    <textarea id="jeText"></textarea>
+    <div id="jeCommands"></div>
+  </div>
+
   <div id="enlarged" class="hidden"></div>
 
   <script type="module"> {{JS}} </script>

--- a/client/room.html
+++ b/client/room.html
@@ -241,7 +241,7 @@
       <div id="jeWidgetLayer12"></div>
     </div>
     <div id="jeTextHighlight"></div>
-    <div id="jeText" contenteditable="true"></div>
+    <div id="jeText" contenteditable="true" spellcheck="false"></div>
     <div id="jeCommands"></div>
   </div>
 

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -19,6 +19,7 @@ export default function minifyRoom() {
         'client/css/layout.css',
 
         'client/css/editmode.css',
+        'client/css/jsonedit.css',
 
         'client/css/overlays/players.css',
         'client/css/overlays/states.css',
@@ -44,6 +45,7 @@ export default function minifyRoom() {
           'client/js/serverstate.js',
           'client/js/editmode.js',
           'client/js/geometry.js',
+          'client/js/jsonedit.js',
           'client/js/mousehandling.js',
           'client/js/statemanaged.js',
           'client/js/widgets/widget.js',


### PR DESCRIPTION
Yesterday evening I had a few ideas and was thinking: what would the editor look like that I would want to use?

It is inspired by the discussion we had last meeting about #135. This is meant for power users who edit JSON manually on the PC with a big screen. It will **definitely not** replace any of the other editors (well, the JSON one maybe).

I have **a lot** more ideas and plans for this but now is the first time where it might be useful.

The basic ideas:

- JSON editing front and center. Complete browser height to have as much visible as possible.
- **Many** context-sensitive hotkeys using `CTRL` and `SHIFT` to modify the JSON and the widgets. Most of them visible on the screen.
- The room itself should always be visible and playable.

Press `CTRL+J` to toggle it. Then `CTRL`-click on a widget. I'll add a hint for that somewhere appropriate.