### PR TITLE
preserve white space in widget text

### DIFF
--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -157,6 +157,7 @@ body {
   position: absolute;
   left: 0;
   top: 0;
+  white-space: pre-wrap;
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center center;


### PR DESCRIPTION
closes #177 

This defaults all widgets to `white-space: pre-wrap`. `white-space: pre-line` would also preserve newline characters but collapse horizontal white space characters. Since all widget DOM elements are generated by the js code there shouldn't be any extra whitespace in any of them so `white-space: pre-wrap` should be fine.