### PR TITLE
fixed GET sum of empty collection

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -621,11 +621,17 @@ export class Widget extends StateManaged {
               break;
             case 'sum':
               variables[a.variable] = c.map(w=>+w).reduce((a, b) => a + b);
+              break;
             default:
               problems.push(`Aggregation ${a.aggregation} is unsupported.`);
             }
-          } else
+          } else if(a.aggregation == 'sum') {
+            variables[a.variable] = 0;
+          } else if(a.aggregation == 'array') {
+            variables[a.variable] = [];
+          } else {
             problems.push(`Collection ${a.collection} is empty.`);
+          }
         }
       }
       if(a.func == 'IF') {


### PR DESCRIPTION
PR #383 accidentally changed the result of a `GET` with `aggregation: sum` on an empty collection from `0` to `undefined` (not setting the variable at all actually). This PR reverts that change and additionally changes the result of `aggregation: array` on an empty collection to be an empty array.