### PR TITLE
Ensure uniqueness of widget IDs (fixes #289)

### DIFF
--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -1,10 +1,16 @@
 let edit = false;
 
+function generateUniqueWidgetID() {
+  let id;
+  do {
+    id = Math.random().toString(36).substring(3, 7);
+  } while (widgets.has(id));
+  return id;
+}
+
 function addWidgetLocal(widget) {
   if (!widget.id)
-    do {
-      widget.id = Math.random().toString(36).substring(3, 7);
-    } while (widgets.has(widget.id));
+    widget.id = generateUniqueWidgetID();
   sendPropertyUpdate(widget.id, widget);
   sendDelta(true);
 }
@@ -253,7 +259,7 @@ function populateAddWidgetOverlay() {
   });
 
   addCompositeWidgetToAddWidgetOverlay(generateCardDeckWidgets('add-deck', x, 500), function() {
-    for(const w of generateCardDeckWidgets(Math.random().toString(36).substring(3, 7), x, 500))
+    for(const w of generateCardDeckWidgets(generateUniqueWidgetID(), x, 500))
       addWidgetLocal(w);
   });
 
@@ -338,7 +344,7 @@ function populateAddWidgetOverlay() {
   }
 
   addCompositeWidgetToAddWidgetOverlay(generateCounterWidgets('add-counter', 820, 700), function() {
-    for(const w of generateCounterWidgets(Math.random().toString(36).substring(3, 7), 820, 700))
+    for(const w of generateCounterWidgets(generateUniqueWidgetID(), 820, 700))
       addWidgetLocal(w);
   });
 

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -1,8 +1,10 @@
 let edit = false;
 
 function addWidgetLocal(widget) {
-  if(!widget.id)
-    widget.id = Math.random().toString(36).substring(3, 7);
+  if (!widget.id)
+    do {
+      widget.id = Math.random().toString(36).substring(3, 7);
+    } while (widgets.has(widget.id));
   sendPropertyUpdate(widget.id, widget);
   sendDelta(true);
 }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -73,7 +73,7 @@ const jeCommands = [
       if(css)
         cardType.css = css;
       jeStateNow.cardTypes['###SELECT ME###'] = cardType;
-      jeSetAndSelect(Math.random().toString(36).substring(3, 7));
+      jeSetAndSelect(getUniqueWidgetID());
     }
   },
   {


### PR DESCRIPTION
The code for creating a widget ID, in `addWidgetLocal`, was removed to its own function. All four places in the client code where a random widget ID was created now call that function (three in editmode.js, one in jsonedit.js).

The other places in the client code where `Math.random` is called are:
1. Determining a player name in players.js. Apparently there is no convenient client-available list of all players, so I've left that one alone. The odds of a conflict are relatively low, since there will likely be no more than 10 players and the random number has 3 digits.
2. In pile.js and button.js, to do a shuffle. Conflicts here likely happen regularly, and they don't matter since JavaScript has an algorithm for resolving siblings with the same z-value. Left alone.
3. Places where randomness is explicitly wanted: in code dealing with random face-flipping, spinners, and the `RANDOM` function itself. Obviously left alone.