### PR TITLE
Fix for collapsing labels

### DIFF
--- a/client/css/widgets/label.css
+++ b/client/css/widgets/label.css
@@ -13,7 +13,7 @@
   text-align: inherit;
   font: inherit;
   width: 100%;
-  height: 100%;
+  min-height: 100%;
   resize: none;
 }
 


### PR DESCRIPTION
This should fix the issue of labels collapsing or showing a scrollbar when they are empty.  Feel free to close this one and add the change to another PR, I just wanted to be able to test it on the server.