### PR TITLE
Remove width/height equal to cardDefault/cardType

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1400,7 +1400,7 @@ function jePreProcessObject(o) {
     const match = key.match(/^(.*?)(\*)?(#)?$/);
     if(o[match[1]] !== undefined)
       copy[match[1]] = o[match[1]];
-    else if(match[2] == '*' && !o.inheritFrom)
+    else if(match[2] == '*' && !o.inheritFrom && (o.type != 'card' && (key != 'width' && key != 'height')))
       copy[match[1]] = jeWidget.getDefaultValue(match[1]);
     if(match[3] == '#')
       copy[`LINEBREAK${match[1]}`] = null;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1400,7 +1400,7 @@ function jePreProcessObject(o) {
     const match = key.match(/^(.*?)(\*)?(#)?$/);
     if(o[match[1]] !== undefined)
       copy[match[1]] = o[match[1]];
-    else if(match[2] == '*' && !o.inheritFrom && (o.type != 'card' && (key != 'width' && key != 'height')))
+    else if(match[2] == '*' && !o.inheritFrom && (o.type != 'card' || (key != 'width*' && key != 'height*')))
       copy[match[1]] = jeWidget.getDefaultValue(match[1]);
     if(match[3] == '#')
       copy[`LINEBREAK${match[1]}`] = null;


### PR DESCRIPTION
This PR should address issue #680 and remove the width and height if those values are already being inherited from either cardDefault or cardType.  So, if it is a value that is overriding the cardDefault or cardType it will remain on the card, but if it is not, then it will be removed.

This is just 1/2 line of code.  All it does it make it so that if they widget is a card and the property is height or width, then it will be treated the same way inherited properties are treated in the JSON editor (not shown if they are not set to a different value).

else if(match[2] == '*' && !o.inheritFrom **&& (o.type != 'card' || (key != 'width\*' && key != 'height\*'))**)

Examples:
![image](https://user-images.githubusercontent.com/78324099/130368383-eea63c74-7a44-4a08-9a2f-d87e81c1f962.png)
http://212.47.248.129:3711/pr-test
