### PR TITLE
Fix visibility of label and basic widgets

### DIFF
--- a/client/css/widgets/basicwidget.css
+++ b/client/css/widgets/basicwidget.css
@@ -1,8 +1,10 @@
 body.edit .widget.basic {
   border-width: 0;
+  box-sizing: content-box;
+  box-shadow: 0 0 0 3px var(--editColor);
 }
 
 body.edit .widget.basic.hasImage {
   filter: grayscale(100%);
-  opacity: 0.15;
+  opacity: 0.45;
 }

--- a/client/css/widgets/label.css
+++ b/client/css/widgets/label.css
@@ -19,6 +19,8 @@
 
 body.edit .widget.label {
   border: none;
+  box-sizing: content-box;
+  box-shadow:0 0 0 3px var(--editColor);
 }
 
 body.edit .widget.label > * {


### PR DESCRIPTION
 by adding the editmode-colored 3 pixel border in edit mode. Requires adding a drop shadow and changing box-sizing in edit mode as well to avoid apparent widget movement.

Replaces https://github.com/ArnoldSmith86/virtualtabletop/pull/264