### PR TITLE
convert `property` in `SET` to string before setting

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -641,8 +641,8 @@ export class Widget extends StateManaged {
         if(isValidCollection(a.collection)) {
           let c = collections[a.collection];
           if (a.skipMissing)
-            c = c.filter(w=>w.get(a.property) !== null && w.get(a.property) !== undefined);
-          c = JSON.parse(JSON.stringify(c.map(w=>w.get(a.property))));
+            c = c.filter(w=>w.get(String(a.property)) !== null && w.get(String(a.property)) !== undefined);
+          c = JSON.parse(JSON.stringify(c.map(w=>w.get(String(a.property)))));
           if(c.length) {
             switch(a.aggregation) {
             case 'first':

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -850,7 +850,7 @@ export class Widget extends StateManaged {
           problems.push(`Tried setting ${a.property} to ${a.value} which doesn't exist.`);
         } else if(isValidCollection(a.collection)) {
           for(const w of collections[a.collection]) {
-            await w.set(a.property, compute(a.relation, null, w.get(a.property), a.value));
+            await w.set(String(a.property), compute(a.relation, null, w.get(String(a.property)), a.value));
           }
         }
       }


### PR DESCRIPTION
Setting `property` in `SET` to `null` leads to removal of all widgets in the collection because `null` is used for deletion in the server-client-communication.

This PR converts `property` to a string before setting it so `null` would lead to property `"null"` now.

I feel like we should extent `setDefaults` to enforce types of parameters but I would do that in another PR because this seems like a pretty big issue.

I did not test this at all so please do so.