### PR TITLE
add duplicateWidget function to JSON editor

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -247,8 +247,7 @@ const jeCommands = [
   },
   {
     id: 'je_removeProperty',
-    name: _=>`🗑 remove property ${jeContext && jeContext[jeContext.length-1]}`,
-    forceKey: 'r',
+    name: _=>`remove property ${jeContext && jeContext[jeContext.length-1]}`,
     context: ' ↦ (?=[^"]+$)',
     call: function() {
       let pointer = jeGetValue(jeContext.slice(0, -1));
@@ -338,8 +337,7 @@ const jeCommands = [
   },
   {
     id: 'je_applyVariables',
-    name: _=>`⮀ change ${jeContext && jeContext[4]} to applyVariables`,
-    forceKey: 'ArrowLeft',
+    name: _=>`change ${jeContext && jeContext[4]} to applyVariables`,
     context: '^button.*\\) ↦ [a-zA-Z]+',
     call: function() {
       const operation = jeGetValue(jeContext.slice(1, 3));
@@ -845,7 +843,7 @@ function jeShowCommands() {
   }
 
   const displayKey = function (k) {
-    return { ArrowUp: '⬆', ArrowDown: '⬇', ArrowLeft: '🠄'} [k] || k;
+    return { ArrowUp: '⬆', ArrowDown: '⬇'} [k] || k;
   }
   for(const command of jeCommands) {
     const contextMatch = context.match(new RegExp(command.context));

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -248,7 +248,6 @@ const jeCommands = [
   {
     id: 'je_removeProperty',
     name: _=>`🗑 remove property ${jeContext && jeContext[jeContext.length-1]}`,
-    forceKey: 'r',
     context: ' ↦ (?=[^"]+$)',
     call: function() {
       let pointer = jeGetValue(jeContext.slice(0, -1));

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -248,7 +248,7 @@ const jeCommands = [
   {
     id: 'je_removeProperty',
     name: _=>`🗑 remove property ${jeContext && jeContext[jeContext.length-1]}`,
-    forceKey: 'D',
+    forceKey: 'r',
     context: ' ↦ (?=[^"]+$)',
     call: function() {
       let pointer = jeGetValue(jeContext.slice(0, -1));
@@ -275,6 +275,19 @@ const jeCommands = [
       addWidgetLocal(toAdd);
       jeClick(widgets.get(toAdd.id), true);
       jeStateNow.type = '###SELECT ME###';
+      jeSetAndSelect(null);
+    }
+  },
+  {
+    id: 'je_duplicateWidget',
+    name: '✨ duplicate widget',
+    forceKey: 'D',
+    show: _=>jeStateNow,
+    call: function() {
+      var currentWidget = JSON.parse(JSON.stringify(jeWidget.state))
+      currentWidget.id = null;
+      addWidgetLocal(currentWidget);
+      jeClick(widgets.get(currentWidget.id), true);
       jeSetAndSelect(null);
     }
   },

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -248,6 +248,7 @@ const jeCommands = [
   {
     id: 'je_removeProperty',
     name: _=>`🗑 remove property ${jeContext && jeContext[jeContext.length-1]}`,
+    forceKey: 'r',
     context: ' ↦ (?=[^"]+$)',
     call: function() {
       let pointer = jeGetValue(jeContext.slice(0, -1));
@@ -283,11 +284,12 @@ const jeCommands = [
     forceKey: 'D',
     show: _=>jeStateNow,
     call: function() {
-      var currentWidget = JSON.parse(JSON.stringify(jeWidget.state))
+      let currentWidget = JSON.parse(JSON.stringify(jeWidget.state))
       currentWidget.id = null;
       addWidgetLocal(currentWidget);
       jeClick(widgets.get(currentWidget.id), true);
-      jeSetAndSelect(null);
+      jeStateNow.id = '###SELECT ME###';
+      jeSetAndSelect(currentWidget.id);
     }
   },
   {


### PR DESCRIPTION
This adds a button on the top row to duplicate the currently selected widget. The new widget will be added at the very same position, so it won't easily be noticable, but I don't think that's a problem for people working with the JSON editor anyhow.

I've given this function the hotkey Ctrl+Shift+D, which was used by `remove property`, but I think the top row buttons should all have a fixed hotkey and I couldn't think of any other suitable one (Ctrl+Shift+C for copy/clone cannot be used on Windows).

Resolves #212 