### PR TITLE
fixed timer alert animation on Firefox

### DIFF
--- a/client/css/widgets/timer.css
+++ b/client/css/widgets/timer.css
@@ -4,9 +4,8 @@
   text-align: right;
   color: #525252;
   padding-right:3px;
-  border-top: 1px solid var(--AnimationColor);
-  border-bottom: 1px solid var(--AnimationColor);
-  --AnimationColor: var(--wcBorderNormal);
+  border-top: 1px solid var(--wcBorderNormal);
+  border-bottom: 1px solid var(--wcBorderNormal);
   --wcBorderNormal: #00000000;
   --wcBorderAlert: red;
   --wcFontAlert: red;
@@ -23,7 +22,7 @@
 
 @keyframes blinker {
   50% {
-    --AnimationColor: var(--wcBorderAlert);
+    border-color: var(--wcBorderAlert);
   }
 }
 


### PR DESCRIPTION
For me the blinking border never worked in Firefox. It looks to me like Firefox does not support setting CSS variables inside keyframes. I modified the CSS a bit to work in Chrome and Firefox for me but it takes away flexibility: `--AnimationColor` is no longer set so it can not be used for anything other than `border-color` now. I could not find a solution that would leave those features in.