### PR TITLE
added overflow:hidden to cards again

### DIFF
--- a/client/css/widgets/card.css
+++ b/client/css/widgets/card.css
@@ -1,3 +1,7 @@
+.card {
+  overflow: hidden;
+}
+
 body.edit .card {
   display: none;
 }


### PR DESCRIPTION
This is the fix for #240 @96LawDawg proposed in #241.

The problem is that it hides parts of child widgets that are not overlapping the card.

But I think it's completely reasonable to enforce that nothing sticks out of the card.

Please test this in the browsers that currently show the problem.