### PR TITLE
Improve default counters for mobile devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage
 node_modules
 save
 *.tgz
+*.heapsnapshot

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -191,8 +191,8 @@ function generateCounterWidgets(id, x, y) {
   const down = {
     id: id+'D',
     parent: id,
-    x: 4,
-    y: -2,
+    x: -38,
+    y: 1,
     width: 36,
     height: 36,
     type: 'button',
@@ -203,9 +203,9 @@ function generateCounterWidgets(id, x, y) {
   };
 
   return [
-    { type:'label', text: 0, id, x, y, width: 140, height: 44, css:'font-size: 30px;', editable: true },
+    { type:'label', text: 0, id, x, y, width: 65, height: 40, css:'font-size: 30px;', editable: true },
     down,
-    Object.assign({ ...down }, { id: id+'U', text: '+', x: 100, clickRoutine: [ Object.assign({ ...r }, { mode: 'inc' }) ] })
+    Object.assign({ ...down }, { id: id+'U', text: '+', x: 68, clickRoutine: [ Object.assign({ ...r }, { mode: 'inc' }) ] })
   ];
 }
 
@@ -335,8 +335,8 @@ function populateAddWidgetOverlay() {
     y += 120;
   }
 
-  addCompositeWidgetToAddWidgetOverlay(generateCounterWidgets('add-counter', 780, 700), function() {
-    for(const w of generateCounterWidgets(Math.random().toString(36).substring(3, 7), 780, 700))
+  addCompositeWidgetToAddWidgetOverlay(generateCounterWidgets('add-counter', 820, 700), function() {
+    for(const w of generateCounterWidgets(Math.random().toString(36).substring(3, 7), 820, 700))
       addWidgetLocal(w);
   });
 

--- a/server.mjs
+++ b/server.mjs
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import v8 from 'v8';
 
 import express from 'express';
 import bodyParser from 'body-parser';
@@ -85,6 +86,10 @@ MinifyRoom().then(function(result) {
 
       res.send(content);
     });
+  });
+
+  app.post('/heapsnapshot', function(req, res) {
+    v8.getHeapSnapshot().pipe(fs.createWriteStream('memory.heapsnapshot'));
   });
 
   app.post('/quit', function(req, res) {


### PR DESCRIPTION
Default counters are almost unusable on mobile devices because the plus and minus buttons sit within the overly large label text area.  This change shrinks the size of the text area box and slightly repositions the plus and minus buttons in relationship to the new box.  Values -999 to 999 still fit.  See screenshot for example of change; new default counter is on top and the original one is on the bottom.  The other change was needed to slightly reposition the default counter in the add widget menu to account for the change in size.

![Counter](https://user-images.githubusercontent.com/76912527/108642986-1277d580-746e-11eb-8a89-329f984b1c5c.jpg)
