### PR TITLE
fixed `INPUT` type `select`

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -279,9 +279,7 @@ export class Widget extends StateManaged {
 
       if(field.type == 'checkbox') {
         result[field.variable] = document.getElementById(this.get('id') + ';' + field.variable).checked;
-      }
-
-      if(field.type == 'color' || field.type == 'number' || field.type == 'string') {
+      } else {
         result[field.variable] = document.getElementById(this.get('id') + ';' + field.variable).value;
       }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -279,7 +279,7 @@ export class Widget extends StateManaged {
 
       if(field.type == 'checkbox') {
         result[field.variable] = document.getElementById(this.get('id') + ';' + field.variable).checked;
-      } else {
+      } else if(field.type != 'text') {
         result[field.variable] = document.getElementById(this.get('id') + ';' + field.variable).value;
       }
 


### PR DESCRIPTION
When used in a routine the `INPUT` type `select` would display the dropdown correctly in the overlay but it would not set the selected value to the variable.