### PR TITLE
greatly improved conflict detection

### DIFF
--- a/server/player.mjs
+++ b/server/player.mjs
@@ -53,9 +53,18 @@ export default class Player {
       for(const conflictDelta of this.possiblyConflictingDeltas) {
         for(const widgetID in delta.s) {
           if(conflictDelta.s[widgetID] !== undefined) {
-            this.waitingForStateConfirmation = true;
-            this.room.receiveInvalidDelta(this, delta, widgetID);
-            return;
+            if((delta.s[widgetID] === null) != (conflictDelta.s[widgetID] === null)) {
+              this.waitingForStateConfirmation = true;
+              this.room.receiveInvalidDelta(this, delta, widgetID, '<deletion>');
+              return;
+            }
+            for(const key in delta.s[widgetID]) {
+              if(conflictDelta.s[widgetID][key] !== undefined && delta.s[widgetID][key] !== conflictDelta.s[widgetID][key]) {
+                this.waitingForStateConfirmation = true;
+                this.room.receiveInvalidDelta(this, delta, widgetID, key);
+                return;
+              }
+            }
           }
         }
       }

--- a/server/player.mjs
+++ b/server/player.mjs
@@ -52,13 +52,18 @@ export default class Player {
     if(delta.id < this.latestDeltaIDbyDifferentPlayer) {
       for(const conflictDelta of this.possiblyConflictingDeltas) {
         for(const widgetID in delta.s) {
-          if(conflictDelta.s[widgetID] !== undefined) {
-            if((delta.s[widgetID] === null) != (conflictDelta.s[widgetID] === null)) {
+          if(conflictDelta.id > delta.id && conflictDelta.s[widgetID] !== undefined) {
+            // widget was deleted in both deltas - no problem
+            if(delta.s[widgetID] === null && conflictDelta.s[widgetID] === null)
+              continue;
+            // widget was deleted in ONE of the deltas -> conflict
+            if(delta.s[widgetID] === null || conflictDelta.s[widgetID] === null) {
               this.waitingForStateConfirmation = true;
               this.room.receiveInvalidDelta(this, delta, widgetID, '<deletion>');
               return;
             }
             for(const key in delta.s[widgetID]) {
+              // a property of the widget was changed in both deltas and not to the same value -> conflict
               if(conflictDelta.s[widgetID][key] !== undefined && delta.s[widgetID][key] !== conflictDelta.s[widgetID][key]) {
                 this.waitingForStateConfirmation = true;
                 this.room.receiveInvalidDelta(this, delta, widgetID, key);

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -275,8 +275,8 @@ export default class Room {
     this.broadcast('delta', delta, player);
   }
 
-  receiveInvalidDelta(player, delta, widgetID) {
-    Logging.log(`WARNING: received conflicting delta data for widget ${widgetID} from player ${player.name} in room ${this.id} - sending game state at ${this.deltaID}`);
+  receiveInvalidDelta(player, delta, widgetID, property) {
+    Logging.log(`WARNING: received conflicting delta data for property ${property} of widget ${widgetID} from player ${player.name} in room ${this.id} - sending game state at ${this.deltaID}`);
     this.state._meta.deltaID = ++this.deltaID;
     player.send('state', this.state);
   }


### PR DESCRIPTION
The conflict detection in VTT is responsible for making sure that every client has the same room state. If two clients edit the same widget "at the same time" (so before knowing about the changes by the other client), the server tells the later client that the change was invalid and resends the entire room state.

In general this seems to be working quite well. I am not aware of any instance where two clients diverged from each other.

There have been issues with falsely detected conflicts though. So the conflict resolution was triggered seemingly unnecessarily and one player saw the room blink (state reloaded) and whatever widget they tried to drag got ripped out of their "hand".

When working on JSON editor and timer improvements yesterday, I refined the conflict detection to work on property basis (previously a conflict was triggered if the same widget was changed - no matter which properties were affected). But afterwards I still had conflicts I did not expect.

Turns out the conflict detection was looking at older deltas than it needed to.

This PR changes the conflict detection to property level and restricts it to only look at deltas that are newer than the one the conflicting delta was based on.

This should be tested thoroughly because I do not want clients to have diverging room states. I would much prefer the current state where too many conflicts are detected than too few.