### PR TITLE
improved game file uploads significantly

### DIFF
--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -36,10 +36,15 @@ export function selectFile(getContents, multipleCallback) {
     upload.type = 'file';
     if (typeof multipleCallback === 'function') upload.setAttribute('multiple', true);
     upload.addEventListener('change', function(e) {
-      if(!getContents)
-        resolve(e.target.files[0]);
+      if(!getContents && typeof multipleCallback !== 'function')
+        return resolve(e.target.files[0]);
 
       for(const file of e.target.files) {
+        if(!getContents && typeof multipleCallback === 'function') {
+          multipleCallback(file);
+          continue;
+        }
+
         const name = file.name;
         const reader = new FileReader();
         reader.addEventListener('load', function(e) {

--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -2,7 +2,10 @@ let waitingForStateCreation = null;
 let variantIDjustUpdated = null;
 
 async function addState(e, type, src, id) {
-  const initialStatus = e && e.target.innerText;
+  const initialStatus = e && (e.target.dataset.initialText || e.target.innerText);
+  if(e && !e.target.dataset.initialText)
+    e.target.dataset.initialText = initialStatus;
+
   const status = function(t) {
     if(e)
       e.target.innerText=t;

--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -1,19 +1,82 @@
 let waitingForStateCreation = null;
 let variantIDjustUpdated = null;
 
-function addState(e, type, src, id) {
+async function addState(e, type, src, id) {
+  const initialStatus = e && e.target.innerText;
+  const status = function(t) {
+    if(e)
+      e.target.innerText=t;
+  };
+
   if(type == 'link' && (!src || !src.match(/^http/)))
     return;
   if(!id)
     id = Math.random().toString(36).substring(3, 7);
 
+  let blob = null;
+  try {
+    if(type == 'file') {
+      status('Loading file...');
+      const zip = await JSZip.loadAsync(src);
+      const assets = {};
+      for(const filename in zip.files)
+        if(filename.match(/^\/?(user)?assets/) && zip.files[filename]._data && zip.files[filename]._data.crc32)
+          assets[zip.files[filename]._data.crc32 + '_' + zip.files[filename]._data.uncompressedSize] = filename;
+
+      status('Checking assets...');
+      const result = await fetch('/assetcheck', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(Object.keys(assets))
+      });
+
+      const exist = await result.json();
+
+      let total = 0;
+      let removed = 0;
+      for(const asset in exist) {
+        ++total;
+        if(exist[asset]) {
+          ++removed;
+          zip.remove(assets[asset]);
+        }
+      }
+
+      if(removed > total/2) {
+        zip.file('asset-map.json', JSON.stringify(assets));
+        status(`Rebuilding file (${removed}/${total} assets already exist)...`);
+        blob = await zip.generateAsync({ type: 'blob', compression: total-removed < 5 ? 'DEFLATE' : 'STORE' });
+      } else {
+        blob = src;
+      }
+    } else {
+      blob = new Blob([ src ], { type: 'text/plain' });
+    }
+  } catch(e) {
+    alert(e);
+    status(initialStatus);
+    return;
+  }
+
+  let url = `/addState/${roomID}/${id}/${type}/${src && src.name && encodeURIComponent(src.name)}/`;
+  waitingForStateCreation = id;
   if(e && (e.target.parentNode == $('#addVariant') || e.target.className == 'update')) {
     waitingForStateCreation = $('#stateEditOverlay').dataset.id;
-    toServer('addState', { id, type, src, addAsVariant: $('#stateEditOverlay').dataset.id });
-  } else {
-    waitingForStateCreation = id;
-    toServer('addState', { id, type, src });
+    url += $('#stateEditOverlay').dataset.id;
   }
+
+  var req = new XMLHttpRequest();
+  req.onload = function(e) {
+    if(e.target.status != 200)
+      alert(`${e.target.status}: ${e.target.response}`);
+    status(initialStatus);
+  };
+  req.upload.onprogress = e=>status(`Uploading (${Math.floor(e.loaded/e.total*100)}%)...`);
+
+  req.open('PUT', url, true);
+  req.setRequestHeader('Content-type', 'application/octet-stream');
+  status('Starting upload...');
+  req.send(blob);
 }
 
 function addStateFromLibrary(e) {
@@ -229,7 +292,7 @@ onLoad(function() {
   on('#addState .create,  #addVariant .create',  'click', e=>addState(e, 'state'));
   on('#addState .library, #addVariant .library', 'click', e=>addStateFromLibrary(e));
 
-  on('#addState .upload, #emptyRoom .upload, #addVariant .upload',  'click', e=>selectFile(true, f=>addState(e, 'file', f)));
+  on('#addState .upload, #emptyRoom .upload, #addVariant .upload',  'click', e=>selectFile(false, f=>addState(e, 'file', f)));
   on('#addState .link,   #emptyRoom .link,   #addVariant .link',    'click', e=>addState(e, 'link', prompt('Enter shared URL:')));
 
   on('#addState .download', 'click', _=>downloadState(null));

--- a/client/room.html
+++ b/client/room.html
@@ -8,7 +8,7 @@
   <link rel="shortcut icon" href="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="/>
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
-  <script src="https://cdn.jsdelivr.net/npm/vue@3.0.7/dist/vue.global.prod.js"></script>
+  <script src="https://cdn.jsdelivr.net/combine/npm/vue@3.0.7/dist/vue.global.prod.js,npm/jszip@3.6.0/dist/jszip.min.js"></script>
   <base target="_blank">
   <style> {{CSS}} </style>
 </head>

--- a/server/fileloader.mjs
+++ b/server/fileloader.mjs
@@ -5,6 +5,7 @@ import JSZip from 'jszip';
 
 import { VERSION } from './fileupdater.mjs';
 import PCIO from './pcioimport.mjs';
+import Logging from './logging.mjs';
 
 const dirname = path.resolve() + '/save/links';
 const filename = dirname + '.json';
@@ -51,6 +52,8 @@ async function readStatesFromBuffer(buffer) {
     if(filename.match(/\.(vtt|pcio)$/) && zip.files[filename]._data)
       states[filename] = await readVariantsFromBuffer(await zip.files[filename].async('nodebuffer'));
   }
+  if(states.length == 0)
+    throw new Logging.UserError(404, 'Did not find any JSON files in the ZIP file.');
   return states;
 }
 
@@ -89,10 +92,10 @@ async function readVariantsFromBuffer(buffer) {
 
       if(filename.match(/^[^\/]+\.json$/) && filename != 'asset-map.json' && zip.files[filename]._data) {
         if(zip.files[filename]._data.uncompressedSize >= 20971520)
-          throw `${filename} is bigger than 20 MiB.`;
+          throw new Logging.UserError(403, `${filename} is bigger than 20 MiB.`);
         const variant = JSON.parse(await zip.files[filename].async('string'));
         if(typeof variant._meta.version != 'number' || variant._meta.version > VERSION || variant._meta.version < 0)
-          throw `Found a valid JSON file but version ${variant._meta.version} is not supported. Please update your server.`;
+          throw new Logging.UserError(403, `Found a valid JSON file but version ${variant._meta.version} is not supported. Please update your server.`);
         variants[filename] = variant;
       }
 
@@ -104,7 +107,7 @@ async function readVariantsFromBuffer(buffer) {
 
     }
     if(!Object.keys(variants).length)
-      throw 'Did not find any JSON files in the ZIP file.';
+      throw new Logging.UserError(404, 'Did not find any JSON files in the ZIP file.');
     return variants;
   }
 }

--- a/server/fileloader.mjs
+++ b/server/fileloader.mjs
@@ -87,7 +87,7 @@ async function readVariantsFromBuffer(buffer) {
     const variants = {};
     for(const filename in zip.files) {
 
-      if(filename.match(/^[^\/]+\.json$/) && zip.files[filename]._data) {
+      if(filename.match(/^[^\/]+\.json$/) && filename != 'asset-map.json' && zip.files[filename]._data) {
         if(zip.files[filename]._data.uncompressedSize >= 20971520)
           throw `${filename} is bigger than 20 MiB.`;
         const variant = JSON.parse(await zip.files[filename].async('string'));

--- a/server/logging.mjs
+++ b/server/logging.mjs
@@ -14,7 +14,9 @@ function logError(message, e) {
 }
 
 function userErrorHandler(err, req, res, next) {
-  if(err instanceof UserError)
+  if(err.message == 'request entity too large')
+    res.status(403).send('Too big.');
+  else if(err instanceof UserError)
     res.status(err.code).send(err.message);
   else
     next(err);

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -19,6 +19,12 @@ export default async function convertPCIO(content) {
   const widgets = JSON.parse(await zip.files['widgets.json'].async('string'));
 
   const nameMap = {};
+  try {
+    // created by the client while removing already uploaded assets
+    for(const [ k, v ] of Object.entries(JSON.parse(await zip.files['asset-map.json'].async('string'))))
+      nameMap[`package://${v}`] = `/assets/${k}`;
+  } catch(e) {}
+
   for(const filename in zip.files) {
     if(filename.match(/^\/?userassets/) && zip.files[filename]._data && zip.files[filename]._data.uncompressedSize < 2097152) {
       const targetFile = '/assets/' + zip.files[filename]._data.crc32 + '_' + zip.files[filename]._data.uncompressedSize;

--- a/server/player.mjs
+++ b/server/player.mjs
@@ -20,8 +20,6 @@ export default class Player {
 
   messageReceived = async (func, args) => {
     try {
-      if(func == 'addState')
-        await this.room.addState(this, args.id, args.type, args.src, args.addAsVariant, args.name);
       if(func == 'confirm')
         this.waitingForStateConfirmation = false;
       if(func == 'delta')

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -28,30 +28,33 @@ export default class Room {
     this.sendMetaUpdate();
   }
 
-  async addState(player, id, type, src, addAsVariant) {
+  async addState(id, type, src, srcName, addAsVariant) {
     const initialAddAsVariant = addAsVariant;
     let stateID = addAsVariant || id;
     let variantID = id;
 
     let states = { room: [ this.state ] };
     let etag = null;
+
+    if(type == 'link')
+      src = src.toString('utf8');
+
     try {
       if(type == 'file')
-        states = await FileLoader.readStatesFromBuffer(Buffer.from(src.content.replace(/^data.*?,/, ''), 'base64'));
+        states = await FileLoader.readStatesFromBuffer(src);
       if(type == 'link')
         states = await FileLoader.readStatesFromLink(src);
     } catch(e) {
       Logging.log(`ERROR LOADING FILE: ${e.toString()}`);
       try {
-        fs.writeFileSync(path.resolve() + '/save/errors/' + Math.random().toString(36).substring(3, 7), Buffer.from(src.replace(/^data.*?,/, ''), 'base64'));
+        fs.writeFileSync(path.resolve() + '/save/errors/' + Math.random().toString(36).substring(3, 7), src);
       } catch(e) {}
-      player.send('error', e.toString());
-      return;
+      throw e;
     }
 
     for(const state in states) {
       for(const v in states[state]) {
-        let name = type == 'file' && src.name || 'Unnamed';
+        let name = type == 'file' && srcName || 'Unnamed';
         if(state.match(/\.pcio$/))
           name = state;
 


### PR DESCRIPTION
Uploading VTT files failed randomly in the past and using WebSockets there was no way to get information about the current progress.

I now changed it to use XMLHttpRequest which allows for a progress indicator and I think it used base64 before so this already saves some bandwidth.

I used the opportunity to also implement a check that actually opens the vtt file clientside, checks if the assets are already on the server and if more than half of them are, it deletes them from the archive and uploads a newly created file. This should make >90% of all uploads near instant.

# To do
- [x] Uploading multiple files doesn't reset the button text correctly.
- [x] Uploading a zip file without states in it doesn't trigger the appropriate error message.