### PR TITLE
Retain order of top 2 cards SET to new parent

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1503,8 +1503,9 @@ export class Widget extends StateManaged {
           if(this.get('owner') !== null)
             pile.owner = this.get('owner');
           addWidgetLocal(pile);
-          await this.set('parent', pile.id);
           await widget.set('parent', pile.id);
+          await this.bringToFront();
+          await this.set('parent', pile.id);
           break;
         }
 

--- a/tests/testcafe/tests.js
+++ b/tests/testcafe/tests.js
@@ -306,25 +306,25 @@ test('Dynamic expressions', async t => {
     .pressKey('ctrl+j')
 });
 
-publicLibraryButtons('Blue',               0, '6681bcf652fe87f58945797e2f909036', [
+publicLibraryButtons('Blue',               0, 'ce94b53a7943ab19ff1c5a5618d12d58', [
   'fcc3fa2c-c091-41bc-8737-54d8b9d3a929', 'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_incrementButton',
   'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_incrementButton', 'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_decrementButton',
   'reset_button', 'buttonInputGo', 'fcc3fa2c-c091-41bc-8737-54d8b9d3a929', '9n2q'
 ]);
 publicLibraryButtons('FreeCell',           0, 'b3339b3c5d42f47f4def7a164be69823', [ 'reset', 'jemz', 'reset' ]);
-publicLibraryButtons('Reward',             0, 'f46d98d8c5b9ec8930524a1173364e10', [
+publicLibraryButtons('Reward',             0, '24bbc23f8b2d109c3172030f41a27253', [
   'gmex', 'kprc', 'oksq', 'j1wz', 'vfhn', '0i6i', 'Orange Recall', 'buttonInputGo', 'b09z'
 ]);
-publicLibraryButtons('Rummy Tiles',        0, '3e7716fb5b94c59969861a72fad9ce90', [ 'startMix', 'draw14' ]);
-publicLibraryButtons('Undercover',         1, '2ae852ce49304b1074b483138026b1b0', [ 'Reset', 'Spy Master Button' ]);
+publicLibraryButtons('Rummy Tiles',        0, '875067f1af33f8df3447bf60b996e4a4', [ 'startMix', 'draw14' ]);
+publicLibraryButtons('Undercover',         1, '829c56cb5b12d363a53ab382b32a8e19', [ 'Reset', 'Spy Master Button' ]);
 publicLibraryButtons('Dice',               0, 'd8b6edd6f7a25767781af4294ecda8fc', [ 'k18u', 'hy65', 'gghr', 'dsfa', 'f34a', 'fusq' ]);
-publicLibraryButtons('Functions - CALL',   0, 'def80a1f8ae3047bd435007cc7cd4aa3', [
+publicLibraryButtons('Functions - CALL',   0, '843183453983a96f3465a60f19236312', [
   'n4cw_8_C', '5a52', '5a52', '66kr', 'qeg1', 'n4cwB', '8r6p', 'qeg1', 'qeg1', 'n5eu'
 ]);
 publicLibraryButtons('Functions - CLICK',  0, 'd98299a0065b24a44b0d03a79900e0ef', [ '7u2q' ]);
 publicLibraryButtons('Functions - ROTATE', 0, '747586b12401e43382a7db2b2505f25e', [ 'c44c', '9kdj', 'w53c', 'w53c' ]);
 publicLibraryButtons('Functions - SELECT', 0, '4db86f0a95509b1c4fe5ebd6a1f822a9', [ 'oeh9', '9fhb', 'njkk', 'ffwl', 'bomo' ]);
-publicLibraryButtons('Functions - SORT',   1, 'dd047343b667795ad6d3f366aa2ae2fd', [
+publicLibraryButtons('Functions - SORT',   1, '40b54c927835422dd8cdc6dd8419a657', [
   'ingw', 'k131', 'cnfu', 'i6yz', 'z394', '0v3h', '1h8o', 'v5ra', 'ingw-copy001', 'k131-copy001', 'cnfu-copy001',
   'i6yz-copy001', 'z394-copy001', '0v3h-copy001'
 ]);


### PR DESCRIPTION
Game makers have had some difficulty maintaining the order of cards in games where the order matters. When piles form after a SET, the order of the top two cards currently flip.  This PR would cause that to NOT happen.

Addresses issue described in #741.

If cards are piled 1, 2, 3, 4, 5 and you SET a new parent then the order they will wind up in is 4, 5, 3, 2, 1, always switching the top card (5) and the second card (4).

I do not believe there is any workaround that would be affected by this update.  Any workaround would likely use MOVE or FOREACH.

Can be tested with green and red buttons in pr-test room.