### PR TITLE
IF and SELECT support of ===, in and !in relation

### DIFF
--- a/client/js/compute.js
+++ b/client/js/compute.js
@@ -455,6 +455,13 @@ const compute_ops = [
     hash: '403c82322543026867587d570e62f0c0'
   },
   {
+    name: '!in',
+    desc: 'returns true if string x is NOT included in string/array y (or property x NOT in object y) - case sensitive',
+    sample: 'var a = ${x} !in ${y}',
+    call: function(v, x, y) { return v = Array.isArray(y) || typeof y == 'string' ? y.indexOf(x) == -1 : !(x in y) },
+    hash: 'c44839d188a729d1482ebbb38deba694'
+  },
+  {
     name: 'includes',
     desc: 'returns true if string/array x includes value y (or object x includes property y) - case sensitive',
     sample: 'var a = ${x} includes ${y}',

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -481,7 +481,7 @@ function jeAddCommands() {
   jeAddEnumCommands('^.*\\(CLICK\\) ↦ mode', [ 'respect', 'ignoreClickable', 'ignoreClickRoutine', 'ignoreAll' ]);
   jeAddEnumCommands('^.*\\(FLIP\\) ↦ faceCycle', [ 'forward', 'backward', 'random' ]);
   jeAddEnumCommands('^.*\\(GET\\) ↦ aggregation', [ 'first', 'last', 'array', 'average', 'median', 'min', 'max', 'sum' ]);
-  jeAddEnumCommands('^.*\\((IF|SELECT)\\) ↦ relation', [ '<', '<=', '==', '===', '!=', '>', '>=', 'in' ]);
+  jeAddEnumCommands('^.*\\((IF|SELECT)\\) ↦ relation', [ '<', '<=', '==', '===', '!=', '>', '>=', 'in', '!in' ]);
   jeAddEnumCommands('^.*\\(LABEL\\) ↦ mode', [ 'set', 'dec', 'inc', 'append' ]);
   jeAddEnumCommands('^.*\\(ROTATE\\) ↦ angle', [ 45, 60, 90, 135, 180 ]);
   jeAddEnumCommands('^.*\\(ROTATE|SELECT\\) ↦ mode', [ 'set', 'add' ]);

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -481,7 +481,7 @@ function jeAddCommands() {
   jeAddEnumCommands('^.*\\(CLICK\\) ↦ mode', [ 'respect', 'ignoreClickable', 'ignoreClickRoutine', 'ignoreAll' ]);
   jeAddEnumCommands('^.*\\(FLIP\\) ↦ faceCycle', [ 'forward', 'backward', 'random' ]);
   jeAddEnumCommands('^.*\\(GET\\) ↦ aggregation', [ 'first', 'last', 'array', 'average', 'median', 'min', 'max', 'sum' ]);
-  jeAddEnumCommands('^.*\\((IF|SELECT)\\) ↦ relation', [ '<', '<=', '==', '!=', '>', '>=', 'in' ]);
+  jeAddEnumCommands('^.*\\((IF|SELECT)\\) ↦ relation', [ '<', '<=', '==', '===', '!=', '>', '>=', 'in' ]);
   jeAddEnumCommands('^.*\\(LABEL\\) ↦ mode', [ 'set', 'dec', 'inc', 'append' ]);
   jeAddEnumCommands('^.*\\(ROTATE\\) ↦ angle', [ 45, 60, 90, 135, 180 ]);
   jeAddEnumCommands('^.*\\(ROTATE|SELECT\\) ↦ mode', [ 'set', 'add' ]);

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -481,12 +481,10 @@ function jeAddCommands() {
   jeAddEnumCommands('^.*\\(CLICK\\) ↦ mode', [ 'respect', 'ignoreClickable', 'ignoreClickRoutine', 'ignoreAll' ]);
   jeAddEnumCommands('^.*\\(FLIP\\) ↦ faceCycle', [ 'forward', 'backward', 'random' ]);
   jeAddEnumCommands('^.*\\(GET\\) ↦ aggregation', [ 'first', 'last', 'array', 'average', 'median', 'min', 'max', 'sum' ]);
-  jeAddEnumCommands('^.*\\(IF\\) ↦ relation', [ '<', '<=', '==', '!=', '>', '>=' ]);
+  jeAddEnumCommands('^.*\\((IF|SELECT)\\) ↦ relation', [ '<', '<=', '==', '!=', '>', '>=', 'in' ]);
   jeAddEnumCommands('^.*\\(LABEL\\) ↦ mode', [ 'set', 'dec', 'inc', 'append' ]);
   jeAddEnumCommands('^.*\\(ROTATE\\) ↦ angle', [ 45, 60, 90, 135, 180 ]);
-  jeAddEnumCommands('^.*\\(ROTATE\\) ↦ mode', [ 'set', 'add' ]);
-  jeAddEnumCommands('^.*\\(SELECT\\) ↦ mode', [ 'set', 'add' ]);
-  jeAddEnumCommands('^.*\\(SELECT\\) ↦ relation', [ '<', '<=', '==', '!=', '>', '>=', 'in' ]);
+  jeAddEnumCommands('^.*\\(ROTATE|SELECT\\) ↦ mode', [ 'set', 'add' ]);
   jeAddEnumCommands('^.*\\(SELECT\\) ↦ type', [ 'all', null, 'button', 'card', 'deck', 'holder', 'label', 'spinner' ]);
   jeAddEnumCommands('^.*\\(SET\\) ↦ relation', [ '+', '-', '=', "*", "/",'!' ]);
   jeAddEnumCommands('^.*\\(TIMER\\) ↦ mode', [ 'pause', 'start', 'toggle', 'set', 'dec', 'inc', 'reset']);

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -683,7 +683,7 @@ export class Widget extends StateManaged {
 
       if(a.func == 'IF') {
         setDefaults(a, { relation: '==' });
-        if (['==', '!=', '<', '<=', '>=', '>'].indexOf(a.relation) < 0) {
+        if (['===', '==', '!=', '<', '<=', '>=', '>', 'in'].indexOf(a.relation) < 0) {
           problems.push(`Relation ${a.relation} is unsupported. Using '==' relation.`);
           a.relation = '==';
         }
@@ -806,7 +806,7 @@ export class Widget extends StateManaged {
       }
 
       if(a.func == 'SELECT') {
-        setDefaults(a, { type: 'all', property: 'parent', relation: '==', value: null, max: 999999, collection: 'DEFAULT', mode: 'set', source: 'all' });
+        setDefaults(a, { type: 'all', property: 'parent', relation: '===', value: null, max: 999999, collection: 'DEFAULT', mode: 'set', source: 'all' });
         if(a.source == 'all' || isValidCollection(a.source)) {
           if([ 'add', 'set' ].indexOf(a.mode) == -1)
             problems.push(`Warning: Mode ${a.mode} interpreted as set.`);
@@ -815,21 +815,15 @@ export class Widget extends StateManaged {
               return false;
             if(a.type != 'all' && (w.get('type') != a.type && (a.type != 'card' || w.get('type') != 'pile')))
               return false;
-            if(a.relation === '<')
-              return w.get(a.property) < a.value;
-            else if(a.relation === '<=')
-              return w.get(a.property) <= a.value;
-            else if(a.relation === '!=')
-              return w.get(a.property) != a.value;
-            else if(a.relation === '>=')
-              return w.get(a.property) >= a.value;
-            else if(a.relation === '>')
-              return w.get(a.property) > a.value;
-            else if(a.relation === 'in' && Array.isArray(a.value))
-              return a.value.indexOf(w.get(a.property)) != -1;
-            if(a.relation != '==')
-              problems.push(`Warning: Relation ${a.relation} interpreted as ==.`);
-            return w.get(a.property) === a.value;
+            if(a.relation == '==') {
+                problems.push(`Warning: Relation == interpreted as ===`);
+                a.relation = '===';
+            }
+            if (['===', '==', '!=', '<', '<=', '>=', '>', 'in'].indexOf(a.relation) < 0) {
+              problems.push(`Relation ${a.relation} is unsupported. Using '===' relation.`);
+              a.relation = '===';
+            }
+            return compute(a.relation, null, w.get(a.property), a.value);
           }).slice(0, a.max).concat(a.mode == 'add' ? collections[a.collection] || [] : []);
 
           // resolve piles

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -683,7 +683,7 @@ export class Widget extends StateManaged {
 
       if(a.func == 'IF') {
         setDefaults(a, { relation: '==' });
-        if (['===', '==', '!=', '<', '<=', '>=', '>', 'in'].indexOf(a.relation) < 0) {
+        if (['===', '==', '!=', '<', '<=', '>=', '>', 'in', '!in'].indexOf(a.relation) < 0) {
           problems.push(`Relation ${a.relation} is unsupported. Using '==' relation.`);
           a.relation = '==';
         }
@@ -819,7 +819,7 @@ export class Widget extends StateManaged {
                 problems.push(`Warning: Relation == interpreted as ===`);
                 a.relation = '===';
             }
-            if (['===', '==', '!=', '<', '<=', '>=', '>', 'in'].indexOf(a.relation) < 0) {
+            if (['===', '==', '!=', '<', '<=', '>=', '>', 'in', '!in'].indexOf(a.relation) < 0) {
               problems.push(`Relation ${a.relation} is unsupported. Using '===' relation.`);
               a.relation = '===';
             }


### PR DESCRIPTION
This PR addresses the following:
* IF supports `===` and `in` relation (in addition to `==`) to match SELECT
* SELECT is refactored to use compute functions for `relation`
* SELECT explains in debug that it uses `===` (in case relation `==` or no relation is used)
* `!in` relation is added to compute and can be used in IF and SELECT (resolves #586)