### PR TITLE
only show games list for an empty room once

### DIFF
--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -12,6 +12,7 @@ let delta = { s: {} };
 let deltaChanged = false;
 let deltaID = 0;
 let batchDepth = 0;
+let overlayShownForEmptyRoom = false;
 
 export function addWidget(widget, instance) {
   if(widget.parent && !widgets.has(widget.parent)) {
@@ -163,8 +164,10 @@ onLoad(function() {
         isEmpty = false;
       }
     }
-    if(isEmpty && !urlProperties.load && !urlProperties.askID)
+    if(isEmpty && !overlayShownForEmptyRoom && !urlProperties.load && !urlProperties.askID) {
       showOverlay('statesOverlay');
+      overlayShownForEmptyRoom = true;
+    }
     toServer('confirm');
   });
   setScale();


### PR DESCRIPTION
When there are no widgets in the room, the game list overlay is shown automatically to help new users. This leads to confusing behaviour if you actually want to load an empty "game" to clear the room. This PR changes this feature so it only displays the game list _once_ until you reload the page.