### PR TITLE
fixed crashes in JSON editor when having inconsistent indentation

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -859,6 +859,7 @@ function jeGetContext() {
     jeJSONerror = e;
   }
 
+  // go through all the lines up until the cursor and use the indentation to figure out the context
   let keys = [ t ];
   for(const line of v.split('\n').slice(0, v.substr(0, s).split('\n').length)) {
     const m = line.match(/^( +)(["{])([^"]*)/);
@@ -871,6 +872,20 @@ function jeGetContext() {
     if(mClose)
       keys = keys.slice(0, mClose[1].length/2+1);
   }
+
+  // make sure the context actually exists in the widget
+  if(!jeJSONerror) {
+    let pointer = jeStateNow;
+    for(let i=1; i<keys.length; ++i) {
+      if(pointer[keys[i]] === undefined) {
+        keys = keys.slice(0, i);
+        break;
+      }
+      pointer = pointer[keys[i]];
+    }
+  }
+
+  // insert the operation type as a virtual key so commands can check which operation they're in
   try {
     for(let i=1; i<keys.length-1; ++i) {
       if(String(keys[i]).match(/Routine$/) && typeof keys[i+1] == 'number' && !jeJSONerror) {


### PR DESCRIPTION
The context detection in the JSON editor uses the indentation to try to figure out where the cursor is and what commands to display.

When the indentation is not perfect, this does not work reliably.

This PR adds a sanity check to the context detection that makes sure that the detected context actually exists in the widget. If it does not, everything that cannot be found is removed from the context.