### PR TITLE
Move parent of non-movable widget.

### DIFF
--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -26,10 +26,13 @@ function inputHandler(name, e) {
     target = target.parentNode;
   
   let moveTarget = target;
-  while(moveTarget && !widgets.get(moveTarget).p(edit ? 'movableInEdit' : 'movable')) {
-    while(moveTarget && (!moveTarget.id || !widgets.has(moveTarget.id)))
-      moveTarget = moveTarget.parentNode;
-  }
+  let movable = false;
+  do {
+    movable = widgets.get(moveTarget).p(edit ? 'movableInEdit' : 'movable');
+    if (!movable)
+      while(moveTarget && (!moveTarget.id || !widgets.has(moveTarget.id)))
+        moveTarget = moveTarget.parentNode;
+  } while (moveTarget && !movable);
 
   const coords = eventCoords(name, e);
   if(name == 'mousedown') {

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -30,8 +30,9 @@ function inputHandler(name, e) {
   while (moveTarget && !movable) {
     movable = widgets.get(moveTarget).p(edit ? 'movableInEdit' : 'movable');
     if (!movable)
-      while(moveTarget && (!moveTarget.id || !widgets.has(moveTarget.id)))
+      do {
         moveTarget = moveTarget.parentNode;
+      } while(moveTarget && (!moveTarget.id || !widgets.has(moveTarget.id)));
   }
 
   const coords = eventCoords(name, e);
@@ -56,7 +57,7 @@ function inputHandler(name, e) {
       const ms = mouseStatus[target.id];
       const timeSinceStart = +new Date() - ms.start;
       const pixelsMoved = ms.coords ? Math.abs(ms.coords[0] - ms.downCoords[0]) + Math.abs(ms.coords[1] - ms.downCoords[1]) : 0;
-      if(moveTarget)
+      if(movable)
         ms.widget.moveEnd();
       if(ms.status == 'initial' || timeSinceStart < 250 && pixelsMoved < 10) {
         if(typeof jeEnabled == 'boolean' && jeEnabled)
@@ -78,7 +79,7 @@ function inputHandler(name, e) {
           offset: [ downCoords[0] - (targetRect.left + targetRect.width/2), downCoords[1] - (targetRect.top + targetRect.height/2) ],
           widget: widgets.get(moveTarget? moveTarget.id : target.id)
         });
-        if(moveTarget)
+        if(movable)
           mouseStatus[target.id].widget.moveStart();
       }
       mouseStatus[target.id].coords = coords;

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -27,19 +27,18 @@ function inputHandler(name, e) {
   
   let moveTarget = target;
   let movable = false;
-  do {
+  while (moveTarget && !movable) {
     movable = widgets.get(moveTarget).p(edit ? 'movableInEdit' : 'movable');
     if (!movable)
       while(moveTarget && (!moveTarget.id || !widgets.has(moveTarget.id)))
         moveTarget = moveTarget.parentNode;
-  } while (moveTarget && !movable);
+  }
 
   const coords = eventCoords(name, e);
   if(name == 'mousedown') {
     mouseTarget = target;
     mouseMoveTarget = moveTarget;
-  }
-  else if(name == 'mousemove' || name == 'mouseup') {
+  } else if(name == 'mousemove' || name == 'mouseup') {
     target = mouseTarget;
     moveTarget = mouseMoveTarget;
   }


### PR DESCRIPTION
Fixes #184 

Adds `moveTarget` to mousehandling. At time of `mousedown` or `touchstart` target widget is evaluated to see if it can be moved in the current context. If not movable, the closest ancestor widget that is movable in the current context is found. 