### PR TITLE
Enter in label no longer registered in JSON editor

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1513,11 +1513,6 @@ window.addEventListener('keydown', async function(e) {
   if(e.key == 'Shift')
     jeState.shift = true;
 
-  if(e.key == 'Enter') {
-    jeNewline();
-    e.preventDefault();
-  }
-
   if(e.ctrlKey) {
     if(e.key == ' ' && jeMode == 'widget') {
       const locationLine = String(jeJSONerror).match(/line ([0-9]+) column ([0-9]+)/);
@@ -1556,6 +1551,13 @@ window.addEventListener('keydown', async function(e) {
       jeSelectWidget(jeWidgetLayers[+functionKey[1]], false, e.shiftKey);
     }
   }
+});
+
+document.getElementById("jsonEditor").addEventListener('keydown', async function(e) {
+	if(e.key == 'Enter') {
+		jeNewline();
+		e.preventDefault();
+		}
 });
 
 window.addEventListener('keydown', function(e) {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1553,11 +1553,11 @@ window.addEventListener('keydown', async function(e) {
   }
 });
 
-document.getElementById("jsonEditor").addEventListener('keydown', async function(e) {
-	if(e.key == 'Enter') {
-		jeNewline();
-		e.preventDefault();
-		}
+on('#jsonEditor', 'keydown', function(e) {
+  if(e.key == 'Enter') {
+    jeNewline();
+    e.preventDefault();
+  }
 });
 
 window.addEventListener('keydown', function(e) {

--- a/client/js/widgets/label.js
+++ b/client/js/widgets/label.js
@@ -18,7 +18,7 @@ export class Label extends Widget {
 
     this.domElement.appendChild(this.input);
     this.input.addEventListener('keyup', e=>{
-      if(this.get('editable') && e.target.value != this.get('text'))
+      if(this.get('editable') && e.target.value !== this.get('text'))
         this.setText(e.target.value)
     });
   }


### PR DESCRIPTION
This is a fix for #660.  It moves the event listener for enter from being applied to the entire window to only being applied to the JSON editor.

Added in fix for #659.  Apparently, the white space (enter) didn't register as different enough to be evaluated as different by !=.

I do believe these two very minor fixes are both working as expected.  I also suspect these are desired changes.  However, this needs a code review to make sure I put the eventListener in the right place, and to make sure the getElementById is required <s>(which I believe it is in this case)</s>.