### PR TITLE
fixed that COMPUTE wouldn't allow setting stuff to null

### DIFF
--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -302,7 +302,7 @@ export class Button extends Widget {
           v = 0;
           problems.push(`Exception: ${e.toString()}`);
         }
-        if(v === null || typeof v === 'number' && !isFinite(v)) {
+        if(o !== '=' && (v === null || typeof v === 'number' && !isFinite(v))) {
           v = 0;
           problems.push(`The operation evaluated to null, Infinity or NaN. Setting the variable to 0.`);
         }


### PR DESCRIPTION
The introduction of `compute` in `SET` also introduced the check that the result is numeric. So `null` was replaced by `0` which breaks everything if that's what you set a widget's `parent` to.