### PR TITLE
SET = instead of + if value is null

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1065,7 +1065,8 @@ export class Widget extends StateManaged {
           for(const w of collections[a.collection]) {
             if(a.relation == '+' && w.get(String(a.property)) == null)
               a.relation = '=';
-            await w.set(String(a.property), compute(a.relation, null, w.get(String(a.property)), a.value));
+             if(!(a.relation == '+' && a.value == null))
+               await w.set(String(a.property), compute(a.relation, null, w.get(String(a.property)), a.value));
           }
         }
         if(jeRoutineLogging)

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1066,7 +1066,7 @@ export class Widget extends StateManaged {
             if(a.relation == '+' && w.get(String(a.property)) == null)
               a.relation = '=';
             if(a.relation == '+' && a.value == null)
-              problems.push(`null value being appended, SET ignored`)
+              problems.push(`null value being appended, SET ignored`);
             else
               await w.set(String(a.property), compute(a.relation, null, w.get(String(a.property)), a.value));
           }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1065,8 +1065,10 @@ export class Widget extends StateManaged {
           for(const w of collections[a.collection]) {
             if(a.relation == '+' && w.get(String(a.property)) == null)
               a.relation = '=';
-             if(!(a.relation == '+' && a.value == null))
-               await w.set(String(a.property), compute(a.relation, null, w.get(String(a.property)), a.value));
+            if(a.relation == '+' && a.value == null)
+              problems.push(`null value being appended, SET ignored`)
+            else
+              await w.set(String(a.property), compute(a.relation, null, w.get(String(a.property)), a.value));
           }
         }
         if(jeRoutineLogging)

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1063,6 +1063,8 @@ export class Widget extends StateManaged {
           }
         } else if(isValidCollection(a.collection)) {
           for(const w of collections[a.collection]) {
+            if(a.relation == '+' && w.get(String(a.property)) == null)
+              a.relation = '=';
             await w.set(String(a.property), compute(a.relation, null, w.get(String(a.property)), a.value));
           }
         }


### PR DESCRIPTION
This addresses issue #727

It would make it so the JSON below would give you "property1": "new text" instead of "property1": "nullnew text" if the property was a null value previously.
{
"func": "SET",
"property": "property1",
"relation": "+",
"value": "new text",
"collection": "thisButton"
}

Updated to NOT perform a SET if the relationship is `+` and the new value is `null` to prevent results where the property gets set to "old valuenull" instead of remaining "old value".

Game-breaking potential:

- `SET` `+` is mistakenly used on a `null` property instead of `SET` `=`
- The property is then used as a operand in an `IF` statement
- The 'working' behavior is for the property to NOT be equal to what it was just `SET` to be
OR
NOTE: with conditions, currently `SET` `+` `false` to a `null` value gives 0 and   `SET` `+` `true` to a `null` value gives 1, so they should operate the same.
