### PR TITLE
Fix bug in CLONE

### DIFF
--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -110,7 +110,7 @@ export class Button extends Widget {
       }
 
       if(a.func == 'CLONE'){
-        setDefaults(a, { source: 'DEFAULT', count: 1, xOffset: 0, yOffset: 0, collection: 'DEFAULT' });
+        setDefaults(a, { source: 'DEFAULT', count: 1, xOffset: 0, yOffset: 0, properties: {}, collection: 'DEFAULT' });
         if(a.properties.applyVariables) {
           this.applyVariables(a.properties, variables, problems);
           delete a.properties["applyVariables"];


### PR DESCRIPTION
Added properties: {} to the list of defaults to avoid crash if properties is not present.