### PR TITLE
fixed fileupdater crash for string routine entries

### DIFF
--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -157,6 +157,9 @@ function v3RemoveComputeAndRandomAndApplyVariables(routine) {
   }
 
   for(const [ i, op ] of Object.entries(routine)) {
+    if(!op || !op.func)
+      continue;
+
     removeExistingVariablesRecursively(op, i);
     dissolveApplyVariables(op, i);
     delete routine[i].applyVariables;


### PR DESCRIPTION
When routines contain entries that are just a string (like the new dynamic expressions), the fileupdater for v3 would crash.

This PR makes it skip any entries that do not have a `func` parameter.