### PR TITLE
added importer support for game pieces

### DIFF
--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -270,10 +270,11 @@ export default async function convertPCIO(content) {
       if(widget.parent)
         w.parent = widget.parent;
       w.cardTypes = widget.cardTypes;
-      w.faceTemplates = [
-        widget.backTemplate,
-        widget.faceTemplate
-      ];
+      w.faceTemplates = [];
+      if(widget.backTemplate)
+        w.faceTemplates.push(widget.backTemplate);
+      if(widget.faceTemplate)
+        w.faceTemplates.push(widget.faceTemplate);
       w.cardDefaults = {
         pilesWith: {
           type: 'card'
@@ -308,7 +309,7 @@ export default async function convertPCIO(content) {
       for(const type in w.cardTypes)
         for(const key in w.cardTypes[type])
           w.cardTypes[type][key] = mapName(w.cardTypes[type][key]);
-    } else if(widget.type == 'card') {
+    } else if(widget.type == 'card' || widget.type == 'piece') {
       if(!byID[widget.deck]) // orphan card without deck
         continue;
 


### PR DESCRIPTION
Internally they are pretty much the same as cards so only minimal importer changes are needed.

So far I only tested it with https://boardgamegeek.com/geeklist/272690/item/8176781#item8176781.

For now it links to the game piece images of PCIO but for most of them we should already have alternatives. I will work on replacing the ones we already have in this PR.