### PR TITLE
fix Go button (alternative)

### DIFF
--- a/client/room.html
+++ b/client/room.html
@@ -112,10 +112,12 @@
     </div>
 
     <div id="buttonInputOverlay" class="overlay">
-      <h1>Button Input</h1>
-      <div id="buttonInputFields"></div>
-      <button id="buttonInputGo">Go</button>
-      <button id="buttonInputCancel">Cancel</button>
+      <form onsubmit="return false">
+        <h1>Button Input</h1>
+        <div id="buttonInputFields"></div>
+        <button id="buttonInputGo">Go</button>
+        <button id="buttonInputCancel">Cancel</button>
+      </form>
     </div>
 
     <div id="playerOverlay" class="overlay">


### PR DESCRIPTION
I've tested [ArnoldSmith86 suggestion](https://github.com/ArnoldSmith86/virtualtabletop/pull/273#pullrequestreview-616219277) for an alternative button fix and found that it works similar, but not identical and I'm not sure which is better.

On my iPhone, PR #273 shows the Go and Cancel buttons as short buttons, not in the wide button styles used in pile actions. Also, I had the option to "Open" or submit the form via the iPhone keyboard.

In this PR, the buttons use the same style as the pile actions (although at first the buttons didn't render correctly) and the iPhone keyboard does not show an "Open" option. To submit the form, you have to click the Go button.

I'm not sure which alternative is better, which is why I'm opening this for others to test as well.

Resolves #271 