### PR TITLE
fixed cursor in JSON editor jumping to the start

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -722,8 +722,13 @@ function jeSelectWidget(widget, dontFocus, addToSelection, restoreCursorPosition
     const v = $('#jeText').textContent;
     const linesUntilCursor = v.split('\n').slice(0, v.substr(0, s).split('\n').length);
     const currentLine = linesUntilCursor.pop();
+    let defaultValueToAdd = null;
+    const defaultValueMatch = currentLine.match(/^  "([^"]+)": (.*?),?$/);
+    if(defaultValueMatch && jeWidget && jeWidget.getDefaultValue(defaultValueMatch[1]) === JSON.parse(defaultValueMatch[2]))
+      defaultValueToAdd = defaultValueMatch[1];
     var cursorState = {
       currentLine,
+      defaultValueToAdd,
       sameLinesBefore: linesUntilCursor.filter(l=>l==currentLine).length,
       start: s-linesUntilCursor.join('\n').length,
       end: e-linesUntilCursor.join('\n').length
@@ -735,8 +740,10 @@ function jeSelectWidget(widget, dontFocus, addToSelection, restoreCursorPosition
   } else {
     jeMode = 'widget';
     jeWidget = widget;
-    jeStateNow = widget.state;
-    jeSet(jeStateBefore = jePreProcessText(JSON.stringify(jePreProcessObject(widget.state), null, '  ')), dontFocus);
+    jeStateNow = JSON.parse(JSON.stringify(widget.state));
+    if(restoreCursorPosition && cursorState.defaultValueToAdd && jeStateNow[cursorState.defaultValueToAdd] === undefined)
+      jeStateNow[cursorState.defaultValueToAdd] = jeWidget.getDefaultValue(cursorState.defaultValueToAdd);
+    jeSet(jeStateBefore = jePreProcessText(JSON.stringify(jePreProcessObject(jeStateNow), null, '  ')), dontFocus);
   }
 
   if(restoreCursorPosition) {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -805,9 +805,11 @@ function jeSelectWidget(widget, dontFocus, addToSelection, restoreCursorPosition
     const linesUntilCursor = v.split('\n').slice(0, v.substr(0, s).split('\n').length);
     const currentLine = linesUntilCursor.pop();
     let defaultValueToAdd = null;
-    const defaultValueMatch = currentLine.match(/^  "([^"]+)": (.*?),?$/);
-    if(defaultValueMatch && jeWidget && jeWidget.getDefaultValue(defaultValueMatch[1]) === JSON.parse(defaultValueMatch[2]))
-      defaultValueToAdd = defaultValueMatch[1];
+    try {
+      const defaultValueMatch = currentLine.match(/^  "([^"]+)": (.*?),?$/);
+      if(defaultValueMatch && jeWidget && jeWidget.getDefaultValue(defaultValueMatch[1]) === JSON.parse(defaultValueMatch[2]))
+        defaultValueToAdd = defaultValueMatch[1];
+    } catch(e) {}
     var cursorState = {
       currentLine,
       defaultValueToAdd,

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1360,7 +1360,8 @@ window.addEventListener('keydown', async function(e) {
 });
 
 window.addEventListener('keydown', function(e) {
-  jeKeyIsDown = true;
+  if(e.key != 'Control')
+    jeKeyIsDown = true;
 });
 
 window.addEventListener('keyup', function(e) {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -791,6 +791,7 @@ function jeSelectWidget(widget, dontFocus, addToSelection, restoreCursorPosition
   } else {
     jeMode = 'widget';
     jeWidget = widget;
+    jeKeyIsDownDeltas = [];
     jeStateNow = JSON.parse(JSON.stringify(widget.state));
     if(restoreCursorPosition && cursorState.defaultValueToAdd && jeStateNow[cursorState.defaultValueToAdd] === undefined)
       jeStateNow[cursorState.defaultValueToAdd] = jeWidget.getDefaultValue(cursorState.defaultValueToAdd);

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -281,7 +281,7 @@ const jeCommands = [
       const oldStart = getSelection().anchorOffset;
       const oldEnd   = getSelection().focusOffset;
       jeSet(JSON.stringify(jeStateNow, null, '  '));
-      jeSelect(oldStart, oldEnd);
+      jeSelect(oldStart, oldEnd, true);
     },
     show: function() {
       return jeGetValue(jeContext.slice(0, -1))[jeContext[jeContext.length-1]] !== undefined;
@@ -804,7 +804,7 @@ function jeSelectWidget(widget, dontFocus, addToSelection, restoreCursorPosition
     let linesFound = 0;
     for(const line of lines) {
       if(line == cursorState.currentLine && linesFound++ == cursorState.sameLinesBefore) {
-        jeSelect(offset + cursorState.start - 1, offset + cursorState.end - 1);
+        jeSelect(offset + cursorState.start - 1, offset + cursorState.end - 1, false);
         break;
       } else {
         offset += line.length + 1;
@@ -1046,7 +1046,7 @@ function jePasteText(text, select) {
   $('#jeText').textContent = v.substr(0, s) + text + v.substr(e);
   $('#jeText').focus();
   jeColorize();
-  jeSelect(select ? s : s + text.length, s + text.length);
+  jeSelect(select ? s : s + text.length, s + text.length, false);
 }
 
 function jePostProcessObject(o) {
@@ -1091,7 +1091,7 @@ function jePreProcessText(t) {
   return t.replace(/(\n +"LINEBREAK.*": null,)+/g, '\n').replace(/(,\n +"LINEBREAK.*": null)+/g, '');
 }
 
-function jeSelect(start, end) {
+function jeSelect(start, end, scrollToCursor) {
   const t = $('#jeText');
   const text = t.textContent;
   try {
@@ -1103,7 +1103,9 @@ function jeSelect(start, end) {
     t.scrollTop = 50000;
     t.textContent = text;
 
-    if(t.scrollTop) {
+    if(!scrollToCursor) {
+      t.scrollTop = scroll;
+    } else if(t.scrollTop) {
       if(Math.abs(t.scrollTop + t.clientHeight/2 - scroll) < t.clientHeight*.25)
         t.scrollTop = scroll;
       else
@@ -1149,7 +1151,7 @@ function jeSetAndSelect(replaceBy, insideString) {
 
   jeSet(jsonString);
   const quote = typeof replaceBy == 'string' && !insideString ? 1 : 0;
-  jeSelect(startIndex + quote, startIndex+jsonString.length-length - quote);
+  jeSelect(startIndex + quote, startIndex+jsonString.length-length - quote, true);
 }
 
 function jeShowCommands() {
@@ -1318,12 +1320,12 @@ window.addEventListener('keydown', async function(e) {
       const locationLine = String(jeJSONerror).match(/line ([0-9]+) column ([0-9]+)/);
       if(locationLine) {
         const pos = $('#jeText').textContent.split('\n').slice(0, locationLine[1]-1).join('\n').length + +locationLine[2];
-        jeSelect(pos, pos);
+        jeSelect(pos, pos, true);
       }
 
       const locationPostion = String(jeJSONerror).match(/position ([0-9]+)/);
       if(locationPostion)
-        jeSelect(+locationPostion[1], +locationPostion[1]);
+        jeSelect(+locationPostion[1], +locationPostion[1], true);
     } else if(e.key == 'j') {
       e.preventDefault();
       jeToggle();

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -648,7 +648,7 @@ function jeApplyDelta(delta) {
         if(delta.s[jeStateNow[field]] === null)
           jeDisplayTree();
         else
-          jeSelectWidget(widgets.get(jeStateNow.id), document.activeElement !== $('#jeText'));
+          jeSelectWidget(widgets.get(jeStateNow.id), document.activeElement !== $('#jeText'), false, true);
       }
     }
   }
@@ -692,7 +692,23 @@ async function jeClick(widget, e) {
   }
 }
 
-function jeSelectWidget(widget, dontFocus, addToSelection) {
+function jeSelectWidget(widget, dontFocus, addToSelection, restoreCursorPosition) {
+  if(restoreCursorPosition) {
+    const aO = getSelection().anchorOffset;
+    const fO = getSelection().focusOffset;
+    const s = Math.min(aO, fO);
+    const e = Math.max(aO, fO);
+    const v = $('#jeText').textContent;
+    const linesUntilCursor = v.split('\n').slice(0, v.substr(0, s).split('\n').length);
+    const currentLine = linesUntilCursor.pop();
+    var cursorState = {
+      currentLine,
+      sameLinesBefore: linesUntilCursor.filter(l=>l==currentLine).length,
+      start: s-linesUntilCursor.join('\n').length,
+      end: e-linesUntilCursor.join('\n').length
+    };
+  }
+
   if(addToSelection && (jeMode == 'widget' || jeMode == 'multi')) {
     jeSelectWidgetMulti(widget, dontFocus);
   } else {
@@ -700,6 +716,21 @@ function jeSelectWidget(widget, dontFocus, addToSelection) {
     jeWidget = widget;
     jeStateNow = widget.state;
     jeSet(jeStateBefore = jePreProcessText(JSON.stringify(jePreProcessObject(widget.state), null, '  ')), dontFocus);
+  }
+
+  if(restoreCursorPosition) {
+    const v = $('#jeText').textContent;
+    const lines = v.split('\n');
+    let offset = 0;
+    let linesFound = 0;
+    for(const line of lines) {
+      if(line == cursorState.currentLine && linesFound++ == cursorState.sameLinesBefore) {
+        jeSelect(offset + cursorState.start - 1, offset + cursorState.end - 1);
+        break;
+      } else {
+        offset += line.length + 1;
+      }
+    }
   }
 }
 

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1083,6 +1083,12 @@ function jeInsert(context, key, value) {
   }
 }
 
+function jeNewline() {
+  const s = Math.min(getSelection().anchorOffset, getSelection().focusOffset);
+  const match = $('#jeText').textContent.substr(0,s).match(/( *)[^\n]*$/);
+  jePasteText('\n' + match[1], false);
+}
+
 function jePasteText(text, select) {
   const aO = getSelection().anchorOffset;
   const fO = getSelection().focusOffset;
@@ -1363,13 +1369,20 @@ onLoad(function() {
 });
 
 window.addEventListener('keydown', async function(e) {
+  if(e.ctrlKey && e.key == 'j') {
+    e.preventDefault();
+    jeToggle();
+  }
+  if(!jeEnabled)
+    return;
+
   if(e.key == 'Control')
     jeState.ctrl = true;
   if(e.key == 'Shift')
     jeState.shift = true;
 
-  if(e.key == 'Enter' && jeEnabled) {
-    document.execCommand('insertHTML', false, '\n');
+  if(e.key == 'Enter') {
+    jeNewline();
     e.preventDefault();
   }
 
@@ -1384,9 +1397,6 @@ window.addEventListener('keydown', async function(e) {
       const locationPostion = String(jeJSONerror).match(/position ([0-9]+)/);
       if(locationPostion)
         jeSelect(+locationPostion[1], +locationPostion[1], true);
-    } else if(e.key == 'j') {
-      e.preventDefault();
-      jeToggle();
     } else {
       for(const command of jeCommands) {
         if(command.currentKey == e.key) {
@@ -1417,11 +1427,15 @@ window.addEventListener('keydown', async function(e) {
 });
 
 window.addEventListener('keydown', function(e) {
+  if(!jeEnabled)
+    return;
   if(e.key != 'Control')
     jeKeyIsDown = true;
 });
 
 window.addEventListener('keyup', function(e) {
+  if(!jeEnabled)
+    return;
   if(e.key == 'Control')
     jeState.ctrl = false;
   if(e.key == 'Shift')


### PR DESCRIPTION
Whenever the JSON editor updates its text editor because of external changes to the widget, the cursor position would be reset to the beginning.

This PR saves the cursor position before external changes and tries to restore it afterwards. It tries to find the same line and restore the position inside that line because a lot about the widget structure might have changed in the update.

In practice this means it should be possible - after #540 - to edit running timers and - in combination with #539 - it should even be possible for multiple people to edit the same widget (just not the same line) at the same time.