### PR TITLE
Fix editing cards directly in JSON editor

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -854,8 +854,8 @@ async function jeApplyExternalChanges(state) {
     if(state.cardType === before.cardType) {
       const cardTypes = widgets.get(state.deck).get('cardTypes');
       const cardType = cardTypes[state.cardType];
-      if(JSON.stringify(state['cardType  ['+ o.cardType + '] (in deck)']) != JSON.stringify(cardType)) {
-        cardTypes[state.cardType] = state['cardType ['+ o.cardType + '] (in deck)'];
+      if(JSON.stringify(state['cardType  ['+ state.cardType + '] (in deck)']) != JSON.stringify(cardType)) {
+        cardTypes[state.cardType] = state['cardType ['+ state.cardType + '] (in deck)'];
         await widgets.get(state.deck).set('cardTypes', { ...cardTypes });
       }
     }


### PR DESCRIPTION
With PR #737 I broke directly editing cards in the JSON editor by using o.cardType instead of state.cardType in the function jeApplyExternalChanges in jsonedit.js.

This simply corrects that error.

Currently on the production server typing in the JSON editor on a card won't update the JSON (because I broke it on accident).  With this PR that functionality is restored.  