### PR TITLE
Fix for duplicate ID in selected collection

### DIFF
--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -463,7 +463,7 @@ export class Button extends Widget {
             problems.push(`Warning: Mode ${a.mode} interpreted as set.`);
           let c = (a.source == 'all' ? Array.from(widgets.values()) : collections[a.source]).filter(function(w) {
             if (typeof collections[a.collection] === 'object') {
-              if(typeof collections[a.collection].find(o => o.id === w.p('id')) !== 'undefined')
+              if(typeof collections[a.collection].find(o => o.p('id') === w.p('id')) !== 'undefined')
                 return false;
             }
             if(a.type != 'all' && w.p('type') != a.type)

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -462,6 +462,10 @@ export class Button extends Widget {
           if([ 'add', 'set' ].indexOf(a.mode) == -1)
             problems.push(`Warning: Mode ${a.mode} interpreted as set.`);
           let c = (a.source == 'all' ? Array.from(widgets.values()) : collections[a.source]).filter(function(w) {
+            if (typeof collections[a.collection] === 'object') {
+              if(typeof collections[a.collection].find(o => o.id === w.p('id')) !== 'undefined')
+                return false;
+            }
             if(a.type != 'all' && w.p('type') != a.type)
               return false;
             if(a.relation === '<')


### PR DESCRIPTION
I found that JavaScript does not prevent duplicate array entries in case of an array of objects. So, I had to add some lines so that widgets are ignored when their id is already in the collection.

Resolves #277 