### PR TITLE
fixed that setting activeFace to invalid values crashes the client

### DIFF
--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -22,8 +22,11 @@ class BasicWidget extends Widget {
 
   applyDeltaToDOM(delta) {
     super.applyDeltaToDOM(delta);
-    if(delta.activeFace !== undefined || delta.faces !== undefined)
-      this.applyDelta(this.p('faces')[this.p('activeFace')]);
+    if(delta.activeFace !== undefined || delta.faces !== undefined) {
+      let face = this.p('faces')[this.p('activeFace')];
+      if(face !== undefined)
+        this.applyDelta(face);
+    }
     if(delta.text !== undefined)
       this.domElement.textContent = delta.text;
   }


### PR DESCRIPTION
If you set `activeFace: 1` on a `BasicWidget` without a `faces` definition it crashes the client.