### PR TITLE
Clickable property

### DIFF
--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -43,7 +43,8 @@ class BasicWidget extends Widget {
   }
 
   click() {
-    this.flip();
+    if(this.p('clickable'))
+      this.flip();
   }
 
   css() {

--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -6,6 +6,7 @@ class BasicWidget extends Widget {
 
     this.addDefaults({
       typeClasses: 'widget basic',
+      clickable: true,
 
       faces: [ {} ],
       faceCycle: 'ordered',

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -15,6 +15,7 @@ export class Button extends Widget {
       typeClasses: 'widget button',
       layer: -1,
       movable: false,
+      clickable: true,
 
       text: '',
       clickRoutine: [],

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -48,7 +48,9 @@ export class Button extends Widget {
         return true;
       problems.push(`Widget ID ${id} does not exist.`);
     }
-
+   
+   if(!this.p('clickable')) return;
+    
     batchStart();
 
     if(this.p('debug'))

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -55,7 +55,8 @@ class Card extends Widget {
   }
 
   click() {
-    this.flip();
+    if(this.p('clickable'))
+      this.flip();
   }
 
   createFaces(faceTemplates) {

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -6,6 +6,7 @@ class Card extends Widget {
       width: 103,
       height: 160,
       typeClasses: 'widget card',
+      clickable: true,
 
       faceCycle: 'ordered',
       activeFace: 0,

--- a/client/js/widgets/spinner.js
+++ b/client/js/widgets/spinner.js
@@ -38,6 +38,7 @@ class Spinner extends Widget {
   }
 
   click() {
+    if(!this.p('clickable')) return;
     const angle = this.p('angle') + Math.floor((2+Math.random())*360);
     const o = this.p('options');
     this.p('angle', angle);

--- a/client/js/widgets/spinner.js
+++ b/client/js/widgets/spinner.js
@@ -6,6 +6,7 @@ class Spinner extends Widget {
       width: 110,
       height: 110,
       typeClasses: 'widget spinner',
+      clickable: true,
 
       options: [ 1, 2, 3, 4, 5, 6 ],
       value: '🎲',

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -25,7 +25,7 @@ export class Widget extends StateManaged {
       css: '',
       movable: true,
       movableInEdit: true,
-      clickable: true,
+      clickable: false,
 
       grid: [],
       enlarge: false,

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -25,6 +25,7 @@ export class Widget extends StateManaged {
       css: '',
       movable: true,
       movableInEdit: true,
+      clickable: true,
 
       grid: [],
       enlarge: false,


### PR DESCRIPTION
This PR adds a clickable property to BasicWidgets, Cards, Spinners and Buttons. It defaults to true, and disables the widget's click functionality when set to false. This is mostly useful in context of holders and the onLeave/onEnter feature, allowing you to disable card flips once a card is moved into a holder. It may also be useful fur buttons or spinners, so I just added it to all clickable widgets.