### PR TITLE
fixed that you couldn't edit holder classes through JSON anymore

### DIFF
--- a/client/components/baseEditOverlay.js
+++ b/client/components/baseEditOverlay.js
@@ -7,7 +7,7 @@ export const baseEditOverlay = {
   },
   methods: {
       update() {
-        onClickUpdateWidget();
+        onClickUpdateWidget(!this.jsonEdit);
       },
       duplicate() {
         onClickDuplicateWidget();

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -360,7 +360,7 @@ function uploadWidget(preset) {
   });
 }
 
-function onClickUpdateWidget() {
+function onClickUpdateWidget(applyChangesFromUI) {
     const previousState = JSON.parse($('#editWidgetJSON').dataset.previousState);
     try {
       var widget = JSON.parse($('#editWidgetJSON').value);
@@ -369,7 +369,8 @@ function onClickUpdateWidget() {
       return;
     }
 
-    applyEditOptions(widget);
+    if(applyChangesFromUI)
+      applyEditOptions(widget);
 
     const children = Widget.prototype.children.call(widgets.get(previousState.id));
     const cards = widgetFilter(w=>w.p('deck')==previousState.id);

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -529,7 +529,7 @@ function jeApplyChanges() {
     jeStateBeforeRaw = currentStateRaw;
     $('#editWidgetJSON').dataset.previousState = jeStateBefore;
     $('#editWidgetJSON').value = jeStateBefore = currentState;
-    onClickUpdateWidget();
+    onClickUpdateWidget(false);
     jeDeltaIsOurs = false;
   }
 }


### PR DESCRIPTION
The Vue transition removed a check that only applied the UI element values (for example the "Transparent" checkbox of the holder) if you didn't edit the JSON directly. Without that check the value of the checkbox gets applied even if you changed its property in the JSON.