### PR TITLE
COMPUTE with toFixed, parseFloat, randint and randrange

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -450,6 +450,9 @@ export class Widget extends StateManaged {
           case 'length':
             v = x.length;
             break;
+          case 'parseFloat':
+            v = parseFloat(x);
+            break;
           case 'toLowerCase':
           case 'toUpperCase':
           case 'trim':
@@ -473,6 +476,7 @@ export class Widget extends StateManaged {
           case 'search':
           case 'split':
           case 'startsWith':
+          case 'toFixed':
           case 'toLocaleLowerCase':
           case 'toLocaleUpperCase':
             v = x[o](y);
@@ -517,6 +521,14 @@ export class Widget extends StateManaged {
           case 'push':
           case 'unshift':
             v[o](x);
+            break;
+
+          // random values
+          case 'randint':
+            v = Math.floor((Math.random() * (y - x + 1)) + x);
+            break;
+          case 'randrange':
+            v = Math.floor((Math.random() * (y - x) / (z || 1))) * (z || 1) + x;
             break;
           default:
             problems.push(`Operation ${o} is unsupported.`);

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -524,10 +524,10 @@ export class Widget extends StateManaged {
             break;
 
           // random values
-          case 'randint':
+          case 'randInt':
             v = Math.floor((Math.random() * (y - x + 1)) + x);
             break;
-          case 'randrange':
+          case 'randRange':
             v = Math.round(Math.floor((Math.random() * (y - x) / (z || 1))) * (z || 1) + x);
             break;
           default:

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -528,7 +528,7 @@ export class Widget extends StateManaged {
             v = Math.floor((Math.random() * (y - x + 1)) + x);
             break;
           case 'randrange':
-            v = Math.floor((Math.random() * (y - x) / (z || 1))) * (z || 1) + x;
+            v = Math.round(Math.floor((Math.random() * (y - x) / (z || 1))) * (z || 1) + x);
             break;
           default:
             problems.push(`Operation ${o} is unsupported.`);


### PR DESCRIPTION
Resolves #345 which needed the addition of COMPUTE operations dealing with decimal numbers. I also added two functions to generate random whole numbers based on the Python equivalent.

The new functions are:
* toFixed: converts a number into a string, rounding the number to keep only the specified amount of decimals
* parseFloat: parses a string and returns a floating point number. It determines if the first character in the specified string is a number. If it is, it parses the string until it reaches the end of the number, and returns the number as a number, not as a string.
* randInt: generates a random integer in a min-max range, including the end points (identical to RANDOM button operation)
* randRange: generates a random integer in a min-max range, excluding the max point. Allows to set a step interval (defaults to 1).

Note that COMPUTE currently applies default values of 1 for operands - which is going to be changed eventually, so it is strongly recommended to specify each operand and not rely on the default value.