### PR TITLE
apply fileupdater to CLONE properties and fix version in downloaded states

### DIFF
--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -36,6 +36,9 @@ function updateRoutine(routine, v) {
     return;
 
   for(const operation of routine) {
+    if(operation.func == 'CLONE') {
+      updateProperties(operation.properties, v);
+    }
     if(operation.func == 'IF') {
       updateRoutine(operation.thenRoutine, v);
       updateRoutine(operation.elseRoutine, v);

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -165,7 +165,7 @@ export default class Room {
         state = await FileLoader.readVariantFromLink(v.link);
       else
         state = JSON.parse(fs.readFileSync(this.variantFilename(stateID, vID)));
-      state._meta = { version: this.state._meta.version, info: { ...this.state._meta.states[stateID] } };
+      state._meta = { version: state._meta.version, info: { ...this.state._meta.states[stateID] } };
       Object.assign(state._meta.info, state._meta.info.variants[vID]);
       delete state._meta.info.variants;
       delete state._meta.info.link;


### PR DESCRIPTION
This PR makes the fileupdater treat the `properties` parameter of the `CLONE` operation as if it was a widget of its own because it just contains a set of properties.

This means that any `*Routine` properties in there will now receive updates as well.


I also noticed that when downloading a state from a room, the downloaded file would have the unchanged JSON from the state but it received the version number from the room itself. This is a very big issue unfortunately because it leads to broken VTT files (and subsequently imports).