### PR TITLE
IF using variable for default condition

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -637,18 +637,21 @@ export class Widget extends StateManaged {
 
       if(a.func == 'IF') {
         setDefaults(a, { condition: variables['condition'], relation: '==' });
-        if (a.operand1 !== undefined) {
-          if (['==', '!=', '<', '<=', '>=', '>'].indexOf(a.relation) < 0) {
-            problems.push(`Relation ${a.relation} is unsupported. Using '==' relation.`);
-            a.relation = '==';
+        if(a.condition !== undefined || a.operand1 !== undefined) {
+          if (a.operand1 !== undefined) {
+            if (['==', '!=', '<', '<=', '>=', '>'].indexOf(a.relation) < 0) {
+              problems.push(`Relation ${a.relation} is unsupported. Using '==' relation.`);
+              a.relation = '==';
+            }
+            a.condition = compute(a.relation, null, a.operand1, a.operand2);
           }
-          a.condition = compute(a.relation, null, a.operand1, a.operand2);
-        }
-        const branch = a.condition ? 'thenRoutine' : 'elseRoutine';
-        if (Array.isArray(a[branch])) {
-          $('#debugButtonOutput').textContent += `\n\n\nIF ${branch}\n`;
-          await this.evaluateRoutine(a[branch], variables, collections, (depth || 0) + 1, true);
-        }
+          const branch = a.condition ? 'thenRoutine' : 'elseRoutine';
+          if (Array.isArray(a[branch])) {
+            $('#debugButtonOutput').textContent += `\n\n\nIF ${branch}\n`;
+            await this.evaluateRoutine(a[branch], variables, collections, (depth || 0) + 1, true);
+          }
+        } else
+        problems.push(`IF operation is missing the 'condition' or 'operand1' parameter.`);
       }
 
       if(a.func == 'INPUT') {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -638,7 +638,7 @@ export class Widget extends StateManaged {
       if(a.func == 'IF') {
         setDefaults(a, { condition: variables['condition'], relation: '==' });
         if(a.condition !== undefined || a.operand1 !== undefined) {
-          if (a.operand1 !== undefined) {
+          if (a.condition === undefined) {
             if (['==', '!=', '<', '<=', '>=', '>'].indexOf(a.relation) < 0) {
               problems.push(`Relation ${a.relation} is unsupported. Using '==' relation.`);
               a.relation = '==';

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -636,13 +636,14 @@ export class Widget extends StateManaged {
       }
 
       if(a.func == 'IF') {
-        setDefaults(a, { condition: variables['condition'],  relation: '==' });
-        if (['==', '!=', '<', '<=', '>=', '>'].indexOf(a.relation) < 0) {
-          problems.push(`Relation ${a.relation} is unsupported. Using '==' relation.`);
-          a.relation = '==';
-        }
-        if (a.operand1 && a.operand2)
+        setDefaults(a, { condition: variables['condition'], relation: '==' });
+        if (a.operand1 !== undefined) {
+          if (['==', '!=', '<', '<=', '>=', '>'].indexOf(a.relation) < 0) {
+            problems.push(`Relation ${a.relation} is unsupported. Using '==' relation.`);
+            a.relation = '==';
+          }
           a.condition = compute(a.relation, null, a.operand1, a.operand2);
+        }
         const branch = a.condition ? 'thenRoutine' : 'elseRoutine';
         if (Array.isArray(a[branch])) {
           $('#debugButtonOutput').textContent += `\n\n\nIF ${branch}\n`;

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -651,7 +651,7 @@ export class Widget extends StateManaged {
             await this.evaluateRoutine(a[branch], variables, collections, (depth || 0) + 1, true);
           }
         } else
-        problems.push(`IF operation is missing the 'condition' or 'operand1' parameter.`);
+          problems.push(`IF operation is missing the 'condition' or 'operand1' parameter.`);
       }
 
       if(a.func == 'INPUT') {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -634,22 +634,20 @@ export class Widget extends StateManaged {
           }
         }
       }
+
       if(a.func == 'IF') {
-        setDefaults(a, { relation: '==' });
+        setDefaults(a, { condition: variables['condition'],  relation: '==' });
         if (['==', '!=', '<', '<=', '>=', '>'].indexOf(a.relation) < 0) {
           problems.push(`Relation ${a.relation} is unsupported. Using '==' relation.`);
           a.relation = '==';
         }
-        if(a.condition !== undefined || a.operand1 !== undefined) {
-          if (a.condition === undefined)
-            a.condition = compute(a.relation, null, a.operand1, a.operand2);
-          const branch = a.condition ? 'thenRoutine' : 'elseRoutine';
-          if (Array.isArray(a[branch])) {
-            $('#debugButtonOutput').textContent += `\n\n\nIF ${branch}\n`;
-            await this.evaluateRoutine(a[branch], variables, collections, (depth || 0) + 1, true);
-          }
-        } else
-          problems.push(`IF operation is missing the 'condition' or 'operand1' parameter.`);
+        if (a.operand1 && a.operand2)
+          a.condition = compute(a.relation, null, a.operand1, a.operand2);
+        const branch = a.condition ? 'thenRoutine' : 'elseRoutine';
+        if (Array.isArray(a[branch])) {
+          $('#debugButtonOutput').textContent += `\n\n\nIF ${branch}\n`;
+          await this.evaluateRoutine(a[branch], variables, collections, (depth || 0) + 1, true);
+        }
       }
 
       if(a.func == 'INPUT') {


### PR DESCRIPTION
This PR allows to omit the `condition` parameter in IF operations. If omitted, it evaluates the 'condition' variable for true or false. 

```
  "clickRoutine": [
    {
      "func": "COMPUTE",
      "operand1": 1,
      "operand2": 1,
      "operation": "==",
      "variable": "condition"
    },
    {
      "func": "IF",
      "thenRoutine": [
        {
          "func": "LABEL",
          "label": "hpyx",
          "value": "success"
        }
      ],
      "elseRoutine": [
        {
          "func": "LABEL",
          "label": "hpyx",
          "value": "failure"
        }
      ]
    }
  ]
```