### PR TITLE
npm run debug across environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean": "rm -rf coverage",
     "clobber": "npm clean && rm -rf save",
-    "debug": "NOCOMPRESS=1 nodemon -e js,mjs,css,html --ignore save --ignore coverage --ignore tests --inspect server.mjs",
+    "debug": "cross-env NOCOMPRESS=1 nodemon -e js,mjs,css,html --ignore save --ignore coverage --ignore tests --inspect server.mjs",
     "start": "node server.mjs",
     "test": "node --experimental-vm-modules node_modules/.bin/jest --coverage",
     "test-cont": "nodemon -e js,mjs,css,html --ignore save --ignore coverage --experimental-vm-modules node_modules/.bin/jest"
@@ -45,6 +45,7 @@
   "devDependencies": {
     "jest": "^26.6.3",
     "jest-environment-jsdom": "^26.6.2",
-    "jest-environment-jsdom-global": "^2.0.4"
+    "jest-environment-jsdom-global": "^2.0.4",
+    "cross-env": "^7.0.3"
   }
 }


### PR DESCRIPTION
This adds the ability to run a local VTT in debug mode (uncompressed JS) across environments. Without this, you have to run it with "SET NOCOMPRESS=1" on Windows, but even then I only got it to work with Chrome. I hope this change doesn't affect environments other than Windows.