### PR TITLE
fixed some edge cases with default values

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -541,17 +541,17 @@ function jeAddNumberCommand(name, key, callback) {
 function jeAddWidgetPropertyCommands(object) {
   for(const property in object.defaults)
     if(property != 'typeClasses')
-      jeAddWidgetPropertyCommand(object.defaults, property);
+      jeAddWidgetPropertyCommand(object, property);
   object.applyRemove();
 }
 
-function jeAddWidgetPropertyCommand(defaults, property) {
+function jeAddWidgetPropertyCommand(object, property) {
   jeCommands.push({
     id: 'widget_' + property,
     name: property,
-    context: `^${defaults.typeClasses.replace('widget ', '')}`,
+    context: `^${object.getDefaultValue('typeClasses').replace('widget ', '')}`,
     call: async function() {
-      jeInsert([], property, property.match(/Routine$/) ? [] : defaults[property]);
+      jeInsert([], property, property.match(/Routine$/) ? [] : object.getDefaultValue(property));
     },
     show: function() {
       return jeStateNow[property] === undefined;
@@ -637,14 +637,14 @@ function jeColorize() {
     for(const l of langObj) {
       const match = line.match(l[0]);
       if(match) {
-        if(match[1] == '  "' && l[2] == 'key' && (l[4] == "null" && match[4] == "null" || String(jeWidget.defaults[match[2]]) == match[4])) {
+        if(match[1] == '  "' && l[2] == 'key' && (l[4] == "null" && match[4] == "null" || String(jeWidget.getDefaultValue(match[2])) == match[4])) {
           out.push(`<i class=default>${line}</i>`);
           foundMatch = true;
           break;
         }
 
         const c = {...l};
-        if(match[1] == '  "' && l[2] == 'key' && [ 'id', 'type' ].indexOf(match[2]) == -1 && jeWidget.defaults[match[2]] === undefined)
+        if(match[1] == '  "' && l[2] == 'key' && [ 'id', 'type' ].indexOf(match[2]) == -1 && jeWidget.getDefaultValue(match[2]) === undefined)
           c[2] = 'custom';
 
         for(let i=1; i<l.length; ++i)
@@ -792,7 +792,7 @@ function jePasteText(text, select) {
 function jePostProcessObject(o) {
   const copy = { ...o };
   for(const key in copy)
-    if(copy[key] === jeWidget.defaults[key] || key.match(/in deck/))
+    if(copy[key] === jeWidget.getDefaultValue(key) || key.match(/in deck/))
       copy[key] = null;
   return copy;
 }
@@ -808,7 +808,7 @@ function jePreProcessObject(o) {
     if(o[match[1]] !== undefined)
       copy[match[1]] = o[match[1]];
     else if(match[2] == '*')
-      copy[match[1]] = jeWidget.defaults[match[1]];
+      copy[match[1]] = jeWidget.getDefaultValue(match[1]);
     if(match[3] == '#')
       copy[`LINEBREAK${match[1]}`] = null;
   }

--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -43,7 +43,7 @@ export class StateManaged {
   }
 
   async set(property, value) {
-    if(value === this.defaults[property])
+    if(value === this.getDefaultValue(property))
       value = null;
     if(this.state[property] === value || this.state[property] === undefined && value === null)
       return;

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -918,7 +918,9 @@ export class Widget extends StateManaged {
     this.hoverTargetDistance = 99999;
     this.hoverTarget = null;
 
+    this.disablePileUpdateAfterParentChange = true;
     await this.set('parent', null);
+    delete this.disablePileUpdateAfterParentChange;
 
     for(const t of this.dropTargets)
       t.domElement.classList.add('droppable');
@@ -1021,7 +1023,8 @@ export class Widget extends StateManaged {
         if(Array.isArray(newParent.get('enterRoutine')))
           await newParent.evaluateRoutine('enterRoutine', { oldParentID: oldValue === undefined ? null : oldValue }, { child: [ this ] });
       }
-      await this.updatePiles();
+      if(!this.disablePileUpdateAfterParentChange)
+        await this.updatePiles();
     }
   }
 


### PR DESCRIPTION
There were a few places in the code that directly accessed `widget.defaults` instead of `widget.getDefaultValue()`. For the most part that is not a problem but for cards default values can be changed in the deck.

The problem that came up is #337: Setting a `x: 100` in `cardDefaults` would not change the behaviour that moving the card to `x: 0` would remove `x` from the card. The system assumed that the default would be `x: 0` but as soon as it is removed it would use the `x: 100` from `cardDefaults`.