### PR TITLE
grids can now set any property on widgets

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -963,8 +963,9 @@ export class Widget extends StateManaged {
       if(closest) {
         x = x + closest.x/2 - (x - (closest.offsetX || 0)) % closest.x;
         y = y + closest.y/2 - (y - (closest.offsetY || 0)) % closest.y;
-        if(closest.rotation !== undefined)
-          this.p('rotation', closest.rotation);
+        for(const p in closest)
+          if([ 'x', 'y', 'minX', 'minY', 'maxX', 'maxY', 'offsetX', 'offsetY' ].indexOf(p) == -1)
+            this.p(p, closest[p]);
       }
 
       this.snappingToGrid = false;


### PR DESCRIPTION
Until now `grid`s could only define a custom `rotation` which could be used to make something like roads in Catan.

While actually using it, I actually wanted to replace the `image` depending on the rotation because of a 3D perspective effect.

The example on the right of the test room now sets `rotation` and `scale` as an example.