### PR TITLE
Adjust for viewport units on mobile

### DIFF
--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -45,7 +45,6 @@ button:hover {
   width: 100%;
   position: fixed;
 
-  top: calc((100vh - var(--roomHeight) * var(--scale)) / 2 + var(--roomHeight) * var(--scale) - var(--toolbarSize) / 2 - 1px);
   top: calc((calc(var(--vh, 1vh) * 100) - var(--roomHeight) * var(--scale)) / 2 + var(--roomHeight) * var(--scale) - var(--toolbarSize) / 2 - 1px);
 
   left: 0;
@@ -60,7 +59,6 @@ button:hover {
   width: calc(var(--roomWidth) * var(--scale));
   height: calc(var(--roomHeight) * var(--scale));
 
-  top: calc((100vh - var(--roomHeight) * var(--scale)) / 2 - var(--toolbarSize) / 2);
   top: calc((calc(var(--vh, 1vh) * 100) - var(--roomHeight) * var(--scale)) / 2 - var(--toolbarSize) / 2);
 
   left: 0;

--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -46,6 +46,8 @@ button:hover {
   position: fixed;
 
   top: calc((100vh - var(--roomHeight) * var(--scale)) / 2 + var(--roomHeight) * var(--scale) - var(--toolbarSize) / 2 - 1px);
+  top: calc((calc(var(--vh, 1vh) * 100) - var(--roomHeight) * var(--scale)) / 2 + var(--roomHeight) * var(--scale) - var(--toolbarSize) / 2 - 1px);
+
   left: 0;
   width: 100%;
   height: var(--toolbarSize);
@@ -59,6 +61,8 @@ button:hover {
   height: calc(var(--roomHeight) * var(--scale));
 
   top: calc((100vh - var(--roomHeight) * var(--scale)) / 2 - var(--toolbarSize) / 2);
+  top: calc((calc(var(--vh, 1vh) * 100) - var(--roomHeight) * var(--scale)) / 2 - var(--toolbarSize) / 2);
+
   left: 0;
   z-index: 1;
 }

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -126,6 +126,8 @@ function checkURLproperties() {
 function setScale() {
   const w = window.innerWidth;
   const h = window.innerHeight;
+  let vh = window.innerHeight * 0.01;
+  document.documentElement.style.setProperty('--vh', `${vh}px`);
   if(jeEnabled) {
     const targetWidth = jeZoomOut ? 3200 : 1600;
     scale = (w-920)/targetWidth;


### PR DESCRIPTION
Fixed calculations based on VH in mobile WebKit where 100vh extended past the bottom of the browser.

As far as I know this only affects users on iPadOS 15.

Attached images that show the issue and with it fixed.

Problem:
![IMG_1901-smaller](https://user-images.githubusercontent.com/12822213/134720415-77ec9a34-d60d-427f-bb0d-78b076da2ed1.jpg)

Fixed:
![IMG_1902-smaller](https://user-images.githubusercontent.com/12822213/134720425-a859ff43-a885-4176-ae13-de46faaac7b4.jpg)


