### PR TITLE
Place cursor within [] or {} in JSON editor

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1476,11 +1476,12 @@ function jeSetAndSelect(replaceBy, insideString) {
     var jsonString = JSON.stringify(jeStateNow, null, '  ');
   const startIndex = jsonString.indexOf(insideString ? '###SELECT ME###' : '"###SELECT ME###"');
   let length = jsonString.length-15-(insideString ? 0 : 2);
-
+  
+  const replaceByString = JSON.stringify(replaceBy);
   if(insideString)
-    jsonString = jsonString.replace(/###SELECT ME###/, JSON.stringify(replaceBy).substr(1, JSON.stringify(replaceBy).length-2));
+    jsonString = jsonString.replace(/###SELECT ME###/, replaceByString.substr(1, replaceByString.length-2));
   else
-    jsonString = jsonString.replace(/"###SELECT ME###"/, JSON.stringify(replaceBy));
+    jsonString = jsonString.replace(/"###SELECT ME###"/, replaceByString);
 
   jeSet(jsonString);
   const quote = typeof replaceBy == 'string' && !insideString ? 1 : 0;
@@ -1488,9 +1489,9 @@ function jeSetAndSelect(replaceBy, insideString) {
   let wavybracket = 0;
   let dollarsign = 0;
   if(replaceBy){
-    bracket = JSON.stringify(replaceBy).includes('[') ? 1 : 0;
-    wavybracket = JSON.stringify(replaceBy).includes('{') ? 1 : 0;
-    dollarsign = JSON.stringify(replaceBy).includes(String.fromCharCode(36)) ? 1 : 0;
+    bracket = replaceByString.includes('[') ? 1 : 0;
+    wavybracket = replaceByString.includes('{') ? 1 : 0;
+    dollarsign = replaceByString.includes(String.fromCharCode(36)) ? 1 : 0;
   }
   jeSelect(startIndex + quote + bracket + wavybracket + dollarsign, startIndex+jsonString.length-length - quote - bracket - wavybracket, true);
 }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -554,7 +554,7 @@ function jeAddCommands() {
   jeAddEnumCommands('^.*\\(SET\\) ↦ relation', [ '+', '-', '=', "*", "/",'!' ]);
   jeAddEnumCommands('^.*\\(TIMER\\) ↦ mode', [ 'pause', 'start', 'toggle', 'set', 'dec', 'inc', 'reset']);
   jeAddEnumCommands('^.*\\(TIMER\\) ↦ value', [ 0, 'start', 'end', 'milliseconds']);
-  jeAddEnumCommands('^.*\\([A-Z]+\\) ↦ property', [ 'id', 'parent', 'type', 'rotation' ]);
+  jeAddEnumCommands('^.*\\([A-Z]+\\) ↦ property', [ 'id', 'parent', 'text', 'type', 'rotation' ]);
 
   jeAddEnumCommands('^.*\\((CLICK|COUNT|DELETE|FLIP|GET|LABEL|ROTATE|SET|SORT|SHUFFLE)\\) ↦ collection', [ 'DEFAULT', 'thisButton', 'child' ]);
   jeAddEnumCommands('^.*\\(CLONE\\) ↦ source', [ 'DEFAULT', 'thisButton', 'child' ]);

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1490,7 +1490,7 @@ function jeSetAndSelect(replaceBy, insideString) {
   if(replaceBy){
     bracket = JSON.stringify(replaceBy).includes('[') ? 1 : 0;
     wavybracket = JSON.stringify(replaceBy).includes('{') ? 1 : 0;
-    dollarsign = JSON.stringify(replaceBy).includes('$') ? 1 : 0;
+    dollarsign = JSON.stringify(replaceBy).includes(String.fromCharCode(36)) ? 1 : 0; // the minifier doesn't like '$' here
   }
   jeSelect(startIndex + quote + bracket + wavybracket + dollarsign, startIndex+jsonString.length-length - quote - bracket - wavybracket, true);
 }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1491,42 +1491,43 @@ function jeSetAndSelect(replaceBy, insideString) {
 
   jeSet(jsonString);
 
-  if(replaceBy !== undefined){ 
-    const lbracket = replaceByString.lastIndexOf('[');
-    const lwavybracket = replaceByString.lastIndexOf('{');
-    const rbracket = replaceByString.lastIndexOf(']') > -1 ? replaceByString.lastIndexOf(']') : replaceByString.length;
-    const rwavybracket = replaceByString.lastIndexOf('}') > -1 ? replaceByString.lastIndexOf('}') : replaceByString.length;
+  if(replaceBy !== undefined){
     const quoteArray = getAllIndexes(replaceByString,'\"');
+    const bracket = replaceByString.lastIndexOf('[') + 1;
+    const wavybracket = replaceByString.lastIndexOf('{') + 1;
     let begin = 0;
     let end = 0;
-
-    if(quoteArray.length > 0) { // adjust selection area to inside last set of quotes
-      begin = quoteArray[quoteArray.length-2]+1;
-      end = quoteArray[quoteArray.length-1];
-    } else { // adjust selection area to inside last set of brackets, or whole string if none
-      begin = Math.max(lbracket+1, lwavybracket+1);
-      end = Math.min(rbracket, rwavybracket);
+    if(quoteArray.length > 2) { // adjusts selection area to inside last set of quotes
+      begin = quoteArray[2] + 1;
+      end = quoteArray[3];
+    } else if (quoteArray.length > 0) {
+      begin = quoteArray[0] + 1;
+      end = quoteArray[1];
+    } else { // adjusts selection area to inside brackets
+      begin = Math.max(bracket, wavybracket);
+      end = begin > 0 ? begin : replaceByString.length;
+    }
+    // adjusts selection area for formatting of arrays and objects
+    if((bracket > 0 && (quoteArray.length > 0 || wavybracket > 0)) || (quoteArray.length > 0 && wavybracket > 0)) {
+      begin = begin + 5;
+      end = end + 5;
+      if(wavybracket > 0 && quoteArray.length > 0 && bracket > 0) {
+        begin = begin + 8;
+        end = end + 8;
+      }
     }
 
-    if(replaceByString.includes(String.fromCharCode(36)+'{}')) { // put cursor as ${|}
+    if(replaceByString.includes(String.fromCharCode(36))) { // put cursor as ${|}
       begin = 3;
-      end = 3
-    } else if(replaceByString.includes('increment')) { // highlight entire var string
+      end = 3;
+    }
+    if(replaceByString.includes('increment')) { // highlight entire var string
       begin = 0;
-      end = 31
-    } else if(replaceByString.includes('random')) { // highlight entire var string
+      end = 31;
+    }
+    if(replaceByString.includes('random')) { // highlight entire var string
       begin = 0;
-      end = 21
-    } else { // adjusts selection area for formatting of arrays and objects
-      if ((lbracket > -1 && lwavybracket > -1) || (lbracket > -1 && quoteArray.length > 0)
-          || (lwavybracket > -1 && quoteArray.length > 0)) {
-        begin = begin + 6;
-        end = end + 6;
-        if((lbracket > -1 && lwavybracket > -1 && quoteArray.length > 0)) {
-          begin = begin + 7;
-          end = end + 7;
-        }
-      }
+      end = 21;
     }
     jeSelect(startIndex + begin, startIndex + end, true);
   }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1458,6 +1458,14 @@ function jeSelect(start, end, scrollToCursor) {
   }
 }
 
+function getAllIndexes(arr, val) {
+  var indexes = [], i;
+  for(i = 0; i < arr.length; i++)
+    if (arr[i] === val)
+      indexes.push(i);
+  return indexes;
+}
+
 function jeSet(text, dontFocus) {
   try {
     $('#jeText').textContent = jePreProcessText(JSON.stringify(jePreProcessObject(JSON.parse(text)), null, '  '));

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1494,8 +1494,8 @@ function jeSetAndSelect(replaceBy, insideString) {
   if(replaceBy !== undefined){ 
     const lbracket = replaceByString.lastIndexOf('[');
     const lwavybracket = replaceByString.lastIndexOf('{');
-    const rbracket = replaceByString.lastIndexOf(']') > -1 ? replaceByString.lastIndexOf(']') : replaceByString.length;
-    const rwavybracket = replaceByString.lastIndexOf('}') > -1 ? replaceByString.lastIndexOf('}') : replaceByString.length;
+    const rbracket = replaceByString.lastIndexOf(']') > -1 ? 1 : replaceByString.length;
+    const rwavybracket = replaceByString.lastIndexOf('}') > -1 ? 1 : replaceByString.length;
     const quoteArray = getAllIndexes(replaceByString,'\"');
     let begin = 0;
     let end = 0;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1491,51 +1491,45 @@ function jeSetAndSelect(replaceBy, insideString) {
 
   jeSet(jsonString);
 
-  let bracket = 0;
-  let wavybracket = 0;
-  let begin = 0;
-  let end = 0;
   if(replaceBy !== undefined){ 
+    const lbracket = replaceByString.lastIndexOf('[');
+    const lwavybracket = replaceByString.lastIndexOf('{');
+    const rbracket = replaceByString.lastIndexOf(']') > -1 ? replaceByString.lastIndexOf(']') : replaceByString.length;
+    const rwavybracket = replaceByString.lastIndexOf('}') > -1 ? replaceByString.lastIndexOf('}') : replaceByString.length;
     const quoteArray = getAllIndexes(replaceByString,'\"');
-    if(quoteArray.length > 2) { // adjusts selection area to inside last set of quotes
-      begin = quoteArray[2] + 1;
-      end = quoteArray[3];
-    } else if (quoteArray.length > 0) {
-      begin = quoteArray[0] + 1;
-      end = quoteArray[1];
-    } else { // adjusts selection area to inside brackets
-      bracket = replaceByString.lastIndexOf('[') + 1;
-      wavybracket = replaceByString.lastIndexOf('{')+ 1;
-      begin = Math.max(bracket, wavybracket, 0);
-      bracket = replaceByString.lastIndexOf(']') > -1 ? replaceByString.lastIndexOf(']') - 1 : replaceByString.length;
-      wavybracket = replaceByString.lastIndexOf('}') > -1 ? replaceByString.lastIndexOf('}') - 1 : replaceByString.length;
-      end = Math.min(bracket, wavybracket);
+    let begin = 0;
+    let end = 0;
+
+    if(quoteArray.length > 0) { // adjust selection area to inside last set of quotes
+      begin = quoteArray[quoteArray.length-2]+1;
+      end = quoteArray[quoteArray.length-1];
+    } else { // adjust selection area to inside last set of brackets, or whole string if none
+      begin = Math.max(lbracket+1, lwavybracket+1);
+      end = Math.min(rbracket, rwavybracket);
     }
 
-    // adjusts selection area for formatting of arrays and objects
-    if((replaceByString.indexOf('[') > -1 && (replaceByString.indexOf('\"') > -1 || replaceByString.indexOf('{') > -1)) || (replaceByString.indexOf('\"') > -1 && replaceByString.indexOf('{') > -1)) {
-     begin = begin + 6;
-      end = end + 6;
-      if(replaceByString.indexOf('{') > -1 && replaceByString.indexOf('\"') > -1 && replaceByString.indexOf('[') > -1) {
-        begin = begin + 7;
-        end = end + 7;
+    if(replaceByString.includes(String.fromCharCode(36)+'{}')) { // put cursor as ${|}
+      begin = 3;
+      end = 3
+    } else if(replaceByString.includes('increment')) { // highlight entire var string
+      begin = 0;
+      end = 31
+    } else if(replaceByString.includes('random')) { // highlight entire var string
+      begin = 0;
+      end = 21
+    } else { // adjusts selection area for formatting of arrays and objects
+      if ((lbracket > -1 && lwavybracket > -1) || (lbracket > -1 && quoteArray.length > 0)
+          || (lwavybracket > -1 && quoteArray.length > 0)) {
+        begin = begin + 6;
+        end = end + 6;
+        if((lbracket > -1 && lwavybracket > -1 && quoteArray.length > 0)) {
+          begin = begin + 7;
+          end = end + 7;
+        }
       }
     }
-    // variables with dollar signs and dynamic expressions
-    if(replaceByString.includes(String.fromCharCode(36){})) {
-      begin = 3
-      end = 3
-    }
-    if(replaceByString.includes('increment')) {
-      begin = 14
-      end = 26
-    }
-    if(replaceByString.includes('random')) {
-      begin = 19
-      end = 21
-    }
+    jeSelect(startIndex + begin, startIndex + end, true);
   }
-  jeSelect(startIndex + begin, startIndex + end, true);
 }
 
 function jeShowCommands() {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1507,14 +1507,14 @@ function jeSetAndSelect(replaceBy, insideString) {
       bracket = replaceByString.lastIndexOf('[') + 1;
       wavybracket = replaceByString.lastIndexOf('{')+ 1;
       begin = Math.max(bracket, wavybracket, 0);
-      bracket = replaceByString.lastIndexOf(']') > 0 ? replaceByString.lastIndexOf(']') > - 1 : replaceByString.length;
-      wavybracket = replaceByString.lastIndexOf('}') > 0 ? replaceByString.lastIndexOf('}') > - 1 : replaceByString.length;
+      bracket = replaceByString.lastIndexOf(']') > -1 ? replaceByString.lastIndexOf(']') - 1 : replaceByString.length;
+      wavybracket = replaceByString.lastIndexOf('}') > -1 ? replaceByString.lastIndexOf('}') - 1 : replaceByString.length;
       end = Math.min(bracket, wavybracket);
     }
 
     // adjusts selection area for formatting of arrays and objects
-    if((replaceByString.indexOf('[') > -1 && (replaceByString.indexOf('\"') > -1 || replaceByString.indexOf('{') > -1)) || replaceByString.indexOf('\"') > -1 && replaceByString.indexOf('{') > -1) {
-      begin = begin + 6;
+    if((replaceByString.indexOf('[') > -1 && (replaceByString.indexOf('\"') > -1 || replaceByString.indexOf('{') > -1)) || (replaceByString.indexOf('\"') > -1 && replaceByString.indexOf('{') > -1)) {
+     begin = begin + 6;
       end = end + 6;
       if(replaceByString.indexOf('{') > -1 && replaceByString.indexOf('\"') > -1 && replaceByString.indexOf('[') > -1) {
         begin = begin + 7;
@@ -1522,7 +1522,7 @@ function jeSetAndSelect(replaceBy, insideString) {
       }
     }
     // variables with dollar signs and dynamic expressions
-    if(replaceByString.includes(String.fromCharCode(36))) {
+    if(replaceByString.includes(String.fromCharCode(36){})) {
       begin = 3
       end = 3
     }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1527,8 +1527,8 @@ function jeSetAndSelect(replaceBy, insideString) {
       end = 3
     }
     if(replaceByString.includes('increment')) {
-      begin = 30
-      end = 31
+      begin = 14
+      end = 26
     }
     if(replaceByString.includes('random')) {
       begin = 19

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1494,8 +1494,8 @@ function jeSetAndSelect(replaceBy, insideString) {
   if(replaceBy !== undefined){ 
     const lbracket = replaceByString.lastIndexOf('[');
     const lwavybracket = replaceByString.lastIndexOf('{');
-    const rbracket = replaceByString.lastIndexOf(']') > -1 ? 1 : replaceByString.length;
-    const rwavybracket = replaceByString.lastIndexOf('}') > -1 ? 1 : replaceByString.length;
+    const rbracket = replaceByString.lastIndexOf(']') > -1 ? replaceByString.lastIndexOf(']') : replaceByString.length;
+    const rwavybracket = replaceByString.lastIndexOf('}') > -1 ? replaceByString.lastIndexOf('}') : replaceByString.length;
     const quoteArray = getAllIndexes(replaceByString,'\"');
     let begin = 0;
     let end = 0;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1484,7 +1484,15 @@ function jeSetAndSelect(replaceBy, insideString) {
 
   jeSet(jsonString);
   const quote = typeof replaceBy == 'string' && !insideString ? 1 : 0;
-  jeSelect(startIndex + quote, startIndex+jsonString.length-length - quote, true);
+  let bracket = 0;
+  let wavybracket = 0;
+  let dollarsign = 0;
+  if(replaceBy){
+    bracket = JSON.stringify(replaceBy).includes('[') ? 1 : 0;
+    wavybracket = JSON.stringify(replaceBy).includes('{') ? 1 : 0;
+    dollarsign = JSON.stringify(replaceBy).includes('$') ? 1 : 0;
+  }
+  jeSelect(startIndex + quote + bracket + wavybracket + dollarsign, startIndex+jsonString.length-length - quote - bracket - wavybracket, true);
 }
 
 function jeShowCommands() {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1490,7 +1490,7 @@ function jeSetAndSelect(replaceBy, insideString) {
   if(replaceBy){
     bracket = JSON.stringify(replaceBy).includes('[') ? 1 : 0;
     wavybracket = JSON.stringify(replaceBy).includes('{') ? 1 : 0;
-    dollarsign = JSON.stringify(replaceBy).includes(String.fromCharCode(36)) ? 1 : 0; // the minifier doesn't like '$' here
+    dollarsign = JSON.stringify(replaceBy).includes(String.fromCharCode(36)) ? 1 : 0;
   }
   jeSelect(startIndex + quote + bracket + wavybracket + dollarsign, startIndex+jsonString.length-length - quote - bracket - wavybracket, true);
 }


### PR DESCRIPTION
Considering some small changes.

This PR is intended to adjust the selection area in the JSON editor so the cursor will be put inside of brackets and wavy brackets instead of selecting everything inside the quotation marks or instead of selecting the brackets.  It also addresses changes caused to formatting such as with faces and dropTarget.  Additionally I placed the selection over the last number of the randInt dynamic expression and over the variable name of the increment dynamic expression because I thought they would be the most likely things edited.

![image](https://user-images.githubusercontent.com/78324099/135760856-0feb281f-5bbf-4215-9367-d1954b067dc3.png)

The most notable changes are with "${}", {}, [], dropTarget, faces, and the two dynamic expressions.

Part of this is not needed right now, but I thought might be needed in the future.  This part below would adjust for an object within an array where we wanted to have a preset value in the object so that the value would be selected (such as if in #777 if the default was updated to `"dropTarget": [{"type": "card"}]`).
```json
"propertyname": [
     {
         "key": "value"
     }
]
```
![image](https://user-images.githubusercontent.com/78324099/135760881-22308c66-62b0-43e9-a977-8a8cc688ecf4.png)


Also added 'text' as an option under `property` in the JSON editor.

It also adds a function to get all indexes of a value and place them in an array, which might be useful in other places in the future.
![image](https://user-images.githubusercontent.com/78324099/135761692-e9cdf476-37ab-4067-86b7-a6ee4323870f.png)
