### PR TITLE
update to Node.js 16

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,14 +25,6 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -41,7 +33,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
-        languages: ${{ matrix.language }}
+        languages: javascript
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,17 +14,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [15.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 16.x
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/.github/workflows/production-environment.yml
+++ b/.github/workflows/production-environment.yml
@@ -16,10 +16,10 @@ jobs:
       uses: actions/checkout@v2
     - name: Checkout submodules
       uses: textbook/git-checkout-submodule-action@master
-    - name: Install Node.js 15.x
+    - name: Install Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 15.x
+        node-version: 16.x
     - name: Install dependencies
       run: npm ci
     - name: Start virtualtabletop server with production settings

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -16,10 +16,10 @@ jobs:
       uses: actions/checkout@v2
     - name: Checkout submodules
       uses: textbook/git-checkout-submodule-action@master
-    - name: Install Node.js 15.x
+    - name: Install Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 15.x
+        node-version: 16.x
     - name: Install dependencies
       run: npm ci
     - name: Start virtualtabletop server

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 tasks:
-  - init: nvm install 15; nvm use 15; npm install
+  - init: nvm install 16; nvm use 16; npm install
     command: (sleep 2; gp preview $(gp url 8272)/test) & npm run debug
 ports:
   - port: 8272

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The games in the public library have their license information and attributions 
 This assumes a Debian based Linux. Find Node.js repositories for other Linux distributions at https://node.dev/node-binary. Consult your distribution's documentation for how to install the git and nodejs packages if your distribution does not use apt.
 
 ```
-curl -sL https://deb.nodesource.com/setup_15.x | sudo -E bash -                         # adds a repository for Node.js v15
+curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -                         # adds a repository for Node.js v16
 sudo apt install -y git nodejs                                                          # installs the required software
 git clone --recurse-submodules https://github.com/ArnoldSmith86/virtualtabletop.git     # downloads everything in this repository
 cd virtualtabletop                                                                      # changes to the newly created directory

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virtualtabletop",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "description": "a virtual surface in the browser on which you can play board, dice and card games",
   "main": "server.mjs",
   "type": "module",


### PR DESCRIPTION
This PR updates the build instructions and the automated tests on GitHub to Node.js v16. We currently use v15 and it is no longer supported.

Merging this PR does not update Node.js on the production server. I will have to do that manually but with this PR I want to make sure that the GitHub test tools support v16.