### PR TITLE
Fix typos in TIMER code for new debugger.

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1146,11 +1146,11 @@ export class Widget extends StateManaged {
            (a.timer != undefined || (isValidCollection(a.collection) && collections[a.collection].length))) {
           const phrase = (a.timer == undefined) ? `timers in '${a.collection}'` : `'${a.timer}'`;
           if(a.mode == 'set')
-            jeRoutineLoggingOperationSummary(`${phrase} to ${a.value}`)
+            jeLoggingRoutineOperationSummary(`${phrase} to ${a.value}`)
           else if(a.mode == 'inc' || a.mode == 'dec')
             jeRoutineLoggingOperationSummary(`${phrase} by ${a.value}`)
           else
-            jeRoutineLoggingOperationSummary(`${a.mode} ${phrase}`)
+            jeLoggingRoutineOperationSummary(`${a.mode} ${phrase}`)
         }
       }
 


### PR DESCRIPTION
Logging routine name was misspelled twice in the `TIMER` code in widgets.js, was untested by test room.