### PR TITLE
Return null for undefined properties

### DIFF
--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -32,10 +32,7 @@ export class StateManaged {
   }
 
   getDefaultValue(key) {
-    if(this.defaults.hasOwnProperty(key))
-      return this.defaults[key]
-    else
-      return null;
+    return this.defaults[key];
   }
 
   p(property, value) {
@@ -49,7 +46,7 @@ export class StateManaged {
     if(this.state[property] !== undefined)
       return [ 'x', 'y', 'width', 'height', 'z', 'layer' ].indexOf(property) != -1 ? +this.state[property] : this.state[property];
     else
-      return this.getDefaultValue(property);
+      return this.getDefaultValue(property) !== undefined ? this.getDefaultValue(property) : null;
   }
 
   propertySet(property, value) {

--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -32,7 +32,10 @@ export class StateManaged {
   }
 
   getDefaultValue(key) {
-    return this.defaults[key];
+    if(this.defaults.hasOwnProperty(key))
+      return this.defaults[key]
+    else
+      return null;
   }
 
   p(property, value) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -141,7 +141,7 @@ export class Widget extends StateManaged {
           let w = this;
           if (v.widget)
             w = this.isValidID(v.widget, problems) ? widgets.get(v.widget) : this;
-          field[v.parameter] = w.p(v.property);
+          field[v.parameter] = w.get(v.property);
         } else {
           problems.push('Entry in parameter applyVariables does not contain "parameter" together with "variable", "property", or "template".');
         }
@@ -308,7 +308,7 @@ export class Widget extends StateManaged {
       });
     }
 
-    const routine = this.p(property) !== null ? this.p(property) : property;
+    const routine = this.get(property) !== null ? this.get(property) : property;
 
     for(const original of routine) {
       const a = JSON.parse(JSON.stringify(original));

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -138,7 +138,7 @@ export class Widget extends StateManaged {
           let w = this;
           if (v.widget)
             w = this.isValidID(v.widget, problems) ? widgets.get(v.widget) : this;
-          field[v.parameter] = (w.p(v.property) === undefined) ? null : w.p(v.property);
+          field[v.parameter] = w.p(v.property);
         } else {
           problems.push('Entry in parameter applyVariables does not contain "parameter" together with "variable", "property", or "template".');
         }
@@ -304,7 +304,7 @@ export class Widget extends StateManaged {
       });
     }
 
-    const routine = this.p(property) !== undefined ? this.p(property) : property;
+    const routine = this.p(property) !== null ? this.p(property) : property;
 
     for(const original of routine) {
       const a = JSON.parse(JSON.stringify(original));


### PR DESCRIPTION
We delete properties when they are set to null, so we should return null for undefined properties.