### PR TITLE
fixed that leaveRoutine would be called twice

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1129,7 +1129,7 @@ export class Widget extends StateManaged {
       if(oldValue) {
         const oldParent = widgets.get(oldValue);
         await oldParent.onChildRemove(this);
-        if(this.get('type') != 'holder' && Array.isArray(oldParent.get('leaveRoutine')))
+        if(oldParent.get('type') != 'holder' && Array.isArray(oldParent.get('leaveRoutine')))
           await oldParent.evaluateRoutine('leaveRoutine', {}, { child: [ this ] });
       }
       if(newValue) {


### PR DESCRIPTION
This PR fixes basically a typo that caused leaveRoutine to be triggered twice.

This was part of #495 but while there were many issues mentioned in that PR (that should be fixed), this is an obvious issue that should be fixed ASAP before too many games break because of the fix.