### PR TITLE
hide inactive guests from player list

### DIFF
--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -25,6 +25,9 @@ function fillPlayerList(players, active) {
   removeFromDOM('#playerList > div, #roomArea > .cursor');
 
   for(const player in players) {
+    if(activePlayers.indexOf(player) == -1 && player.match(/^Guest/))
+      continue;
+
     const entry = domByTemplate('template-playerlist-entry');
     $('.teamColor', entry).value = players[player];
     $('.playerName', entry).value = player;

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -25,9 +25,6 @@ function fillPlayerList(players, active) {
   removeFromDOM('#playerList > div, #roomArea > .cursor');
 
   for(const player in players) {
-    if(activePlayers.indexOf(player) == -1 && player.match(/^Guest/))
-      continue;
-
     const entry = domByTemplate('template-playerlist-entry');
     $('.teamColor', entry).value = players[player];
     $('.playerName', entry).value = player;

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -330,7 +330,7 @@ export default class Room {
     Logging.log(`removing player ${player.name} from room ${this.id}`);
 
     this.players = this.players.filter(e => e != player);
-    if(player.name.match(/^Guest/) && !Object.values(this.state).filter(w=>w.owner==player.name).length)
+    if(player.name.match(/^Guest/) && !Object.values(this.state).filter(w=>w.owner==player.name||Array.isArray(w.owner)&&w.owner.indexOf(player.name)!=-1).length)
       delete this.state._meta.players[player.name];
 
     if(this.players.length == 0) {

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -328,7 +328,11 @@ export default class Room {
   removePlayer(player) {
     this.trace('removePlayer', { player: player.name });
     Logging.log(`removing player ${player.name} from room ${this.id}`);
+
     this.players = this.players.filter(e => e != player);
+    if(player.name.match(/^Guest/) && !Object.values(this.state).filter(w=>w.owner==player.name).length)
+      delete this.state._meta.players[player.name];
+
     if(this.players.length == 0) {
       this.unload();
       this.unloadCallback();


### PR DESCRIPTION
I am not sure if I want this or not but I thought I would throw it into a PR.

Rooms used for a longer time tend to accumulate guest players in the player list. This PR hides them if they are inactive (not currently connected).