### PR TITLE
Public library: Add Adedanha, others

### DIFF
--- a/tests/testcafe/tests.js
+++ b/tests/testcafe/tests.js
@@ -217,7 +217,7 @@ test('Dynamic expressions', async t => {
   };
 });
 
-publicLibraryButtons('Blue',               0, '958779d826b6e2dbfafc67e68cc8ae67', [
+publicLibraryButtons('Blue',               0, '1d07cb56897ca1216481c6727b737659', [
   'fcc3fa2c-c091-41bc-8737-54d8b9d3a929', 'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_incrementButton',
   'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_incrementButton', 'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_decrementButton',
   'fdc25f83-ed33-4845-a97c-ff35fa8a094f_shuffleButton', 'buttonInputGo', 'fcc3fa2c-c091-41bc-8737-54d8b9d3a929', '9n2q'
@@ -233,7 +233,6 @@ publicLibraryButtons('Functions - CALL',   0, '073854a669798982ecd7a365e079d00e'
   'n4cw_8_C', '5a52', '5a52', '66kr', 'qeg1', 'n4cwB', '8r6p', 'qeg1', 'qeg1', 'n5eu'
 ]);
 publicLibraryButtons('Functions - CLICK',  0, 'b2430bd4589116a05df1fcedb55337c4', [ '7u2q' ]);
-publicLibraryButtons('Functions - RANDOM', 0, '81fa0b7e8256c85fbffd32308d2cdb5c', [ '9fhb', 'yqji', 'oeh9' ]);
 publicLibraryButtons('Functions - ROTATE', 0, '747586b12401e43382a7db2b2505f25e', [ 'c44c', '9kdj', 'w53c', 'w53c' ]);
 publicLibraryButtons('Functions - SELECT', 0, '4db86f0a95509b1c4fe5ebd6a1f822a9', [ 'oeh9', '9fhb', 'njkk', 'ffwl', 'bomo' ]);
 publicLibraryButtons('Functions - SORT',   1, 'dd047343b667795ad6d3f366aa2ae2fd', [


### PR DESCRIPTION
Public Library
- Adedanha. New game by RaphaelAlvez.  Similar to Scattergories.
- Liar's Dice. New game by RaphaelAlvez.
- Blue. Updated after DevGameNight. Added automation to arrows.
- Flora. Updated after DevGameNight. Added 2 automation buttons, discard holders, changed one card color, updated Unicode to images, removed grid from bottom row, and changed onLeave flip behavior.

Public Tutorials:
- changeRoutine.  New. Uses the concept of sliders to illustrate changeRoutine.
- Timer. New. Has basic variant and variant demonstrating how to made a card dealing animation.
- Button appearance. Revised to reflect changes to button color properties from PR #461. Add a basic appearance intro and revised the text only appearance variant.
- Hexagonal cards. Updated “find width” functions to properly limit decimal places to 3.
- Random.  Removed as it is no longer a stand-alone function.