### PR TITLE
Add Fantasy Wars, Hangman, other updates

### DIFF
--- a/client/js/main.js
+++ b/client/js/main.js
@@ -53,6 +53,12 @@ function getMaxZ(layer) {
   return maxZ[layer] || 0;
 }
 
+async function resetMaxZ(layer) {
+  maxZ[layer] = 0;
+  for(const w of widgetFilter(w=>w.get('layer')==layer&&w.state.z).sort((a,b)=>a.get('z')-b.get('z')))
+    await w.set('z', ++maxZ[layer]);
+}
+
 function updateMaxZ(layer, z) {
   maxZ[layer] = Math.max(maxZ[layer] || 0, z);
 }

--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -48,8 +48,11 @@ export class StateManaged {
     if(this.state[property] === value || this.state[property] === undefined && value === null)
       return;
 
-    if(property == 'z')
+    if(property == 'z') {
       updateMaxZ(this.get('layer'), value);
+      if(value > 90000)
+        return await resetMaxZ(this.get('layer'));
+    }
 
     const oldValue = this.state[property];
     if(value === null)

--- a/tests/testcafe/tests.js
+++ b/tests/testcafe/tests.js
@@ -223,7 +223,7 @@ publicLibraryButtons('Blue',               0, '1d07cb56897ca1216481c6727b737659'
   'fdc25f83-ed33-4845-a97c-ff35fa8a094f_shuffleButton', 'buttonInputGo', 'fcc3fa2c-c091-41bc-8737-54d8b9d3a929', '9n2q'
 ]);
 publicLibraryButtons('FreeCell',           0, 'b3339b3c5d42f47f4def7a164be69823', [ 'reset', 'jemz', 'reset' ]);
-publicLibraryButtons('Reward',             0, 'cbf8598d244e1290efe98f0d7fb3ccc8', [
+publicLibraryButtons('Reward',             0, '0bc118deb3c79e40f75fac7dd8180b20', [
   'gmex', 'kprc', 'oksq', 'j1wz', 'vfhn', '0i6i', 'Orange Recall', 'buttonInputGo', 'b09z'
 ]);
 publicLibraryButtons('Rummy Tiles',        0, 'c593e557612c383acaa757b4124a4d36', [ 'startMix', 'draw14' ]);

--- a/tests/testcafe/tests.js
+++ b/tests/testcafe/tests.js
@@ -217,13 +217,13 @@ test('Dynamic expressions', async t => {
   };
 });
 
-publicLibraryButtons('Blue',               0, '1d07cb56897ca1216481c6727b737659', [
+publicLibraryButtons('Blue',               0, 'e25ceda4c84138c16410f428d1021914', [
   'fcc3fa2c-c091-41bc-8737-54d8b9d3a929', 'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_incrementButton',
   'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_incrementButton', 'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_decrementButton',
   'fdc25f83-ed33-4845-a97c-ff35fa8a094f_shuffleButton', 'buttonInputGo', 'fcc3fa2c-c091-41bc-8737-54d8b9d3a929', '9n2q'
 ]);
 publicLibraryButtons('FreeCell',           0, 'b3339b3c5d42f47f4def7a164be69823', [ 'reset', 'jemz', 'reset' ]);
-publicLibraryButtons('Reward',             0, '0bc118deb3c79e40f75fac7dd8180b20', [
+publicLibraryButtons('Reward',             0, '44336b9a60311a8fcdaf11af3227d76c', [
   'gmex', 'kprc', 'oksq', 'j1wz', 'vfhn', '0i6i', 'Orange Recall', 'buttonInputGo', 'b09z'
 ]);
 publicLibraryButtons('Rummy Tiles',        0, 'c593e557612c383acaa757b4124a4d36', [ 'startMix', 'draw14' ]);


### PR DESCRIPTION
Public Library:
- Blue: Fixed layers on a couple of labels.
- Connex: Updated with css rotation animation for game pieces.
- Fantasy Wars. New game by RaphaelAlvez.  Similar to War Chest.
- Hangman. New game by LawDawg.  Portuguese word list by RaphaelAlvez.
- Medieval VNO. Added variant with automation following play on Dev Game Night.
- Reward. Updated with lower z values.
- Tantrums. Updated with css rotation animation for game pieces and replaced Unicode symbols with svg images.

Public Tutorials:
- Button Appearance.  Added on buton on CSS Shapes Variant
- changeRoutine. Optimized all the JSON for dynamic expressions.
- Functions – GET. Added a comment about using dynamic expressions.
- Hexagonal Cards. Fixed typo on button in The Basics variant for calculator of height and width.  Optimized some JSON for dynamic expressions.
- Holders. Optimized some JSON for dynamic expressions on Offset: Advanced and Moving: Basic variants.

Public Assets:
- Other Widgets.  Renamed the Coordinate Helper variant to Misc Tools and added a new widget by Interitus that provides a list of widgets in a room sorted by layer, type, and then alphabetical.

Updated library.json and tests.js (with new Blue checksum).

For some reason, the tests.js file replaced the existing one completely without showing just the change, but the only change is the Blue checksum.