### PR TITLE
Move parent widget if not movable

### DIFF
--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -43,10 +43,10 @@ function inputHandler(name, e) {
       moveTarget = target;
       while (moveTarget && !movable) {
         movable = wigets.get(moveTarget.id).p(edit ? 'movableInEdit' : 'movable');
-        if (!movable)
+        if (!movable) {
           do {
             moveTarget = moveTarget.parentNode;
-          } while (moveTarget && (!moveTarget.id || !widgets.has(moveTarget.id));
+          } while (moveTarget && (!moveTarget.id || !widgets.has(moveTarget.id)));
       }
     } else if(name == 'mouseup' || name == 'touchend') {
       batchStart();

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -1,4 +1,5 @@
 let mouseTarget = null;
+let moveTarget = null;
 const mouseStatus = {};
 
 function eventCoords(name, e) {
@@ -38,12 +39,21 @@ function inputHandler(name, e) {
         start: new Date(),
         downCoords: coords
       };
+      let movable = false;
+      moveTarget = target
+      while (moveTarget && !movable) {
+        movable = wigets.get(moveTarget.id).p(edit ? 'movableInEdit' : 'movable');
+        if (!movable)
+          do {
+            moveTarget = moveTarget.parentNode;
+          } while (moveTarget && (!moveTarget.id || !widgets.has(moveTarget.id));
+      }
     } else if(name == 'mouseup' || name == 'touchend') {
       batchStart();
       const ms = mouseStatus[target.id];
       const timeSinceStart = +new Date() - ms.start;
       const pixelsMoved = ms.coords ? Math.abs(ms.coords[0] - ms.downCoords[0]) + Math.abs(ms.coords[1] - ms.downCoords[1]) : 0;
-      if(ms.status != 'initial' && (jeEnabled || ms.widget.p(edit ? 'movableInEdit' : 'movable')))
+      if(ms.status != 'initial' && moveTarget)
         ms.widget.moveEnd();
       if(ms.status == 'initial' || timeSinceStart < 250 && pixelsMoved < 10) {
         if(typeof jeEnabled == 'boolean' && jeEnabled)
@@ -58,27 +68,29 @@ function inputHandler(name, e) {
     } else if(name == 'mousemove' || name == 'touchmove') {
       batchStart();
       if(mouseStatus[target.id].status == 'initial') {
-        const targetRect = target.getBoundingClientRect();
+        const targetRect = moveTarget ? MoveTarget.getBoundingClientRect() : target.getBoundingClientRect();
         const downCoords = mouseStatus[target.id].downCoords;
         Object.assign(mouseStatus[target.id], {
           status: 'moving',
           offset: [ downCoords[0] - (targetRect.left + targetRect.width/2), downCoords[1] - (targetRect.top + targetRect.height/2) ],
-          widget: widgets.get(target.id)
+          widget: widgets.get(moveTarget ? moveTarget.id : target.id)
         });
-        if(jeEnabled || mouseStatus[target.id].widget.p(edit ? 'movableInEdit' : 'movable'))
+        if(moveTarget)
           mouseStatus[target.id].widget.moveStart();
       }
       mouseStatus[target.id].coords = coords;
       const x = Math.floor((coords[0] - roomRectangle.left - mouseStatus[target.id].offset[0]) / scale);
       const y = Math.floor((coords[1] - roomRectangle.top  - mouseStatus[target.id].offset[1]) / scale);
-      if(jeEnabled || mouseStatus[target.id].widget.p(edit ? 'movableInEdit' : 'movable'))
+      if(moveTarget)
         mouseStatus[target.id].widget.move(x, y);
       batchEnd();
     }
   }
 
-  if(name == 'mouseup')
+  if(name == 'mouseup') {
     mouseTarget = null;
+    moveTarget = null;
+  }
   if(name == 'mousemove' || name == 'touchmove')
     toServer('mouse', [ Math.floor((coords[0] - roomRectangle.left)/scale), Math.floor((coords[1] - roomRectangle.top)/scale) ]);
 }

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -40,7 +40,7 @@ function inputHandler(name, e) {
         downCoords: coords
       };
       let movable = false;
-      moveTarget = target
+      moveTarget = target;
       while (moveTarget && !movable) {
         movable = wigets.get(moveTarget.id).p(edit ? 'movableInEdit' : 'movable');
         if (!movable)

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -42,7 +42,7 @@ function inputHandler(name, e) {
       let movable = false;
       moveTarget = target;
       while (moveTarget && !movable) {
-        movable = wigets.get(moveTarget.id).p(edit ? 'movableInEdit' : 'movable');
+        movable = widgets.get(moveTarget.id).p(edit ? 'movableInEdit' : 'movable');
         if (!movable) {
           do {
             moveTarget = moveTarget.parentNode;

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -69,7 +69,7 @@ function inputHandler(name, e) {
     } else if(name == 'mousemove' || name == 'touchmove') {
       batchStart();
       if(mouseStatus[target.id].status == 'initial') {
-        const targetRect = moveTarget ? MoveTarget.getBoundingClientRect() : target.getBoundingClientRect();
+        const targetRect = moveTarget ? moveTarget.getBoundingClientRect() : target.getBoundingClientRect();
         const downCoords = mouseStatus[target.id].downCoords;
         Object.assign(mouseStatus[target.id], {
           status: 'moving',

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -47,6 +47,7 @@ function inputHandler(name, e) {
           do {
             moveTarget = moveTarget.parentNode;
           } while (moveTarget && (!moveTarget.id || !widgets.has(moveTarget.id)));
+        }
       }
     } else if(name == 'mouseup' || name == 'touchend') {
       batchStart();


### PR DESCRIPTION
Adds moveTarget. moveTarget is the mouse target if the widget is movable in current context, Otherwise it is the nearest ancestor widget that is movable. If no movable ancestor is found moveTarget is null. Fixes #184 