### PR TITLE
ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 save
 *.tgz
 *.heapsnapshot
+package-lock.json


### PR DESCRIPTION
package-lock.json is an auto generated file that changes all the time so it adds noise to the revision history if it is tracked, therefore it should be ignored.