### PR TITLE
place value compression of repeating color values

### DIFF
--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -54,7 +54,7 @@ class Canvas extends Widget {
 
   compress(str) {
     const startStr = str;
-    str = str.replaceAll(/(.)\1+/, (match, char, offset, str) => {
+    str = str.replaceAll(/(.)\1+/g, (match, char, offset, str) => {
       if(match.length + offset == str.length) {
         return char;
       } else if(match.length == 2) {
@@ -73,7 +73,7 @@ class Canvas extends Widget {
   }
 
   decompress(str) {
-    str = str.replaceAll(/[^\u0020-\u002F][\u0020-\u002F]+/, match => {
+    str = str.replaceAll(/[^\u0020-\u002F][\u0020-\u002F]+/g, match => {
       return match.split("").reduce((acc, char, index) => {
         return acc + acc.charAt(0).repeat((char.charCodeAt(0)-32)*16**(index-1));
       });

--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -88,7 +88,7 @@ class Canvas extends Widget {
     let n = length;
     let c = 0;
     let code = "";
-    while n > 0 {
+    while(n > 0) {
       c = (n - 1) % base;
       code += String.fromCharCode(baseCode - c);
       n = Math.floor((n - c) / base);

--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -57,14 +57,24 @@ class Canvas extends Widget {
     str = str.replaceAll(/(.)\1+/g, (match, char, offset, str) => {
       if(match.length + offset == str.length) {
         return char;
+      } else if(char == "0") {
+        let n = match.length;
+        let c = 0;
+        let code = "";
+        while (n > 0) {
+          c = (n - 1) % 7;
+          code += String.fromCharCode(48 - c);
+          n = Math.floor((n - c) / 7);
+        }
+        return code
       } else if(match.length == 2) {
         return match;
       } else {
         let n = match.length - 1;
         let code = char;
         while (n > 0) {
-          code += String.fromCharCode(35 + n % 13);
-          n = Math.floor(n / 13);
+          code += String.fromCharCode(35 + n % 6);
+          n = Math.floor(n / 6);
         }
         return code;
       }
@@ -73,10 +83,16 @@ class Canvas extends Widget {
   }
 
   decompress(str) {
-    str = str.replaceAll(/[^\u0023-\u002F][\u0023-\u002F]+/g, match => {
-      return match.split("").reduce((acc, char, index) => {
-        return acc + acc.charAt(0).repeat((char.charCodeAt(0)-35)*13**(index-1));
-      });
+    str = str.replaceAll(/([\u0029-\u0030]+)|[^\u0023-\u0030][\u0023-\u0028]+/g, (match, bc) => {
+      if (bc != undefined) {
+        return match.split("").reduce((acc, char, index, , "") => {
+          return acc + "0".repeat((49-char.charCodeAt(0))*7**(index));
+        });
+      } else {
+        return match.split("").reduce((acc, char, index) => {
+          return acc + acc.charAt(0).repeat((char.charCodeAt(0)-35)*6**(index-1));
+        });
+      }
     });
     str = str.padEnd(this.getResolution()**2/100,str.slice(-1));
     return str;

--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -63,8 +63,8 @@ class Canvas extends Widget {
         let n = match.length - 1;
         let code = char;
         while (n > 0) {
-          code += String.fromCharCode(33 + n % 15);
-          n = Math.floor(n / 15);
+          code += String.fromCharCode(36 + n % 8);
+          n = Math.floor(n / 8);
         }
         return code;
       }
@@ -73,9 +73,9 @@ class Canvas extends Widget {
   }
 
   decompress(str) {
-    str = str.replaceAll(/[^\u0021-\u002F][\u0021-\u002F]+/g, match => {
+    str = str.replaceAll(/[^\u0024-\u002B][\u0024-\u002B]+/g, match => {
       return match.split("").reduce((acc, char, index) => {
-        return acc + acc.charAt(0).repeat((char.charCodeAt(0)-33)*15**(index-1));
+        return acc + acc.charAt(0).repeat((char.charCodeAt(0)-36)*8**(index-1));
       });
     });
     str = str.padEnd(this.getResolution()**2/100,str.slice(-1));

--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -63,8 +63,8 @@ class Canvas extends Widget {
         let n = match.length - 1;
         let code = char;
         while (n > 0) {
-          code += String.fromCharCode(32 + n % 16);
-          n = Math.floor(n / 16);
+          code += String.fromCharCode(33 + n % 15);
+          n = Math.floor(n / 15);
         }
         return code;
       }
@@ -73,9 +73,9 @@ class Canvas extends Widget {
   }
 
   decompress(str) {
-    str = str.replaceAll(/[^\u0020-\u002F][\u0020-\u002F]+/g, match => {
+    str = str.replaceAll(/[^\u0021-\u002F][\u0021-\u002F]+/g, match => {
       return match.split("").reduce((acc, char, index) => {
-        return acc + acc.charAt(0).repeat((char.charCodeAt(0)-32)*16**(index-1));
+        return acc + acc.charAt(0).repeat((char.charCodeAt(0)-32)*15**(index-1));
       });
     });
     str = str.padEnd(this.getResolution()**2/100,str.slice(-1));

--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -59,7 +59,7 @@ class Canvas extends Widget {
         return char;
       } else if(char == "0") {
         return this.encodeLength(48, match.length, 7);
-      } else if(match.length == 2) {
+      } else if(match.length == 2 && char.charCodeAt(0) < 128) {
         return match;
       } else {
         return char + this.encodeLength(41, match.length - 1, 7);

--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -62,7 +62,7 @@ class Canvas extends Widget {
       } else if(match.length == 2) {
         return match;
       } else {
-        return char + this.encodeLength(41, match.length-1, 7);
+        return char + this.encodeLength(41, match.length - 1, 7);
       }
     });
     return str;
@@ -73,7 +73,7 @@ class Canvas extends Widget {
       if (backLength != undefined) {
         return "0".repeat(this.decodeLength(backLength, 48, 7));
       } else {
-        return color.repeat(this.decodeLength(colorLength, 41, 7));
+        return color.repeat(this.decodeLength(colorLength, 41, 7) + 1);
       }
     });
     str = str.padEnd(this.getResolution()**2/100,str.slice(-1));

--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -85,9 +85,9 @@ class Canvas extends Widget {
   decompress(str) {
     str = str.replaceAll(/([\u0029-\u0030]+)|[^\u0023-\u0030][\u0023-\u0028]+/g, (match, bc) => {
       if (bc != undefined) {
-        return match.split("").reduce((acc, char, index, arr, "") => {
+        return match.split("").reduce((acc, char, index) => {
           return acc + "0".repeat((49-char.charCodeAt(0))*7**(index));
-        });
+        }, "");
       } else {
         return match.split("").reduce((acc, char, index) => {
           return acc + acc.charAt(0).repeat((char.charCodeAt(0)-35)*6**(index-1));

--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -63,8 +63,8 @@ class Canvas extends Widget {
         let n = match.length - 1;
         let code = char;
         while (n > 0) {
-          code += String.fromCharCode(36 + n % 8);
-          n = Math.floor(n / 8);
+          code += String.fromCharCode(35 + n % 13);
+          n = Math.floor(n / 13);
         }
         return code;
       }
@@ -73,9 +73,9 @@ class Canvas extends Widget {
   }
 
   decompress(str) {
-    str = str.replaceAll(/[^\u0024-\u002B][\u0024-\u002B]+/g, match => {
+    str = str.replaceAll(/[^\u0023-\u002F][\u0023-\u002F]+/g, match => {
       return match.split("").reduce((acc, char, index) => {
-        return acc + acc.charAt(0).repeat((char.charCodeAt(0)-36)*8**(index-1));
+        return acc + acc.charAt(0).repeat((char.charCodeAt(0)-35)*13**(index-1));
       });
     });
     str = str.padEnd(this.getResolution()**2/100,str.slice(-1));

--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -75,7 +75,7 @@ class Canvas extends Widget {
   decompress(str) {
     str = str.replaceAll(/[^\u0021-\u002F][\u0021-\u002F]+/g, match => {
       return match.split("").reduce((acc, char, index) => {
-        return acc + acc.charAt(0).repeat((char.charCodeAt(0)-32)*15**(index-1));
+        return acc + acc.charAt(0).repeat((char.charCodeAt(0)-33)*15**(index-1));
       });
     });
     str = str.padEnd(this.getResolution()**2/100,str.slice(-1));

--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -58,44 +58,42 @@ class Canvas extends Widget {
       if(match.length + offset == str.length) {
         return char;
       } else if(char == "0") {
-        let n = match.length;
-        let c = 0;
-        let code = "";
-        while (n > 0) {
-          c = (n - 1) % 7;
-          code += String.fromCharCode(48 - c);
-          n = Math.floor((n - c) / 7);
-        }
-        return code;
+        return this.encodeLength(48, match.length, 7);
       } else if(match.length == 2) {
         return match;
       } else {
-        let n = match.length - 1;
-        let code = char;
-        while (n > 0) {
-          code += String.fromCharCode(35 + n % 6);
-          n = Math.floor(n / 6);
-        }
-        return code;
+        return char + this.encodeLength(41, match.length-1, 7);
       }
     });
     return str;
   }
 
   decompress(str) {
-    str = str.replaceAll(/([\u0029-\u0030]+)|[^\u0023-\u0030][\u0023-\u0028]+/g, (match, bc) => {
-      if (bc != undefined) {
-        return match.split("").reduce((acc, char, index) => {
-          return acc + "0".repeat((49-char.charCodeAt(0))*7**(index));
-        }, "");
+    str = str.replaceAll(/([\u002A-\u0030]+)|([^\u0023-\u0030])([\u0023-\u0029]+)/g, (match, backLength, color, colorLength) => {
+      if (backLength != undefined) {
+        return "0".repeat(this.decodeLength(backLength, 48, 7));
       } else {
-        return match.split("").reduce((acc, char, index) => {
-          return acc + acc.charAt(0).repeat((char.charCodeAt(0)-35)*6**(index-1));
-        });
+        return color.repeat(this.decodeLength(colorLength, 41, 7));
       }
     });
     str = str.padEnd(this.getResolution()**2/100,str.slice(-1));
     return str;
+  }
+  
+  decodeLength(str, baseCode, base) {
+    return str.split("").reduce((length, char, index) => length + (baseCode - char.charCodeAt(0) + 1) * base**index , 0);
+  }
+  
+  encodeLength(baseCode, length, base) {
+    let n = length;
+    let c = 0;
+    let code = "";
+    while n > 0 {
+      c = (n - 1) % base;
+      code += String.fromCharCode(baseCode - c);
+      n = Math.floor((n - c) / base);
+    }
+    return code;
   }
 
   getResolution() {

--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -66,7 +66,7 @@ class Canvas extends Widget {
           code += String.fromCharCode(48 - c);
           n = Math.floor((n - c) / 7);
         }
-        return code
+        return code;
       } else if(match.length == 2) {
         return match;
       } else {
@@ -85,7 +85,7 @@ class Canvas extends Widget {
   decompress(str) {
     str = str.replaceAll(/([\u0029-\u0030]+)|[^\u0023-\u0030][\u0023-\u0028]+/g, (match, bc) => {
       if (bc != undefined) {
-        return match.split("").reduce((acc, char, index, , "") => {
+        return match.split("").reduce((acc, char, index, arr, "") => {
           return acc + "0".repeat((49-char.charCodeAt(0))*7**(index));
         });
       } else {


### PR DESCRIPTION
This uses `#$%&'()` to encode the repeat length for most colors. The color character is encoded first, then the code for how many times it is repeated if the color occurs for at least 3 pixels in a row (a color occurring only twice in a row the color code simply gets repeated). The characters `*+,-./0` encode the repeat length of the color `0`; but `0` is not always in the encoding. To make `0` mean one `0` the values of the characters used are 1-7 with the highest code point representing the lowest value (no zero is needed, 14 is encoded as 7 ones + 1 seven, 56 is 7 ones + 7 sevens). For the maximum supported canvas size (500x500 - 2500 pixels per region) the maximum possible length of a repeat encoding is 4 characters (7 + 7 x 7 + 7 x 7^2 + 7 x 7^3 = 2800). For a 200x200 canvas (400 pixels per region) 3 character repeat codes are always sufficient (7 + 7 x 7 + 7 x 7^2 = 399).