### PR TITLE
fix new json Editor overlay

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -528,7 +528,7 @@ function jeApplyChanges() {
     jeStateBeforeRaw = currentStateRaw;
     $('#editWidgetJSON').dataset.previousState = jeStateBefore;
     $('#editWidgetJSON').value = jeStateBefore = currentState;
-    $('#updateWidgetJSON').click();
+    onClickUpdateWidget();
     jeDeltaIsOurs = false;
   }
 }


### PR DESCRIPTION
The browser crashes everytime I Ctrl-Click a widget in json Editor mode. I think I've found and fixed the problem, but maybe someone else can confirm.