### PR TITLE
JSON editor fixes

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -25,6 +25,7 @@
   height: 100%;
   width: 350px;
   right: 350px;
+  overflow-wrap: break-word;
 }
 
 #jeText {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -693,6 +693,8 @@ function jeGetContext() {
       jeJSONerror = `Parent ${jeStateNow.parent} does not exist.`;
     else if(jeStateNow.type == 'card' && (!jeStateNow.deck || !widgets.has(jeStateNow.deck)))
       jeJSONerror = `Deck ${jeStateNow.deck} does not exist.`;
+    else if(jeStateNow.type == 'card' && !widgets.get(jeStateNow.deck).p('cardTypes'))
+      jeJSONerror = `Given widget ${jeStateNow.deck} is not a deck or doesn't define cardTypes.`;
     else if(jeStateNow.type == 'card' && (!jeStateNow.cardType || !widgets.get(jeStateNow.deck).p('cardTypes')[jeStateNow.cardType]))
       jeJSONerror = `Card type ${jeStateNow.cardType} does not exist in deck ${jeStateNow.deck}.`;
     else

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -381,7 +381,8 @@ function jeAddRoutineOperationCommands(command, defaults) {
       else
         routine.splice(operationIndex+1, 0, {func: '###SELECT ME###'});
       jeSetAndSelect(command);
-    })
+    }),
+    show: jeRoutineCall((_, routine)=>Array.isArray(routine))
   });
 
   defaults.skip = false;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -688,7 +688,7 @@ function jeGetContext() {
       jeJSONerror = 'No ID given.';
     else if(JSON.parse(jeStateBefore).id != jeStateNow.id && widgets.has(jeStateNow.id))
       jeJSONerror = `ID ${jeStateNow.id} is already in use.`;
-    else if(jeStateNow.parent !== undefined && !widgets.has(jeStateNow.parent))
+    else if(jeStateNow.parent && !widgets.has(jeStateNow.parent))
       jeJSONerror = `Parent ${jeStateNow.parent} does not exist.`;
     else if(jeStateNow.type == 'card' && (!jeStateNow.deck || !widgets.has(jeStateNow.deck)))
       jeJSONerror = `Deck ${jeStateNow.deck} does not exist.`;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -604,7 +604,8 @@ function jeColorize() {
     [ /^( +)(.*)( \()([a-z]+)( - )([0-9-]+)(,)([0-9-]+)(.*)$/, null, 'key', null, 'string', null, 'number', null, 'number', null ]
   ];
   let out = [];
-  for(const line of $('#jeText').textContent.split('\n')) {
+  for(let line of $('#jeText').textContent.split('\n')) {
+    line = line.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
     let foundMatch = false;
     for(const l of langObj) {
       const match = line.match(l[0]);

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -653,8 +653,10 @@ function jeDisplayTreeAddWidgets(allWidgets, parent, indent) {
 }
 
 function jeGetContext() {
-  const s = getSelection().anchorOffset;
-  const e = getSelection().focusOffset;
+  const aO = getSelection().anchorOffset;
+  const fO = getSelection().focusOffset;
+  const s = Math.min(aO, fO);
+  const e = Math.max(aO, fO);
   const v = $('#jeText').textContent;
   const t = jeStateNow && jeStateNow.type || 'basic';
 
@@ -736,8 +738,10 @@ function jeInsert(context, key, value) {
 }
 
 function jePasteText(text) {
-  const s = getSelection().anchorOffset;
-  const e = getSelection().focusOffset;
+  const aO = getSelection().anchorOffset;
+  const fO = getSelection().focusOffset;
+  const s = Math.min(aO, fO);
+  const e = Math.max(aO, fO);
   const v = $('#jeText').textContent;
 
   jeSet(v.substr(0, s) + text + v.substr(e));

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -706,7 +706,7 @@ function jeGetContext() {
   }
 
   let keys = [ t ];
-  for(const line of v.substr(0, s).split('\n')) {
+  for(const line of v.split('\n').slice(0, v.substr(0, s).split('\n').length)) {
     const m = line.match(/^( +)(["{])([^"]*)/);
     if(m) {
       const depth = m[1].length/2;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -461,7 +461,7 @@ function jeAddCSScommands() {
       name: css,
       context: '^.* ↦ (css|[a-z]+CSS)',
       call: function() {
-        jePasteText(css + '; ');
+        jePasteText(css + '; ', true);
       },
       show: function() {
         return !jeGetValue()[jeGetLastKey()].match(css.split(':')[0]);
@@ -749,15 +749,17 @@ function jeInsert(context, key, value) {
   }
 }
 
-function jePasteText(text) {
+function jePasteText(text, select) {
   const aO = getSelection().anchorOffset;
   const fO = getSelection().focusOffset;
   const s = Math.min(aO, fO);
   const e = Math.max(aO, fO);
   const v = $('#jeText').textContent;
 
-  jeSet(v.substr(0, s) + text + v.substr(e));
-  jeSelect(s, s + text.length);
+  $('#jeText').textContent = v.substr(0, s) + text + v.substr(e);
+  $('#jeText').focus();
+  jeColorize();
+  jeSelect(select ? s : s + text.length, s + text.length);
 }
 
 function jePostProcessObject(o) {
@@ -982,6 +984,14 @@ window.addEventListener('mouseup', function(e) {
   }
 });
 
+onLoad(function() {
+  on('#jeText', 'paste', function(e) {
+    const paste = (e.clipboardData || window.clipboardData).getData('text');
+    jePasteText(paste, false);
+    e.preventDefault();
+  });
+});
+
 window.addEventListener('keydown', function(e) {
   if(e.key == 'Control')
     jeState.ctrl = true;
@@ -1042,7 +1052,7 @@ window.addEventListener('keydown', function(e) {
       let id = jeWidgetLayers[+functionKey[1]].p('id');
       if(jeContext[jeContext.length-1] == '"null"')
         id = `"${id}"`;
-      jePasteText(id);
+      jePasteText(id, true);
     } else {
       jeSelectWidget(jeWidgetLayers[+functionKey[1]]);
     }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -464,7 +464,7 @@ function jeAddCSScommands() {
         jePasteText(css + '; ', true);
       },
       show: function() {
-        return !jeGetValue()[jeGetLastKey()].match(css.split(':')[0]);
+        return !String(jeGetValue()[jeGetLastKey()]).match(css.split(':')[0]);
       }
     });
   }

--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -44,7 +44,7 @@ export class StateManaged {
 
   propertyGet(property) {
     if(this.state[property] !== undefined)
-      return this.state[property];
+      return [ 'x', 'y', 'width', 'height', 'z', 'layer' ].indexOf(property) != -1 ? +this.state[property] : this.state[property];
     else
       return this.getDefaultValue(property);
   }


### PR DESCRIPTION
Selecting text from right to left produces the correct context for commands.

Macros are still not incredibly useful but at least they should work again.

If `x`, `y`, `width` or `height` are numeric strings, the `F1` keys now show the correct widgets because the values are converted to numbers by function `p` now.

Explicitly setting `"parent": null` in the widget will no longer trigger the "parent exists" test.

Special HTML characters were not escaped, leading to problems in the JSON editor.

There's now a check that looks if the widget given with property `deck` contains `cardTypes`.

Copying text to the JSON editor now pastes it as plain text using a custom paste event handler so that the browser doesn't insert weird stuff into the contenteditable editor that messes up commands and editing.

Setting a number to `css` no longer crashes the client. I tested quite a few other properties but others didn't lead to a crash.