### PR TITLE
PCIO import support for RECALL_CARDS

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -458,7 +458,7 @@ function jeAddCommands() {
   jeAddRoutineOperationCommands('LABEL', { value: 0, mode: 'set', label: null, collection: 'DEFAULT' });
   jeAddRoutineOperationCommands('MOVE', { count: 1, face: null, from: null, to: null });
   jeAddRoutineOperationCommands('MOVEXY', { count: 1, face: null, from: null, x: 0, y: 0 });
-  jeAddRoutineOperationCommands('RECALL', { owned: true, holder: null });
+  jeAddRoutineOperationCommands('RECALL', { owned: true, contained: true, deck: null, face: null, holder: null });
   jeAddRoutineOperationCommands('ROTATE', { count: 1, angle: 90, mode: 'add', holder: null, collection: 'DEFAULT' });
   jeAddRoutineOperationCommands('SELECT', { type: 'all', property: 'parent', relation: '==', value: null, max: 999999, collection: 'DEFAULT', mode: 'add', source: 'all', sortBy: 'null' });
   jeAddRoutineOperationCommands('SET', { collection: 'DEFAULT', property: 'parent', relation: '=', value: null });

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -776,10 +776,10 @@ export class Widget extends StateManaged {
 
       if(a.func == 'RECALL') {
         setDefaults(a, { owned: true, contained: true });
-        if(a.deck !== undefined) {
-          if(this.isValidID(a.deck, problems))
-            a.holder = widgets.get(a.deck).get('parent');
-        }
+
+        if(a.deck !== undefined && this.isValidID(a.deck, problems))
+          a.holder = toA(a.deck).map(d=>widgets.get(d).get('parent')).filter(d=>d!==null);
+
         if(this.isValidID(a.holder, problems)) {
           for(const holder of toA(a.holder)) {
             const decks = widgetFilter(w=>w.get('type')=='deck'&&w.get('parent')==holder);

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -259,8 +259,7 @@ export default async function convertPCIO(content) {
           movableInEdit: false,
 
           clickRoutine: recallConfirmation([
-            { func: 'RECALL',  holder: widget.id },
-            { func: 'FLIP',    holder: widget.id, face: 0 },
+            { func: 'RECALL',  holder: widget.id, face: 0 },
             { func: 'SHUFFLE', holder: widget.id }
           ])
         };
@@ -494,6 +493,25 @@ export default async function convertPCIO(content) {
           };
           if(c.holder.length == 1)
             c.holder = c.holder[0];
+        }
+        if(c.func == 'RECALL_CARDS') {
+          if(!c.args.decks)
+            continue;
+          const includeHolders = c.args.includeHolders && c.args.includeHolders.value;
+          const includeHands = c.args.includeHands && c.args.includeHands.value;
+          const flip = c.args.flip && c.args.flip.value;
+          c = {
+            func: 'RECALL',
+            deck: c.args.decks.value
+          };
+          if(c.deck.length == 1)
+            c.deck = c.deck[0];
+          if(includeHolders == 'normal')
+            c.contained = false;
+          if(includeHands && includeHands != 'hands')
+            c.owned = false;
+          if(flip && flip != 'none')
+            c.face = flip == 'faceDown' ? 0 : 1
         }
         if(c.func == "FLIP_CARDS") {
           if(!c.args.holders)


### PR DESCRIPTION
This is part of #442. It adds RECALL_CARDS to the PCIO importer and implements missing functionality in our `RECALL`:

- `deck`: `RECALL` now supports the parameter `deck` in addition to `holder` (only one works at a time) which sets `holder` to the parents of the given `deck`(s).
- `contained`: If set to `false` the `RECALL` will not move any cards that are not inside of holders.
- `face`: An integer face index the cards will be flipped to.