### PR TITLE
fixed that `CLONE` did not set `x` or `y` to 0

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -590,8 +590,8 @@ export class Widget extends StateManaged {
 
               // moveToHolder causes the position to be wrong if the target holder does not have alignChildren
               if(!parent || !widgets.get(parent).get('alignChildren')) {
-                await cWidget.set('x', (a.properties.x || w.get('x')) + a.xOffset * i);
-                await cWidget.set('y', (a.properties.y || w.get('y')) + a.yOffset * i);
+                await cWidget.set('x', (a.properties.x !== undefined ? a.properties.x : w.get('x')) + a.xOffset * i);
+                await cWidget.set('y', (a.properties.y !== undefined ? a.properties.x : w.get('y')) + a.yOffset * i);
                 await cWidget.updatePiles();
               }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -591,7 +591,7 @@ export class Widget extends StateManaged {
               // moveToHolder causes the position to be wrong if the target holder does not have alignChildren
               if(!parent || !widgets.get(parent).get('alignChildren')) {
                 await cWidget.set('x', (a.properties.x !== undefined ? a.properties.x : w.get('x')) + a.xOffset * i);
-                await cWidget.set('y', (a.properties.y !== undefined ? a.properties.x : w.get('y')) + a.yOffset * i);
+                await cWidget.set('y', (a.properties.y !== undefined ? a.properties.y : w.get('y')) + a.yOffset * i);
                 await cWidget.updatePiles();
               }
 


### PR DESCRIPTION
It would instead fallback to the `x` and `y` of the cloned widget.