### PR TITLE
Edit Mode converts width and height to float value

### DIFF
--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -47,9 +47,9 @@ function applyEditOptionsBasic(widget) {
     delete widget.image;
   else
     widget.image = $('#basicImage').value;
-
-  widget.width = parseFloat($('#basicWidthNumber').value);
-  widget.height = parseFloat($('#basicHeightNumber').value);
+  
+  isNaN($('#basicWidthNumber')) === false ? widget.width = parseFloat($('#basicWidthNumber').value) :	widget.width = widget.width;
+  isNaN($('#basicHeightNumber')) === false ? widget.height = parseFloat($('#basicHeightNumber').value) : widget.height = widget.height;
 
   if ($('#basicFullscreen').checked){
     widget.width = 1600;
@@ -237,9 +237,9 @@ function populateEditOptionsLabel(widget) {
 
 function applyEditOptionsLabel(widget) {
   widget.text = $('#labelText').value;
-
-  widget.width = parseFloat($('#labelWidthNumber').value);
-  widget.height = parseFloat($('#labelHeightNumber').value);
+  
+  isNaN($('#labelWidthNumber')) === false ? widget.width = parseFloat($('#labelWidthNumber').value) : widget.width = widget.width;
+  isNaN($('#labelHeightNumber')) === false ? widget.height = parseFloat($('#labelHeightNumber').value) : widget.height = widget.height;
 
   widget.editable = $('#labelEditable').checked;
 

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -48,8 +48,8 @@ function applyEditOptionsBasic(widget) {
   else
     widget.image = $('#basicImage').value;
 
-  widget.width = $('#basicWidth').value;
-  widget.height = $('#basicHeight').value;
+  widget.width = parseFloat($('#basicWidth').value);
+  widget.height = parseFloat($('#basicHeight').value);
 
   if ($('#basicFullscreen').checked){
     widget.width = 1600;
@@ -238,8 +238,8 @@ function populateEditOptionsLabel(widget) {
 function applyEditOptionsLabel(widget) {
   widget.text = $('#labelText').value;
 
-  widget.width = $('#labelWidth').value;
-  widget.height = $('#labelHeight').value;
+  widget.width = parseFloat($('#labelWidth').value);
+  widget.height = parseFloat($('#labelHeight').value);
 
   widget.editable = $('#labelEditable').checked;
 

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -48,8 +48,14 @@ function applyEditOptionsBasic(widget) {
   else
     widget.image = $('#basicImage').value;
   
-  isNaN($('#basicWidthNumber')) === false ? widget.width = parseFloat($('#basicWidthNumber').value) :	widget.width = widget.width;
-  isNaN($('#basicHeightNumber')) === false ? widget.height = parseFloat($('#basicHeightNumber').value) : widget.height = widget.height;
+  if(($('#basicWidthNumber').value).replaceAll(/\d/g, '').replace(/\./g, '')  === '')
+    widget.width = parseFloat($('#basicWidthNumber').value)
+  else
+    widget.width = widget.width;
+  if(($('#basicHeightNumber').value).replaceAll(/\d/g, '').replace(/\./g, '')  === '')
+    widget.height = parseFloat($('#basicHeightNumber').value)
+  else
+    widget.height = widget.height;
 
   if ($('#basicFullscreen').checked){
     widget.width = 1600;
@@ -238,8 +244,14 @@ function populateEditOptionsLabel(widget) {
 function applyEditOptionsLabel(widget) {
   widget.text = $('#labelText').value;
   
-  isNaN($('#labelWidthNumber')) === false ? widget.width = parseFloat($('#labelWidthNumber').value) : widget.width = widget.width;
-  isNaN($('#labelHeightNumber')) === false ? widget.height = parseFloat($('#labelHeightNumber').value) : widget.height = widget.height;
+  if(($('#labelWidthNumber').value).replaceAll(/\d/g, '').replace(/\./g, '')  === '')
+    widget.width = parseFloat($('#labelWidthNumber').value)
+  else
+    widget.width = widget.width;
+  if(($('#labelHeightNumber').value).replaceAll(/\d/g, '').replace(/\./g, '')  === '')
+    widget.height = parseFloat($('#labelHeightNumber').value)
+  else
+    widget.height = widget.height;
 
   widget.editable = $('#labelEditable').checked;
 

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -34,6 +34,10 @@ function populateEditOptionsBasic(widget) {
   $('#basicEnlarge').checked = widget.enlarge;
 }
 
+function applyWidthHeight(widget, value, dimension) {
+  return value.replaceAll(/\d/g, '').replace(/\./g, '')  === '' ? widget[dimension] = parseFloat(value): widget[dimension] = widget[dimension];
+}
+
 function applyEditOptionsBasic(widget) {
   if ($('#basicTypeBoard').checked == true){
     widget.layer = -4;
@@ -48,14 +52,8 @@ function applyEditOptionsBasic(widget) {
   else
     widget.image = $('#basicImage').value;
   
-  if(($('#basicWidthNumber').value).replaceAll(/\d/g, '').replace(/\./g, '')  === '')
-    widget.width = parseFloat($('#basicWidthNumber').value)
-  else
-    widget.width = widget.width;
-  if(($('#basicHeightNumber').value).replaceAll(/\d/g, '').replace(/\./g, '')  === '')
-    widget.height = parseFloat($('#basicHeightNumber').value)
-  else
-    widget.height = widget.height;
+  applyWidthHeight(widget, $('#basicWidthNumber').value, 'width');
+  applyWidthHeight(widget, $('#basicHeightNumber').value, 'height');
 
   if ($('#basicFullscreen').checked){
     widget.width = 1600;
@@ -244,17 +242,10 @@ function populateEditOptionsLabel(widget) {
 function applyEditOptionsLabel(widget) {
   widget.text = $('#labelText').value;
   
-  if(($('#labelWidthNumber').value).replaceAll(/\d/g, '').replace(/\./g, '')  === '')
-    widget.width = parseFloat($('#labelWidthNumber').value)
-  else
-    widget.width = widget.width;
-  if(($('#labelHeightNumber').value).replaceAll(/\d/g, '').replace(/\./g, '')  === '')
-    widget.height = parseFloat($('#labelHeightNumber').value)
-  else
-    widget.height = widget.height;
-
+  applyWidthHeight(widget, $('#labelWidthNumber').value, 'width');
+  applyWidthHeight(widget, $('#labelHeightNumber').value, 'height');
+  
   widget.editable = $('#labelEditable').checked;
-
 }
 
 //piece widget functions

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -48,8 +48,8 @@ function applyEditOptionsBasic(widget) {
   else
     widget.image = $('#basicImage').value;
 
-  widget.width = parseFloat($('#basicWidth').value);
-  widget.height = parseFloat($('#basicHeight').value);
+  widget.width = parseFloat($('#basicWidthNumber').value);
+  widget.height = parseFloat($('#basicHeightNumber').value);
 
   if ($('#basicFullscreen').checked){
     widget.width = 1600;
@@ -238,8 +238,8 @@ function populateEditOptionsLabel(widget) {
 function applyEditOptionsLabel(widget) {
   widget.text = $('#labelText').value;
 
-  widget.width = parseFloat($('#labelWidth').value);
-  widget.height = parseFloat($('#labelHeight').value);
+  widget.width = parseFloat($('#labelWidthNumber').value);
+  widget.height = parseFloat($('#labelHeightNumber').value);
 
   widget.editable = $('#labelEditable').checked;
 


### PR DESCRIPTION
This is to address issue #708

Changes:
- Width and height are converted to float values instead of strings
- Value is taken from the text input rather than the range (slider), so that it will not round values to nearest range (slider) step (currently every 10 px)
- Width and height will not update if a valid number is not entered (numbers and possibly a decimal point)

This only affects tokens, boards, and labels as they are the only widgets that have a width and height in Edit Mode.