### PR TITLE
Legacy compute modes

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -411,11 +411,12 @@ export class Widget extends StateManaged {
             }
           };
           const getValue = function(input) {
-            const toNum = s=>typeof s == 'string' && modes.has('autoConvertToNumber') && s.match(/^[-+]?[0-9]+(\.[0-9]+)?$/) ? +s : s;
+            const toNum = s=>typeof s == 'string' && modes.has('autoToNum') && s.match(/^[-+]?[0-9]+(\.[0-9]+)?$/) ? +s : s;
+            const dV = modes.has('defaultOne') ? 1 : null;
             if(match[14] && match[9] !== undefined)
-              return compute(match[13] ? variables[match[14]] : match[14], input, toNum(getParam(9, 1)), toNum(getParam(15, 1)), toNum(getParam(19, 1)));
+              return compute(match[13] ? variables[match[14]] : match[14], input, toNum(getParam(9, dv)), toNum(getParam(15, dv)), toNum(getParam(19, dv)));
             else if(match[14])
-              return compute(match[13] ? variables[match[14]] : match[14], input, toNum(getParam(15, 1)), toNum(getParam(19, 1)), toNum(getParam(23, 1)));
+              return compute(match[13] ? variables[match[14]] : match[14], input, toNum(getParam(15, dv)), toNum(getParam(19, dv)), toNum(getParam(23, dv)));
             else
               return getParam(5, null);
           };
@@ -429,7 +430,7 @@ export class Widget extends StateManaged {
           else
             variables[variable] = getValue(variables[variable]);
         } else if(modeSwitch.test(a)) {
-          modes = new Set(a.replace(modeSwitch,'').trim().split(/,?/s+/));
+          modes = new Set(a.replace(modeSwitch,'').trim().split(/,?\s+/));
         } else {
           problems.push('String could not be interpreted as expression. Please check your syntax and note that many characters have to be escaped.');
         }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -412,7 +412,7 @@ export class Widget extends StateManaged {
           };
           const getValue = function(input) {
             const toNum = s=>typeof s == 'string' && modes.has('autoToNum') && s.match(/^[-+]?[0-9]+(\.[0-9]+)?$/) ? +s : s;
-            const dV = modes.has('defaultOne') ? 1 : null;
+            const dv = modes.has('defaultOne') ? 1 : null;
             if(match[14] && match[9] !== undefined)
               return compute(match[13] ? variables[match[14]] : match[14], input, toNum(getParam(9, dv)), toNum(getParam(15, dv)), toNum(getParam(19, dv)));
             else if(match[14])
@@ -430,7 +430,7 @@ export class Widget extends StateManaged {
           else
             variables[variable] = getValue(variables[variable]);
         } else if(modeSwitch.test(a)) {
-          modes = new Set(a.replace(modeSwitch,'').trim().split(/,?\s+/));
+          modes = new Set(a.replace(modeSwitch,'').trim().split(/[, ]+/));
         } else {
           problems.push('String could not be interpreted as expression. Please check your syntax and note that many characters have to be escaped.');
         }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -340,7 +340,8 @@ export class Widget extends StateManaged {
       $('#debugButtonOutput').textContent = '';
 
     let variables = initialVariables;
-    let collections = initialCollections
+    let collections = initialCollections;
+    let modes = new Set([]);
     if(!byReference) {
       variables = Object.assign({}, initialVariables, {
         playerName,
@@ -382,6 +383,8 @@ export class Widget extends StateManaged {
 
         const match = a.match(new RegExp(regex + '\x24')); // the minifier doesn't like a "$" here
 
+        const modeSwitch = /^mode:/;
+
         if(match) {
           const getParam = (offset, defaultValue)=>{
             if(typeof match[offset+3] == 'string') {
@@ -408,7 +411,7 @@ export class Widget extends StateManaged {
             }
           };
           const getValue = function(input) {
-            const toNum = s=>typeof s == 'string' && s.match(/^[-+]?[0-9]+(\.[0-9]+)?$/) ? +s : s;
+            const toNum = s=>typeof s == 'string' && modes.has('autoConvertToNumber') && s.match(/^[-+]?[0-9]+(\.[0-9]+)?$/) ? +s : s;
             if(match[14] && match[9] !== undefined)
               return compute(match[13] ? variables[match[14]] : match[14], input, toNum(getParam(9, 1)), toNum(getParam(15, 1)), toNum(getParam(19, 1)));
             else if(match[14])
@@ -425,6 +428,8 @@ export class Widget extends StateManaged {
             variables[variable][index] = getValue(variables[variable][index]);
           else
             variables[variable] = getValue(variables[variable]);
+        } else if(modeSwitch.test(a)) {
+          modes = new Set(a.replace(modeSwitch,'').trim().split(/,?/s+/));
         } else {
           problems.push('String could not be interpreted as expression. Please check your syntax and note that many characters have to be escaped.');
         }

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -50,7 +50,7 @@ function updateRoutine(routine, v) {
 
   v<2 && v2UpdateSelectDefault(routine);
   v<3 && v3RemoveComputeAndRandomAndApplyVariables(routine);
-  v<4 && routineModeSwitch(routine, 'autoConvertToNumber');
+  v<4 && routineModeSwitch(routine, 'autoToNum defaultOne');
 }
 
 function routineModeSwitch(routine, modeSwitch) {

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -1,4 +1,4 @@
-export const VERSION = 3;
+export const VERSION = 4;
 
 export default function FileUpdater(state) {
   const v = state._meta.version;
@@ -50,6 +50,17 @@ function updateRoutine(routine, v) {
 
   v<2 && v2UpdateSelectDefault(routine);
   v<3 && v3RemoveComputeAndRandomAndApplyVariables(routine);
+  v<4 && routineModeSwitch(routine, 'autoConvertToNumber');
+}
+
+function routineModeSwitch(routine, modeSwitch) {
+  const re = /^mode:/;
+  for(const operation of routine) {
+    if(typeof operation == 'string' && re.test(operation))
+      operation += ' ' + modeSwitch;
+  }
+  if(typeof routine[0] != 'string' || !re.test(routine[0]))
+    routine.unshift('mode: ' + modeSwitch);
 }
 
 function v2UpdateSelectDefault(routine) {


### PR DESCRIPTION
Adds "mode: ..." switch to activate legacy modes in routines. Removes automatic conversion of numerical strings to numbers (activate legacy mode with "mode: autoToNum"). Removes operands defaulting to 1 (activate legacy mode with "mode: defaultOne"). "mode: autoToNum defaultOne" added to beginning of each routine by file updater.