### PR TITLE
added changeRoutine, enterRoutine and leaveRoutine

### DIFF
--- a/client/components/deckEditor.js
+++ b/client/components/deckEditor.js
@@ -34,7 +34,7 @@ export const deckEditor = {
         onClickDecrementAllCardTypes()
       },
 
-      _addCardCallback(imagePath, fileName) {
+      async addCardCallback(imagePath, fileName) {
         let value = {
           "image": imagePath,
         }
@@ -43,7 +43,7 @@ export const deckEditor = {
         const card = { deck:this.widgetState.id, type:'card', cardType:fileName };
         addWidgetLocal(card);
         if(this.widgetState.parent)
-          widgets.get(card.id).moveToHolder(widgets.get(this.widgetState.parent));
+          await widgets.get(card.id).moveToHolder(widgets.get(this.widgetState.parent));
       },
 
       async uploadCards() {

--- a/client/components/deckEditor.js
+++ b/client/components/deckEditor.js
@@ -34,7 +34,7 @@ export const deckEditor = {
         onClickDecrementAllCardTypes()
       },
 
-      async addCardCallback(imagePath, fileName) {
+      async _addCardCallback(imagePath, fileName) {
         let value = {
           "image": imagePath,
         }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -26,7 +26,7 @@ const jeCommands = [
     id: 'je_toggleBoolean',
     name: 'toggle boolean',
     context: '.*"(true|false)"',
-    call: function() {
+    call: async function() {
       jeInsert(jeContext.slice(1), jeContext[jeContext.length-2], jeContext[jeContext.length-1]=='"false"');
     }
   },
@@ -34,7 +34,7 @@ const jeCommands = [
     id: 'je_openWidgetById',
     name: 'open widget by ID',
     context: '.*"([^"]+)"',
-    call: function() {
+    call: async function() {
       const m = jeContext.join('').match(/"([^"]+)"/);
       jeSelectWidget(widgets.get(m[1]));
     },
@@ -47,7 +47,7 @@ const jeCommands = [
     id: 'je_uploadAsset',
     name: 'upload a different asset',
     context: '.*"(/assets/[0-9_-]+)"|^basic ↦ faces ↦ [0-9]+ ↦ image|^deck ↦ cardTypes ↦ .*? ↦ image',
-    call: function() {
+    call: async function() {
       uploadAsset().then(a=> {
         if(a) {
           jeInsert(null, jeGetLastKey(), a);
@@ -60,7 +60,7 @@ const jeCommands = [
     id: 'je_cardTypeTemplate',
     name: 'card type template',
     context: '^deck ↦ cardTypes',
-    call: function() {
+    call: async function() {
       const cardType = {};
       const cssVariables = {};
       for(const face of jeStateNow.faceTemplates) {
@@ -102,7 +102,7 @@ const jeCommands = [
     id: 'je_faceTemplate',
     name: 'face template',
     context: '^deck ↦ faceTemplates',
-    call: function() {
+    call: async function() {
       jeStateNow.faceTemplates.push({
         objects: '###SELECT ME###'
       });
@@ -113,7 +113,7 @@ const jeCommands = [
     id: 'je_imageTemplate',
     name: 'image template',
     context: '^deck ↦ faceTemplates ↦ [0-9]+ ↦ objects',
-    call: function() {
+    call: async function() {
       jeStateNow.faceTemplates[+jeContext[2]].objects.push({
         type: 'image',
         x: 0,
@@ -131,7 +131,7 @@ const jeCommands = [
     id: 'je_textTemplate',
     name: 'text template',
     context: '^deck ↦ faceTemplates ↦ [0-9]+ ↦ objects',
-    call: function() {
+    call: async function() {
       jeStateNow.faceTemplates[+jeContext[2]].objects.push({
         type: 'text',
         x: 0,
@@ -150,7 +150,7 @@ const jeCommands = [
     name: 'css',
     context: '^deck ↦ faceTemplates ↦ [0-9]+ ↦ objects ↦ [0-9]+',
     show: _=>!jeStateNow.faceTemplates[+jeContext[2]].objects[+jeContext[4]].css,
-    call: function() {
+    call: async function() {
       jeStateNow.faceTemplates[+jeContext[2]].objects[+jeContext[4]].css = '###SELECT ME###';
       jeSetAndSelect('');
     }
@@ -160,7 +160,7 @@ const jeCommands = [
     name: 'rotation',
     context: '^deck ↦ faceTemplates ↦ [0-9]+ ↦ objects ↦ [0-9]+',
     show: _=>!jeStateNow.faceTemplates[+jeContext[2]].objects[+jeContext[4]].rotation,
-    call: function() {
+    call: async function() {
       jeStateNow.faceTemplates[+jeContext[2]].objects[+jeContext[4]].rotation = '###SELECT ME###';
       jeSetAndSelect(0);
     }
@@ -169,7 +169,7 @@ const jeCommands = [
     id: 'je_toggleValueType',
     name: _=>jeStateNow.faceTemplates[+jeContext[2]].objects[+jeContext[4]].valueType == 'dynamic' ? 'static' : 'dynamic',
     context: '^deck ↦ faceTemplates ↦ [0-9]+ ↦ objects ↦ [0-9]+',
-    call: function() {
+    call: async function() {
       const o = jeStateNow.faceTemplates[+jeContext[2]].objects[+jeContext[4]];
       const d = o.valueType == 'dynamic';
       const v = o.value;
@@ -182,7 +182,7 @@ const jeCommands = [
     id: 'je_toggleZoom',
     name: '🔍 toggle zoom out',
     forceKey: 'Z',
-    call: function() {
+    call: async function() {
       jeZoomOut = !jeZoomOut;
       if(jeZoomOut) {
         $('body').classList.add('jeZoomOut');
@@ -196,7 +196,7 @@ const jeCommands = [
     id: 'je_copyState',
     name: '📋 copy state from another room/server',
     forceKey: 'C',
-    call: function() {
+    call: async function() {
       const sourceURL = (prompt('Please enter the room URL:') || '').replace(/\/[^\/]+$/, a=>`/state${a}`);
       const targetURL = location.href.replace(/\/[^\/]+$/, a=>`/state${a}`);
       fetch(sourceURL).then(r=>r.text()).then(t=>{
@@ -212,7 +212,7 @@ const jeCommands = [
     id: 'je_callMacro',
     name: _=>jeMode == 'macro' ? '▶️ call' : '🎬 macro',
     forceKey: 'M',
-    call: function() {
+    call: async function() {
       if(jeMode != 'macro') {
         jeWidget = null;
         jeMode = 'macro';
@@ -247,7 +247,7 @@ const jeCommands = [
     id: 'je_showWidget',
     name: '👁 show this widget below',
     forceKey: 'S',
-    call: function() {
+    call: async function() {
       if(jeWidget != undefined)
         jeSecondaryWidget = (jeWidget != undefined && jeSecondaryWidget == null || jeStateNow.id != JSON.parse(jeSecondaryWidget).id) ? jeWidget && JSON.stringify(jeWidget.state, null, '  ') : null;
       else
@@ -259,7 +259,7 @@ const jeCommands = [
     id: 'je_tree',
     name: '🔝 tree',
     forceKey: 'T',
-    call: function() {
+    call: async function() {
       jeDisplayTree();
     }
   },
@@ -267,7 +267,7 @@ const jeCommands = [
     id: 'je_removeProperty',
     name: _=>`remove property ${jeContext && jeContext[jeContext.length-1]}`,
     context: ' ↦ (?=[^"]+$)',
-    call: function() {
+    call: async function() {
       let pointer = jeGetValue(jeContext.slice(0, -1));
       if(Array.isArray(pointer))
         pointer.splice(jeContext[jeContext.length-1], 1);
@@ -287,7 +287,7 @@ const jeCommands = [
     id: 'je_addNewWidget',
     name: '➕ add new widget',
     forceKey: 'A',
-    call: function() {
+    call: async function() {
       const toAdd = {};
       addWidgetLocal(toAdd);
       jeSelectWidget(widgets.get(toAdd.id));
@@ -300,7 +300,7 @@ const jeCommands = [
     name: '✨ duplicate widget',
     forceKey: 'D',
     show: _=>jeStateNow,
-    call: function() {
+    call: async function() {
       let currentWidget = JSON.parse(JSON.stringify(jeWidget.state))
       currentWidget.id = null;
       addWidgetLocal(currentWidget);
@@ -326,7 +326,7 @@ const jeCommands = [
     id: 'je_editMode',
     name: '📝 edit mode',
     forceKey: 'F',
-    call: function() {
+    call: async function() {
       if(edit)
         $('body').classList.remove('edit');
       else
@@ -340,7 +340,7 @@ const jeCommands = [
     forceKey: 'ArrowDown',
     context: '^card',
     show: _=>widgets.has(jeStateNow.deck),
-    call: function() {
+    call: async function() {
       jeSelectWidget(widgets.get(jeStateNow.deck));
     }
   },
@@ -349,7 +349,7 @@ const jeCommands = [
     name: '🔼 open parent',
     forceKey: 'ArrowUp',
     show: _=>jeStateNow && widgets.has(jeStateNow.parent),
-    call: function() {
+    call: async function() {
       jeSelectWidget(widgets.get(jeStateNow.parent));
     }
   },
@@ -369,7 +369,7 @@ const jeCommands = [
 ];
 
 function jeRoutineCall(callback) {
-  return function() {
+  return async function() {
     let routineIndex = -1;
     for(let i=jeContext.length-1; i>=0; --i) {
       if(String(jeContext[i]).match(/Routine$/)) {
@@ -478,7 +478,7 @@ function jeAddCSScommands() {
       id: 'css_' + css,
       name: css,
       context: '^.* ↦ (css|[a-z]+CSS)',
-      call: function() {
+      call: async function() {
         jePasteText(css + '; ', true);
       },
       show: function() {
@@ -494,7 +494,7 @@ function jeAddEnumCommands(context, values) {
       id: 'enum_' + String(v),
       name: String(v),
       context: context,
-      call: function() {
+      call: async function() {
         jeInsert(null, jeGetLastKey(), v);
       },
       show: function() {
@@ -511,7 +511,7 @@ function jeAddFaceCommand(key, description, value) {
     name: key+description,
     context: '^deck ↦ faceTemplates ↦ [0-9]+',
     show: _=>!jeStateNow.faceTemplates[+jeContext[2]][key],
-    call: function() {
+    call: async function() {
       jeStateNow.faceTemplates[+jeContext[2]][key] = '###SELECT ME###';
       jeSetAndSelect(value);
     }
@@ -525,7 +525,7 @@ function jeAddNumberCommand(name, key, callback) {
     forceKey: key,
     context: '.*',
     show: _=>jeGetValue()&&typeof jeGetValue()[jeGetLastKey()] == 'number',
-    call: function() {
+    call: async function() {
       const newValue = callback(jeGetValue()[jeGetLastKey()]);
       jeGetValue()[jeGetLastKey()] = '###SELECT ME###';
       jeSetAndSelect(newValue);
@@ -545,7 +545,7 @@ function jeAddWidgetPropertyCommand(defaults, property) {
     id: 'widget_' + property,
     name: property,
     context: `^${defaults.typeClasses.replace('widget ', '')}`,
-    call: function() {
+    call: async function() {
       jeInsert([], property, property == 'clickRoutine' ? [] : defaults[property]);
     },
     show: function() {
@@ -957,7 +957,7 @@ function jeShowCommands() {
 }
 
 const clickButton = async function(event) {
-  jeCommands.find(o => o.id == event.currentTarget.id).call();
+  await jeCommands.find(o => o.id == event.currentTarget.id).call();
   if (jeContext != 'macro') {
     jeGetContext();
     if(jeWidget && !jeJSONerror)
@@ -990,13 +990,13 @@ window.addEventListener('mousemove', function(e) {
   }
 });
 
-window.addEventListener('mouseup', function(e) {
+window.addEventListener('mouseup', async function(e) {
   if(!jeEnabled)
     return;
   if(e.target == $('#jeText') && jeContext != 'macro') {
     jeGetContext();
     if (jeContext[0] == 'Tree' && jeContext[1] != undefined) {
-      jeCommands.find(o => o.id == 'je_openWidgetById').call();
+      await jeCommands.find(o => o.id == 'je_openWidgetById').call();
       jeGetContext();
     }
   }
@@ -1010,7 +1010,7 @@ onLoad(function() {
   });
 });
 
-window.addEventListener('keydown', function(e) {
+window.addEventListener('keydown', async function(e) {
   if(e.key == 'Control')
     jeState.ctrl = true;
   if(e.key == 'Shift')
@@ -1054,7 +1054,7 @@ window.addEventListener('keydown', function(e) {
           e.preventDefault();
           try {
             jeCommandError = null;
-            command.call();
+            await command.call();
           } catch(e) {
             jeCommandError = e;
           }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -575,9 +575,14 @@ async function jeApplyChanges() {
 }
 
 function jeApplyDelta(delta) {
-  for(const field of [ 'id', 'deck' ])
-    if(!jeDeltaIsOurs && jeStateNow && jeStateNow[field] && delta.s[jeStateNow[field]] !== undefined)
-      jeSelectWidget(widgets.get(jeStateNow.id), document.activeElement !== $('#jeText'));
+  for(const field of [ 'id', 'deck' ]) {
+    if(!jeDeltaIsOurs && jeStateNow && jeStateNow[field] && delta.s[jeStateNow[field]] !== undefined) {
+      if(delta.s[jeStateNow[field]] === null)
+        jeDisplayTree();
+      else
+        jeSelectWidget(widgets.get(jeStateNow.id), document.activeElement !== $('#jeText'));
+    }
+  }
   if(jeMode == 'tree')
     jeDisplayTree();
 }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -570,10 +570,9 @@ async function jeApplyChanges() {
 }
 
 function jeApplyDelta(delta) {
-  if(!jeDeltaIsOurs && jeStateNow && jeStateNow.id && delta.s[jeStateNow.id] !== undefined)
-    jeSelectWidget(widgets.get(jeStateNow.id));
-  if(!jeDeltaIsOurs && jeStateNow && jeStateNow.deck && delta.s[jeStateNow.deck] !== undefined)
-    jeSelectWidget(widgets.get(jeStateNow.id));
+  for(const field of [ 'id', 'deck' ])
+    if(!jeDeltaIsOurs && jeStateNow && jeStateNow[field] && delta.s[jeStateNow[field]] !== undefined)
+      jeSelectWidget(widgets.get(jeStateNow.id), document.activeElement !== $('#jeText'));
   if(jeMode == 'tree')
     jeDisplayTree();
 }
@@ -604,11 +603,11 @@ async function jeClick(widget) {
   }
 }
 
-function jeSelectWidget(widget) {
+function jeSelectWidget(widget, dontFocus) {
   jeMode = 'widget';
   jeWidget = widget;
   jeStateNow = widget.state;
-  jeSet(jeStateBefore = jePreProcessText(JSON.stringify(jePreProcessObject(widget.state), null, '  ')));
+  jeSet(jeStateBefore = jePreProcessText(JSON.stringify(jePreProcessObject(widget.state), null, '  ')), dontFocus);
 }
 
 function jeColorize() {
@@ -854,13 +853,14 @@ function jeSelect(start, end) {
   }
 }
 
-function jeSet(text) {
+function jeSet(text, dontFocus) {
   try {
     $('#jeText').textContent = jePreProcessText(JSON.stringify(jePreProcessObject(JSON.parse(text)), null, '  '));
   } catch(e) {
     $('#jeText').textContent = text;
   }
-  $('#jeText').focus();
+  if(!dontFocus)
+    $('#jeText').focus();
   jeColorize();
 }
 

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -551,7 +551,7 @@ function jeAddWidgetPropertyCommand(defaults, property) {
     name: property,
     context: `^${defaults.typeClasses.replace('widget ', '')}`,
     call: async function() {
-      jeInsert([], property, property == 'clickRoutine' ? [] : defaults[property]);
+      jeInsert([], property, property.match(/Routine$/) ? [] : defaults[property]);
     },
     show: function() {
       return jeStateNow[property] === undefined;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -355,7 +355,7 @@ const jeCommands = [
   },
   {
     id: 'je_applyVariables',
-    name: jeRoutineCall(routineIndex=>`change ${jeContext[routineIndex+3]} to applyVariables`),
+    name: jeRoutineCall(routineIndex=>`change ${jeContext[routineIndex+3]} to applyVariables`, true),
     context: '^.*\\) ↦ [a-zA-Z]+',
     call: jeRoutineCall(function(routineIndex, routine, operationIndex, operation) {
       delete operation[jeContext[routineIndex+3]];
@@ -364,12 +364,12 @@ const jeCommands = [
       operation.applyVariables.push({ parameter: jeContext[routineIndex+3], variable: '###SELECT ME###' });
       jeSetAndSelect('');
     }),
-    show: jeRoutineCall(routineIndex=>jeContext[routineIndex+3] !== undefined && jeContext[routineIndex+3] != 'applyVariables')
+    show: jeRoutineCall(routineIndex=>jeContext[routineIndex+3] !== undefined && jeContext[routineIndex+3] != 'applyVariables', true)
   }
 ];
 
-function jeRoutineCall(callback) {
-  return async function() {
+function jeRoutineCall(callback, synchronous) {
+  const f = function() {
     let routineIndex = -1;
     for(let i=jeContext.length-1; i>=0; --i) {
       if(String(jeContext[i]).match(/Routine$/)) {
@@ -384,6 +384,11 @@ function jeRoutineCall(callback) {
     else
       return callback(routineIndex, routine, null, null);
   };
+
+  if(synchronous)
+    return f;
+  else
+    return async _=>f();
 }
 
 function jeAddRoutineOperationCommands(command, defaults) {
@@ -398,7 +403,7 @@ function jeAddRoutineOperationCommands(command, defaults) {
         routine.splice(operationIndex+1, 0, {func: '###SELECT ME###'});
       jeSetAndSelect(command);
     }),
-    show: jeRoutineCall((_, routine)=>Array.isArray(routine))
+    show: jeRoutineCall((_, routine)=>Array.isArray(routine), true)
   });
 
   defaults.skip = false;
@@ -412,7 +417,7 @@ function jeAddRoutineOperationCommands(command, defaults) {
       }),
       show: jeRoutineCall(function(routineIndex, routine, operationIndex, operation) {
         return operation && operation[property] === undefined;
-      })
+      }, true)
     });
   }
 }

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -17,14 +17,14 @@ function getValidDropTargets(widget) {
   const targets = [];
   for(const [ _, t ] of dropTargets) {
     // if the holder has a drop limit and it's reached, skip the holder
-    if(t.p('dropLimit') > -1 && t.p('dropLimit') <= t.children().length)
+    if(t.get('dropLimit') > -1 && t.get('dropLimit') <= t.children().length)
       // don't skip it if the dragged widget is already its child
       if(t.children().indexOf(widget) == -1)
         continue;
 
     let isValid = true;
-    for(const key in t.p('dropTarget')) {
-      if(widget.p(key) != t.p('dropTarget')[key] && (key != 'type' || widget.p(key) != 'deck' || t.p('dropTarget')[key] != 'card')) {
+    for(const key in t.get('dropTarget')) {
+      if(widget.get(key) != t.get('dropTarget')[key] && (key != 'type' || widget.get(key) != 'deck' || t.get('dropTarget')[key] != 'card')) {
         isValid = false;
         break;
       }
@@ -37,8 +37,8 @@ function getValidDropTargets(widget) {
         break;
       }
 
-      if(tt.p('parent'))
-        tt = widgets.get(tt.p('parent'));
+      if(tt.get('parent'))
+        tt = widgets.get(tt.get('parent'));
       else
         break;
     }

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -46,7 +46,7 @@ async function inputHandler(name, e) {
       let movable = false;
       moveTarget = target;
       while (moveTarget && !movable) {
-        movable = widgets.get(moveTarget.id).p(edit ? 'movableInEdit' : 'movable');
+        movable = widgets.get(moveTarget.id).get(edit ? 'movableInEdit' : 'movable');
         if (!movable) {
           do {
             moveTarget = moveTarget.parentNode;
@@ -59,7 +59,7 @@ async function inputHandler(name, e) {
       const timeSinceStart = +new Date() - ms.start;
       const pixelsMoved = ms.coords ? Math.abs(ms.coords[0] - ms.downCoords[0]) + Math.abs(ms.coords[1] - ms.downCoords[1]) : 0;
       if(ms.status != 'initial' && moveTarget)
-        ms.widget.moveEnd();
+        await ms.widget.moveEnd();
       if(ms.status == 'initial' || timeSinceStart < 250 && pixelsMoved < 10) {
         if(typeof jeEnabled == 'boolean' && jeEnabled)
           await jeClick(widgets.get(target.id));
@@ -81,13 +81,13 @@ async function inputHandler(name, e) {
           widget: widgets.get(moveTarget ? moveTarget.id : target.id)
         });
         if(moveTarget)
-          mouseStatus[target.id].widget.moveStart();
+          await mouseStatus[target.id].widget.moveStart();
       }
       mouseStatus[target.id].coords = coords;
       const x = Math.floor((coords[0] - roomRectangle.left - mouseStatus[target.id].offset[0]) / scale);
       const y = Math.floor((coords[1] - roomRectangle.top  - mouseStatus[target.id].offset[1]) / scale);
       if(moveTarget)
-        mouseStatus[target.id].widget.move(x, y);
+        await mouseStatus[target.id].widget.move(x, y);
       batchEnd();
     }
   }

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -64,7 +64,7 @@ export function addWidget(widget, instance) {
     removeWidget(widget.id);
     return;
   }
-  if(w.p('dropTarget'))
+  if(w.get('dropTarget'))
     dropTargets.set(widget.id, w);
 
   if(widget.type == 'deck')

--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -58,6 +58,8 @@ export class StateManaged {
       this.state[property] = value;
     sendPropertyUpdate(this.get('id'), property, value);
     await this.onPropertyChange(property, oldValue, value);
+    if(Array.isArray(this.get('changeRoutine')))
+      await this.evaluateRoutine('changeRoutine', { property, oldValue, value }, {});
   }
 
   async setPosition(x, y, z) {

--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -24,7 +24,7 @@ export class StateManaged {
     this.applyDeltaToDOM(deltaForDOM);
 
     if(delta.z)
-      updateMaxZ(this.p('layer'), delta.z);
+      updateMaxZ(this.get('layer'), delta.z);
   }
 
   applyInitialDelta(delta) {
@@ -35,41 +35,34 @@ export class StateManaged {
     return this.defaults[key];
   }
 
-  p(property, value) {
-    if(value === undefined)
-      return this.propertyGet(property);
-    else
-      this.propertySet(property, value);
-  }
-
-  propertyGet(property) {
+  get(property) {
     if(this.state[property] !== undefined)
       return [ 'x', 'y', 'width', 'height', 'z', 'layer' ].indexOf(property) != -1 ? +this.state[property] : this.state[property];
     else
       return this.getDefaultValue(property);
   }
 
-  propertySet(property, value) {
+  async set(property, value) {
     if(value === this.defaults[property])
       value = null;
     if(this.state[property] === value || this.state[property] === undefined && value === null)
       return;
 
     if(property == 'z')
-      updateMaxZ(this.p('layer'), value);
+      updateMaxZ(this.get('layer'), value);
 
     const oldValue = this.state[property];
     if(value === null)
       delete this.state[property];
     else
       this.state[property] = value;
-    sendPropertyUpdate(this.p('id'), property, value);
-    this.onPropertyChange(property, oldValue, value);
+    sendPropertyUpdate(this.get('id'), property, value);
+    await this.onPropertyChange(property, oldValue, value);
   }
 
-  setPosition(x, y, z) {
-    this.p('x', x);
-    this.p('y', y);
-    this.p('z', z);
+  async setPosition(x, y, z) {
+    await this.set('x', x);
+    await this.set('y', y);
+    await this.set('z', z);
   }
 }

--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -58,6 +58,8 @@ export class StateManaged {
       this.state[property] = value;
     sendPropertyUpdate(this.get('id'), property, value);
     await this.onPropertyChange(property, oldValue, value);
+    if(Array.isArray(this.get(`${property}ChangeRoutine`)))
+      await this.evaluateRoutine(`${property}ChangeRoutine`, { oldValue, value }, {});
     if(Array.isArray(this.get('changeRoutine')))
       await this.evaluateRoutine('changeRoutine', { property, oldValue, value }, {});
   }

--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -23,14 +23,14 @@ class BasicWidget extends Widget {
   applyDeltaToDOM(delta) {
     super.applyDeltaToDOM(delta);
     if(delta.activeFace !== undefined || delta.faces !== undefined) {
-      let face = this.p('faces')[this.p('activeFace')];
+      let face = this.get('faces')[this.get('activeFace')];
       if(face !== undefined)
         this.applyDelta(face);
     }
     if(delta.text !== undefined)
       this.domElement.textContent = delta.text;
 
-    for(const property of Object.values(this.p('svgReplaces') || {}))
+    for(const property of Object.values(this.get('svgReplaces') || {}))
       if(delta[property] !== undefined)
         this.domElement.style.cssText = this.css();
   }
@@ -38,7 +38,7 @@ class BasicWidget extends Widget {
   classes() {
     let className = super.classes();
 
-    if(this.p('image'))
+    if(this.get('image'))
       className += ' hasImage';
 
     return className;
@@ -52,15 +52,15 @@ class BasicWidget extends Widget {
 
   async click() {
     if(!await super.click())
-      this.flip();
+      await this.flip();
   }
 
   css() {
     let css = super.css();
 
-    if(this.p('color'))
-      css += '; --color:' + this.p('color');
-    if(this.p('image'))
+    if(this.get('color'))
+      css += '; --color:' + this.get('color');
+    if(this.get('image'))
       css += '; background-image: url("' + this.getImage() + '")';
 
     return css;
@@ -72,34 +72,34 @@ class BasicWidget extends Widget {
     return p;
   }
 
-  flip(setFlip, faceCycle) {
+  async flip(setFlip, faceCycle) {
     if(setFlip !== undefined && setFlip !== null)
-      this.p('activeFace', setFlip);
+      await this.set('activeFace', setFlip);
     else {
-      const fC = (faceCycle !== undefined && faceCycle !== null) ? faceCycle : this.p('faceCycle');
+      const fC = (faceCycle !== undefined && faceCycle !== null) ? faceCycle : this.get('faceCycle');
       if (fC == 'backward')
-        this.p('activeFace', this.p('activeFace') == 0 ? this.p('faces').length-1 : this.p('activeFace') -1);
+        await this.set('activeFace', this.get('activeFace') == 0 ? this.get('faces').length-1 : this.get('activeFace') -1);
       else
-        this.p('activeFace', Math.floor(this.p('activeFace') + (fC == 'random' ? Math.random()*99999 : 1)) % this.p('faces').length);
+        await this.set('activeFace', Math.floor(this.get('activeFace') + (fC == 'random' ? Math.random()*99999 : 1)) % this.get('faces').length);
     }
   }
 
   getDefaultValue(property) {
-    if(property == 'faces' || property == 'activeFace' || !this.p('faces') || !this.p('faces')[this.p('activeFace')])
+    if(property == 'faces' || property == 'activeFace' || !this.get('faces') || !this.get('faces')[this.get('activeFace')])
       return super.getDefaultValue(property);
-    const d = this.p('faces')[this.p('activeFace')][property];
+    const d = this.get('faces')[this.get('activeFace')][property];
     if(d !== undefined)
       return d;
     return super.getDefaultValue(property);
   }
 
   getImage() {
-    if(!Object.keys(this.p('svgReplaces')).length)
-      return this.p('image');
+    if(!Object.keys(this.get('svgReplaces')).length)
+      return this.get('image');
 
     const replaces = {};
-    for(const key in this.p('svgReplaces'))
-      replaces[key] = this.p(this.p('svgReplaces')[key]);
-    return getSVG(this.p('image'), replaces, _=>this.domElement.style.cssText = this.css());
+    for(const key in this.get('svgReplaces'))
+      replaces[key] = this.get(this.get('svgReplaces')[key]);
+    return getSVG(this.get('image'), replaces, _=>this.domElement.style.cssText = this.css());
   }
 }

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -26,7 +26,7 @@ export class Button extends Widget {
     if(delta.text !== undefined)
       this.domElement.textContent = delta.text;
 
-    for(const property of Object.values(this.p('svgReplaces') || {}))
+    for(const property of Object.values(this.get('svgReplaces') || {}))
       if(delta[property] !== undefined)
         this.domElement.style.cssText = this.css();
   }
@@ -34,9 +34,9 @@ export class Button extends Widget {
   css() {
     let css = super.css();
 
-    if(this.p('color'))
-      css += '; --color:' + this.p('color');
-    if(this.p('image'))
+    if(this.get('color'))
+      css += '; --color:' + this.get('color');
+    if(this.get('image'))
       css += '; background-image: url("' + this.getImage() + '")';
 
     return css;
@@ -49,13 +49,13 @@ export class Button extends Widget {
   }
 
   getImage() {
-    if(!Object.keys(this.p('svgReplaces')).length)
-      return this.p('image');
+    if(!Object.keys(this.get('svgReplaces')).length)
+      return this.get('image');
 
     const replaces = {};
-    for(const key in this.p('svgReplaces'))
-      replaces[key] = this.p(this.p('svgReplaces')[key]);
-    return getSVG(this.p('image'), replaces, _=>this.domElement.style.cssText = this.css());
+    for(const key in this.get('svgReplaces'))
+      replaces[key] = this.get(this.get('svgReplaces')[key]);
+    return getSVG(this.get('image'), replaces, _=>this.domElement.style.cssText = this.css());
   }
 }
 

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -27,7 +27,7 @@ class Card extends Widget {
       if(delta.deck) {
         this.deck = widgets.get(delta.deck);
         this.deck.addCard(this);
-        this.createFaces(this.deck.p('faceTemplates'));
+        this.createFaces(this.deck.get('faceTemplates'));
       } else {
         this.deck = null;
       }
@@ -35,7 +35,7 @@ class Card extends Widget {
 
     if(delta.cardType !== undefined && this.deck) {
       const applyForCardType = {};
-      for(const [ k, v ] of Object.entries(this.deck.p('cardTypes')[this.p('cardType')] || {}))
+      for(const [ k, v ] of Object.entries(this.deck.get('cardTypes')[this.get('cardType')] || {}))
         if(this.state[k] === undefined)
           applyForCardType[k] = v;
       this.applyDeltaToDOM(applyForCardType);
@@ -43,7 +43,7 @@ class Card extends Widget {
 
     if(delta.deck !== undefined || delta.activeFace !== undefined) {
       for(let i=0; i<this.domElement.children.length; ++i) {
-        if(i == this.p('activeFace'))
+        if(i == this.get('activeFace'))
           this.domElement.children[i].classList.add('active');
         else
           this.domElement.children[i].classList.remove('active');
@@ -65,14 +65,14 @@ class Card extends Widget {
       throw `card "${delta.id}" requires property cardType`;
     if(!(widgets.get(delta.deck) instanceof Deck))
       throw `card "${delta.id}" has "${delta.deck}" as a deck which is not a deck`;
-    if(!widgets.get(delta.deck).p('cardTypes')[delta.cardType])
+    if(!widgets.get(delta.deck).get('cardTypes')[delta.cardType])
       throw `card type "${delta.cardType}" not found in deck "${delta.deck}"`;
     super.applyInitialDelta(delta);
   }
 
   async click() {
     if(!await super.click())
-      this.flip();
+      await this.flip();
   }
 
   createFaces(faceTemplates) {
@@ -94,14 +94,14 @@ class Card extends Widget {
         css += object.rotation ? `; transform: rotate(${object.rotation}deg)` : '';
         objectDiv.style.cssText = css;
         const setValue = _=>{
-          let value = object.valueType == 'static' ? object.value : this.p(object.value);
+          let value = object.valueType == 'static' ? object.value : this.get(object.value);
           if(object.type == 'image') {
             if(value) {
               if(object.svgReplaces) {
                 const replaces = { ...object.svgReplaces };
                 for(const key in replaces)
-                  replaces[key] = this.p(replaces[key]);
-                value = getSVG(value, replaces, _=>this.applyDeltaToDOM({ deck:this.p('deck') }));
+                  replaces[key] = this.get(replaces[key]);
+                value = getSVG(value, replaces, _=>this.applyDeltaToDOM({ deck:this.get('deck') }));
               }
               objectDiv.style.backgroundImage = `url("${value}")`;
             }
@@ -135,21 +135,21 @@ class Card extends Widget {
     return p;
   }
 
-  flip(setFlip, faceCycle) {
+  async flip(setFlip, faceCycle) {
     if(setFlip !== undefined && setFlip !== null)
-      this.p('activeFace', setFlip);
+      await this.set('activeFace', setFlip);
     else {
-      const fC = (faceCycle !== undefined && faceCycle !== null) ? faceCycle : this.p('faceCycle');
+      const fC = (faceCycle !== undefined && faceCycle !== null) ? faceCycle : this.get('faceCycle');
       if (fC == 'backward')
-        this.p('activeFace', this.p('activeFace') == 0 ? this.deck.p('faceTemplates').length-1 : this.p('activeFace') -1);
+        await this.set('activeFace', this.get('activeFace') == 0 ? this.deck.get('faceTemplates').length-1 : this.get('activeFace') -1);
       else
-        this.p('activeFace', Math.floor(this.p('activeFace') + (fC == 'random' ? Math.random()*99999 : 1)) % this.deck.p('faceTemplates').length);
+        await this.set('activeFace', Math.floor(this.get('activeFace') + (fC == 'random' ? Math.random()*99999 : 1)) % this.deck.get('faceTemplates').length);
     }
   }
 
   getDefaultValue(property) {
     if(this.deck) {
-      const d = this.deck.cardPropertyGet(this.p('cardType'), property);
+      const d = this.deck.cardPropertyGet(this.get('cardType'), property);
       if(d !== undefined)
         return d;
     }

--- a/client/js/widgets/deck.js
+++ b/client/js/widgets/deck.js
@@ -16,7 +16,7 @@ class Deck extends Widget {
   }
 
   addCard(card) {
-    this.cards[card.p('id')] = card;
+    this.cards[card.get('id')] = card;
     ++this.domElement.textContent;
   }
 
@@ -24,18 +24,18 @@ class Deck extends Widget {
     super.applyDeltaToDOM(delta);
     if(delta.cardDefaults !== undefined || delta.cardTypes !== undefined || delta.faceTemplates !== undefined)
       for(const cardID in this.cards)
-        this.cards[cardID].applyDeltaToDOM({ deck: this.p('id') });
+        this.cards[cardID].applyDeltaToDOM({ deck: this.get('id') });
   }
 
   cardPropertyGet(cardType, property) {
-    if(this.p('cardTypes')[cardType][property] !== undefined)
-      return this.p('cardTypes')[cardType][property];
+    if(this.get('cardTypes')[cardType][property] !== undefined)
+      return this.get('cardTypes')[cardType][property];
 
-    return this.p('cardDefaults')[property];
+    return this.get('cardDefaults')[property];
   }
 
   removeCard(card) {
-    delete this.cards[card.p('id')];
+    delete this.cards[card.get('id')];
     --this.domElement.textContent;
   }
 }

--- a/client/js/widgets/holder.js
+++ b/client/js/widgets/holder.js
@@ -52,6 +52,8 @@ class Holder extends Widget {
           await w.set(property, this.get('onLeave')[property]);
     if(this.get('alignChildren') && (this.get('stackOffsetX') || this.get('stackOffsetY')))
       await this.receiveCard(null);
+    if(Array.isArray(this.get('leaveRoutine')))
+      await this.evaluateRoutine('leaveRoutine', {}, { child: [ card ] });
   }
 
   async onChildAdd(child, oldParentID) {

--- a/client/js/widgets/label.js
+++ b/client/js/widgets/label.js
@@ -24,7 +24,7 @@ export class Label extends Widget {
     super.applyDeltaToDOM(delta);
     if(delta.text !== undefined || delta.twoRowBottomAlign !== undefined) {
       this.input.value = delta.text;
-      if(this.p('twoRowBottomAlign')) {
+      if(this.get('twoRowBottomAlign')) {
         this.input.style.height = '20px';
         this.input.style.paddingTop = '';
         if(this.input.scrollHeight == 20)
@@ -32,7 +32,7 @@ export class Label extends Widget {
         else
           this.input.style.height = '40px';
       } else {
-        this.input.style.height = `${this.p('height')}px`;
+        this.input.style.height = `${this.get('height')}px`;
         this.input.style.paddingTop = 'unset';
       }
     }

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -31,12 +31,12 @@ class Pile extends Widget {
   applyDeltaToDOM(delta) {
     super.applyDeltaToDOM(delta);
     if(this.handle && (delta.width !== undefined || delta.height !== undefined)) {
-      if(this.p('width') < 50 || this.p('height') < 50)
+      if(this.get('width') < 50 || this.get('height') < 50)
         this.handle.classList.add('small');
       else
         this.handle.classList.remove('small');
     }
-    for(const e of [ [ 'x', 'right', 1600-this.p('width')-20 ], [ 'y', 'bottom', 20 ] ]) {
+    for(const e of [ [ 'x', 'right', 1600-this.get('width')-20 ], [ 'y', 'bottom', 20 ] ]) {
       if(this.handle && (delta[e[0]] !== undefined || delta.parent !== undefined)) {
         if(this.absoluteCoord(e[0]) < e[2])
           this.handle.classList.add(e[1]);
@@ -52,13 +52,13 @@ class Pile extends Widget {
     const flipButton = document.createElement('button');
     flipButton.textContent = 'Flip pile';
     let z=1;
-    flipButton.addEventListener('click', e=>{
+    flipButton.addEventListener('click', async e=>{
       batchStart();
-      this.children().forEach(c=>{
-        c.p('z', z++);
+      for(const c of this.children()) {
+        await c.set('z', z++);
         if(c.flip)
-          c.flip();
-      });
+          await c.flip();
+      };
       showOverlay();
       batchEnd();
     });
@@ -66,9 +66,10 @@ class Pile extends Widget {
 
     const shuffleButton = document.createElement('button');
     shuffleButton.textContent = 'Shuffle pile';
-    shuffleButton.addEventListener('click', e=>{
+    shuffleButton.addEventListener('click', async e=>{
       batchStart();
-      this.children().forEach(c=>c.p('z', Math.floor(Math.random()*10000)));
+      for(const c of this.children())
+        await c.set('z', Math.floor(Math.random()*10000));
       showOverlay();
       batchEnd();
     });
@@ -89,16 +90,16 @@ class Pile extends Widget {
     countDiv.prepend(splitLabel);
     const splitButton = document.createElement('button');
     splitButton.textContent = 'Split pile';
-    splitButton.addEventListener('click', e=>{
+    splitButton.addEventListener('click', async e=>{
       batchStart();
-      this.children().reverse().slice(childCount-splitInput.value).forEach(c=>{
-        c.p('parent', null);
-        c.p('x', this.absoluteCoord('x'));
+      for(const c of this.children().reverse().slice(childCount-splitInput.value)) {
+        await c.set('parent', null);
+        await c.set('x', this.absoluteCoord('x'));
         const y = this.absoluteCoord('y');
-        c.p('y', y < 100 ? y+60 : y-60);
-        c.updatePiles();
-        c.bringToFront();
-      });
+        await c.set('y', y < 100 ? y+60 : y-60);
+        await c.updatePiles();
+        await c.bringToFront();
+      };
       showOverlay();
       batchEnd();
     });
@@ -107,26 +108,26 @@ class Pile extends Widget {
     showOverlay('pileOverlay');
   }
 
-  onChildRemove(child) {
-    super.onChildRemove(child);
+  async onChildRemove(child) {
+    await super.onChildRemove(child);
     if(this.children().length == 1) {
       const c = this.children()[0];
-      const p = this.p('parent');
-      const x = this.p('x');
-      const y = this.p('y');
+      const p = this.get('parent');
+      const x = this.get('x');
+      const y = this.get('y');
 
       // this is added in removeWidgetLocal aswell but needed before the set parent so that the child isn't added to the same pile again during updatePiles
       this.isBeingRemoved = true;
 
-      c.p('x', c.p('x') + x);
-      c.p('y', c.p('y') + y);
-      c.p('parent', p);
+      await c.set('x', c.get('x') + x);
+      await c.set('y', c.get('y') + y);
+      await c.set('parent', p);
 
-      removeWidgetLocal(this.p('id'));
+      await removeWidgetLocal(this.get('id'));
     }
 
-    if(this.parent && this.parent.p('type') == 'holder')
-      this.parent.dispenseCard(child);
+    if(this.parent && this.parent.get('type') == 'holder')
+      await this.parent.dispenseCard(child);
   }
 
   supportsPiles() {

--- a/client/js/widgets/spinner.js
+++ b/client/js/widgets/spinner.js
@@ -30,7 +30,7 @@ class Spinner extends Widget {
       if(this.timeout)
         clearTimeout(this.timeout);
       this.timeout = setTimeout(_=>{
-        this.value.textContent = this.p('value');
+        this.value.textContent = this.get('value');
         this.value.classList.remove('hidden')
       }, 1300);
     }
@@ -38,10 +38,10 @@ class Spinner extends Widget {
 
   async click() {
     if(!await super.click()) {
-      const angle = this.p('angle') + Math.floor((2+Math.random())*360);
-      const o = this.p('options');
-      this.p('angle', angle);
-      this.p('value', o[Math.floor(angle/(360/o.length))%o.length]);
+      const angle = this.get('angle') + Math.floor((2+Math.random())*360);
+      const o = this.get('options');
+      await this.set('angle', angle);
+      await this.set('value', o[Math.floor(angle/(360/o.length))%o.length]);
     }
   }
 
@@ -50,10 +50,10 @@ class Spinner extends Widget {
 
     const bg = document.createElementNS(ns, 'svg');
     bg.setAttribute('class', 'background');
-    bg.setAttribute('style', this.p('backgroundCSS'));
+    bg.setAttribute('style', this.get('backgroundCSS'));
     bg.setAttribute('viewBox', '0 0 100 100');
 
-    const options = this.p('options');
+    const options = this.get('options');
     for(const i in options) {
       const line = document.createElementNS(ns, 'line');
       line.setAttribute('x1', 50);
@@ -78,19 +78,19 @@ class Spinner extends Widget {
 
     this.spinner = document.createElement('div');
     this.spinner.setAttribute('class', 'spinner');
-    this.spinner.setAttribute('style', this.p('spinnerCSS'));
+    this.spinner.setAttribute('style', this.get('spinnerCSS'));
     this.domElement.appendChild(this.spinner);
 
     this.value = document.createElement('div');
     this.value.setAttribute('class', 'value');
-    this.value.setAttribute('style', this.p('valueCSS'));
-    this.value.textContent = this.p('value');
+    this.value.setAttribute('style', this.get('valueCSS'));
+    this.value.textContent = this.get('value');
     this.domElement.appendChild(this.value);
   }
 
   css() {
     let css = super.css();
-    css += `; font-size:${Math.min(this.p('width'), this.p('height')) * 0.4}px`;
+    css += `; font-size:${Math.min(this.get('width'), this.get('height')) * 0.4}px`;
     return css;
   }
 }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -42,6 +42,9 @@ export class Widget extends StateManaged {
       inheritChildZ: false,
 
       clickRoutine: null,
+      changeRoutine: null,
+      enterRoutine: null,
+      leaveRoutine: null,
       debug: false
     });
 
@@ -51,7 +54,7 @@ export class Widget extends StateManaged {
   }
 
   absoluteCoord(coord) {
-    return this.p(coord) + (this.p('parent') ? widgets.get(this.p('parent')).absoluteCoord(coord) : 0);
+    return this.get(coord) + (this.get('parent') ? widgets.get(this.get('parent')).absoluteCoord(coord) : 0);
   }
 
   applyChildAdd(child) {
@@ -113,15 +116,15 @@ export class Widget extends StateManaged {
       }
     }
 
-    if($('#enlarged').dataset.id == this.p('id') && !$('#enlarged').className.match(/hidden/))
+    if($('#enlarged').dataset.id == this.get('id') && !$('#enlarged').className.match(/hidden/))
       this.showEnlarged();
   }
 
   applyRemove() {
-    if(this.p('parent') && widgets.has(this.p('parent')))
-      widgets.get(this.p('parent')).applyChildRemove(this);
-    if(this.p('deck') && widgets.has(this.p('deck')))
-      widgets.get(this.p('deck')).removeCard(this);
+    if(this.get('parent') && widgets.has(this.get('parent')))
+      widgets.get(this.get('parent')).applyChildRemove(this);
+    if(this.get('deck') && widgets.has(this.get('deck')))
+      widgets.get(this.get('deck')).removeCard(this);
     removeFromDOM(this.domElement);
   }
 
@@ -138,7 +141,7 @@ export class Widget extends StateManaged {
           let w = this;
           if (v.widget)
             w = this.isValidID(v.widget, problems) ? widgets.get(v.widget) : this;
-          field[v.parameter] = (w.p(v.property) === undefined) ? null : w.p(v.property);
+          field[v.parameter] = (w.get(v.property) === undefined) ? null : w.get(v.property);
         } else {
           problems.push('Entry in parameter applyVariables does not contain "parameter" together with "variable", "property", or "template".');
         }
@@ -149,49 +152,49 @@ export class Widget extends StateManaged {
   }
 
   applyZ(force) {
-    if(this.p('inheritChildZ') || force) {
+    if(this.get('inheritChildZ') || force) {
       this.domElement.style.zIndex = this.calculateZ();
-      if(this.p('parent') && this.p('inheritChildZ'))
-        widgets.get(this.p('parent')).applyZ();
+      if(this.get('parent') && this.get('inheritChildZ'))
+        widgets.get(this.get('parent')).applyZ();
     }
   }
 
-  bringToFront() {
-    this.p('z', getMaxZ(this.p('layer')) + 1);
+  async bringToFront() {
+    await this.set('z', getMaxZ(this.get('layer')) + 1);
   }
 
   calculateZ() {
-    let z = ((this.p('layer') + 10) * 100000) + this.p('z');
-    if(this.p('inheritChildZ'))
+    let z = ((this.get('layer') + 10) * 100000) + this.get('z');
+    if(this.get('inheritChildZ'))
       for(const child of this.childrenOwned())
         z = Math.max(z, child.calculateZ());
     return z;
   }
 
   children() {
-    return this.childArray.sort((a,b)=>b.p('z')-a.p('z'));
+    return this.childArray.sort((a,b)=>b.get('z')-a.get('z'));
   }
 
   childrenOwned() {
-    return this.children().filter(c=>!c.p('owner') || c.p('owner')==playerName);
+    return this.children().filter(c=>!c.get('owner') || c.get('owner')==playerName);
   }
 
-  checkParent(forceDetach) {
+  async checkParent(forceDetach) {
     if(this.currentParent && (forceDetach || !overlap(this.domElement, this.currentParent.domElement))) {
-      this.p('parent', null);
-      this.p('owner',  null);
+      await this.set('parent', null);
+      await this.set('owner',  null);
       if(this.currentParent.dispenseCard)
-        this.currentParent.dispenseCard(this);
+        await this.currentParent.dispenseCard(this);
       delete this.currentParent;
     }
   }
 
   classes() {
-    let className = this.p('typeClasses') + ' ' + this.p('classes');
+    let className = this.get('typeClasses') + ' ' + this.get('classes');
 
-    if(Array.isArray(this.p('owner')) && this.p('owner').indexOf(playerName) == -1)
+    if(Array.isArray(this.get('owner')) && this.get('owner').indexOf(playerName) == -1)
       className += ' foreign';
-    if(typeof this.p('owner') == 'string' && this.p('owner') != playerName)
+    if(typeof this.get('owner') == 'string' && this.get('owner') != playerName)
       className += ' foreign';
 
     return className;
@@ -202,10 +205,10 @@ export class Widget extends StateManaged {
   }
 
   async click() {
-    if(!this.p('clickable'))
+    if(!this.get('clickable'))
       return true;
 
-    if(Array.isArray(this.p('clickRoutine'))) {
+    if(Array.isArray(this.get('clickRoutine'))) {
       await this.evaluateRoutine('clickRoutine', {}, {});
       return true;
     } else {
@@ -214,10 +217,10 @@ export class Widget extends StateManaged {
   }
 
   css() {
-    let css = this.p('css');
+    let css = this.get('css');
 
-    css += '; width:'  + this.p('width')  + 'px';
-    css += '; height:' + this.p('height') + 'px';
+    css += '; width:'  + this.get('width')  + 'px';
+    css += '; height:' + this.get('height') + 'px';
     css += '; z-index:' + this.calculateZ();
     css += '; transform:' + this.cssTransform();
 
@@ -229,12 +232,12 @@ export class Widget extends StateManaged {
   }
 
   cssTransform() {
-    let transform = `translate(${this.p('x')}px, ${this.p('y')}px)`;
+    let transform = `translate(${this.get('x')}px, ${this.get('y')}px)`;
 
-    if(this.p('rotation'))
-      transform += ` rotate(${this.p('rotation')}deg)`;
-    if(this.p('scale') != 1)
-      transform += ` scale(${this.p('scale')})`;
+    if(this.get('rotation'))
+      transform += ` rotate(${this.get('rotation')}deg)`;
+    if(this.get('scale') != 1)
+      transform += ` scale(${this.get('scale')})`;
 
     return transform;
   }
@@ -248,11 +251,11 @@ export class Widget extends StateManaged {
     for(const field of o.fields) {
 
       if(field.type == 'checkbox') {
-        result[field.variable] = document.getElementById(this.p('id') + ';' + field.variable).checked;
+        result[field.variable] = document.getElementById(this.get('id') + ';' + field.variable).checked;
       }
 
       if(field.type == 'color' || field.type == 'number' || field.type == 'string') {
-        result[field.variable] = document.getElementById(this.p('id') + ';' + field.variable).value;
+        result[field.variable] = document.getElementById(this.get('id') + ';' + field.variable).value;
       }
 
     }
@@ -281,13 +284,14 @@ export class Widget extends StateManaged {
       return typeof ids == 'string' ? [ ids ] : ids;
     }
 
-    function w(ids, callback) {
-      return widgetFilter(w=>toA(ids).indexOf(w.p('id')) != -1).forEach(callback);
+    async function w(ids, callback) {
+      for(const a of widgetFilter(w=>toA(ids).indexOf(w.get('id')) != -1))
+        await callback(a);
     }
 
     batchStart();
 
-    if(this.p('debug') && !depth)
+    if(this.get('debug') && !depth)
       $('#debugButtonOutput').textContent = '';
 
     let variables = initialVariables;
@@ -297,20 +301,20 @@ export class Widget extends StateManaged {
         playerName,
         playerColor,
         activePlayers,
-        thisID : this.p('id')
+        thisID : this.get('id')
       });
       collections = Object.assign({}, initialCollections, {
         thisButton : [this]
       });
     }
 
-    const routine = this.p(property) !== undefined ? this.p(property) : property;
+    const routine = this.get(property) !== undefined ? this.get(property) : property;
 
     for(const original of routine) {
       const a = JSON.parse(JSON.stringify(original));
       var problems = [];
 
-      if(this.p('debug')) console.log(`${this.id}: ${JSON.stringify(original)}`);
+      if(this.get('debug')) console.log(`${this.id}: ${JSON.stringify(original)}`);
 
       if(a.applyVariables) this.applyVariables(a, variables, problems);
 
@@ -320,11 +324,11 @@ export class Widget extends StateManaged {
       }
 
       if(a.func == 'CALL') {
-        setDefaults(a, { widget: this.p('id'), routine: 'clickRoutine', 'return': true, arguments: {}, variable: 'result', collection: 'result' });
+        setDefaults(a, { widget: this.get('id'), routine: 'clickRoutine', 'return': true, arguments: {}, variable: 'result', collection: 'result' });
         if(!a.routine.match(/Routine$/)) {
           problems.push('Routine parameters have to end with "Routine".');
         } else if(this.isValidID(a.widget)) {
-          if(!Array.isArray(widgets.get(a.widget).p(a.routine))) {
+          if(!Array.isArray(widgets.get(a.widget).get(a.routine))) {
             problems.push(`Widget ${a.widget} does not contain ${a.routine} (or it is no array).`);
           } else {
             // make sure everything is passed in a way that the variables and collections of this routine won't be changed
@@ -365,7 +369,7 @@ export class Widget extends StateManaged {
             for(let i=1; i<=a.count; ++i) {
               const clone = Object.assign(JSON.parse(JSON.stringify(w.state)), a.properties);
               const parent = clone.parent;
-              clone.clonedFrom = w.p('id');
+              clone.clonedFrom = w.get('id');
 
               delete clone.id;
               delete clone.parent;
@@ -375,15 +379,15 @@ export class Widget extends StateManaged {
               if(parent) {
                 // use moveToHolder so that CLONE triggers onEnter and similar features
                 cWidget.movedByButton = true;
-                cWidget.moveToHolder(widgets.get(parent));
+                await cWidget.moveToHolder(widgets.get(parent));
                 delete cWidget.movedByButton;
               }
 
               // moveToHolder causes the position to be wrong if the target holder does not have alignChildren
-              if(!parent || !widgets.get(parent).p('alignChildren')) {
-                cWidget.p('x', (a.properties.x || w.p('x')) + a.xOffset * i);
-                cWidget.p('y', (a.properties.y || w.p('y')) + a.yOffset * i);
-                cWidget.updatePiles();
+              if(!parent || !widgets.get(parent).get('alignChildren')) {
+                await cWidget.set('x', (a.properties.x || w.get('x')) + a.xOffset * i);
+                await cWidget.set('y', (a.properties.y || w.get('y')) + a.yOffset * i);
+                await cWidget.updatePiles();
               }
 
               c.push(cWidget);
@@ -570,7 +574,7 @@ export class Widget extends StateManaged {
         setDefaults(a, { collection: 'DEFAULT' });
         if(isValidCollection(a.collection)) {
           for(const w of collections[a.collection]) {
-            removeWidgetLocal(w.p('id'));
+            await removeWidgetLocal(w.get('id'));
             for(const c in collections)
               collections[c] = collections[c].filter(x=>x!=w);
           }
@@ -580,13 +584,19 @@ export class Widget extends StateManaged {
       if(a.func == 'FLIP') {
         setDefaults(a, { count: 0, face: null, faceCyle: null, collection: 'DEFAULT' });
         if(a.holder !== undefined) {
-          if(this.isValidID(a.holder,problems))
-            w(a.holder, holder=>holder.children().slice(0, a.count || 999999).forEach(c=>c.flip&&c.flip(a.face,a.faceCycle)));
+          if(this.isValidID(a.holder,problems)) {
+            await w(a.holder, async holder=>{
+              for(const c of holder.children().slice(0, a.count || 999999))
+                c.flip && await c.flip(a.face,a.faceCycle);
+            });
+          }
         } else if(isValidCollection(a.collection)) {
-          if(collections[a.collection].length)
-            collections[a.collection].slice(0, a.count || 999999).forEach(c=>c.flip&&c.flip(a.face,a.faceCycle));
-          else
+          if(collections[a.collection].length) {
+            for(const c of collections[a.collection].slice(0, a.count || 999999))
+              c.flip && await c.flip(a.face,a.faceCycle);
+          } else {
             problems.push(`Collection ${a.collection} is empty.`);
+          }
         }
       }
 
@@ -595,8 +605,8 @@ export class Widget extends StateManaged {
         if(isValidCollection(a.collection)) {
           let c = collections[a.collection];
           if (a.skipMissing)
-            c = c.filter(w=>w.p(a.property) !== null && w.p(a.property) !== undefined);
-          c = JSON.parse(JSON.stringify(c.map(w=>w.p(a.property))));
+            c = c.filter(w=>w.get(a.property) !== null && w.get(a.property) !== undefined);
+          c = JSON.parse(JSON.stringify(c.map(w=>w.get(a.property))));
           if(c.length) {
             switch(a.aggregation) {
             case 'first':
@@ -662,15 +672,17 @@ export class Widget extends StateManaged {
           problems.push(`Warning: Mode ${a.mode} will be interpreted as set.`);
         if(a.label !== undefined) {
           if (this.isValidID(a.label, problems)) {
-            w(a.label, widget=> {
-              widget.setText(a.value, a.mode, this.p('debug'), problems)
+            await w(a.label, async widget=>{
+              await widget.setText(a.value, a.mode, this.get('debug'), problems)
             });
           }
         } else if(isValidCollection(a.collection)) {
-          if(collections[a.collection].length)
-            collections[a.collection].forEach(c=>c.setText(a.value, a.mode, this.p('debug'), problems));
-          else
+          if(collections[a.collection].length) {
+            for(const c of collections[a.collection])
+              await c.setText(a.value, a.mode, this.get('debug'), problems);
+          } else {
             problems.push(`Collection ${a.collection} is empty.`);
+          }
         }
       }
 
@@ -679,31 +691,35 @@ export class Widget extends StateManaged {
         const count = a.count || 999999;
 
         if(this.isValidID(a.from, problems) && this.isValidID(a.to, problems)) {
-          w(a.from, source=>w(a.to, target=>source.children().slice(0, count).reverse().forEach(c=> {
-            if(a.face !== null && c.flip)
-              c.flip(a.face);
-            if(source == target) {
-              c.bringToFront();
-            } else {
-              c.movedByButton = true;
-              c.moveToHolder(target);
-              delete c.movedByButton;
+          await w(a.from, async source=>await w(a.to, async target=>{
+            for(const c of source.children().slice(0, count).reverse()) {
+              if(a.face !== null && c.flip)
+                c.flip(a.face);
+              if(source == target) {
+                await c.bringToFront();
+              } else {
+                c.movedByButton = true;
+                await c.moveToHolder(target);
+                delete c.movedByButton;
+              }
             }
-          })));
+          }));
         }
       }
 
       if(a.func == 'MOVEXY') {
         setDefaults(a, { count: 1, face: null, x: 0, y: 0 });
         if(this.isValidID(a.from, problems)) {
-          w(a.from, source=>source.children().slice(0, a.count || 999999).reverse().forEach(c=> {
-            if(a.face !== null && c.flip)
-              c.flip(a.face);
-            c.p('parent', null);
-            c.bringToFront();
-            c.setPosition(a.x, a.y, a.z || c.p('z'));
-            c.updatePiles();
-          }));
+          await w(a.from, async source=>{
+            for(const c of source.children().slice(0, a.count || 999999).reverse()) {
+              if(a.face !== null && c.flip)
+                c.flip(a.face);
+              await c.set('parent', null);
+              await c.bringToFront();
+              await c.setPosition(a.x, a.y, a.z || c.get('z'));
+              await c.updatePiles();
+            }
+          });
         }
       }
 
@@ -715,28 +731,30 @@ export class Widget extends StateManaged {
       if(a.func == 'RECALL') {
         setDefaults(a, { owned: true });
         if(this.isValidID(a.holder, problems)) {
-          toA(a.holder).forEach(holder=>{
-            const decks = widgetFilter(w=>w.p('type')=='deck'&&w.p('parent')==holder);
+          for(const holder of toA(a.holder)) {
+            const decks = widgetFilter(w=>w.get('type')=='deck'&&w.get('parent')==holder);
             if(decks.length) {
               for(const deck of decks) {
-                let cards = widgetFilter(w=>w.p('deck')==deck.p('id'));
+                let cards = widgetFilter(w=>w.get('deck')==deck.get('id'));
                 if(!a.owned)
-                  cards = cards.filter(c=>!c.p('owner'));
-                cards.forEach(c=>c.moveToHolder(widgets.get(holder)));
+                  cards = cards.filter(c=>!c.get('owner'));
+                for(const c of cards)
+                  await c.moveToHolder(widgets.get(holder));
               }
             } else {
               problems.push(`Holder ${holder} does not have a deck.`);
             }
-          });
+          };
         }
       }
 
       if(a.func == 'ROTATE') {
         setDefaults(a, { count: 1, angle: 90, mode: 'add' });
         if(this.isValidID(a.holder, problems)) {
-          w(a.holder, holder=>holder.children().slice(0, a.count || 999999).forEach(c=>{
-            c.rotate(a.angle, a.mode);
-          }));
+          await w(a.holder, async holder=>{
+            for(const c of holder.children().slice(0, a.count || 999999))
+              await c.rotate(a.angle, a.mode);
+          });
         }
       }
 
@@ -748,29 +766,29 @@ export class Widget extends StateManaged {
           let c = (a.source == 'all' ? Array.from(widgets.values()) : collections[a.source]).filter(function(w) {
             if(w.isBeingRemoved)
               return false;
-            if(a.type != 'all' && (w.p('type') != a.type && (a.type != 'card' || w.p('type') != 'pile')))
+            if(a.type != 'all' && (w.get('type') != a.type && (a.type != 'card' || w.get('type') != 'pile')))
               return false;
             if(a.relation === '<')
-              return w.p(a.property) < a.value;
+              return w.get(a.property) < a.value;
             else if(a.relation === '<=')
-              return w.p(a.property) <= a.value;
+              return w.get(a.property) <= a.value;
             else if(a.relation === '!=')
-              return w.p(a.property) != a.value;
+              return w.get(a.property) != a.value;
             else if(a.relation === '>=')
-              return w.p(a.property) >= a.value;
+              return w.get(a.property) >= a.value;
             else if(a.relation === '>')
-              return w.p(a.property) > a.value;
+              return w.get(a.property) > a.value;
             else if(a.relation === 'in' && Array.isArray(a.value))
-              return a.value.indexOf(w.p(a.property)) != -1;
+              return a.value.indexOf(w.get(a.property)) != -1;
             if(a.relation != '==')
               problems.push(`Warning: Relation ${a.relation} interpreted as ==.`);
-            return w.p(a.property) === a.value;
+            return w.get(a.property) === a.value;
           }).slice(0, a.max).concat(a.mode == 'add' ? collections[a.collection] || [] : []);
 
           // resolve piles
           if(a.type != 'pile') {
-            c.filter(w=>w.p('type')=='pile').forEach(w=>c.push(...w.children()));
-            c = c.filter(w=>w.p('type')!='pile');
+            c.filter(w=>w.get('type')=='pile').forEach(w=>c.push(...w.children()));
+            c = c.filter(w=>w.get('type')!='pile');
           }
           collections[a.collection] = [...new Set(c)];
         }
@@ -786,7 +804,7 @@ export class Widget extends StateManaged {
           problems.push(`Tried setting ${a.property} to ${a.value} which doesn't exist.`);
         } else if(isValidCollection(a.collection)) {
           for(const w of collections[a.collection]) {
-            w.p(a.property, compute(a.relation, null, w.p(a.property), a.value));
+            await w.set(a.property, compute(a.relation, null, w.get(a.property), a.value));
           }
         }
       }
@@ -794,32 +812,34 @@ export class Widget extends StateManaged {
       if(a.func == 'SORT') {
         setDefaults(a, { key: 'value', reverse: false });
         if(this.isValidID(a.holder, problems)) {
-          w(a.holder, holder=>{
+          await w(a.holder, async holder=>{
             let z = 1;
             let children = holder.children().reverse().sort((w1,w2)=>{
-              if(typeof w1.p(a.key) == 'number')
-                return w1.p(a.key) - w2.p(a.key);
+              if(typeof w1.get(a.key) == 'number')
+                return w1.get(a.key) - w2.get(a.key);
               else
-                return w1.p(a.key).localeCompare(w2.p(a.key));
+                return w1.get(a.key).localeCompare(w2.get(a.key));
             });
             if(a.reverse)
               children = children.reverse();
-            children.forEach(c=>c.p('z', ++z));
-            holder.updateAfterShuffle();
+            for(const c of children)
+              await c.set('z', ++z);
+            await holder.updateAfterShuffle();
           });
         }
       }
 
       if(a.func == 'SHUFFLE') {
         if(this.isValidID(a.holder, problems)) {
-          w(a.holder, holder=>{
-            holder.children().forEach(c=>c.p('z', Math.floor(Math.random()*10000)));
-            holder.updateAfterShuffle();
+          await w(a.holder, async holder=>{
+            for(const c of holder.children())
+              await c.set('z', Math.floor(Math.random()*10000));
+            await holder.updateAfterShuffle();
           });
         }
       }
 
-      if(this.p('debug')) {
+      if(this.get('debug')) {
         let msg = ''
         msg += '\n\n\nOPERATION: \n' + JSON.stringify(a, null, '  ');
         if(problems.length)
@@ -827,7 +847,7 @@ export class Widget extends StateManaged {
         msg += '\n\n\nVARIABLES: \n' + JSON.stringify(variables, null, '  ');
         msg += '\n\nCOLLECTIONS: \n';
         for(const name in collections) {
-          msg += '  ' + name + ': ' + collections[name].map(w=>`${w.p('id')} (${w.p('type')})`).join(', ') + '\n';
+          msg += '  ' + name + ': ' + collections[name].map(w=>`${w.get('id')} (${w.get('type')})`).join(', ') + '\n';
         }
         $('#debugButtonOutput').textContent += msg.replace(/^/gm, '    '.repeat(depth));
         console.log(msg);
@@ -836,7 +856,7 @@ export class Widget extends StateManaged {
       }
     }
 
-    if(this.p('debug') && !depth)
+    if(this.get('debug') && !depth)
       showOverlay('debugButtonOverlay');
 
     batchEnd();
@@ -855,38 +875,38 @@ export class Widget extends StateManaged {
     problems.push(`Widget ID ${id} does not exist.`);
   }
 
-  moveToHolder(holder) {
-    this.bringToFront();
-    if(this.p('parent') && !this.currentParent)
-      this.currentParent = widgets.get(this.p('parent'));
+  async moveToHolder(holder) {
+    await this.bringToFront();
+    if(this.get('parent') && !this.currentParent)
+      this.currentParent = widgets.get(this.get('parent'));
     if(this.currentParent != holder)
-      this.checkParent(true);
+      await this.checkParent(true);
 
-    this.p('owner',  null);
-    this.p('parent', holder.p('id'));
+    await this.set('owner',  null);
+    await this.set('parent', holder.get('id'));
   }
 
-  moveStart() {
-    this.bringToFront();
+  async moveStart() {
+    await this.bringToFront();
     this.dropTargets = this.validDropTargets();
-    this.currentParent = widgets.get(this.p('parent'));
+    this.currentParent = widgets.get(this.get('parent'));
     this.hoverTargetDistance = 99999;
     this.hoverTarget = null;
 
-    this.p('parent', null);
+    await this.set('parent', null);
 
     for(const t of this.dropTargets)
       t.domElement.classList.add('droppable');
   }
 
-  move(x, y) {
-    const newX = (jeZoomOut ? x : Math.max(0-this.p('width' )*0.25, Math.min(1600+this.p('width' )*0.25, x))) - this.p('width' )/2;
-    const newY = (jeZoomOut ? y : Math.max(0-this.p('height')*0.25, Math.min(1000+this.p('height')*0.25, y))) - this.p('height')/2;
+  async move(x, y) {
+    const newX = (jeZoomOut ? x : Math.max(0-this.get('width' )*0.25, Math.min(1600+this.get('width' )*0.25, x))) - this.get('width' )/2;
+    const newY = (jeZoomOut ? y : Math.max(0-this.get('height')*0.25, Math.min(1000+this.get('height')*0.25, y))) - this.get('height')/2;
 
-    this.setPosition(newX, newY, this.p('z'));
+    await this.setPosition(newX, newY, this.get('z'));
     const myCenter = center(this.domElement);
 
-    this.checkParent();
+    await this.checkParent();
 
     this.hoverTargetChanged = false;
     if(this.hoverTarget) {
@@ -921,70 +941,76 @@ export class Widget extends StateManaged {
     }
   }
 
-  moveEnd() {
+  async moveEnd() {
     for(const t of this.dropTargets)
       t.domElement.classList.remove('droppable');
 
-    this.checkParent();
+    await this.checkParent();
 
     if(this.hoverTarget) {
-      this.moveToHolder(this.hoverTarget);
+      await this.moveToHolder(this.hoverTarget);
       this.hoverTarget.domElement.classList.remove('droptarget');
     }
 
     this.hideEnlarged();
-    this.updatePiles();
+    await this.updatePiles();
   }
 
-  onChildAdd(child, oldParentID) {
+  async onChildAdd(child, oldParentID) {
     this.childArray = this.childArray.filter(c=>c!=child);
     this.childArray.push(child);
-    this.onChildAddAlign(child, oldParentID);
+    await this.onChildAddAlign(child, oldParentID);
+    if(Array.isArray(this.get('enterRoutine')))
+      await this.evaluateRoutine('enterRoutine', { oldParentID }, { child: [ child ] });
   }
 
-  onChildAddAlign(child, oldParentID) {
-    let childX = child.p('x');
-    let childY = child.p('y');
+  async onChildAddAlign(child, oldParentID) {
+    let childX = child.get('x');
+    let childY = child.get('y');
 
     if(!oldParentID) {
       childX -= this.absoluteCoord('x');
       childY -= this.absoluteCoord('y');
     }
 
-    if(this.p('alignChildren'))
-      child.setPosition(this.p('dropOffsetX'), this.p('dropOffsetY'), child.p('z'));
+    if(this.get('alignChildren'))
+      await child.setPosition(this.get('dropOffsetX'), this.get('dropOffsetY'), child.get('z'));
     else
-      child.setPosition(childX, childY, child.p('z'));
+      await child.setPosition(childX, childY, child.get('z'));
   }
 
-  onChildRemove(child) {
+  async onChildRemove(child) {
     this.childArray = this.childArray.filter(c=>c!=child);
     this.applyZ();
+    if(Array.isArray(this.get('leaveRoutine')))
+      await this.evaluateRoutine('leaveRoutine', {}, { child: [ child ] });
   }
 
-  onPropertyChange(property, oldValue, newValue) {
+  async onPropertyChange(property, oldValue, newValue) {
     if(property == 'parent') {
       if(oldValue)
-        widgets.get(oldValue).onChildRemove(this);
+        await widgets.get(oldValue).onChildRemove(this);
       if(newValue)
-        widgets.get(newValue).onChildAdd(this, oldValue);
-      this.updatePiles();
+        await widgets.get(newValue).onChildAdd(this, oldValue);
+      await this.updatePiles();
     }
+    if(Array.isArray(this.get('changeRoutine')))
+      await this.evaluateRoutine('changeRoutine', { property, oldValue, newValue }, {});
   }
 
-  rotate(degrees, mode) {
+  async rotate(degrees, mode) {
     if(!mode || mode == 'add')
-      this.p('rotation', (this.p('rotation') + degrees) % 360);
+      await this.set('rotation', (this.get('rotation') + degrees) % 360);
     else
-      this.p('rotation', degrees);
+      await this.set('rotation', degrees);
   }
 
-  setPosition(x, y, z) {
-    if(this.p('grid').length && !this.p('parent')) {
+  async setPosition(x, y, z) {
+    if(this.get('grid').length && !this.get('parent')) {
       let closest = null;
       let closestDistance = 999999;
 
-      for(const grid of this.p('grid')) {
+      for(const grid of this.get('grid')) {
         if(x < (grid.minX || -99999) || x > (grid.maxX || 99999))
           continue;
         if(y < (grid.minY || -99999) || y > (grid.maxY || 99999))
@@ -1000,39 +1026,39 @@ export class Widget extends StateManaged {
         x = x + closest.x/2 - (x - (closest.offsetX || 0)) % closest.x;
         y = y + closest.y/2 - (y - (closest.offsetY || 0)) % closest.y;
         if(closest.rotation !== undefined)
-          this.p('rotation', closest.rotation);
+          await this.set('rotation', closest.rotation);
       }
 
       this.snappingToGrid = false;
     }
-    super.setPosition(x, y, z);
+    await super.setPosition(x, y, z);
   }
 
-  setText(text, mode, debug, problems) {
-    if (this.p('text') !== undefined) {
+  async setText(text, mode, debug, problems) {
+    if (this.get('text') !== undefined) {
       if(mode == 'inc' || mode == 'dec')
-        this.p('text', (parseInt(this.p('text')) || 0) + (mode == 'dec' ? -1 : 1) * text);
+        await this.set('text', (parseInt(this.get('text')) || 0) + (mode == 'dec' ? -1 : 1) * text);
       else if(mode == 'append')
-        this.p('text', this.p('text') + text);
+        await this.set('text', this.get('text') + text);
       else if(Array.isArray(text))
-        this.p('text', text.join(', '));
+        await this.set('text', text.join(', '));
       else if(typeof text == 'string' && text.match(/^[-+]?[0-9]+(\.[0-9]+)?$/))
-        this.p('text', +text);
+        await this.set('text', +text);
       else
-        this.p('text', text);
+        await this.set('text', text);
     } else
       problems.push(`Tried setting text property which doesn't exist for ${this.id}.`);
   }
 
   showEnlarged(event) {
-    if(this.p('enlarge')) {
+    if(this.get('enlarge')) {
       const e = $('#enlarged');
       e.innerHTML = this.domElement.innerHTML;
       e.className = this.domElement.className;
-      e.dataset.id = this.p('id');
+      e.dataset.id = this.get('id');
       e.style.cssText = this.domElement.style.cssText;
       e.style.display = this.domElement.style.display;
-      e.style.transform = `scale(calc(${this.p('enlarge')} * var(--scale)))`;
+      e.style.transform = `scale(calc(${this.get('enlarge')} * var(--scale)))`;
       if(this.domElement.getBoundingClientRect().left < window.innerWidth/2)
         e.classList.add('right');
     }
@@ -1060,7 +1086,7 @@ export class Widget extends StateManaged {
           label.textContent = field.label;
           dom.appendChild(input);
           dom.appendChild(label);
-          label.htmlFor = input.id = this.p('id') + ';' + field.variable;
+          label.htmlFor = input.id = this.get('id') + ';' + field.variable;
         }
 
         if(field.type == 'color') {
@@ -1071,7 +1097,7 @@ export class Widget extends StateManaged {
           label.textContent = field.label;
           dom.appendChild(label);
           dom.appendChild(input);
-          label.htmlFor = input.id = this.p('id') + ';' + field.variable;
+          label.htmlFor = input.id = this.get('id') + ';' + field.variable;
         }
 
         if(field.type == 'number') {
@@ -1084,7 +1110,7 @@ export class Widget extends StateManaged {
           label.textContent = field.label;
           dom.appendChild(label);
           dom.appendChild(input);
-          label.htmlFor = input.id = this.p('id') + ';' + field.variable;
+          label.htmlFor = input.id = this.get('id') + ';' + field.variable;
         }
 
         if(field.type == 'string') {
@@ -1094,7 +1120,7 @@ export class Widget extends StateManaged {
           label.textContent = field.label;
           dom.appendChild(label);
           dom.appendChild(input);
-          label.htmlFor = input.id = this.p('id') + ';' + field.variable;
+          label.htmlFor = input.id = this.get('id') + ';' + field.variable;
         }
 
         if(field.type == 'text') {
@@ -1130,51 +1156,53 @@ export class Widget extends StateManaged {
     this.domElement.className = this.classes();
   }
 
-  updatePiles() {
-    if(this.isBeingRemoved || this.p('parent') && !widgets.get(this.p('parent')).supportsPiles())
+  async updatePiles() {
+    if(this.isBeingRemoved || this.get('parent') && !widgets.get(this.get('parent')).supportsPiles())
       return;
 
     for(const [ widgetID, widget ] of widgets) {
       // check if this widget is closer than 10px from another widget in the same parent
-      if(widget != this && widget.p('parent') == this.p('parent') && Math.abs(widget.p('x')-this.p('x')) < 10 && Math.abs(widget.p('y')-this.p('y')) < 10) {
-        if(widget.p('owner') !== this.p('owner') || widget.isBeingRemoved)
+      if(widget != this && widget.get('parent') == this.get('parent') && Math.abs(widget.get('x')-this.get('x')) < 10 && Math.abs(widget.get('y')-this.get('y')) < 10) {
+        if(widget.get('owner') !== this.get('owner') || widget.isBeingRemoved)
           continue;
 
         // if a card gets dropped onto a card, they create a new pile and are added to it
-        if(widget.p('type') == 'card' && this.p('type') == 'card') {
+        if(widget.get('type') == 'card' && this.get('type') == 'card') {
           const pile = {
             type: 'pile',
-            parent: this.p('parent'),
-            x: widget.p('x'),
-            y: widget.p('y'),
-            width: this.p('width'),
-            height: this.p('height')
+            parent: this.get('parent'),
+            x: widget.get('x'),
+            y: widget.get('y'),
+            width: this.get('width'),
+            height: this.get('height')
           };
           addWidgetLocal(pile);
-          this.p('parent', pile.id);
-          widget.p('parent', pile.id);
+          await this.set('parent', pile.id);
+          await widget.set('parent', pile.id);
           break;
         }
 
         // if a pile gets dropped onto a pile, all children of one pile are moved to the other (the empty one destroys itself)
-        if(widget.p('type') == 'pile' && this.p('type') == 'pile') {
-          this.children().reverse().forEach(w=>{w.p('parent', widget.p('id')); w.bringToFront()});
+        if(widget.get('type') == 'pile' && this.get('type') == 'pile') {
+          for(const w of this.children().reverse())
+            await w.set('parent', widget.get('id')); await w.bringToFront();
           break;
         }
 
         // if a pile gets dropped onto a card, the card is added to the pile but the pile is moved to the original position of the card
-        if(widget.p('type') == 'card' && this.p('type') == 'pile') {
-          this.children().reverse().forEach(w=>w.bringToFront());
-          this.p('x', widget.p('x'));
-          this.p('y', widget.p('y'));
-          widget.p('parent', this.p('id'));
+        if(widget.get('type') == 'card' && this.get('type') == 'pile') {
+          for(const w of this.children().reverse())
+            await w.bringToFront();
+          await this.set('x', widget.get('x'));
+          await this.set('y', widget.get('y'));
+          await widget.set('parent', this.get('id'));
           break;
         }
 
         // if a card gets dropped onto a pile, it simply gets added to the pile
-        if(widget.p('type') == 'pile' && this.p('type') == 'card') {
-          this.bringToFront();
-          this.p('parent', widget.p('id'));
+        if(widget.get('type') == 'pile' && this.get('type') == 'card') {
+          await this.bringToFront();
+          await this.set('parent', widget.get('id'));
           break;
         }
       }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -987,7 +987,7 @@ export class Widget extends StateManaged {
       if(oldValue) {
         const oldParent = widgets.get(oldValue);
         await oldParent.onChildRemove(this);
-        if(Array.isArray(oldParent.get('leaveRoutine')))
+        if(this.get('type') != 'holder' && Array.isArray(oldParent.get('leaveRoutine')))
           await oldParent.evaluateRoutine('leaveRoutine', {}, { child: [ this ] });
       }
       if(newValue) {

--- a/tests/client/widget-click.test.js
+++ b/tests/client/widget-click.test.js
@@ -45,13 +45,13 @@ describe("Scenarios: Clicking widgets", () => {
     testLabel = addLabel(`${testName}-test-label`);
   });
   afterAll(() => {
-    removeWidget(testWidget.p('id'));
-    removeWidget(testLabel.p('id'));
+    removeWidget(testWidget.get('id'));
+    removeWidget(testLabel.get('id'));
   });
 
   describe("Given a widget that clicks widgets from an undefined collection", () => {
-    beforeAll(() => {
-      testWidget.p('clickRoutine', [
+    beforeAll(async () => {
+      await testWidget.set('clickRoutine', [
         {
           "func": "CLICK",
           "collection": "undefined"
@@ -66,8 +66,8 @@ describe("Scenarios: Clicking widgets", () => {
   });
 
   describe("Given a widget that clicks widgets with property 'clickThis'", () => {
-    beforeAll(() => {
-      testWidget.p('clickRoutine', [
+    beforeAll(async () => {
+      await testWidget.set('clickRoutine', [
         {
           "func": "SELECT",
           "property": "clickThis",
@@ -81,40 +81,40 @@ describe("Scenarios: Clicking widgets", () => {
 
     describe("And there are 2 widgets with 'clickThis' and 1 without", () => {
       let widgets;
-      beforeEach(() => {
+      beforeEach(async () => {
         const numWidgets = 3;
         const numWithClickThis = 2;
         widgets = createClickThisWidgets(testName, numWidgets, numWithClickThis);
-        testLabel.p('text', 0);
+        await testLabel.set('text', 0);
       });
       afterEach(() => {
-        widgets.forEach(w => removeWidget(w.p('id')));
+        widgets.forEach(w => removeWidget(w.get('id')));
       });
 
       describe("When clicked", () => {
         test("Then it clicks 2 'clickThis' widgets", async () => {
           await testWidget.click();
-          expect(testLabel.p('text')).toBe(2);
+          expect(testLabel.get('text')).toBe(2);
         });
       });
     });
 
     describe("And there are 0 widgets with 'clickThis'", () => {
       let widgets;
-      beforeEach(() => {
+      beforeEach(async () => {
         const numWidgets = 1;
         const numWithClickThis = 0;
         widgets = createClickThisWidgets(testName, numWidgets, numWithClickThis);
-        testLabel.p('text', 0);
+        await testLabel.set('text', 0);
       });
       afterEach(() => {
-        widgets.forEach(w => removeWidget(w.p('id')));
+        widgets.forEach(w => removeWidget(w.get('id')));
       });
 
       describe("When clicked", () => {
         test("Then it clicks 0 'clickThis' widgets", async () => {
           await testWidget.click();
-          expect(testLabel.p('text')).toBe(0);
+          expect(testLabel.get('text')).toBe(0);
         });
       });
     });

--- a/tests/client/widget-count.test.js
+++ b/tests/client/widget-count.test.js
@@ -19,13 +19,13 @@ describe("Scenarios: Counting widgets", () => {
     testLabel = addLabel(`${testName}-test-label`);
   });
   afterAll(() => {
-    removeWidget(testWidget.p('id'));
-    removeWidget(testLabel.p('id'));
+    removeWidget(testWidget.get('id'));
+    removeWidget(testLabel.get('id'));
   });
 
   describe("Given a widget that counts widgets from an undefined collection", () => {
-    beforeAll(() => {
-      testWidget.p('clickRoutine', [
+    beforeAll(async () => {
+      await testWidget.set('clickRoutine', [
         {
           "func": "COUNT",
           "collection": "undefined"
@@ -40,8 +40,8 @@ describe("Scenarios: Counting widgets", () => {
   });
 
   describe("Given a widget that counts widgets with property 'countThis'", () => {
-    beforeAll(() => {
-      testWidget.p('clickRoutine', [
+    beforeAll(async () => {
+      await testWidget.set('clickRoutine', [
         {
           "func": "SELECT",
           "property": "text",
@@ -65,21 +65,21 @@ describe("Scenarios: Counting widgets", () => {
 
     describe("And there are 2 widgets with 'countThis' and 1 without", () => {
       const widgets = [];
-      beforeEach(() => {
+      beforeEach(async () => {
         widgets[0] = addLabel(`${testName}-label-one`);
         widgets[1] = addLabel(`${testName}-label-two`);
         widgets[2] = addLabel(`${testName}-label-three`);
-        widgets[0].p("text", "countThis");
-        widgets[2].p("text", "countThis");
+        await widgets[0].set("text", "countThis");
+        await widgets[2].set("text", "countThis");
       });
       afterEach(() => {
-        widgets.forEach(w => removeWidget(w.p('id')));
+        widgets.forEach(w => removeWidget(w.get('id')));
       });
 
       describe("When clicked", () => {
         test("Then it reports 2 'countThis' widgets found", async () => {
           await testWidget.click();
-          expect(testLabel.p('text')).toBe(2);
+          expect(testLabel.get('text')).toBe(2);
         });
       });
     });
@@ -93,7 +93,7 @@ describe("Scenarios: Counting widgets", () => {
       describe("When clicked", () => {
         test("Then it reports 0 'countThis' widgets found", async () => {
           await testWidget.click();
-          expect(testLabel.p('text')).toBe(0);
+          expect(testLabel.get('text')).toBe(0);
         });
       });
     });


### PR DESCRIPTION
This was removed from #197 when I realized that every writing access to widget states now has to be async.

This adds new properties to all widgets. They are each an array of operations just like `clickRoutine`:

1. `changeRoutine` which gets called whenever a property of the widget it is in changes. The routine will have preset variables `property`, `oldValue` and `value`.
2. `enterRoutine` which gets called whenever a new child gets added to the widget it is in. The routine will have the preset variable `oldParentID` and the preset collection `child`.
3. `leaveRoutine` which gets called whenever a child gets removed from the widget it is in. The routine will have the preset collection `child`.

In addition you can define changeRoutines for a single property. Just add "ChangeRoutine" to the property you want to monitor. The routines will have preset variables `oldValue` and `value`.<br>For example: `xChangeRoutine`, `parentChangeRoutine`, `activeFaceChangeRoutine`, `MY_CUSTOM_PROPERTYChangeRoutine`

To do:

- [x] Change routine defaults in the JSON editor from `null` to `[]`.
- [x] Fix `applyVariables` in JSON editor.
- [x] Fix bug with updating in JSON editor.