### PR TITLE
SELECT with sort

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -407,7 +407,7 @@ function jeAddCommands() {
   jeAddButtonOperationCommands('RANDOM', { min: 1, max: 10, variable: 'RANDOM' });
   jeAddButtonOperationCommands('RECALL', { owned: true, holder: null });
   jeAddButtonOperationCommands('ROTATE', { count: 1, angle: 90, mode: 'add', holder: null });
-  jeAddButtonOperationCommands('SELECT', { type: 'all', property: 'parent', relation: '==', value: null, max: 999999, collection: 'DEFAULT', mode: 'add', source: 'all' });
+  jeAddButtonOperationCommands('SELECT', { type: 'all', property: 'parent', relation: '==', value: null, max: 999999, collection: 'DEFAULT', mode: 'add', source: 'all', key: null, reverse: false });
   jeAddButtonOperationCommands('SET', { collection: 'DEFAULT', property: 'parent', relation: '=', value: null });
   jeAddButtonOperationCommands('SORT', { key: 'value', reverse: false, holder: null });
   jeAddButtonOperationCommands('SHUFFLE', { holder: null });

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -466,7 +466,7 @@ export class Button extends Widget {
       }
 
       if(a.func == 'SELECT') {
-        setDefaults(a, { type: 'all', property: 'parent', relation: '==', value: null, max: 999999, collection: 'DEFAULT', mode: 'add', source: 'all' });
+        setDefaults(a, { type: 'all', property: 'parent', relation: '==', value: null, max: 999999, collection: 'DEFAULT', mode: 'add', source: 'all', key: null, reverse: false });
         if(a.source == 'all' || isValidCollection(a.source)) {
           if([ 'add', 'set' ].indexOf(a.mode) == -1)
             problems.push(`Warning: Mode ${a.mode} interpreted as set.`);
@@ -494,6 +494,17 @@ export class Button extends Widget {
           c.filter(w=>w.p('type')=='pile').forEach(w=>c.push(...w.children()));
           c = c.filter(w=>w.p('type')!='pile');
           collections[a.collection] = [...new Set(c)];
+
+          if (a.key) {
+            collections[a.collection].sort((w1,w2)=>{
+              if(typeof w1.p(a.key) == 'number')
+                return w1.p(a.key) - w2.p(a.key);
+              else
+                return w1.p(a.key).localeCompare(w2.p(a.key));
+            });
+            if(a.reverse)
+            collections[a.collection].reverse();
+          }
         }
       }
 


### PR DESCRIPTION
Currently, the order in which collections are processed is unclear (possibly based on the widget's creation order). However, when using the count/limit or aggregation parameter in operations, it is important to have a specific order in the collection.

This PR adds the `key` and `reverse` parameters from SORT to SELECT. With key set to "z", this will ensure that the selected widgets follow the z-order (from low to high - or reversed).

```
    {
      "func": "SELECT",
      "property": "parent",
      "value": "holderID",
      "key": "z",
      "reverse": true
    }
```

As stated in #257, I originally wanted to have multiple sort criteria, but I believe this should be done in a way that it also applies to the SORT button operation, which was beyond the scope of this PR.