### PR TITLE
improve enforcement of valid parent

### DIFF
--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -491,6 +491,11 @@ async function onClickUpdateWidget(applyChangesFromUI) {
       return;
     }
 
+    if(widget.parent !== undefined && (widget.parent === null || !widgets.has(widget.parent))) {
+      alert(`Parent widget ${widget.parent} does not exist.`);
+      return;
+    }
+
     if(applyChangesFromUI)
       await applyEditOptions(widget);
 
@@ -599,7 +604,14 @@ onLoad(function() {
   on('#uploadToken', 'click', _=>uploadWidget('token'));
 
   on('#addWidget', 'click', function() {
-    addWidgetLocal(JSON.parse($('#widgetText').value));
+    const widget = JSON.parse($('#widgetText').value);
+
+    if(widget.parent !== undefined && (widget.parent === null || !widgets.has(widget.parent))) {
+      alert(`Parent widget ${widget.parent} does not exist.`);
+      return;
+    }
+
+    addWidgetLocal(widget);
     showOverlay();
   });
 

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -491,7 +491,11 @@ async function onClickUpdateWidget(applyChangesFromUI) {
       return;
     }
 
-    if(widget.parent !== undefined && (widget.parent === null || !widgets.has(widget.parent))) {
+    for(const key in widget)
+      if(widget[key] === null)
+        delete widget[key];
+
+    if(widget.parent !== undefined && !widgets.has(widget.parent)) {
       alert(`Parent widget ${widget.parent} does not exist.`);
       return;
     }
@@ -606,7 +610,11 @@ onLoad(function() {
   on('#addWidget', 'click', function() {
     const widget = JSON.parse($('#widgetText').value);
 
-    if(widget.parent !== undefined && (widget.parent === null || !widgets.has(widget.parent))) {
+    for(const key in widget)
+      if(widget[key] === null)
+        delete widget[key];
+
+    if(widget.parent !== undefined && !widgets.has(widget.parent)) {
       alert(`Parent widget ${widget.parent} does not exist.`);
       return;
     }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -942,7 +942,7 @@ function jePasteText(text, select) {
 function jePostProcessObject(o) {
   const copy = { ...o };
   for(const key in copy)
-    if(copy[key] === jeWidget.getDefaultValue(key) || key.match(/in deck/))
+    if(copy[key] === null || copy[key] === jeWidget.getDefaultValue(key) || key.match(/in deck/))
       delete copy[key];
   return copy;
 }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -844,7 +844,7 @@ function jeGetContext() {
       jeJSONerror = 'No ID given.';
     else if(JSON.parse(jeStateBefore).id != jeStateNow.id && widgets.has(jeStateNow.id))
       jeJSONerror = `ID ${jeStateNow.id} is already in use.`;
-    else if(jeStateNow.parent && !widgets.has(jeStateNow.parent))
+    else if(jeStateNow.parent !== undefined && jeStateNow.parent !== null && !widgets.has(jeStateNow.parent))
       jeJSONerror = `Parent ${jeStateNow.parent} does not exist.`;
     else if(jeStateNow.type == 'card' && (!jeStateNow.deck || !widgets.has(jeStateNow.deck)))
       jeJSONerror = `Deck ${jeStateNow.deck} does not exist.`;
@@ -943,7 +943,7 @@ function jePostProcessObject(o) {
   const copy = { ...o };
   for(const key in copy)
     if(copy[key] === jeWidget.getDefaultValue(key) || key.match(/in deck/))
-      copy[key] = null;
+      delete copy[key];
   return copy;
 }
 


### PR DESCRIPTION
You could use the legacy JSON editor to set `parent` to an invalid value which would make the client unresponsive.

This also forced me to fix that the new JSON editor sets properties to `null` instead of removing them.