### PR TITLE
added commands to add or remove all cards of a deck

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -83,23 +83,51 @@ const jeCommands = [
   },
   {
     id: 'je_addCard',
-    name: 'add card',
+    name: _=>`add card ${widgetFilter(w=>w.get('deck')==jeStateNow.id&&w.get('cardType')==jeContext[2]).length + 1}`,
     context: '^deck ↦ cardTypes ↦ .*? ↦',
     call: async function() {
       const card = { deck:jeStateNow.id, type:'card', cardType:jeContext[2] };
       addWidgetLocal(card);
       if(jeStateNow.parent)
         await widgets.get(card.id).moveToHolder(widgets.get(jeStateNow.parent));
+      else
+        await widgets.get(card.id).updatePiles();
+    }
+  },
+  {
+    id: 'je_addAllCards',
+    name: _=>`add one card of all ${Object.keys(jeStateNow.cardTypes).length} cardTypes`,
+    context: '^deck',
+    show: _=>jeStateNow.cardTypes,
+    call: async function() {
+      for(const cardType in jeStateNow.cardTypes) {
+        const card = { deck:jeStateNow.id, type:'card', cardType };
+        addWidgetLocal(card);
+        if(jeStateNow.parent)
+          await widgets.get(card.id).moveToHolder(widgets.get(jeStateNow.parent));
+        else
+          await widgets.get(card.id).updatePiles();
+      }
     }
   },
   {
     id: 'je_removeCard',
-    name: 'remove card',
+    name: _=>`remove card ${widgetFilter(w=>w.get('deck')==jeStateNow.id&&w.get('cardType')==jeContext[2]).length}`,
     context: '^deck ↦ cardTypes ↦ .*? ↦',
     show: _=>widgetFilter(w=>w.get('deck')==jeStateNow.id&&w.get('cardType')==jeContext[2]).length,
     call: async function() {
       const card = widgetFilter(w=>w.get('deck')==jeStateNow.id&&w.get('cardType')==jeContext[2])[0];
       await removeWidgetLocal(card.get('id'));
+    }
+  },
+  {
+    id: 'je_removeAllCards',
+    name: _=>`remove all ${widgetFilter(w=>w.get('deck')==jeStateNow.id).length} cards`,
+    context: '^deck',
+    show: _=>widgetFilter(w=>w.get('deck')==jeStateNow.id).length,
+    call: async function() {
+      for(const card of widgetFilter(w=>w.get('deck')==jeStateNow.id))
+        await removeWidgetLocal(card.get('id'));
     }
   },
   {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -67,7 +67,7 @@ const jeCommands = [
     call: async function() {
       const cardType = {};
       const cssVariables = {};
-      for(const face of jeStateNow.faceTemplates) {
+      for(const face of jeStateNow.faceTemplates || []) {
         for(const object of face.objects) {
           if(object.valueType == 'dynamic')
             cardType[object.value] = '';
@@ -84,7 +84,7 @@ const jeCommands = [
   {
     id: 'je_addCard',
     name: _=>`add card ${widgetFilter(w=>w.get('deck')==jeStateNow.id&&w.get('cardType')==jeContext[2]).length + 1}`,
-    context: '^deck ↦ cardTypes ↦ .*? ↦',
+    context: '^deck ↦ cardTypes ↦ [^"↦]+',
     call: async function() {
       const card = { deck:jeStateNow.id, type:'card', cardType:jeContext[2] };
       addWidgetLocal(card);
@@ -97,8 +97,8 @@ const jeCommands = [
   {
     id: 'je_addAllCards',
     name: _=>`add one card of all ${Object.keys(jeStateNow.cardTypes).length} cardTypes`,
-    context: '^deck',
-    show: _=>jeStateNow.cardTypes,
+    context: '^deck ↦ cardTypes',
+    show: _=>Object.keys(jeStateNow.cardTypes).length,
     call: async function() {
       for(const cardType in jeStateNow.cardTypes) {
         const card = { deck:jeStateNow.id, type:'card', cardType };
@@ -113,7 +113,7 @@ const jeCommands = [
   {
     id: 'je_removeCard',
     name: _=>`remove card ${widgetFilter(w=>w.get('deck')==jeStateNow.id&&w.get('cardType')==jeContext[2]).length}`,
-    context: '^deck ↦ cardTypes ↦ .*? ↦',
+    context: '^deck ↦ cardTypes ↦ [^"↦]+',
     show: _=>widgetFilter(w=>w.get('deck')==jeStateNow.id&&w.get('cardType')==jeContext[2]).length,
     call: async function() {
       const card = widgetFilter(w=>w.get('deck')==jeStateNow.id&&w.get('cardType')==jeContext[2])[0];
@@ -123,7 +123,7 @@ const jeCommands = [
   {
     id: 'je_removeAllCards',
     name: _=>`remove all ${widgetFilter(w=>w.get('deck')==jeStateNow.id).length} cards`,
-    context: '^deck',
+    context: '^deck ↦ cardTypes',
     show: _=>widgetFilter(w=>w.get('deck')==jeStateNow.id).length,
     call: async function() {
       for(const card of widgetFilter(w=>w.get('deck')==jeStateNow.id))


### PR DESCRIPTION
I wanted to copy a deck of cards with 96 different cardTypes to a different game. Using the normal edit mode to add every card did not work because it screws up the variables for more complicated decks. So I added a JSON editor command to do it and while I was at it, I added one to remove all cards and I updated the existing ones that only handle a single cardType to show the number of cards on the command button