### PR TITLE
dynamic expression string literal whitelist

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -415,7 +415,7 @@ export class Widget extends StateManaged {
 
       if(typeof a == 'string') {
         const identifier = '(?:[a-zA-Z0-9_-]|\\\\u[0-9a-fA-F]{4})+';
-        const string     = `'((?:[a-zA-Z0-9,.() _-]|\\\\u[0-9a-fA-F]{4})*)'`;
+        const string     = `'((?:[ !#-&(-[\\]-~]|\\\\u[0-9a-fA-F]{4})*)'`;
         const number     = '(-?(?:0|[1-9][0-9]*)(?:\\.[0-9]+)?)';
         const variable   = `(\\$\\{[^}]+\\})`;
         const parameter  = `(null|true|false|\\[\\]|\\{\\}|${number}|${variable}|${string})`;

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -180,7 +180,7 @@ function v3RemoveComputeAndRandomAndApplyVariables(routine) {
         if(typeof op[o] === 'string' && op[o].match(/^\$\{[^}]+\}$/))
           return op[o];
         if(typeof op[o] === 'string')
-          return `'${escapeString(op[o], /^[ !#-&(-[\\]-~]$/)}'`;
+          return `'${escapeString(op[o], /^[ !#-&(-[\]-~]$/)}'`;
         return String(op[o]);
       };
 

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -180,7 +180,7 @@ function v3RemoveComputeAndRandomAndApplyVariables(routine) {
         if(typeof op[o] === 'string' && op[o].match(/^\$\{[^}]+\}$/))
           return op[o];
         if(typeof op[o] === 'string')
-          return `'${escapeString(op[o], /^[a-zA-Z0-9,.() _-]$/)}'`;
+          return `'${escapeString(op[o], /^[ !#-&(-[\\]-~]$/)}'`;
         return String(op[o]);
       };
 


### PR DESCRIPTION
Allows most ASCII printable characters in dynamic expression string literal. fixes #471

Dynamic Expresions wiki page:

~Finally, valid characters for strings are alphanumerics, , (comma), . (period), ( (left parenthesis), ) (right parenthesis), space, _ (underscore), and - (hyphen).~

String literals in dynamic expressions can contain any [printable ASCII character](https://en.wikipedia.org/wiki/ASCII#Printable_characters) (\u0020 to \u007e) except single quote `'` (\u0027), double quote `"` (\u0022), and backslash `\` (\u005c).