### PR TITLE
fixed that a property variable would not create a copy

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -291,7 +291,7 @@ export class Widget extends StateManaged {
             return null;
           widget = widgets.get(id);
         }
-        return widget.get(evaluateIdentifier(match[5], match[6]));
+        return JSON.parse(JSON.stringify(widget.get(evaluateIdentifier(match[5], match[6]))));
       }
 
       return null;


### PR DESCRIPTION
When using `${PROPERTY array}`, it would not create a deep copy of the property but instead return a reference.

This leads to unintended behavior because changing a resulting variable directly changes the property of the widget and at the same time the system does not get notified of the change because it is the _same_ array.

This should be fixed ASAP because the change is a breaking change but IMHO unavoidable.