### PR TITLE
fix issue with = vs == in relation

### DIFF
--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -174,7 +174,7 @@ export class Button extends Widget {
       function compute(o, v, x, y, z) {
         try {
           switch(o) {
-          case '=':  v = y;    break;
+          case '=':  v = y;      break;
           case '+':  v = x + y;  break;
           case '-':  v = x - y;  break;
           case '*':  v = x * y;  break;

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -174,7 +174,7 @@ export class Button extends Widget {
       function compute(o, v, x, y, z) {
         try {
           switch(o) {
-          case '=':  v = y;      break;
+          case 'set':  v = y;    break;
           case '+':  v = x + y;  break;
           case '-':  v = x - y;  break;
           case '*':  v = x * y;  break;
@@ -505,6 +505,9 @@ export class Button extends Widget {
 
       if(a.func == 'SET') {
         setDefaults(a, { collection: 'DEFAULT', property: 'parent', relation: '=', value: null });
+        if(a.relation == '==')
+          problems.push(`Warning: Relation == interpreted as =`);
+        a.relation = (a.relation != '==' && a.relation != '=') ? a.relation : 'set';
         if((a.property == 'parent' || a.property == 'deck') && a.value !== null && !widgets.has(a.value)) {
           problems.push(`Tried setting ${a.property} to ${a.value} which doesn't exist.`);
         } else if(isValidCollection(a.collection)) {

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -174,7 +174,7 @@ export class Button extends Widget {
       function compute(o, v, x, y, z) {
         try {
           switch(o) {
-          case 'set':  v = y;    break;
+          case '=':  v = y;    break;
           case '+':  v = x + y;  break;
           case '-':  v = x - y;  break;
           case '*':  v = x * y;  break;
@@ -505,9 +505,10 @@ export class Button extends Widget {
 
       if(a.func == 'SET') {
         setDefaults(a, { collection: 'DEFAULT', property: 'parent', relation: '=', value: null });
-        if(a.relation == '==')
+        if(a.relation == '==') {
           problems.push(`Warning: Relation == interpreted as =`);
-        a.relation = (a.relation != '==' && a.relation != '=') ? a.relation : 'set';
+          a.relation = '=';
+        }
         if((a.property == 'parent' || a.property == 'deck') && a.value !== null && !widgets.has(a.value)) {
           problems.push(`Tried setting ${a.property} to ${a.value} which doesn't exist.`);
         } else if(isValidCollection(a.collection)) {


### PR DESCRIPTION
Until we added all COMPUTE relations to SET (PR #279), people could use SET with `==` to set a property to the given value, although `==` is a comparator, not an assignment operator.

Non-programmers frequently get confused about when to use `==` instead of `=`, so this PR aims to fix this issue by allowing for `==` in SET but giving a warning.

This change means that `==` cannot be used as a comparator in SET, only in COMPUTE.