### PR TITLE
Stop enlarged from flickering

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -58,7 +58,9 @@ export class Widget extends StateManaged {
     this.domElement.addEventListener('contextmenu', e => this.showEnlarged(e), false);
     this.domElement.addEventListener('mouseenter',  e => this.showEnlarged(e), false);
     this.domElement.addEventListener('mouseleave',  e => this.hideEnlarged(e), false);
-    this.domElement.addEventListener("touchstart", e => this.touchstart());
+    this.domElement.addEventListener('mousedown',  e => this.moving(), false);
+    this.domElement.addEventListener('mouseup',  e => this.notMoving(), false);
+    this.domElement.addEventListener("touchstart", e => this.touchstart(), false);
     this.domElement.addEventListener("touchend", e => this.touchend(), false);
     
     this.touchstart = function() {
@@ -1199,7 +1201,8 @@ export class Widget extends StateManaged {
   }
 
   hideEnlarged() {
-    $('#enlarged').classList.add('hidden');
+    if (!this.domElement.className.match(/moving/))
+      $('#enlarged').classList.add('hidden');
   }
 
   isValidID(id, problems) {
@@ -1309,8 +1312,6 @@ export class Widget extends StateManaged {
         this.hoverTarget.domElement.classList.remove('droptarget');
       }
     }
-
-    this.hideEnlarged();
     await this.updatePiles();
   }
 
@@ -1411,7 +1412,15 @@ export class Widget extends StateManaged {
     } else
       problems.push(`Tried setting text property which doesn't exist for ${this.id}.`);
   }
-
+  
+  moving() {
+    this.domElement.classList.add('moving');
+  }
+  
+  notMoving() {
+    this.domElement.classList.remove('moving');
+  }
+  
   showEnlarged(event) {
     if(this.get('enlarge')) {
       const e = $('#enlarged');

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -58,8 +58,8 @@ export class Widget extends StateManaged {
     this.domElement.addEventListener('contextmenu', e => this.showEnlarged(e), false);
     this.domElement.addEventListener('mouseenter',  e => this.showEnlarged(e), false);
     this.domElement.addEventListener('mouseleave',  e => this.hideEnlarged(e), false);
-    this.domElement.addEventListener('mousedown',  e => this.moving(), false);
-    this.domElement.addEventListener('mouseup',  e => this.notMoving(), false);
+    this.domElement.addEventListener('mousedown',  e => this.selected(), false);
+    this.domElement.addEventListener('mouseup',  e => this.notSelected(), false);
     this.domElement.addEventListener("touchstart", e => this.touchstart(), false);
     this.domElement.addEventListener("touchend", e => this.touchend(), false);
     
@@ -1200,7 +1200,7 @@ export class Widget extends StateManaged {
   }
 
   hideEnlarged() {
-    if (!this.domElement.className.match(/moving/))
+    if (!this.domElement.className.match(/selected/))
       $('#enlarged').classList.add('hidden');
   }
 
@@ -1412,12 +1412,12 @@ export class Widget extends StateManaged {
       problems.push(`Tried setting text property which doesn't exist for ${this.id}.`);
   }
   
-  moving() {
-    this.domElement.classList.add('moving');
+  selected() {
+    this.domElement.classList.add('selected');
   }
   
-  notMoving() {
-    this.domElement.classList.remove('moving');
+  notSelected() {
+    this.domElement.classList.remove('selected');
   }
   
   showEnlarged(event) {


### PR DESCRIPTION
- Stops enlarged view from flickering if mouse moves faster than the widget and the mouse moves off of the widget while moving.
- Stops enlarged view from ending if mouse temporarily moves off the screen while a widget is being moved.
- Makes the enlarged view end when mouseleave happens rather than when mouseup happens.  

This addresses issues #31 and #715.