### PR TITLE
changed the GitPod config so it always opens the same room (test)

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 tasks:
-  - init: npm install
+  - init: npm install; git checkout package-lock.json
     command: (sleep 2; gp preview $(gp url 8272)/test) & npm run debug
 ports:
   - port: 8272

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,10 @@
 tasks:
   - init: npm install
-    command: npm run debug
+    command: (sleep 2; gp preview $(gp url 8272)/test) & npm run debug
 ports:
   - port: 8272
     visibility: public
-    onOpen: open-preview
+    onOpen: ignore
   - port: 9229
     visibility: private
     onOpen: ignore


### PR DESCRIPTION
https://gitpod.io/#https://github.com/ArnoldSmith86/virtualtabletop/pull/283 should start the built in test browser to the `/test` room now. Before it just opened `/` and in turn created a new room every time it was reloaded.