### PR TITLE
Add hidden "Test Room" to public library for TestCafe

### DIFF
--- a/tests/testcafe/tests.js
+++ b/tests/testcafe/tests.js
@@ -346,6 +346,6 @@ publicLibraryButtons('Master Button',      0, 'eb19dffdb38641d5556e5fdb2c47c62b'
   'violetbutton', 'fae4', 'vbx5'
 ]);
 
-hiddenLibraryButtons('Test_Room',          0, '78940abbe4b0789d9a902561951d16e9', [
+hiddenLibraryButtons('Test_Room',          0, '7fe7593189739bc9cdee6d68acdf1527', [
   'clickThis', 'button1', 'button2', 'type', 'button3', 'button4'
 ]);


### PR DESCRIPTION
Clean place to start over for #724.

This PR allows rooms to be added as a TestCafe test by being added to the Public Library, but without being added to the list of Public Library games and Tutorials.

Instead of the test rooms being added through the public library list (library.json), they are added through the "Enter Link" button.

It also adds one test room file "Test_Room.vtt" to the public library that runs a lot of functions and changes a lot of properties.