### PR TITLE
Fix je apply delta always run

### DIFF
--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -105,7 +105,8 @@ function receiveDelta(delta) {
       widgets.get(widgetID).applyDelta(delta.s[widgetID]);
     }
   }
-  if(typeof jeApplyDelta == 'function')
+  if(jeEnabled == true)
+    console.log("whee")
     jeApplyDelta(delta);
 }
 

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -106,7 +106,6 @@ function receiveDelta(delta) {
     }
   }
   if(jeEnabled == true)
-    console.log("whee")
     jeApplyDelta(delta);
 }
 


### PR DESCRIPTION
The new (and awesome) json editor Delta function was called on every delta accidentally. PC's could handle this overhead well enough, but older mobile devices could not.
This changes it so it will only update when the json editor is currently open, which is probably what was meant to happen.

Tested on my old phone 😄 