### PR TITLE
improve cacheability of assets

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -98,6 +98,8 @@ MinifyRoom().then(function(result) {
       else
         Logging.log(`WARNING: Unknown file type of asset ${req.params.name}`);
 
+      res.setHeader('Cache-Control', 'public, max-age=30000000');
+      res.setHeader('Expires', new Date(Date.now() + 30000000000).toUTCString());
       res.send(content);
     });
   });


### PR DESCRIPTION
This PR tells browsers to not ask the server for changes to assets it already has in its cache. The assets have a checksum of their contents in the URL so every change to the content would lead to a new URL anyway.