### PR TITLE
added a command for testcafe in gitpod

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "testcafe-chromium": "testcafe chromium tests/testcafe/tests.js",
     "testcafe-chromium-headless": "testcafe chromium:headless tests/testcafe/tests.js",
     "testcafe-firefox": "testcafe firefox tests/testcafe/tests.js",
-    "testcafe-firefox-headless": "testcafe firefox:headless tests/testcafe/tests.js"
+    "testcafe-firefox-headless": "testcafe firefox:headless tests/testcafe/tests.js",
+    "testcafe-gitpod": "bash tests/testcafe/gitpod.sh"
   },
   "repository": {
     "type": "git",

--- a/tests/testcafe/gitpod.sh
+++ b/tests/testcafe/gitpod.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+if ! which firefox >/dev/null 2>&1; then
+  sudo apt update
+  sudo apt install -y firefox
+fi
+npm run testcafe-firefox-headless


### PR DESCRIPTION
TestCafé works fine in GitPod. It's just that no browser is installed.

This PR adds the command `npm run testcafe-gitpod` which first installs Firefox and then runs `npm run testcafe-firefox-headless`.