### PR TITLE
Fix visibility of basic widgets.

### DIFF
--- a/client/css/widgets/basicwidget.css
+++ b/client/css/widgets/basicwidget.css
@@ -1,8 +1,8 @@
 body.edit .widget.basic {
-  border-width: 0;
+  border-width: 3px solid var(--editColor);
 }
 
 body.edit .widget.basic.hasImage {
   filter: grayscale(100%);
-  opacity: 0.15;
+  opacity: 0.45;
 }

--- a/client/css/widgets/label.css
+++ b/client/css/widgets/label.css
@@ -18,7 +18,7 @@
 }
 
 body.edit .widget.label {
-  border: none;
+  border: 3px solid var(--editColor);
 }
 
 body.edit .widget.label > * {


### PR DESCRIPTION
Changed the opacity of basic widgets from 0.15 to 0.45 to improve visibility.

Also added a blue border to basic widgets, and also to labels and headers, when in edit mode. Note that if a basic widget contains an image, the border will be grayed out as a result of overall grayscaling of the widget.

See comments on #256, now closed, for more information.