### PR TITLE
fixed undefined collections after `FOREACH`

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -619,9 +619,11 @@ export class Widget extends StateManaged {
           }
           await this.evaluateRoutine(a.loopRoutine, variables, collections, (depth || 0) + 1, true);
           for(const add in addVariables)
-            variables[add] = variableBackups[add];
+            if(variableBackups[add] !== undefined)
+              variables[add] = variableBackups[add];
           for(const add in addCollections)
-            collections[add] = collectionBackups[add];
+            if(collectionBackups[add] !== undefined)
+              collections[add] = collectionBackups[add];
         }
         if(a.in) {
           for(const key in a.in)

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -618,12 +618,18 @@ export class Widget extends StateManaged {
             collections[add] = addCollections[add];
           }
           await this.evaluateRoutine(a.loopRoutine, variables, collections, (depth || 0) + 1, true);
-          for(const add in addVariables)
+          for(const add in addVariables) {
             if(variableBackups[add] !== undefined)
               variables[add] = variableBackups[add];
-          for(const add in addCollections)
+            else
+              delete variables[add];
+          }
+          for(const add in addCollections) {
             if(collectionBackups[add] !== undefined)
               collections[add] = collectionBackups[add];
+            else
+              delete collections[add];
+          }
         }
         if(a.in) {
           for(const key in a.in)


### PR DESCRIPTION
`FOREACH` backups and restores variables and collections it sets for its `loopRoutine` so that everything is restored to the state it was before the `FOREACH`.

I did not check for `undefined` because I thought it would be fine to just restore it as undefined. But technically there is a slight difference between actually setting a variable to value `undefined` or just not setting it at all.

This PR only restores variables and collections if they were not `undefined` before the `FOREACH`. I did not test this one single bit so please do some testing.