### PR TITLE
fixed disappearing children of cards, basicwidgets and buttons

### DIFF
--- a/client/css/widgets/card.css
+++ b/client/css/widgets/card.css
@@ -6,18 +6,11 @@ body.edit .card {
   display: none;
 }
 
-.card > div {
-  /* targets inactive faces */
+.card > .cardFace {
   display: none;
 }
 
-.card > div.widget {
-  /* child widgets of the card */
-  display: block;
-}
-
-.card > div.active {
-  /* active face */
+.card > .active.cardFace {
   display: block;
   overflow: hidden;
   width: 100%;
@@ -26,8 +19,7 @@ body.edit .card {
   box-sizing: border-box;
 }
 
-.card > div.active > div {
-  /* active face objects */
+.card > .active.cardFace > .cardFaceObject {
   position: absolute;
   background-size: contain;
   background-repeat: no-repeat;

--- a/client/css/widgets/label.css
+++ b/client/css/widgets/label.css
@@ -4,7 +4,7 @@
   text-align: center;
 }
 
-.label textarea {
+.label > textarea {
   border: none;
   background: none;
   padding: 0;

--- a/client/css/widgets/spinner.css
+++ b/client/css/widgets/spinner.css
@@ -1,4 +1,4 @@
-.spinner svg.background {
+.spinner > svg.background {
   position: absolute;
   background: white;
   color: black;
@@ -9,7 +9,7 @@
   box-sizing: border-box;
 }
 
-.spinner div.spinner {
+.spinner > div.spinningPart {
   position: absolute;
   background-image: url(/i/spinner/SpinnerVTTblue.svg);
   background-size: 70% 70%;
@@ -20,7 +20,7 @@
   height: 100%;
 }
 
-.spinner div.value {
+.spinner > div.value {
   position: absolute;
   display: flex;
   justify-content: center;
@@ -37,7 +37,7 @@
   opacity: 1;
 }
 
-.spinner div.value.hidden {
+.spinner > div.value.hidden {
   opacity: 0;
 }
 
@@ -45,11 +45,11 @@ body.edit .spinner {
   border-radius: 100%;
 }
 
-body.edit .spinner svg.background, body.edit .spinner div.spinner {
+body.edit .spinner > svg.background, body.edit .spinner > div.spinningPart {
   display: none;
 }
 
-body.edit .spinner div.value {
+body.edit .spinner > div.value {
   color: var(--editColor);
   background: transparent;
 }

--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -6,6 +6,16 @@ export function $a(selector, parent) {
   return (parent || document).querySelectorAll(selector);
 }
 
+export function setText(node, text) {
+  for(const child of node.childNodes) {
+    if(child.nodeType == Node.TEXT_NODE) {
+      child.nodeValue = text;
+      return;
+    }
+  }
+  node.appendChild(document.createTextNode(text));
+}
+
 export function removeFromDOM(node) {
   if(typeof node == 'string') {
     for(const c of $a(node))

--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -28,7 +28,7 @@ class BasicWidget extends Widget {
         this.applyDelta(face);
     }
     if(delta.text !== undefined)
-      this.domElement.textContent = delta.text;
+      setText(this.domElement, delta.text);
 
     for(const property of Object.values(this.get('svgReplaces') || {}))
       if(delta[property] !== undefined)

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -24,7 +24,7 @@ export class Button extends Widget {
   applyDeltaToDOM(delta) {
     super.applyDeltaToDOM(delta);
     if(delta.text !== undefined)
-      this.domElement.textContent = delta.text;
+      setText(this.domElement, delta.text);
 
     for(const property of Object.values(this.get('svgReplaces') || {}))
       if(delta[property] !== undefined)

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -20,6 +20,7 @@ class Card extends Widget {
 
   applyDeltaToDOM(delta) {
     if(delta.deck !== undefined) {
+      const childNodes = [...this.domElement.childNodes];
       if(this.deck) {
         this.domElement.innerHTML = '';
         this.deck.removeCard(this);
@@ -31,6 +32,9 @@ class Card extends Widget {
       } else {
         this.deck = null;
       }
+      for(const child of childNodes)
+        if(!child.className.match(/cardFace/))
+          this.domElement.appendChild(child);
     }
 
     if(delta.cardType !== undefined && this.deck) {
@@ -80,6 +84,7 @@ class Card extends Widget {
     for(const face of faceTemplates) {
       const faceDiv = document.createElement('div');
 
+      faceDiv.classList.add('cardFace');
       if(face.css !== undefined)
         faceDiv.style.cssText = face.css;
       faceDiv.style.border = face.border ? face.border + 'px black solid' : 'none';
@@ -87,6 +92,7 @@ class Card extends Widget {
 
       for(const object of face.objects) {
         const objectDiv = document.createElement('div');
+        objectDiv.classList.add('cardFaceObject');
         const x = face.border ? object.x-face.border : object.x;
         const y = face.border ? object.y-face.border : object.y;
         let css = object.css ? object.css + '; ' : '';

--- a/client/js/widgets/spinner.js
+++ b/client/js/widgets/spinner.js
@@ -48,6 +48,7 @@ class Spinner extends Widget {
   }
 
   createChildNodes() {
+    const childNodes = [...this.domElement.childNodes];
     const ns = 'http://www.w3.org/2000/svg'
 
     const bg = document.createElementNS(ns, 'svg');
@@ -90,6 +91,10 @@ class Spinner extends Widget {
     this.value.setAttribute('style', this.get('valueCSS'));
     this.value.textContent = this.get('value');
     this.domElement.appendChild(this.value);
+
+    for(const child of childNodes)
+      if(String(child.className).match(/widget/))
+        this.domElement.appendChild(child);
   }
 
   css() {

--- a/client/js/widgets/spinner.js
+++ b/client/js/widgets/spinner.js
@@ -81,7 +81,7 @@ class Spinner extends Widget {
     this.domElement.appendChild(bg);
 
     this.spinner = document.createElement('div');
-    this.spinner.setAttribute('class', 'spinner');
+    this.spinner.setAttribute('class', 'spinningPart');
     this.spinner.setAttribute('style', this.get('spinnerCSS'));
     this.domElement.appendChild(this.spinner);
 


### PR DESCRIPTION
This PR fixes some cases where children would break:

- If properties of a card or spinner changed that triggered a rebuild of their DOM, all their children would disappear.
- If the text of a BasicWidget or button would change, all its children would disappear.
- If a spinner was a child of another spinner it would have the spinning part as another background (because of a CSS rule `.spinner > .spinner` (the spinning part of a spinner also had class `spinner`).