### PR TITLE
new players get unique color

### DIFF
--- a/server/room.mjs
+++ b/server/room.mjs
@@ -264,7 +264,7 @@ export default class Room {
       const b = parseInt(c.slice(5,7), 16) / 255;
       const min = Math.min(r,g,b);
       const max = Math.max(r,g,b);
-      if(min == max)
+      if((max - min) < .25)
         next;
       if(r == max)
         hues.push(Math.floor(360 + (g - b) * 60 / (max - min)) % 360)

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -278,7 +278,8 @@ export default class Room {
       hue = Math.floor(Math.random() * 360);
     } else {
       const gaps = hues.sort((a,b)=>a-b).map((h, i, a) => (i != (a.length - 1)) ? a[i + 1 ] - h : a[0] + 360 - h);
-      hue = Math.floor(Math.random() * gap / 3 + hues[gaps.indexOf(Math.max(...gaps))] + gap / 3) % 360;
+      const gap = Math.max(...gaps);
+      hue = Math.floor(Math.random() * gap / 3 + hues[gaps.indexOf(gap)] + gap / 3) % 360;
     }
     const f = n => {
       const k = (n + hue / 30) % 12;

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -268,18 +268,18 @@ export default class Room {
       if((max - min) < .25)
         next;
       if(r == max)
-        hues.push(Math.floor(360 + (g - b) * 60 / (max - min)) % 360)
+        hues.push((360 + (g - b) * 60 / (max - min)) % 360)
       else if(g == max)
-        hues.push(Math.floor(120 + (b - r) * 60 / (max - min)))
+        hues.push(120 + (b - r) * 60 / (max - min))
       else
-        hues.push(Math.floor(240 + (r - g) * 60 / (max - min)));
+        hues.push(240 + (r - g) * 60 / (max - min));
     }
     if(hues.length == 0) {
-      hue = Math.floor(Math.random() * 360);
+      hue = Math.random() * 360;
     } else {
       const gaps = hues.sort((a,b)=>a-b).map((h, i, a) => (i != (a.length - 1)) ? a[i + 1 ] - h : a[0] + 360 - h);
       const gap = Math.max(...gaps);
-      hue = Math.floor(Math.random() * gap / 3 + hues[gaps.indexOf(gap)] + gap / 3) % 360;
+      hue = (Math.random() * gap / 3 + hues[gaps.indexOf(gap)] + gap / 3) % 360;
     }
     const f = n => {
       const k = (n + hue / 30) % 12;

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -263,16 +263,14 @@ export default class Room {
       const r = parseInt(hex.slice(1,3), 16) / 255;
       const g = parseInt(hex.slice(3,5), 16) / 255;
       const b = parseInt(hex.slice(5,7), 16) / 255;
-      const min = Math.min(r,g,b);
       const max = Math.max(r,g,b);
-      if((max - min) < .25)
-        next;
-      if(r == max)
-        hues.push((360 + (g - b) * 60 / (max - min)) % 360)
-      else if(g == max)
-        hues.push(120 + (b - r) * 60 / (max - min))
-      else
-        hues.push(240 + (r - g) * 60 / (max - min));
+      const d = max - Math.min(r,g,b);
+      if(d < .25) next;
+      switch(max) {
+        case r: hues.push((360 + (g - b) * 60 / d) % 360); break;
+        case g: hues.push(120 + (b - r) * 60 / d); break;
+        case b: hues.push(240 + (r - g) * 60 / d); break;
+      }
     }
     if(hues.length == 0) {
       hue = Math.random() * 360;

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -256,12 +256,13 @@ export default class Room {
   }
 
   newPlayerColor() {
+    let hue = 0;
     const hues = [];
-    for(const p in this.state._meta.players) {
-      const c = this.state._meta.players[p];
-      const r = parseInt(c.slice(1,3), 16) / 255;
-      const g = parseInt(c.slice(3,5), 16) / 255;
-      const b = parseInt(c.slice(5,7), 16) / 255;
+    for(const player in this.state._meta.players) {
+      const hex = this.state._meta.players[player];
+      const r = parseInt(hex.slice(1,3), 16) / 255;
+      const g = parseInt(hex.slice(3,5), 16) / 255;
+      const b = parseInt(hex.slice(5,7), 16) / 255;
       const min = Math.min(r,g,b);
       const max = Math.max(r,g,b);
       if((max - min) < .25)
@@ -273,21 +274,17 @@ export default class Room {
       else
         hues.push(Math.floor(240 + (r - g) * 60 / (max - min)));
     }
-    if(hues.length == 0)
-      return this.hexFromHsl(Math.floor(Math.random() * 360), 100, 50); 
-    const gaps = hues.sort((a,b)=>a-b).map((h, i, a) => (i != (a.length - 1)) ? a[i + 1 ] - h : a[0] + 360 - h);
-    const gap = Math.max(...gaps);
-    return this.hexFromHsl(Math.floor(Math.random() * gap / 3 + hues[gaps.indexOf(gap)] + gap / 3) % 360, 100, 50);
-  }
-
-  hexFromHsl(h, s, l) {
-    l /= 100;
-    const a = s * Math.min(l, 1 - l) / 100;
+    if(hues.length == 0) {
+      hue = Math.floor(Math.random() * 360);
+    } else {
+      const gaps = hues.sort((a,b)=>a-b).map((h, i, a) => (i != (a.length - 1)) ? a[i + 1 ] - h : a[0] + 360 - h);
+      hue = Math.floor(Math.random() * gap / 3 + hues[gaps.indexOf(Math.max(...gaps))] + gap / 3) % 360;
+    }
     const f = n => {
-      const k = (n + h / 30) % 12;
-      const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
-      return Math.round(255 * color).toString(16).padStart(2, '0');   // convert to Hex and prefix "0" if needed
-    };
+      const k = (n + hue / 30) % 12;
+      const c = .5 - .5 * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+      return Math.round(255 * c).toString(16).padStart(2, '0');
+    }
     return `#${f(0)}${f(8)}${f(4)}`;
   }
 

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -277,8 +277,6 @@ export default class Room {
       return this.hexFromHsl(Math.floor(Math.random() * 360), 100, 50); 
     const gaps = hues.sort((a,b)=>a-b).map((h, i, a) => (i != (a.length - 1)) ? a[i + 1 ] - h : a[0] + 360 - h);
     const gap = Math.max(...gaps);
-    if(gap > 180)
-      return this.hexFromHsl(Math.floor(Math.random() * (gap - 120) + hues[gaps.indexOf(gap)] + 60) % 360, 100, 50);
     return this.hexFromHsl(Math.floor(Math.random() * gap / 3 + hues[gaps.indexOf(gap)] + gap / 3) % 360, 100, 50);
   }
 


### PR DESCRIPTION
Ensures that new players get a color that is a different hue from the hues of existing player colors.

Easiest way to see new feature is to open an empty test room in a browser and look at the player list. Add additional players by repeatedly opening the room in a Incognito/In Private window then closing the window (in Chrome/Edge all Incognito/In Private windows share local storage, so all must be closed before reopening - did not test in Firefox).