### PR TITLE
Shuffle pile children, filters fixedParent & decks

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1075,8 +1075,16 @@ export class Widget extends StateManaged {
         if(a.holder !== undefined) {
           if(this.isValidID(a.holder, problems)) {
             await w(a.holder, async holder=>{
-              for(const c of holder.children())
-                await c.set('z', Math.floor(Math.random()*10000));
+              for(const c of holder.children().filter(w=>w.get('type')!='deck' && w.get('fixedParent')!=true)) {
+                if(c.get('type') == 'pile') {
+                  let arr = c.childArray;
+                  for (let i = 0; i < arr.length; i++) {
+                    await arr[i].set('z', Math.floor(Math.random()*10000));
+                  }
+                }
+                else
+                  await c.set('z', Math.floor(Math.random()*10000));
+              }
               await holder.updateAfterShuffle();
             });
             if(jeRoutineLogging)
@@ -1090,7 +1098,7 @@ export class Widget extends StateManaged {
             problems.push(`Collection ${a.collection} is empty.`);
           }
           if(jeRoutineLogging)
-              jeLoggingRoutineOperationSummary(`collection '${a.collection}'`);
+            jeLoggingRoutineOperationSummary(`collection '${a.collection}'`);
         }
       }
 


### PR DESCRIPTION
Attempt to address issue #596
Pretty confident that decks should not get shuffled as they aren't part of gameplay
Less confident that fixedParent widgets should not get shuffled
Iterates through pile children rather than shuffling the pile
Maybe this should be addressed in the children() function, or with another function instead

Now noticing that MOVE & MOVEXY will move a button if it gets included in holder.children because dropTargets is set to all.  Need a broader solution.