### PR TITLE
added commands to align and distribute widgets

### DIFF
--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -67,10 +67,26 @@ export function formField(field, dom, id) {
     label.htmlFor = input.id = id;
   }
 
+  if(field.type == 'select') {
+    const input = document.createElement('select');
+    const label = document.createElement('label');
+
+    for(const option of field.options) {
+      const optionElement = document.createElement('option');
+      optionElement.value = option.value || '';
+      optionElement.textContent = option.text || option.value || '';
+      input.appendChild(optionElement);
+    }
+    label.textContent = field.label;
+    dom.appendChild(label);
+    dom.appendChild(input);
+    label.htmlFor = input.id = id;
+  }
+
   if(field.type == 'string') {
     const input = document.createElement('input');
     const label = document.createElement('label');
-    input.value = field.value || "";
+    input.value = field.value || '';
     label.textContent = field.label;
     dom.appendChild(label);
     dom.appendChild(input);

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -834,7 +834,7 @@ function jeCommandOptions() {
 
 async function jeClick(widget, e) {
   if(e.ctrlKey) {
-    jeSelectWidget(widget, false, e.shiftKey);
+    jeSelectWidget(widget, false, e.shiftKey || e.which == 3 || e.button == 2);
   } else {
     await widget.click();
   }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -547,6 +547,27 @@ function jeAddAlignmentCommands() {
       jeUpdateMulti();
     }
   });
+  jeCommands.push({
+    id: 'jeMultiDistribute',
+    name: 'distribute',
+    context: '^Multi-Selection ↦ (x|y)',
+    call: async function() {
+      const key = jeContext[1];
+      const sizeKey = key == 'x' ? 'width' : 'height';
+      const selected = jeMultiSelectedWidgets();
+
+      const min = Math.min(...selected.map(w=>w.absoluteCoord(key)));
+      const max = Math.max(...selected.map(w=>w.absoluteCoord(key)+w.get(sizeKey)));
+      const heights = selected.map(w=>w.get(sizeKey)).reduce((a,b)=>a + b);
+      const spacing = (max-min-heights)/(selected.length-1);
+      selected.sort((a,b)=>a.absoluteCoord(key) - b.absoluteCoord(key));
+      for(const widget of selected) {
+        const before = selected.slice(0, selected.findIndex(w=>w.id == widget.id));
+        await widget.set(key, min + before.map(w=>w.get(sizeKey) + spacing).reduce((a,b)=>a + b, 0) - (widget.get('parent') ? widgets.get(widget.get('parent')).absoluteCoord(key) : 0));
+      }
+      jeUpdateMulti();
+    }
+  });
 }
 
 function displayComputeOps() {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -529,19 +529,21 @@ function jeAddAlignmentCommands() {
     context: '^Multi-Selection ↦ (x|y)',
     options: [
       { label: 'Coordinate', type: 'select', options: [ { value: 0.5, text: 'Center' }, { value: 0, text: 'Top/Left' }, { value: 1, text: 'Bottom/Right'  } ] },
-      { label: 'Reference',  type: 'select', options: [ { value: 'First' }, { value: 'Last' }, { value: 'Center of all' } ] }
+      { label: 'Reference',  type: 'select', options: [ { value: 'First selected widget' }, { value: 'Lowest value' }, { value: 'Highest value' }, { value: 'Center of all' } ] }
     ],
     call: async function(options) {
       const key = jeContext[1];
       const sizeKey = key == 'x' ? 'width' : 'height';
       const selected = jeMultiSelectedWidgets();
-      const centers = selected.map(w=>w.absoluteCoord(key) + w.get(sizeKey)*options.Coordinate);
+      const coords = selected.map(w=>w.absoluteCoord(key) + w.get(sizeKey)*options.Coordinate);
 
-      let target = centers[0];
-      if(options.Reference == 'Last')
-        target = centers[centers.length-1];
+      let target = coords[0];
+      if(options.Reference == 'Lowest value')
+        target = Math.min(...coords);
+      if(options.Reference == 'Highest value')
+        target = Math.max(...coords);
       if(options.Reference == 'Center of all')
-        target = (Math.max(...centers) + Math.min(...centers)) / 2;
+        target = (Math.max(...coords) + Math.min(...coords)) / 2;
       for(const w of selected)
         await w.set(key, target - w.get(sizeKey)*options.Coordinate - (w.get('parent') ? widgets.get(w.get('parent')).absoluteCoord(key) : 0));
       jeUpdateMulti();

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -19,7 +19,7 @@ async function inputHandler(name, e) {
 
   const editMovable = edit || typeof jeEnabled == 'boolean' && jeEnabled && e.ctrlKey;
 
-  if(!mouseTarget && [ "TEXTAREA", "INPUT", "BUTTON", "OPTION", "LABEL" ].indexOf(e.target.tagName) != -1)
+  if(!mouseTarget && [ 'TEXTAREA', 'INPUT', 'BUTTON', 'OPTION', 'LABEL', 'SELECT' ].indexOf(e.target.tagName) != -1)
     if(!editMovable || !e.target.parentNode || !e.target.parentNode.className.match(/label/))
       return;
 


### PR DESCRIPTION
As far as I'm concerned this is the biggest feature gap to Ghetto Editor.

Multi-select a few widgets, put the cursor to `x` or `y`, press `align`, select options, press `Go`. All selected widgets will get the same left/top/center/right/bottom coordinate. Even works across different parents.

Multi-select a few widgets, put the cursor to `x` or `y`, press `distribute`. The spacing between all selected widgets is equalized. Even works across different parents.

Because `align` uses it, this also introduces `select` as an `INPUT` type. Something like this:
```
      { label: 'Coordinate', type: 'select', options: [ { value: 0.5, text: 'Center' }, { value: 0, text: 'Top/Left' }, { value: 1, text: 'Bottom/Right'  } ] },
      { label: 'Reference',  type: 'select', options: [ { value: 'First' }, { value: 'Last' }, { value: 'Center of all' } ] }
```
Please test if this also works (well enough) when using `INPUT` in a routine.


And because @rogerl50 reminded me that macOS can't use `CTRL`+`SHIFT`-click, multi-selection can now also be triggered by `CTRL`-rightclick.