### PR TITLE
added an automated test that checks if the server starts with production settings

### DIFF
--- a/.github/workflows/production-environment.yml
+++ b/.github/workflows/production-environment.yml
@@ -1,0 +1,29 @@
+name: Production Environment (checks if server starts)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+
+jobs:
+  build:
+    name: Production Environment
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Checkout submodules
+      uses: textbook/git-checkout-submodule-action@master
+    - name: Install Node.js 15.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 15.x
+    - name: Install dependencies
+      run: npm ci
+    - name: Start virtualtabletop server with production settings
+      run: |
+        npm start &
+        sleep 10
+        curl -I http://localhost:8272

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -512,7 +512,7 @@ function jeAddAlignmentCommands() {
   jeCommands.push({
     id: 'jeCenter',
     name: 'center in parent',
-    context: '^.* ↦ (x|y)( ↦ "[0-9]+")?\x24',
+    context: '^.* ↦ (x|y)( ↦ "[0-9]+")?' + String.fromCharCode(36), // the minifier doesn't like "$" or "\x24" here
     call: async function() {
       const key = jeGetLastKey();
       const sizeKey = key == 'x' ? 'width' : 'height';


### PR DESCRIPTION
The minifier crashes for certain changes when `$` characters are in the wrong place. And until now there is no automated test to check if PRs work with the environment used on the production server.

This PR adds a very simple test.