### PR TITLE
Clicks Test Room button once added to library

### DIFF
--- a/tests/testcafe/tests.js
+++ b/tests/testcafe/tests.js
@@ -332,3 +332,6 @@ publicLibraryButtons('Master Button',      0, 'eb19dffdb38641d5556e5fdb2c47c62b'
   'masterbutton', 'redbutton', 'orangebutton', 'yellowbutton', 'greenbutton', 'bluebutton', 'indigobutton',
   'violetbutton', 'fae4', 'vbx5'
 ]);
+publicLibraryButtons('Test Room',      0, 'hashgoeshere', [
+  'clickThis'
+]);


### PR DESCRIPTION
If the Test Room is added to the library (will not show in the Public Library), then this will click on a button that starts everything.  The hash will need to be updated later.