### PR TITLE
added option "Use inheritFrom" to duplicate command

### DIFF
--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -779,9 +779,17 @@ async function onClickUpdateWidget(applyChangesFromUI) {
     showOverlay();
 }
 
-function duplicateWidget(widget, recursive, increment, xOffset, yOffset, xCopies, yCopies) {
+function duplicateWidget(widget, recursive, inheritFrom, increment, xOffset, yOffset, xCopies, yCopies) {
   const clone = function(widget, recursive, newParent, xOffset, yOffset) {
     let currentWidget = JSON.parse(JSON.stringify(widget.state))
+
+    if(inheritFrom) {
+      const inheritWidget = { inheritFrom: currentWidget.id };
+      for(const key of [ 'id', 'parent', 'type', 'deck' ])
+        if(currentWidget[key] !== undefined)
+          inheritWidget[key] = currentWidget[key];
+      currentWidget = inheritWidget;
+    }
 
     if(increment) {
       const match = currentWidget.id.match(/^(.*?)([0-9]+)([^0-9]*)$/);
@@ -799,9 +807,9 @@ function duplicateWidget(widget, recursive, increment, xOffset, yOffset, xCopies
 
     if(newParent)
       currentWidget.parent = newParent;
-    if(xOffset)
+    if(xOffset || !newParent && inheritFrom)
       currentWidget.x = widget.get('x') + xOffset;
-    if(yOffset)
+    if(yOffset || !newParent && inheritFrom)
       currentWidget.y = widget.get('y') + yOffset;
 
     addWidgetLocal(currentWidget);
@@ -831,7 +839,7 @@ function onClickDuplicateWidget() {
   const widget = widgets.get(JSON.parse($('#editWidgetJSON').dataset.previousState).id);
   const xOffset = widget.absoluteCoord('x') > 1500 ? -20 : 20;
   const yOffset = widget.absoluteCoord('y') >  900 ? -20 : 20;
-  duplicateWidget(widget, true, true, xOffset, yOffset, 1, 0);
+  duplicateWidget(widget, true, false, true, xOffset, yOffset, 1, 0);
   showOverlay();
 }
 

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -785,7 +785,7 @@ function duplicateWidget(widget, recursive, inheritFrom, increment, xOffset, yOf
 
     if(inheritFrom) {
       const inheritWidget = { inheritFrom: currentWidget.id };
-      for(const key of [ 'id', 'parent', 'type', 'deck' ])
+      for(const key of [ 'id', 'type', 'deck', 'cardType' ])
         if(currentWidget[key] !== undefined)
           inheritWidget[key] = currentWidget[key];
       currentWidget = inheritWidget;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -308,16 +308,17 @@ const jeCommands = [
     forceKey: 'D',
     show: _=>jeStateNow,
     options: [
-      { label: 'Recursive',     type: 'checkbox', value: true },
-      { label: 'Increment IDs', type: 'checkbox', value: true },
-      { label: 'X offset',      type: 'number',   value: 0,   min: -1600, max: 1600 },
-      { label: 'Y offset',      type: 'number',   value: 0,   min: -1000, max: 1000 },
-      { label: '# Copies X',    type: 'number',   value: 1,   min:     1, max:  100 },
-      { label: '# Copies Y',    type: 'number',   value: 0,   min:     0, max:  100 }
+      { label: 'Recursive',       type: 'checkbox', value: true  },
+      { label: 'Increment IDs',   type: 'checkbox', value: true  },
+      { label: 'Use inheritFrom', type: 'checkbox', value: false },
+      { label: 'X offset',        type: 'number',   value: 0,   min: -1600, max: 1600 },
+      { label: 'Y offset',        type: 'number',   value: 0,   min: -1000, max: 1000 },
+      { label: '# Copies X',      type: 'number',   value: 1,   min:     1, max:  100 },
+      { label: '# Copies Y',      type: 'number',   value: 0,   min:     0, max:  100 }
     ],
     call: async function(options) {
       for(const id of jeSelectedIDs()) {
-        const clonedWidget = duplicateWidget(widgets.get(id), options.Recursive, options['Increment IDs'], options['X offset'], options['Y offset'], options['# Copies X'], options['# Copies Y']);
+        const clonedWidget = duplicateWidget(widgets.get(id), options.Recursive, options['Use inheritFrom'], options['Increment IDs'], options['X offset'], options['Y offset'], options['# Copies X'], options['# Copies Y']);
         jeSelectWidget(widgets.get(clonedWidget.id));
         jeStateNow.id = '###SELECT ME###';
         jeSetAndSelect(clonedWidget.id);

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -862,6 +862,8 @@ function jeCommandOptions() {
       options[option.label] = option.type == 'checkbox' ? input.checked : input.value;
       if(option.type == 'number')
         options[option.label] = parseFloat(options[option.label]);
+      if(Number.isNaN(options[option.label]))
+        options[option.label] = 0;
     }
 
     await jeCommandWithOptions.call(options);


### PR DESCRIPTION
The duplicate command can now create minimal new widgets that use `inheritFrom` to receive nearly all their contents from the source.

This is pretty much the last feature of PR #479. Only a similar command that syncs children to inheriting widgets is still missing but I am not sure what I will do with that one.