### PR TITLE
make deep copies on variable assignment

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -469,7 +469,7 @@ export class Widget extends StateManaged {
             else if(match[14])
               return compute(match[13] ? variables[match[14]] : match[14], input, toNum(getParam(15, 1)), toNum(getParam(19, 1)), toNum(getParam(23, 1)));
             else
-              return getParam(5, null);
+              return JSON.parse(JSON.stringify(getParam(5, null)));
           };
 
           const variable = match[1] !== undefined ? variables[unescape(match[2])] : unescape(match[2]);


### PR DESCRIPTION
If you assign one variable to another (`var a = ${b}`), this now creates a deep copy so that changes to objects and arrays do not interfere with the source variable.

I am not sure if we should do this, though. Automatic stuff like this that undos inner workings of Javascript have not been the best idea in the past and we are having trouble rolling them back in other areas.