### PR TITLE
leave `==` as default relation

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -814,7 +814,7 @@ export class Widget extends StateManaged {
       }
 
       if(a.func == 'SELECT') {
-        setDefaults(a, { type: 'all', property: 'parent', relation: '===', value: null, max: 999999, collection: 'DEFAULT', mode: 'set', source: 'all' });
+        setDefaults(a, { type: 'all', property: 'parent', relation: '==', value: null, max: 999999, collection: 'DEFAULT', mode: 'set', source: 'all' });
         if(a.source == 'all' || isValidCollection(a.source)) {
           if([ 'add', 'set' ].indexOf(a.mode) == -1)
             problems.push(`Warning: Mode ${a.mode} interpreted as set.`);
@@ -823,13 +823,9 @@ export class Widget extends StateManaged {
               return false;
             if(a.type != 'all' && (w.get('type') != a.type && (a.type != 'card' || w.get('type') != 'pile')))
               return false;
-            if(a.relation == '==') {
-                problems.push(`Warning: Relation == interpreted as ===`);
-                a.relation = '===';
-            }
             if (['===', '==', '!=', '<', '<=', '>=', '>', 'in', '!in', 'includes', '!includes'].indexOf(a.relation) < 0) {
-              problems.push(`Relation ${a.relation} is unsupported. Using '===' relation.`);
-              a.relation = '===';
+              problems.push(`Relation ${a.relation} is unsupported. Using '==' relation.`);
+              a.relation = '==';
             }
             return compute(a.relation, null, w.get(a.property), a.value);
           }).slice(0, a.max).concat(a.mode == 'add' ? collections[a.collection] || [] : []);


### PR DESCRIPTION
Change request for #615.

Since we assign by value, not by reference `===` is always false for objects (or we could redefine `===` to compare JSON representations instead).