### PR TITLE
Improvements to LABEL and COUNT

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -389,7 +389,7 @@ function jeAddCommands() {
   jeAddButtonOperationCommands('FLIP', { count: 0, face: null, faceCycle: 'forward' });
   jeAddButtonOperationCommands('GET', { variable: 'id', collection: 'DEFAULT', property: 'id', aggregation: 'first' });
   // INPUT is missing
-  jeAddButtonOperationCommands('LABEL', { value: 0, mode: 'set', label: null });
+  jeAddButtonOperationCommands('LABEL', { value: 0, mode: 'set', label: null, collection: 'DEFAULT' });
   jeAddButtonOperationCommands('MOVE', { count: 1, face: null, from: null, to: null });
   jeAddButtonOperationCommands('MOVEXY', { count: 1, face: null, from: null, x: 0, y: 0 });
   jeAddButtonOperationCommands('RANDOM', { min: 1, max: 10, variable: 'RANDOM' });

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -384,7 +384,9 @@ function jeAddCommands() {
   jeAddButtonOperationCommands('CLICK', { collection: 'DEFAULT', count: 1 });
   jeAddButtonOperationCommands('COMPUTE', { operation: '+', operand1: 1, operand2: 1, operand3: 1, variable: 'COMPUTE' });
   jeAddButtonOperationCommands('COUNT', { collection: 'DEFAULT', variable: 'COUNT' });
-  jeAddButtonOperationCommands('FLIP', { count: 0, face: null });
+  jeAddButtonOperationCommands('CLONE', { source: 'DEFAULT', collection: 'DEFAULT', xOffset: 0, yOffset: 0, count: 1 });
+  jeAddButtonOperationCommands('DELETE', { collection: 'DEFAULT'});
+  jeAddButtonOperationCommands('FLIP', { count: 0, face: null, faceCycle: 'forward' });
   jeAddButtonOperationCommands('GET', { variable: 'id', collection: 'DEFAULT', property: 'id', aggregation: 'first' });
   // INPUT is missing
   jeAddButtonOperationCommands('LABEL', { value: 0, mode: 'set', label: null });

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -384,7 +384,7 @@ function jeAddCommands() {
   jeAddButtonOperationCommands('CLICK', { collection: 'DEFAULT', count: 1 });
   jeAddButtonOperationCommands('COMPUTE', { operation: '+', operand1: 1, operand2: 1, operand3: 1, variable: 'COMPUTE' });
   jeAddButtonOperationCommands('COUNT', { collection: 'DEFAULT', holder: null, variable: 'COUNT' });
-  jeAddButtonOperationCommands('CLONE', { source: 'DEFAULT', collection: 'DEFAULT', xOffset: 0, yOffset: 0, count: 1 });
+  jeAddButtonOperationCommands('CLONE', { source: 'DEFAULT', collection: 'DEFAULT', xOffset: 0, yOffset: 0, count: 1, properties: null });
   jeAddButtonOperationCommands('DELETE', { collection: 'DEFAULT'});
   jeAddButtonOperationCommands('FLIP', { count: 0, face: null, faceCycle: 'forward', holder: null, collection: 'DEFAULT' });
   jeAddButtonOperationCommands('GET', { variable: 'id', collection: 'DEFAULT', property: 'id', aggregation: 'first' });

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -386,7 +386,7 @@ function jeAddCommands() {
   jeAddButtonOperationCommands('COUNT', { collection: 'DEFAULT', holder: null, variable: 'COUNT' });
   jeAddButtonOperationCommands('CLONE', { source: 'DEFAULT', collection: 'DEFAULT', xOffset: 0, yOffset: 0, count: 1 });
   jeAddButtonOperationCommands('DELETE', { collection: 'DEFAULT'});
-  jeAddButtonOperationCommands('FLIP', { count: 0, face: null, faceCycle: 'forward' });
+  jeAddButtonOperationCommands('FLIP', { count: 0, face: null, faceCycle: 'forward', holder: null, collection: 'DEFAULT' });
   jeAddButtonOperationCommands('GET', { variable: 'id', collection: 'DEFAULT', property: 'id', aggregation: 'first' });
   // INPUT is missing
   jeAddButtonOperationCommands('LABEL', { value: 0, mode: 'set', label: null, collection: 'DEFAULT' });

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -408,6 +408,7 @@ function jeAddCommands() {
 
   jeAddEnumCommands('^[a-z]+ ↦ type', [ null, 'button', 'card', 'deck', 'holder', 'label', 'spinner' ]);
   jeAddEnumCommands('^deck ↦ faceTemplates ↦ [0-9]+ ↦ objects ↦ [0-9]+ ↦ textAlign', [ 'left', 'center', 'right' ]);
+  jeAddEnumCommands('^.*\\(FLIP\\) ↦ faceCycle', [ 'forward', 'backward', 'random' ]);
   jeAddEnumCommands('^.*\\(GET\\) ↦ aggregation', [ 'first', 'sum' ]);
   jeAddEnumCommands('^.*\\(LABEL\\) ↦ mode', [ 'set', 'dec', 'inc' ]);
   jeAddEnumCommands('^.*\\(ROTATE\\) ↦ mode', [ 'set', 'add' ]);

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -383,7 +383,7 @@ function jeAddCommands() {
 
   jeAddButtonOperationCommands('CLICK', { collection: 'DEFAULT', count: 1 });
   jeAddButtonOperationCommands('COMPUTE', { operation: '+', operand1: 1, operand2: 1, operand3: 1, variable: 'COMPUTE' });
-  jeAddButtonOperationCommands('COUNT', { collection: 'DEFAULT', variable: 'COUNT' });
+  jeAddButtonOperationCommands('COUNT', { collection: 'DEFAULT', holder: null, variable: 'COUNT' });
   jeAddButtonOperationCommands('CLONE', { source: 'DEFAULT', collection: 'DEFAULT', xOffset: 0, yOffset: 0, count: 1 });
   jeAddButtonOperationCommands('DELETE', { collection: 'DEFAULT'});
   jeAddButtonOperationCommands('FLIP', { count: 0, face: null, faceCycle: 'forward' });

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -285,7 +285,8 @@ export class Button extends Widget {
         setDefaults(a, { collection: 'DEFAULT', variable: 'COUNT' });
         if(a.holder !== undefined) {
           if(this.isValidID(a.holder,problems))
-            variables[a.variable] = widgets.get(a.holder).children().length;
+            // count children as well as any other widgets except for piles, decks and the regular recall & shuffle button
+            variables[a.variable] = widgets.get(a.holder).children().length + widgets.get(a.holder).childArray.filter( (w) => { if (w.state.type != 'pile' && w.state.type != 'deck' && w.id != a.holder +'B') return true}).length;
         } else if(isValidCollection(a.collection)) {
           variables[a.variable] = collections[a.collection].length;
         }

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -283,8 +283,12 @@ export class Button extends Widget {
 
       if(a.func == 'COUNT') {
         setDefaults(a, { collection: 'DEFAULT', variable: 'COUNT' });
-        if(isValidCollection(a.collection))
+        if(a.holder !== undefined) {
+          if(this.isValidID(a.holder,problems))
+            variables[a.variable] = widgets.get(a.holder).children().length;
+        } else if(isValidCollection(a.collection)) {
           variables[a.variable] = collections[a.collection].length;
+        }
       }
 
       if(a.func == 'DELETE') {
@@ -345,13 +349,22 @@ export class Button extends Widget {
       }
 
       if(a.func == 'LABEL') {
-        setDefaults(a, { value: 0, mode: 'set' });
+        setDefaults(a, { value: 0, mode: 'set', collection: 'DEFAULT' });
         if([ 'set', 'dec', 'inc' ].indexOf(a.mode) == -1)
           problems.push(`Warning: Mode ${a.mode} will be interpreted as add.`);
-        this.w(a.label, label=> {
-          if (this.p('debug')) console.log(`changing ${a.label} ${a.mode} ${a.value}`)
-          label.setText(a.value, a.mode)
-        });
+        if(a.label !== undefined) a.widget = a.label; // remove this line to deprecate the 'label' property in favor of 'widget'
+        if(a.widget !== undefined) {
+          if (this.isValidID(a.widget, problems)) {
+            this.w(a.widget, widget=> {
+              widget.setText(a.value, a.mode, this.p('debug'), problems)
+            });
+          }
+        } else if(isValidCollection(a.collection)) {
+          if(collections[a.collection].length)
+            collections[a.collection].forEach(c=>c.setText(a.value, a.mode, this.p('debug'), problems));
+          else
+            problems.push(`Collection ${a.collection} is empty.`);
+        }
       }
 
       if(a.func == 'MOVE') {

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -383,10 +383,9 @@ export class Button extends Widget {
         setDefaults(a, { value: 0, mode: 'set', collection: 'DEFAULT' });
         if([ 'set', 'dec', 'inc' ].indexOf(a.mode) == -1)
           problems.push(`Warning: Mode ${a.mode} will be interpreted as add.`);
-        if(a.label !== undefined) a.widget = a.label; // remove this line to deprecate the 'label' property in favor of 'widget'
-        if(a.widget !== undefined) {
-          if (this.isValidID(a.widget, problems)) {
-            this.w(a.widget, widget=> {
+        if(a.label !== undefined) {
+          if (this.isValidID(a.label, problems)) {
+            this.w(a.label, widget=> {
               widget.setText(a.value, a.mode, this.p('debug'), problems)
             });
           }

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -316,8 +316,7 @@ export class Button extends Widget {
         setDefaults(a, { collection: 'DEFAULT', variable: 'COUNT' });
         if(a.holder !== undefined) {
           if(this.isValidID(a.holder,problems))
-            // count children as well as any other widgets except for piles, decks and the regular recall & shuffle button
-            variables[a.variable] = widgets.get(a.holder).children().length + widgets.get(a.holder).childArray.filter( (w) => { if (w.state.type != 'pile' && w.state.type != 'deck' && w.id != a.holder +'B') return true}).length;
+            variables[a.variable] = widgets.get(a.holder).children().length;
         } else if(isValidCollection(a.collection)) {
           variables[a.variable] = collections[a.collection].length;
         }

--- a/client/js/widgets/label.js
+++ b/client/js/widgets/label.js
@@ -43,15 +43,4 @@ export class Label extends Widget {
         this.input.setAttribute("readonly", !delta.editable);
     }
   }
-
-  setText(text, mode) {
-    if(mode == 'inc' || mode == 'dec')
-      this.p('text', (parseInt(this.p('text')) || 0) + (mode == 'dec' ? -1 : 1) * text);
-    else if(Array.isArray(text))
-      this.p('text', text.join(', '));
-    else if(typeof text == 'string' && text.match(/^[-+]?[0-9]+(\.[0-9]+)?$/))
-      this.p('text', +text);
-    else
-      this.p('text', text);
-  }
 }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -367,7 +367,6 @@ export class Widget extends StateManaged {
         this.p('text', +text);
       else
         this.p('text', text);
-      if (debug) console.log(`changing ${this.id} ${mode} ${text}`)
     } else
       problems.push(`Tried setting text property which doesn't exist for ${this.id}.`);
   }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -357,6 +357,21 @@ export class Widget extends StateManaged {
     super.setPosition(x, y, z);
   }
 
+    setText(text, mode, debug, problems) {
+    if (this.p('text') !== undefined) {
+      if(mode == 'inc' || mode == 'dec')
+        this.p('text', (parseInt(this.p('text')) || 0) + (mode == 'dec' ? -1 : 1) * text);
+      else if(Array.isArray(text))
+        this.p('text', text.join(', '));
+      else if(typeof text == 'string' && text.match(/^[-+]?[0-9]+(\.[0-9]+)?$/))
+        this.p('text', +text);
+      else
+        this.p('text', text);
+      if (debug) console.log(`changing ${this.id} ${mode} ${text}`)
+    } else
+      problems.push(`Tried setting text property which doesn't exist for ${this.id}.`);
+  }
+
   showEnlarged(event) {
     if(this.p('enlarge')) {
       const e = $('#enlarged');


### PR DESCRIPTION
LABEL also works on collections and can also change the label of Buttons and Basic Widgets

COUNT can also use a `holder` parameter to count any holder's direct children (matching `dropTarget` and resolving piles).

It initially also counted any other widgets it finds in the holder, but as that would make it inconsistent with other button operations, I've removed that part.

It also contains simple fixes to json editor.

Resolves #63 