### PR TITLE
JSON editor respects movable properties

### DIFF
--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -43,7 +43,7 @@ function inputHandler(name, e) {
       const ms = mouseStatus[target.id];
       const timeSinceStart = +new Date() - ms.start;
       const pixelsMoved = ms.coords ? Math.abs(ms.coords[0] - ms.downCoords[0]) + Math.abs(ms.coords[1] - ms.downCoords[1]) : 0;
-      if(ms.status != 'initial' && (jeEnabled || ms.widget.p(edit ? 'movableInEdit' : 'movable')))
+      if(ms.status != 'initial' && (ms.widget.p(edit ? 'movableInEdit' : 'movable')))
         ms.widget.moveEnd();
       if(ms.status == 'initial' || timeSinceStart < 250 && pixelsMoved < 10) {
         if(typeof jeEnabled == 'boolean' && jeEnabled)
@@ -65,13 +65,13 @@ function inputHandler(name, e) {
           offset: [ downCoords[0] - (targetRect.left + targetRect.width/2), downCoords[1] - (targetRect.top + targetRect.height/2) ],
           widget: widgets.get(target.id)
         });
-        if(jeEnabled || mouseStatus[target.id].widget.p(edit ? 'movableInEdit' : 'movable'))
+        if(mouseStatus[target.id].widget.p(edit ? 'movableInEdit' : 'movable'))
           mouseStatus[target.id].widget.moveStart();
       }
       mouseStatus[target.id].coords = coords;
       const x = Math.floor((coords[0] - roomRectangle.left - mouseStatus[target.id].offset[0]) / scale);
       const y = Math.floor((coords[1] - roomRectangle.top  - mouseStatus[target.id].offset[1]) / scale);
-      if(jeEnabled || mouseStatus[target.id].widget.p(edit ? 'movableInEdit' : 'movable'))
+      if(mouseStatus[target.id].widget.p(edit ? 'movableInEdit' : 'movable'))
         mouseStatus[target.id].widget.move(x, y);
       batchEnd();
     }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -229,8 +229,8 @@ export class Widget extends StateManaged {
   }
 
   move(x, y) {
-    const newX = (jeEnabled ? x : Math.max(0-this.p('width' )*0.25, Math.min(1600+this.p('width' )*0.25, x))) - this.p('width' )/2;
-    const newY = (jeEnabled ? y : Math.max(0-this.p('height')*0.25, Math.min(1000+this.p('height')*0.25, y))) - this.p('height')/2;
+    const newX = (jeZoomOut ? x : Math.max(0-this.p('width' )*0.25, Math.min(1600+this.p('width' )*0.25, x))) - this.p('width' )/2;
+    const newY = (jeZoomOut ? y : Math.max(0-this.p('height')*0.25, Math.min(1000+this.p('height')*0.25, y))) - this.p('height')/2;
 
     this.setPosition(newX, newY, this.p('z'));
     const myCenter = center(this.domElement);


### PR DESCRIPTION
Resolves #230. This makes the JSON editor respect `movable` and `movableInEdit` properties. When not zoomed out it also makes the JSON editor respect the room boundaries for moves.