### PR TITLE
added `globalUpdateRoutine`

### DIFF
--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -160,6 +160,7 @@ onLoad(function() {
         widgets.get(widget.id).applyRemove();
     widgets.clear();
     dropTargets.clear();
+    StateManaged.globalUpdateListeners = {};
     maxZ = {};
     let isEmpty = true;
     for(const widgetID in args) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -45,6 +45,7 @@ export class Widget extends StateManaged {
       changeRoutine: null,
       enterRoutine: null,
       leaveRoutine: null,
+      globalUpdateRoutine: null,
       debug: false
     });
 
@@ -113,6 +114,19 @@ export class Widget extends StateManaged {
         this.parent.applyChildAdd(this);
       } else {
         delete this.parent;
+      }
+    }
+
+    for(const key in delta) {
+      const isGlobalUpdateRoutine = key.match(/^(.*)[gG]lobalUpdateRoutine$/);
+      if(isGlobalUpdateRoutine) {
+        const property = isGlobalUpdateRoutine[1] || '*';
+        if(StateManaged.globalUpdateListeners[property] === undefined)
+          StateManaged.globalUpdateListeners[property] = [];
+        if(Array.isArray(delta[key]))
+          StateManaged.globalUpdateListeners[property].push([ this, key ]);
+        else
+          StateManaged.globalUpdateListeners[property] = StateManaged.globalUpdateListeners[property].filter(x=>x[0]!=this);
       }
     }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -118,7 +118,7 @@ export class Widget extends StateManaged {
     }
 
     for(const key in delta) {
-      const isGlobalUpdateRoutine = key.match(/^(.*)[gG]lobalUpdateRoutine$/);
+      const isGlobalUpdateRoutine = key.match(/^(?:(.*)G|g)lobalUpdateRoutine$/);
       if(isGlobalUpdateRoutine) {
         const property = isGlobalUpdateRoutine[1] || '*';
         if(StateManaged.globalUpdateListeners[property] === undefined)


### PR DESCRIPTION
This PR adds the property `globalUpdateRoutine`. It is very similar to the `changeRoutine` but it gets triggered for property changes of other widgets as well.

The main intention behind this is the display of player owned cards for the PCIO seat compatibility (see examples in the test room).

Just like with `changeRoutine`s you can also specify an `ownerGlobalUpdateRoutine` (or any other property) to filter for which property changes the routine will be called. **This is highly recommended to avoid all those `x` and `y` changes you don't care about.**

Contrary to `changeRoutine`s these `globalUpdateRoutine`s do _not_ trigger recursively. So if you change a property inside of the routine, it will not trigger any `globalUpdateRoutine`s. This can be changed easily but I feel like it is not necessary and this way it is a lot harder to build infinite recursion.

I'm not married to the name but it can't end with `ChangeRoutine`.


# Draft Wiki entry (Global properties for every widget)

| Property  | Default value       | Description           | Tutorial              |
| --------  | ------------------- | --------------------- | --------------------- |
| globalUpdateRoutine |  []  | When any property of any widget changes, this [routine](../Functions#Routines) is called. If you want to restrict execution to changes in a particular property, use `<propertyName>GlobalUpdateRoutine` (for example, `ownerGlobalUpdateRoutine` will fire only when the `owner` value of any widget changes so you could update a label with the count of player owned cards).   | 