### PR TITLE
fixed that jeApplyDelta was called even when the new JSON editor was not enabled

### DIFF
--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -105,7 +105,7 @@ function receiveDelta(delta) {
       widgets.get(widgetID).applyDelta(delta.s[widgetID]);
     }
   }
-  if(typeof jeApplyDelta == 'function')
+  if(typeof jeEnabled != 'undefined' && jeEnabled)
     jeApplyDelta(delta);
 }
 


### PR DESCRIPTION
Pretty much the same as #223 but that one doesn't pass the tests.

This should really be merged ASAP though because it's affecting some users.