### PR TITLE
Add backgammon, mancala, other updates

### DIFF
--- a/tests/testcafe/tests.js
+++ b/tests/testcafe/tests.js
@@ -155,13 +155,13 @@ publicLibraryButtons('Reward',             0, 'cbf8598d244e1290efe98f0d7fb3ccc8'
 publicLibraryButtons('Rummy Tiles',        0, '5d171ad18638d051bb79bafaad169583', [ 'startMix', 'draw14' ]);
 publicLibraryButtons('Undercover',         1, 'd3ba0452c9f44e8963d49a484c78e66b', [ 'Reset', 'Spy Master Button' ]);
 publicLibraryButtons('Dice',               0, '3cd34fc98732a94639d37e677c81b7f2', [ 'k18u', 'hy65', 'gghr', 'dsfa', 'f34a', 'fusq' ]);
-publicLibraryButtons('Functions - CALL',   0, '176feb836057ecc4b5074df90ddc4e2f', [
+publicLibraryButtons('Functions - CALL',   0, '8d1cee31b805f7e8135d262b43bfd7df', [
   'n4cw_8_C', '5a52', '5a52', '66kr', 'qeg1', 'n4cwB', '8r6p', 'qeg1', 'qeg1', 'n5eu'
 ]);
-publicLibraryButtons('Functions - CLICK',  0, '15b6f716708d97b769cdc930b1ae24ac', [ '7u2q' ]);
+publicLibraryButtons('Functions - CLICK',  0, 'b2430bd4589116a05df1fcedb55337c4', [ '7u2q' ]);
 publicLibraryButtons('Functions - RANDOM', 0, 'bfd121b54d8ab0fced83cc0bcc09032d', [ '9fhb', 'yqji', 'oeh9' ]);
 publicLibraryButtons('Functions - ROTATE', 0, '747586b12401e43382a7db2b2505f25e', [ 'c44c', '9kdj', 'w53c', 'w53c' ]);
-publicLibraryButtons('Functions - SELECT', 0, 'f116837e48e596c78cb1cac780b21762', [ 'oeh9', '9fhb', 'njkk', 'ffwl', 'bomo' ]);
+publicLibraryButtons('Functions - SELECT', 0, '4db86f0a95509b1c4fe5ebd6a1f822a9', [ 'oeh9', '9fhb', 'njkk', 'ffwl', 'bomo' ]);
 publicLibraryButtons('Functions - SORT',   1, 'dd047343b667795ad6d3f366aa2ae2fd', [
   'ingw', 'k131', 'cnfu', 'i6yz', 'z394', '0v3h', '1h8o', 'v5ra', 'ingw-copy001', 'k131-copy001', 'cnfu-copy001',
   'i6yz-copy001', 'z394-copy001', '0v3h-copy001'


### PR DESCRIPTION
Another big library update.  Details:

Public Assets:
- Marbles. Added as new library file
- Dice. Added new svg 3d dice to 1st variant

Public Tutorials:
- Functions – IF. Added as new library file tutorial (including a cross-reference to the SKIP tutorial)
- SKIP. Updated a comment about the ‘set’ and ‘add’ modes of SELECT that is no longer relevant after the recent file version update changed the default mode to set. Also made a cross-reference to the IF tutorial
- For all 12 button related tutorials, changed the library image from the default green to the new blue and white style

Public Library:
- Backgammon. Added new game
- Mancala. Added new game
- Chinese Checkers. Added shiny marble variant; added reset button
- Chinese Chess (Xiangqui). Added reset button; changed variant names to blank
- Connex. Updated restart symbol to universal version; changed spinner to dice to improve appearance
- Diced. Replaced flat dice with 3d dice
- Go. Added reset button

Updated library.json to reflect changes