### PR TITLE
Add Moving Walls 3D, other updates

### DIFF
--- a/tests/testcafe/tests.js
+++ b/tests/testcafe/tests.js
@@ -304,10 +304,10 @@ test('Dynamic expressions', async t => {
   };
 });
 
-publicLibraryButtons('Blue',               0, '6620353f985e646bb3ca37ec8351695a', [
+publicLibraryButtons('Blue',               0, '6681bcf652fe87f58945797e2f909036', [
   'fcc3fa2c-c091-41bc-8737-54d8b9d3a929', 'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_incrementButton',
   'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_incrementButton', 'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_decrementButton',
-  'fdc25f83-ed33-4845-a97c-ff35fa8a094f_shuffleButton', 'buttonInputGo', 'fcc3fa2c-c091-41bc-8737-54d8b9d3a929', '9n2q'
+  'reset_button', 'buttonInputGo', 'fcc3fa2c-c091-41bc-8737-54d8b9d3a929', '9n2q'
 ]);
 publicLibraryButtons('FreeCell',           0, 'b3339b3c5d42f47f4def7a164be69823', [ 'reset', 'jemz', 'reset' ]);
 publicLibraryButtons('Reward',             0, '45947298cf2e3e9700468b7384a5486b', [

--- a/tests/testcafe/tests.js
+++ b/tests/testcafe/tests.js
@@ -314,7 +314,7 @@ publicLibraryButtons('Reward',             0, '45947298cf2e3e9700468b7384a5486b'
   'gmex', 'kprc', 'oksq', 'j1wz', 'vfhn', '0i6i', 'Orange Recall', 'buttonInputGo', 'b09z'
 ]);
 publicLibraryButtons('Rummy Tiles',        0, '3e7716fb5b94c59969861a72fad9ce90', [ 'startMix', 'draw14' ]);
-publicLibraryButtons('Undercover',         1, 'a2732957c709ccf1d6fd198cd27f7668', [ 'Reset', 'Spy Master Button' ]);
+publicLibraryButtons('Undercover',         1, '2ae852ce49304b1074b483138026b1b0', [ 'Reset', 'Spy Master Button' ]);
 publicLibraryButtons('Dice',               0, 'd8b6edd6f7a25767781af4294ecda8fc', [ 'k18u', 'hy65', 'gghr', 'dsfa', 'f34a', 'fusq' ]);
 publicLibraryButtons('Functions - CALL',   0, 'def80a1f8ae3047bd435007cc7cd4aa3', [
   'n4cw_8_C', '5a52', '5a52', '66kr', 'qeg1', 'n4cwB', '8r6p', 'qeg1', 'qeg1', 'n5eu'


### PR DESCRIPTION
Public Library:

- Moving Walls 3d. New game by Casbuild and ArnoldSmith86.  Similar to 3d Labyrinth.
- Fireworks.  Markers no longer movable, removed pile handle from stacking holders, increased stackOffsetY on discard holders.
- Moving Walls.  New visual elements by Casbuild and fixed game pieces getting lost.
- Undercover. Fixed layer of two cards.
- Undercover Duo. Removed pile handles on top of words.
- Blue. Add automation buttons to empty holders, discard dropped tiles, and improved reset button.

Public Tutorials:
- Arrays.  Activated features enabled by PR 469: in, remove, numericSort.
- Math.  Activated features enabled by PR 469: acos, atan, atan2, asin.