### PR TITLE
fixed server crash when loading a state from an invalid link

### DIFF
--- a/client/js/connection.js
+++ b/client/js/connection.js
@@ -69,6 +69,7 @@ export function toServer(func, args) {
 
 function preventReconnect() {
   lastTimeout = null;
+  userNavigatedAway = true;
 }
 
 function log(str) {

--- a/client/js/connection.js
+++ b/client/js/connection.js
@@ -45,6 +45,7 @@ export function startWebSocket() {
       if(serverStart != null && serverStart != args) {
         console.log('Server restart detected. Reloading...')
         setTimeout(location.reload, Math.random()*10000);
+        showOverlay('connectionLostOverlay', true);
         preventReconnect();
         connection.close();
       }

--- a/server.mjs
+++ b/server.mjs
@@ -72,7 +72,7 @@ MinifyRoom().then(function(result) {
     fs.readFile(savedir + '/assets/' + req.params.name, function(err, content) {
       if(!content) {
         res.sendStatus(404);
-        console.log(new Date().toISOString(), 'WARNING: Could not load asset ' + req.params.name);
+        Logging.log(`WARNING: Could not load asset ${req.params.name}`);
         return;
       }
 
@@ -87,7 +87,7 @@ MinifyRoom().then(function(result) {
       else if(content[0] == 0x52)
         res.setHeader('Content-Type', 'image/webp');
       else
-        console.log(new Date().toISOString(), 'WARNING: Unknown file type of asset ' + req.params.name);
+        Logging.log(`WARNING: Unknown file type of asset ${req.params.name}`);
 
       res.send(content);
     });
@@ -198,7 +198,7 @@ MinifyRoom().then(function(result) {
   app.use(Logging.errorHandler);
 
   server.listen(process.env.PORT || 8272, function() {
-    console.log(new Date().toISOString(), 'Listening on ' + server.address().port);
+    Logging.log(`Listening on ${server.address().port}`);
   });
 });
 

--- a/server.mjs
+++ b/server.mjs
@@ -51,8 +51,13 @@ async function downloadState(res, roomID, stateID, variantID) {
 
 function autosaveRooms() {
   setInterval(function() {
-    for(const [ _, room ] of activeRooms)
-      room.writeToFilesystem();
+    for(const [ _, room ] of activeRooms) {
+      try {
+        room.writeToFilesystem();
+      } catch(e) {
+        Logging.handleGenericException('autosaveRooms', e);
+      }
+    }
   }, 60*1000);
 }
 

--- a/server/connection.mjs
+++ b/server/connection.mjs
@@ -46,8 +46,14 @@ export default class Connection {
   }
 
   closeReceived = _ => {
-    for(const handler of this.closeHandlers)
-      handler();
+    try {
+      for(const handler of this.closeHandlers)
+        handler();
+    } catch(e) {
+      Logging.handleGenericException('closeReceived', e);
+      this.toClient('internal_error', 'unknown');
+      this.close();
+    }
   }
 
   toClient(func, args) {

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -16,7 +16,7 @@ export default class Room {
   }
 
   addPlayer(player) {
-    console.log(new Date().toISOString(), `adding player ${player.name} to room ${this.id}`);
+    Logging.log(`adding player ${player.name} to room ${this.id}`);
     this.players.push(player);
 
     if(!this.state._meta.players[player.name])
@@ -40,7 +40,7 @@ export default class Room {
       if(type == 'link')
         states = await FileLoader.readStatesFromLink(src);
     } catch(e) {
-      console.log(new Date().toISOString(), 'ERROR LOADING FILE: ' + e);
+      Logging.log(`ERROR LOADING FILE: ${e.toString()}`);
       try {
         fs.writeFileSync(path.resolve() + '/save/errors/' + Math.random().toString(36).substring(3, 7), Buffer.from(src.replace(/^data.*?,/, ''), 'base64'));
       } catch(e) {}
@@ -261,7 +261,7 @@ export default class Room {
   }
 
   receiveInvalidDelta(player, delta, widgetID) {
-    console.log(new Date().toISOString(), `WARNING: received conflicting delta data for widget ${widgetID} from player ${player.name} in room ${this.id} - sending game state at ${this.deltaID}`);
+    Logging.log(`WARNING: received conflicting delta data for widget ${widgetID} from player ${player.name} in room ${this.id} - sending game state at ${this.deltaID}`);
     this.state._meta.deltaID = ++this.deltaID;
     player.send('state', this.state);
   }
@@ -272,7 +272,7 @@ export default class Room {
   }
 
   removePlayer(player) {
-    console.log(new Date().toISOString(), `removing player ${player.name} from room ${this.id}`);
+    Logging.log(`removing player ${player.name} from room ${this.id}`);
     this.players = this.players.filter(e => e != player);
     if(this.players.length == 0) {
       this.unload();


### PR DESCRIPTION
Loading the room state from invalid files or links caused server crashes and all kinds of issues. That should be fixed now. Instead the user receives an "Error loading state." message and the room will be set to an empty room (the game list will stay untouched).

Please see #389 for an explanation of why this currently happens a lot.