### PR TITLE
added try-except around client message jsons

### DIFF
--- a/server/connection.mjs
+++ b/server/connection.mjs
@@ -23,12 +23,20 @@ export default class Connection {
     if(func == "room")
       this.newPlayerCallback(this, args);
     for(const handler of this.messageHandlers)
-      handler(func, args);
+      try {
+        handler(func, args);
+      } catch(e) {
+        console.log(`ERROR in message handler: ${e.message}`)
+      }
   }
 
   messageReceived = message => {
-    const { func, args } = JSON.parse(message);
-    this.fromClient(func, args);
+    try {
+      const { func, args } = JSON.parse(message);
+      this.fromClient(func, args);
+    } catch(e) {
+      console.log(`ERROR in received message: ${e.message}`)
+    }
   }
 
   closeReceived = _ => {


### PR DESCRIPTION
There are 2 JSON.Parses currently in the code that have no form of exception handling. One is client facing, so a malformed JSON sent to the server could cause it to crash. The other is used internally, but in parts of the code that may change often.