### PR TITLE
make Gitpod use Node 15 so it doesn't break package-lock.json

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 tasks:
-  - init: npm install
+  - init: nvm install 15; nvm use 15; npm install
     command: (sleep 2; gp preview $(gp url 8272)/test) & npm run debug
 ports:
   - port: 8272


### PR DESCRIPTION
Same problem as Dependabot. It will always downgrade package-lock.json after a `npm install`. This should take care of that problem.