### PR TITLE
Added a special case in 'SET' to change the widget id.

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -602,6 +602,9 @@ function jeAddWidgetPropertyCommand(object, property) {
 }
 
 async function jeApplyChanges() {
+  if(jeMode == 'multi')
+    return await jeApplyChangesMulti();
+
   const currentStateRaw = $('#jeText').textContent;
   const completeState = JSON.parse(jePostProcessText(currentStateRaw));
   const currentState = JSON.stringify(jePostProcessObject(completeState));
@@ -616,15 +619,49 @@ async function jeApplyChanges() {
   }
 }
 
-function jeApplyDelta(delta) {
-  for(const field of [ 'id', 'deck' ]) {
-    if(!jeDeltaIsOurs && jeStateNow && jeStateNow[field] && delta.s[jeStateNow[field]] !== undefined) {
-      if(delta.s[jeStateNow[field]] === null)
-        jeDisplayTree();
-      else
-        jeSelectWidget(widgets.get(jeStateNow.id), document.activeElement !== $('#jeText'));
+async function jeApplyChangesMulti() {
+  const setValueIfNeeded = async function(widget, key, value) {
+    if(widget.get(key) !== value)
+      await widget.set(key, value);
+  };
+
+  const currentState = JSON.parse($('#jeText').textContent);
+  const widgets = widgetFilter(w=>currentState.widgets.indexOf(w.get('id')) != -1);
+  jeDeltaIsOurs = true;
+  for(const key in currentState) {
+    if(key != 'widgets') {
+      for(const w of widgets) {
+        if(typeof currentState[key] != 'object' || currentState[key] === null)
+          await setValueIfNeeded(w, key, currentState[key]);
+        else if(currentState[key][w.get('id')] !== undefined)
+          await setValueIfNeeded(w, key, currentState[key][w.get('id')]);
+      }
     }
   }
+  jeDeltaIsOurs = false;
+}
+
+function jeApplyDelta(delta) {
+  if(jeMode == 'widget') {
+    for(const field of [ 'id', 'deck' ]) {
+      if(!jeDeltaIsOurs && jeStateNow && jeStateNow[field] && delta.s[jeStateNow[field]] !== undefined) {
+        if(delta.s[jeStateNow[field]] === null)
+          jeDisplayTree();
+        else
+          jeSelectWidget(widgets.get(jeStateNow.id), document.activeElement !== $('#jeText'));
+      }
+    }
+  }
+
+  if(jeMode == 'multi' && !jeDeltaIsOurs) {
+    try {
+      for(const selectedWidget of JSON.parse($('#jeText').textContent).widgets)
+        if(delta.s[selectedWidget] !== undefined)
+          return jeUpdateMulti();
+    } catch(e) {
+    }
+  }
+
   if(jeMode == 'tree')
     jeDisplayTree();
 }
@@ -649,17 +686,52 @@ async function jeApplyExternalChanges(state) {
 
 async function jeClick(widget, e) {
   if(e.ctrlKey) {
-    jeSelectWidget(widget);
+    jeSelectWidget(widget, false, e.shiftKey);
   } else {
     await widget.click();
   }
 }
 
-function jeSelectWidget(widget, dontFocus) {
-  jeMode = 'widget';
-  jeWidget = widget;
-  jeStateNow = widget.state;
-  jeSet(jeStateBefore = jePreProcessText(JSON.stringify(jePreProcessObject(widget.state), null, '  ')), dontFocus);
+function jeSelectWidget(widget, dontFocus, addToSelection) {
+  if(addToSelection && (jeMode == 'widget' || jeMode == 'multi')) {
+    jeSelectWidgetMulti(widget, dontFocus);
+  } else {
+    jeMode = 'widget';
+    jeWidget = widget;
+    jeStateNow = widget.state;
+    jeSet(jeStateBefore = jePreProcessText(JSON.stringify(jePreProcessObject(widget.state), null, '  ')), dontFocus);
+  }
+}
+
+function jeSelectWidgetMulti(widget, dontFocus) {
+  const wID = widget.get('id');
+
+  if(jeMode == 'widget')
+    jeStateNow = { widgets: [ jeWidget.get('id'), wID ] };
+  else if(jeStateNow.widgets.indexOf(wID) != -1)
+    jeStateNow.widgets.splice(jeStateNow.widgets.indexOf(wID), 1);
+  else
+    jeStateNow.widgets.push(wID);
+
+  if(jeStateNow.widgets.length == 1 || jeStateNow.widgets[0] == jeStateNow.widgets[1])
+    return jeSelectWidget(widgets.get(jeStateNow.widgets[0]), dontFocus);
+
+  jeWidget = null;
+  jeMode = 'multi';
+  jeUpdateMulti(dontFocus);
+}
+
+function jeUpdateMulti(dontFocus) {
+  const selectedWidgets = widgetFilter(w=>jeStateNow.widgets.indexOf(w.get('id')) != -1);
+
+  for(const key of [ 'x', 'y', 'width', 'height', 'parent', 'z', 'layer' ]) {
+    jeStateNow[key] = {};
+    for(const selectedWidget of selectedWidgets)
+      jeStateNow[key][selectedWidget.get('id')] = selectedWidget.get(key);
+    if(Object.values(jeStateNow[key]).every( (val, i, arr) => val === arr[0] ))
+      jeStateNow[key] = Object.values(jeStateNow[key])[0];
+  }
+  jeSet(jeStateBefore = JSON.stringify(jeStateNow, null, '  '), dontFocus);
 }
 
 function html(string) {
@@ -685,14 +757,14 @@ function jeColorize() {
     for(const l of langObj) {
       const match = line.match(l[0]);
       if(match) {
-        if(match[1] == '  "' && l[2] == 'key' && (l[4] == "null" && match[4] == "null" || String(jeWidget.defaults[match[2]]) == match[4])) {
+        if(jeMode == 'widget' && match[1] == '  "' && l[2] == 'key' && (l[4] == "null" && match[4] == "null" || String(jeWidget.defaults[match[2]]) == match[4])) {
           out.push(`<i class=default>${html(line)}</i>`);
           foundMatch = true;
           break;
         }
 
         const c = {...l};
-        if(match[1] == '  "' && l[2] == 'key' && [ 'id', 'type' ].indexOf(match[2]) == -1 && jeWidget.getDefaultValue(match[2]) === undefined)
+        if(jeMode == 'widget' && match[1] == '  "' && l[2] == 'key' && [ 'id', 'type' ].indexOf(match[2]) == -1 && jeWidget.getDefaultValue(match[2]) === undefined)
           c[2] = 'custom';
 
         for(let i=1; i<l.length; ++i)
@@ -811,6 +883,21 @@ function jeGetContext() {
 
   if(select)
     keys.push(`"${select}"`);
+
+  if(jeMode == 'multi') {
+    try {
+      jeStateNow = JSON.parse(v);
+
+      if(!Array.isArray(jeStateNow.widgets))
+        jeJSONerror = 'Key widgets is not an array.';
+      else
+        jeJSONerror = null;
+    } catch(e) {
+      jeStateNow = null;
+      jeJSONerror = e;
+    }
+    keys[0] = 'Multi-Selection';
+  }
 
   jeContext = keys;
 
@@ -938,7 +1025,10 @@ function jeSet(text, dontFocus) {
 }
 
 function jeSetAndSelect(replaceBy, insideString) {
-  let jsonString = jePreProcessText(JSON.stringify(jePreProcessObject(jeStateNow), null, '  '));
+  if(jeMode == 'widget')
+    var jsonString = jePreProcessText(JSON.stringify(jePreProcessObject(jeStateNow), null, '  '));
+  else
+    var jsonString = JSON.stringify(jeStateNow, null, '  ');
   const startIndex = jsonString.indexOf(insideString ? '###SELECT ME###' : '"###SELECT ME###"');
   let length = jsonString.length-15-(insideString ? 0 : 2);
 
@@ -1049,7 +1139,7 @@ const clickButton = async function(event) {
   await jeCommands.find(o => o.id == event.currentTarget.id).call();
   if (jeContext != 'macro') {
     jeGetContext();
-    if(jeWidget && !jeJSONerror)
+    if((jeWidget || jeMode == 'multi') && !jeJSONerror)
       await jeApplyChanges();
     if (jeContext[0] == '###SELECT ME###')
       jeGetContext();
@@ -1148,7 +1238,7 @@ window.addEventListener('keydown', async function(e) {
         id = `"${id}"`;
       jePasteText(id, true);
     } else {
-      jeSelectWidget(jeWidgetLayers[+functionKey[1]]);
+      jeSelectWidget(jeWidgetLayers[+functionKey[1]], false, jeState.shift);
     }
   }
 });
@@ -1161,7 +1251,7 @@ window.addEventListener('keyup', function(e) {
 
   if(e.target == $('#jeText')) {
     jeGetContext();
-    if(jeWidget && !jeJSONerror)
+    if((jeWidget || jeMode == 'multi') && !jeJSONerror)
       jeApplyChanges();
   }
 });

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -987,12 +987,11 @@ export class Widget extends StateManaged {
         if((a.property == 'parent' || a.property == 'deck') && a.value !== null && !widgets.has(a.value)) {
           problems.push(`Tried setting ${a.property} to ${a.value} which doesn't exist.`);
         } else if (a.property == 'id' && isValidCollection(a.collection)) {
-          if (collections[a.collection].length) {
-            const oldWidget = collections[a.collection][0];
+          for(const oldWidget of collections[a.collection]) {
             const oldState = JSON.stringify(oldWidget.state);
             const oldID = oldWidget.get('id');
             var newState = JSON.parse(oldState);
-            
+
             newState.id = compute(a.relation, null, oldWidget.get(a.property), a.value);
             if(!widgets.has(newState.id)) {
               $('#editWidgetJSON').dataset.previousState = oldState;

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -942,6 +942,19 @@ export class Widget extends StateManaged {
         }
         if((a.property == 'parent' || a.property == 'deck') && a.value !== null && !widgets.has(a.value)) {
           problems.push(`Tried setting ${a.property} to ${a.value} which doesn't exist.`);
+        } else if (a.property == 'id' && isValidCollection(a.collection)) {
+          if (collections[a.collection].length != 1) {
+            problems.push(`Collection ${a.collection} does not contain exactly one widget, ignored.`);
+          } else {
+            const oldWidget = collections[a.collection][0];
+            var newState = oldWidget.state;
+            const oldState = JSON.stringify(oldWidget.state);
+
+            newState.id = compute(a.relation, null, oldWidget.get(a.property), a.value);
+            $('#editWidgetJSON').dataset.previousState = oldState;
+            $('#editWidgetJSON').value = JSON.stringify(newState);
+            await onClickUpdateWidget(false);
+          }
         } else if(isValidCollection(a.collection)) {
           for(const w of collections[a.collection]) {
             await w.set(a.property, compute(a.relation, null, w.get(a.property), a.value));

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -943,17 +943,22 @@ export class Widget extends StateManaged {
         if((a.property == 'parent' || a.property == 'deck') && a.value !== null && !widgets.has(a.value)) {
           problems.push(`Tried setting ${a.property} to ${a.value} which doesn't exist.`);
         } else if (a.property == 'id' && isValidCollection(a.collection)) {
-          if (collections[a.collection].length != 1) {
-            problems.push(`Collection ${a.collection} does not contain exactly one widget, ignored.`);
-          } else {
+          if (collections[a.collection].length) {
             const oldWidget = collections[a.collection][0];
-            var newState = oldWidget.state;
+            var newState = Object.assign({},oldWidget.state);
             const oldState = JSON.stringify(oldWidget.state);
 
             newState.id = compute(a.relation, null, oldWidget.get(a.property), a.value);
-            $('#editWidgetJSON').dataset.previousState = oldState;
-            $('#editWidgetJSON').value = JSON.stringify(newState);
-            await onClickUpdateWidget(false);
+            if(!widgets.has(newState.id)) {
+              $('#editWidgetJSON').dataset.previousState = oldState;
+              $('#editWidgetJSON').value = JSON.stringify(newState);
+              await onClickUpdateWidget(false);
+              sendDelta(true);
+            } else {
+              problems.push(`New id already in use, ignored.`);
+            }
+          } else {
+            problems.push(`Collection ${a.collection} is empty, ignored.`);
           }
         } else if(isValidCollection(a.collection)) {
           for(const w of collections[a.collection]) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -998,7 +998,9 @@ export class Widget extends StateManaged {
               $('#editWidgetJSON').value = JSON.stringify(newState);
               await onClickUpdateWidget(false);
               for(const c in collections)
-                collections[c] = collections[c].map(w=>w.id==oldID ? widgets.get(newState.id) : w)
+                collections[c] = collections[c].map(w=>w.id==oldID ? widgets.get(newState.id) : w);
+              oldWidget.isBeingRemoved = false;
+              oldWidget.inRemovalQueue = false;
               sendDelta(true);
             } else {
               problems.push(`id ${newState.id} already in use, ignored.`);

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -990,6 +990,7 @@ export class Widget extends StateManaged {
           if (collections[a.collection].length) {
             const oldWidget = collections[a.collection][0];
             const oldState = JSON.stringify(oldWidget.state);
+            const oldID = oldWidget.get('id');
             var newState = JSON.parse(oldState);
             
             newState.id = compute(a.relation, null, oldWidget.get(a.property), a.value);
@@ -997,6 +998,8 @@ export class Widget extends StateManaged {
               $('#editWidgetJSON').dataset.previousState = oldState;
               $('#editWidgetJSON').value = JSON.stringify(newState);
               await onClickUpdateWidget(false);
+              for(const c in collections)
+                collections[c] = collections[c].map(w=>w.id==oldID ? widgets.get(newState.id) : w)
               sendDelta(true);
             } else {
               problems.push(`id ${newState.id} already in use, ignored.`);

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -945,9 +945,9 @@ export class Widget extends StateManaged {
         } else if (a.property == 'id' && isValidCollection(a.collection)) {
           if (collections[a.collection].length) {
             const oldWidget = collections[a.collection][0];
-            var newState = Object.assign({},oldWidget.state);
             const oldState = JSON.stringify(oldWidget.state);
-
+            var newState = JSON.parse(oldState);
+            
             newState.id = compute(a.relation, null, oldWidget.get(a.property), a.value);
             if(!widgets.has(newState.id)) {
               $('#editWidgetJSON').dataset.previousState = oldState;
@@ -955,10 +955,8 @@ export class Widget extends StateManaged {
               await onClickUpdateWidget(false);
               sendDelta(true);
             } else {
-              problems.push(`New id already in use, ignored.`);
+              problems.push(`id ${newState.id} already in use, ignored.`);
             }
-          } else {
-            problems.push(`Collection ${a.collection} is empty, ignored.`);
           }
         } else if(isValidCollection(a.collection)) {
           for(const w of collections[a.collection]) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -331,7 +331,7 @@ export class Widget extends StateManaged {
         await callback(a);
     }
 
-    if(this.isBeingRemoved || this.inRemovalQueue)
+    if(!depth && (this.isBeingRemoved || this.inRemovalQueue))
       return;
 
     batchStart();
@@ -999,8 +999,6 @@ export class Widget extends StateManaged {
               await onClickUpdateWidget(false);
               for(const c in collections)
                 collections[c] = collections[c].map(w=>w.id==oldID ? widgets.get(newState.id) : w);
-              oldWidget.isBeingRemoved = false;
-              oldWidget.inRemovalQueue = false;
               sendDelta(true);
             } else {
               problems.push(`id ${newState.id} already in use, ignored.`);


### PR DESCRIPTION
Fixed to update collections containing the old (renamed) widget.

-----------------------------------

This change makes changing a widget id in `SET` work properly. If the source collection has more than one widget, only the `id` of the first widget in the collection will be modified.

----------------------------------

I have a fix for #415 *almost* working, but there remains what may be a large issue. Suppose you have a holder with a widget inside it, and you first change the id of the holder and then the id of the widget using a `SET`. If you do only the first of these in the routine, everything works properly, but if you try to do both, then both changes get batched up, and when the batch is processed, the child of the holder no longer exists. (I've done this using the same hack as in the JSON editor, just putting the id change into the old edit window buffer and calling the appropriate `editmode.js` routine.

The pr-test room contains a simple example.