### PR TITLE
changing the widgets in the multi-selection mode now retrieves their values

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -756,7 +756,6 @@ async function jeApplyChangesMulti() {
   };
 
   const currentState = JSON.parse($('#jeText').textContent);
-  const widgets = widgetFilter(w=>currentState.widgets.indexOf(w.get('id')) != -1);
 
   if(jeGetContext()[1] == 'widgets') {
     var cursorState = jeCursorStateGet();
@@ -766,7 +765,7 @@ async function jeApplyChangesMulti() {
     jeDeltaIsOurs = true;
     for(const key in currentState) {
       if(key != 'widgets') {
-        for(const w of widgets) {
+        for(const w of jeMultiSelectedWidgets()) {
           if(typeof currentState[key] != 'object' || currentState[key] === null)
             await setValueIfNeeded(w, key, currentState[key]);
           else if(currentState[key][w.get('id')] !== undefined)


### PR DESCRIPTION
Multi-selection mode in the JSON editor shows a property `widgets` that lists all selected widget IDs. With this PR you can edit that list directly in the text editor to add or remove widgets. It also supports regular expressions so you can add something like `/Player [0-9]+ Holder/` and it will display the values of all matching widgets.