### PR TITLE
added svgReplaces to BasicWidget and card face objects

### DIFF
--- a/client/js/main.js
+++ b/client/js/main.js
@@ -134,6 +134,29 @@ async function uploadAsset() {
   }).catch(e=>alert(`Uploading failed: ${e.toString()}`));
 }
 
+const svgCache = {};
+function getSVG(url, replaces, callback) {
+  if(typeof svgCache[url] == 'string') {
+    let svg = svgCache[url];
+    for(const replace in replaces)
+      svg = svg.replace(replace, replaces[replace]);
+    return 'data:image/svg+xml;base64,'+btoa(svg);
+  }
+
+  if(!svgCache[url]) {
+    svgCache[url] = [];
+    fetch(url).then(r=>r.text()).then(t=>{
+      const callbacks = svgCache[url];
+      svgCache[url] = t;
+      for(const c of callbacks)
+        c();
+    });
+  }
+
+  svgCache[url].push(callback);
+  return '';
+}
+
 onLoad(function() {
   on('#pileOverlay', 'click', e=>e.target.id=='pileOverlay'&&showOverlay());
 

--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -13,6 +13,8 @@ class BasicWidget extends Widget {
 
       image: '',
       color: 'black',
+      coloredSVG: false,
+      svgReplaces: {},
       layer: 1,
       text: ''
     });
@@ -51,15 +53,14 @@ class BasicWidget extends Widget {
     if(this.p('color'))
       css += '; --color:' + this.p('color');
     if(this.p('image'))
-      css += '; background-image: url("' + this.p('image') + '")';
+      css += '; background-image: url("' + this.getImage() + '")';
 
     return css;
   }
 
   cssProperties() {
     const p = super.cssProperties();
-    p.push('color');
-    p.push('image');
+    p.push('image', 'color', 'coloredSVG', 'svgReplaces');
     return p;
   }
 
@@ -77,5 +78,15 @@ class BasicWidget extends Widget {
     if(d !== undefined)
       return d;
     return super.getDefaultValue(property);
+  }
+
+  getImage() {
+    if(!this.p('coloredSVG') && !Object.keys(this.p('svgReplaces')).length)
+      return this.p('image');
+
+    const replaces = { ...this.p('svgReplaces') };
+    if(this.p('coloredSVG'))
+      replaces.currentColor = this.p('color');
+    return getSVG(this.p('image'), replaces, _=>this.domElement.style.cssText = this.css());
   }
 }

--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -13,7 +13,6 @@ class BasicWidget extends Widget {
 
       image: '',
       color: 'black',
-      coloredSVG: false,
       svgReplaces: {},
       layer: 1,
       text: ''
@@ -60,7 +59,7 @@ class BasicWidget extends Widget {
 
   cssProperties() {
     const p = super.cssProperties();
-    p.push('image', 'color', 'coloredSVG', 'svgReplaces');
+    p.push('image', 'color', 'svgReplaces');
     return p;
   }
 
@@ -81,12 +80,12 @@ class BasicWidget extends Widget {
   }
 
   getImage() {
-    if(!this.p('coloredSVG') && !Object.keys(this.p('svgReplaces')).length)
+    if(!Object.keys(this.p('svgReplaces')).length)
       return this.p('image');
 
-    const replaces = { ...this.p('svgReplaces') };
-    if(this.p('coloredSVG'))
-      replaces.currentColor = this.p('color');
+    const replaces = {};
+    for(const key in this.p('svgReplaces'))
+      replaces[key] = this.p(this.p('svgReplaces')[key]);
     return getSVG(this.p('image'), replaces, _=>this.domElement.style.cssText = this.css());
   }
 }

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -62,14 +62,14 @@ class Card extends Widget {
     for(const face of faceTemplates) {
       const faceDiv = document.createElement('div');
 
-      if(face.css !== undefined) 
+      if(face.css !== undefined)
         faceDiv.style.cssText = face.css;
       faceDiv.style.border = face.border ? face.border + 'px black solid' : 'none';
       faceDiv.style.borderRadius = face.radius ? face.radius + 'px' : '0';
 
       for(const object of face.objects) {
         const objectDiv = document.createElement('div');
-        const value = object.valueType == 'static' ? object.value : this.p(object.value);
+        let value = object.valueType == 'static' ? object.value : this.p(object.value);
         const x = face.border ? object.x-face.border : object.x;
         const y = face.border ? object.y-face.border : object.y;
         let css = object.css ? object.css + '; ' : '';
@@ -77,8 +77,15 @@ class Card extends Widget {
         css += object.rotation ? `; transform: rotate(${object.rotation}deg)` : '';
         objectDiv.style.cssText = css;
         if(object.type == 'image') {
-          if(value)
-            objectDiv.style.backgroundImage = `url(${value})`;
+          if(value) {
+            if(object.svgReplaces) {
+              const replaces = { ...object.svgReplaces };
+              for(const key in replaces)
+                replaces[key] = this.p(replaces[key]);
+              value = getSVG(value, replaces, _=>this.applyDeltaToDOM({ deck:this.p('deck') }));
+            }
+            objectDiv.style.backgroundImage = `url("${value}")`;
+          }
           objectDiv.style.backgroundColor = object.color || 'white';
         } else {
           objectDiv.textContent = value;


### PR DESCRIPTION
I've been wanting to have this since the beginning. We were talking about proper game pieces and `currentColor`. So now this replaces the `currentColor` in an SVG by the `color` attribute of the BasicWidget:

```JSON
{
  "image": "/assets/1351556175_475",
  "svgReplaces": {
    "currentColor": "color"
  },
  "color": "darkgreen"
}
```

This feature is also incredibly useful and powerful for card decks so I also added `svgReplaces` to card face objects:

```JSON
{
  "type": "deck",
  "cardTypes": {
    "blue": {
      "color": "blue"
    },
    "red": {
      "color": "red"
    }
  },
  "faceTemplates": [
    {
      "objects": [
        {
          "type": "image",
          "x": 0,
          "y": 0,
          "width": 50,
          "height": 50,
          "valueType": "static",
          "value": "/assets/1351556175_475",
          "svgReplaces": {
            "currentColor": "color"
          }
        }
      ],
      "border": false,
      "radius": 8
    }
  ]
}
```