### PR TITLE
fixed uploadAsset

### DIFF
--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -34,7 +34,7 @@ export function selectFile(getContents, multipleCallback) {
   return new Promise((resolve, reject) => {
     const upload = document.createElement('input');
     upload.type = 'file';
-    upload.setAttribute('multiple', !!multipleCallback);
+    if (typeof multipleCallback === 'function') upload.setAttribute('multiple', true);
     upload.addEventListener('change', function(e) {
       if(!getContents)
         resolve(e.target.files[0]);

--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -43,7 +43,7 @@ export function selectFile(getContents, multipleCallback) {
         const name = file.name;
         const reader = new FileReader();
         reader.addEventListener('load', function(e) {
-          if(multipleCallback)
+          if(typeof multipleCallback === 'function')
             multipleCallback({ content: e.target.result, name });
           else
             resolve({ content: e.target.result, name });

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -48,7 +48,10 @@ const jeCommands = [
     context: '.*"(/assets/[0-9_-]+)"|^basic ↦ faces ↦ [0-9]+ ↦ image|^deck ↦ cardTypes ↦ .*? ↦ image',
     call: function() {
       uploadAsset().then(a=> {
-          if (a) jeInsert(null, jeGetLastKey(), a)
+          if (a) {
+            jeInsert(null, jeGetLastKey(), a);
+            jeApplyChanges();
+          }
       });
     }
   },

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -47,7 +47,7 @@ const jeCommands = [
     name: 'upload a different asset',
     context: '.*"(/assets/[0-9_-]+)"',
     call: function() {
-      uploadAsset().then(a=>jePasteText(a));
+      uploadAsset().then(a=>jeInsert(null, jeGetLastKey(), a));
     }
   },
   {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -45,7 +45,7 @@ const jeCommands = [
   {
     id: 'je_uploadAsset',
     name: 'upload a different asset',
-    context: '.*"(/assets/[0-9_-]+)"',
+    context: '.*"(/assets/[0-9_-]+)"|^basic ↦ faces ↦ [0-9]+ ↦ image|^deck ↦ cardTypes ↦ .*? ↦ image',
     call: function() {
       uploadAsset().then(a=>jeInsert(null, jeGetLastKey(), a));
     }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -47,7 +47,9 @@ const jeCommands = [
     name: 'upload a different asset',
     context: '.*"(/assets/[0-9_-]+)"|^basic ↦ faces ↦ [0-9]+ ↦ image|^deck ↦ cardTypes ↦ .*? ↦ image',
     call: function() {
-      uploadAsset().then(a=>jeInsert(null, jeGetLastKey(), a));
+      uploadAsset().then(a=> {
+          if (a) jeInsert(null, jeGetLastKey(), a)
+      });
     }
   },
   {


### PR DESCRIPTION
Only for JSONeditor:

Fixed issue when selecting asset URL with surrounding quotes, it was replaced with new ID but without surrounding quotes.

For basicWidgets and Cards, you can now position the cursor on the image value to get the "upload a different asset" context action, instead of having to select the entire URL.

Added check for successful upload of asset before replacing the image value.

Fixed setting of `multiple` attribute in the file input field (undefined callback function would still set the attribute and thereby allow users to select multiple files despite no existing handler).