### PR TITLE
Updates to how Deck Editor deals with data

### DIFF
--- a/client/components/deckEditor.js
+++ b/client/components/deckEditor.js
@@ -61,8 +61,8 @@ export const deckEditor = {
               <td class="properties">
                 <div v-for="prop in dynamicProperties">
                   <label>{{ prop.name }}</label>
-                  <input v-if="typeObject[prop.name] !== undefined" :value="typeObject[prop.name].replaceAll('\\n', '\\u005Cn') || '' ">
-                  <input v-else="typeObject[prop.name] === undefined" :value=null>
+                  <input v-if="typeObject[prop.name] !== undefined && typeObject[prop.name] !== null" :value="typeObject[prop.name].replaceAll('\\n', '\\u005Cn') || '' ">
+                  <input v-else="typeObject[prop.name] === undefined ||  typeObject[prop.name] === null" :value=''>
                   <button v-if="prop.type == 'image'" class="uploadAsset prettyButton" @click="upload(typeID, prop.name)">Upload</button>
                 </div>
               </td>

--- a/client/components/deckEditor.js
+++ b/client/components/deckEditor.js
@@ -61,7 +61,8 @@ export const deckEditor = {
               <td class="properties">
                 <div v-for="prop in dynamicProperties">
                   <label>{{ prop.name }}</label>
-                  <input :value="typeObject[prop.name].replaceAll('\\n', '\\u005Cn') || '' ">
+                  <input v-if="typeObject[prop.name] !== undefined" :value="typeObject[prop.name].replaceAll('\\n', '\\u005Cn') || '' ">
+                  <input v-else="typeObject[prop.name] === undefined" :value=null>
                   <button v-if="prop.type == 'image'" class="uploadAsset prettyButton" @click="upload(typeID, prop.name)">Upload</button>
                 </div>
               </td>

--- a/client/components/deckEditor.js
+++ b/client/components/deckEditor.js
@@ -61,8 +61,10 @@ export const deckEditor = {
               <td class="properties">
                 <div v-for="prop in dynamicProperties">
                   <label>{{ prop.name }}</label>
-                  <input v-if="typeObject[prop.name] !== undefined && typeObject[prop.name] !== null" :value="typeObject[prop.name].replaceAll('\\n', '\\u005Cn') || '' ">
-                  <input v-else="typeObject[prop.name] === undefined ||  typeObject[prop.name] === null" :value=''>
+                  <input v-if="((typeof typeObject[prop.name] === 'string') && (isNaN(typeObject[prop.name]) === true) && (typeObject[prop.name] !== 'true') && (typeObject[prop.name] !== 'false') )" :value="typeObject[prop.name].replaceAll('\\n', '\\u005Cn')">
+                  <input v-else-if="typeof typeObject[prop.name] === 'string'" :value="'\\u0022'+typeObject[prop.name]+'\\u0022'">
+                  <input v-else-if="typeObject[prop.name] !== undefined ||  typeObject[prop.name] !== null" :value="typeObject[prop.name]">
+                  <input v-else :value=null>
                   <button v-if="prop.type == 'image'" class="uploadAsset prettyButton" @click="upload(typeID, prop.name)">Upload</button>
                 </div>
               </td>

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -194,13 +194,18 @@ async function applyEditOptionsDeck(widget) {
         await w.set('cardType', id);
     }
 
-    for(const object of $a('.properties > div', type))
-      if ($('input', object).value !== '')
-        widget.cardTypes[id][$('label', object).textContent] = $('input', object).value.replaceAll('\\n','\n');
-      else if (widget.cardTypes[id][$('label', object).textContent] == undefined)
+    for(const object of $a('.properties > div', type)) {
+      if (widget.cardTypes[id][$('label', object).textContent] == undefined)
         delete widget.cardTypes[id][$('label', object).textContent];
+      else if (!(/\D/).test($('input', object).value))
+        widget.cardTypes[id][$('label', object).textContent] = parseFloat($('input', object).value);
+      else if ($('input', object).value === 'true' || $('input', object).value ==='false')
+        widget.cardTypes[id][$('label', object).textContent] = ($('input', object).value === 'true');
+      else if ($('input', object).value !== '')
+        widget.cardTypes[id][$('label', object).textContent] = $('input', object).value.replaceAll('\\n','\n').replaceAll('\"', '');
       else
         widget.cardTypes[id][$('label', object).textContent] = '';
+    }
   }
 }
 

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -195,7 +195,12 @@ async function applyEditOptionsDeck(widget) {
     }
 
     for(const object of $a('.properties > div', type))
-      widget.cardTypes[id][$('label', object).textContent] = $('input', object).value.replaceAll('\\n','\n');
+      if ($('input', object).value !== '')
+        widget.cardTypes[id][$('label', object).textContent] = $('input', object).value.replaceAll('\\n','\n');
+      else if (widget.cardTypes[id][$('label', object).textContent] == undefined)
+        delete widget.cardTypes[id][$('label', object).textContent];
+      else
+        widget.cardTypes[id][$('label', object).textContent] = '';
   }
 }
 

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -195,7 +195,7 @@ async function applyEditOptionsDeck(widget) {
     }
 
     for(const object of $a('.properties > div', type)) {
-      if (($('input', object).value) == undefined)
+      if (($('input', object).value) == '')
         delete widget.cardTypes[id][$('label', object).textContent];
       else if (!(/\D/).test($('input', object).value))
         widget.cardTypes[id][$('label', object).textContent] = parseFloat($('input', object).value);

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -195,7 +195,7 @@ async function applyEditOptionsDeck(widget) {
     }
 
     for(const object of $a('.properties > div', type)) {
-      if (widget.cardTypes[id][$('label', object).textContent] == undefined)
+      if (($('input', object).value) == undefined)
         delete widget.cardTypes[id][$('label', object).textContent];
       else if (!(/\D/).test($('input', object).value))
         widget.cardTypes[id][$('label', object).textContent] = parseFloat($('input', object).value);


### PR DESCRIPTION
This is a comparison of how the deck editor and JSON editor in this PR display different types of data.

|  | Deck Editor       | JSON Editor           | Card |
| --------  | ------------------- | --------------------- |--------------------- |
|numbers|123|123|123|
|string numbers|"456"|"456"|456|
|booleans|true|true|true|
|string booleans|"false"|"false"|false|
|empty strings|""|""| |
|strings|this is a string <br>(can also be entered with quotation marks)<br>e.g "this is a string"|"this is a string"|this is a string|
|null values| |(deleted by deck editor)| |
|carriage returns|first line\nsecond line|first line\nsecond line|first line<br>second line|

There are some differences between how the deck editor and JSON editor display data.  It could be made the same, but I thought the differences made sense.  I figured that other than numbers, and booleans, text should be assumed to be text, so quotations around text are not **required**.  Also, I thought null values should just not show anything rather than the text 'null'.  It also seemed like null values should be deleted like how properties with null values are deleted. 

I'm just guessing at how people would expect it to work though.