### PR TITLE
applyVariables with property and template functionality

### DIFF
--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -89,7 +89,7 @@ export class Button extends Widget {
             }
             else {
               problems.push('Entry in parameter applyVariables does not contain "parameter" and "variable".');
-          }
+            }
           }
         } else {
           problems.push('Parameter applyVariables is not an array.');

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -386,11 +386,13 @@ export class Button extends Widget {
       }
 
       if(a.func == 'SELECT') {
-        setDefaults(a, { property: 'parent', relation: '==', value: null, max: 999999, collection: 'DEFAULT', mode: 'set', source: 'all' });
+        setDefaults(a, { type: 'all', property: 'parent', relation: '==', value: null, max: 999999, collection: 'DEFAULT', mode: 'add', source: 'all' });
         if(a.source == 'all' || isValidCollection(a.source)) {
           if([ 'add', 'set' ].indexOf(a.mode) == -1)
             problems.push(`Warning: Mode ${a.mode} interpreted as set.`);
           let c = (a.source == 'all' ? Array.from(widgets.values()) : collections[a.source]).filter(function(w) {
+            if(a.type != 'all' && w.p('type') != a.type)
+              return false;
             if(a.relation === '<')
               return w.p(a.property) < a.value;
             else if(a.relation === '<=')
@@ -401,6 +403,8 @@ export class Button extends Widget {
               return w.p(a.property) >= a.value;
             else if(a.relation === '>')
               return w.p(a.property) > a.value;
+            else if(a.relation === 'in' && Array.isArray(a.value))
+              return a.value.indexOf(w.p(a.property)) != -1;
             if(a.relation != '==')
               problems.push(`Warning: Relation ${a.relation} interpreted as ==.`);
             return w.p(a.property) === a.value;

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -70,7 +70,7 @@ export class Button extends Widget {
         if(Array.isArray(a.applyVariables)) {
           for(const v of a.applyVariables) {
             if(v.parameter && v.variable) {
-              a[v.parameter] = variables[v.variable];
+              a[v.parameter] = (v.index === undefined) ? variables[v.variable] : variables[v.variable][v.index];
             } else if (v.parameter && v.template) {
               for (let key in variables) {
                 a[v.parameter] = v.template.replace(/({([^}]+)})/g, function(i) {

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -65,24 +65,22 @@ export class Button extends Widget {
       const a = { ...original };
       var problems = [];
 
-      if (this.p('debug')) console.log(`${this.id}: ${JSON.stringify(original)}`);
+      if(this.p('debug')) console.log(`${this.id}: ${JSON.stringify(original)}`);
       if(a.applyVariables) {
         if(Array.isArray(a.applyVariables)) {
           for(const v of a.applyVariables) {
             if(v.parameter && v.variable) {
               a[v.parameter] = (v.index === undefined) ? variables[v.variable] : variables[v.variable][v.index];
-            } else if (v.parameter && v.template) {
-              for (let key in variables) {
-                a[v.parameter] = v.template.replace(/({([^}]+)})/g, function(i) {
-                  let key = i.replace(/{/, '').replace(/}/, '');
-                  return (variables[key] === undefined) ? "" : variables[key];
-                });
-              }
-            } else if (v.parameter && v.property) {
+            } else if(v.parameter && v.template) {
+              a[v.parameter] = v.template.replace(/\{([^}]+)\}/g, function(i, key) {
+                return (variables[key] === undefined) ? "" : variables[key];
+              });
+            } else if(v.parameter && v.property) {
               let w = isValidID(v.widget) ? widgets.get(v.widget) : this;
               a[v.parameter] = (w.p(v.property) === undefined) ? null : w.p(v.property);
-            } else
+            } else {
               problems.push('Entry in parameter applyVariables does not contain "parameter" together with "variable", "property", or "template".');
+            }
           }
         } else {
           problems.push('Parameter applyVariables is not an array.');

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -70,26 +70,18 @@ export class Button extends Widget {
           for(const v of a.applyVariables) {
             if(v.parameter && v.variable) {
               a[v.parameter] = variables[v.variable];
-            }
-            else if (v.parameter && v.template) {
+            } else if (v.parameter && v.template) {
               for (let key in variables) {
                 a[v.parameter] = v.template.replace(/({([^}]+)})/g, function(i) {
                   let key = i.replace(/{/, '').replace(/}/, '');
-                  if (!variables[key]) return "";
-                  return variables[key];
+                  return (variables[key] === undefined) ? "" : variables[key];
                 });
               }
-            }
-            else if (v.parameter && v.property) {
-              var targetWidget = (v.property.split(".")[0] === "this") ? widgets.get(this.id) : widgets.get(v.property.split(".")[0]);
-              if (typeof targetWidget != undefined) {
-                var targetProperty = targetWidget.state[v.property.split(".")[1]];
-              }
-              a[v.parameter] = (typeof targetProperty != undefined) ? targetProperty : 0;
-            }
-            else {
-              problems.push('Entry in parameter applyVariables does not contain "parameter" and "variable".');
-            }
+            } else if (v.parameter && v.property) {
+              let w = isValidID(v.widget) ? widgets.get(v.widget) : this;
+              a[v.parameter] = (w.p(v.property) === undefined) ? null : w.p(v.property);
+            } else
+              problems.push('Entry in parameter applyVariables does not contain "parameter" together with "variable", "property", or "template".');
           }
         } else {
           problems.push('Parameter applyVariables is not an array.');
@@ -99,8 +91,6 @@ export class Button extends Widget {
         $('#debugButtonOutput').textContent += '\n\n\nOPERATION SKIPPED: \n' + JSON.stringify(a, null, '  ');
         continue;
       }
-
-
 
       if(a.func == 'CLICK') {
         setDefaults(a, { collection: 'DEFAULT', count: 1 });


### PR DESCRIPTION
This PR adds extra functionality to applyVariables:

1. When using `property` instead of `variable`, you can specify the widget ID and one the widget's state properties (e.g. x, y , z, id, etc.) and apply that value to the parameter. 
2. Instead of stating a widget ID, you can refer to the ID of the clicked button with "this"
3. When using `template` instead of `variable`, you can use variable names as placeholders with curly braces in a text, which will then be replaced by the variables value (mostly suitable for LABEL operations)

```
"applyVariables": [
{
  "property": "widgetID.x",
  "parameter": "x"
},
{
  "property": "this.y",
  "parameter": "y"
},
{
  "template": "name: {playerName}",
  "parameter": "value"
}
]
```

EDIT:
I've decided against the "." in the property. Now property is automatically applied against `this` unless you also provide a valid widget ID, which makes it more consistent with other operations and also greatly simplifies the code.
```
"applyVariables": [
{
  "property": "x",
  "parameter": "x"
},
{
  "property": "y",
  "widget": "widgetID",
  "parameter": "y"
},
{
  "template": "name: {playerName}",
  "parameter": "value"
}
]
```
EDIT: I've also added `index` so you can apply values of arrays (or characters of a string):
```
{
  "variable": "arrayName",
  "index": 2,
  "parameter": "value"
}