### PR TITLE
cards now check if their supplied deck is actually a deck

### DIFF
--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -47,9 +47,11 @@ class Card extends Widget {
 
   applyInitialDelta(delta) {
     if(!delta.deck)
-      throw `card ${delta.id} requires property deck`;
+      throw `card "${delta.id}" requires property deck`;
     if(!delta.cardType)
-      throw `card ${delta.id} requires property cardType`;
+      throw `card "${delta.id}" requires property cardType`;
+    if(!(widgets.get(delta.deck) instanceof Deck))
+      throw `card "${delta.id}" has "${delta.deck}" as a deck which is not a deck`;
     if(!widgets.get(delta.deck).p('cardTypes')[delta.cardType])
       throw `card type "${delta.cardType}" not found in deck "${delta.deck}"`;
     super.applyInitialDelta(delta);


### PR DESCRIPTION
If you set the property `deck` to an existing widget which is not actually a `Deck`, the client would continually crash.

I added a check for that which doesn't trigger for every edge case of how to get there but it should break the loop and let you know what's wrong.