### PR TITLE
Add 'intersect' and 'remove' as modes for SELECT

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -521,7 +521,7 @@ function jeAddCommands() {
   jeAddRoutineOperationCommands('MOVEXY', { count: 1, face: null, from: null, x: 0, y: 0 });
   jeAddRoutineOperationCommands('RECALL', { owned: true, holder: null });
   jeAddRoutineOperationCommands('ROTATE', { count: 1, angle: 90, mode: 'add', holder: null, collection: 'DEFAULT' });
-  jeAddRoutineOperationCommands('SELECT', { type: 'all', property: 'parent', relation: '==', value: null, max: 999999, collection: 'DEFAULT', mode: 'add', source: 'all', sortBy: 'null' });
+  jeAddRoutineOperationCommands('SELECT', { type: 'all', property: 'parent', relation: '==', value: null, max: 999999, collection: 'DEFAULT', mode: 'set', source: 'all', sortBy: 'null' });
   jeAddRoutineOperationCommands('SET', { collection: 'DEFAULT', property: 'parent', relation: '=', value: null });
   jeAddRoutineOperationCommands('SORT', { key: 'value', reverse: false, locales: null, options: null, holder: null, collection: 'DEFAULT' });
   jeAddRoutineOperationCommands('SHUFFLE', { holder: null, collection: 'DEFAULT' });

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -548,7 +548,7 @@ function jeAddCommands() {
   jeAddEnumCommands('^.*\\(LABEL\\) ↦ mode', [ 'set', 'dec', 'inc', 'append' ]);
   jeAddEnumCommands('^.*\\(ROTATE\\) ↦ angle', [ 45, 60, 90, 135, 180 ]);
   jeAddEnumCommands('^.*\\(ROTATE\\) ↦ mode', [ 'set', 'add' ]);
-  jeAddEnumCommands('^.*\\(SELECT\\) ↦ mode', [ 'set', 'add' ]);
+  jeAddEnumCommands('^.*\\(SELECT\\) ↦ mode', [ 'set', 'add', 'remove', 'intersect' ]);
   jeAddEnumCommands('^.*\\(SELECT\\) ↦ relation', [ '<', '<=', '==', '!=', '>', '>=', 'in' ]);
   jeAddEnumCommands('^.*\\(SELECT\\) ↦ type', [ 'all', null, 'button', 'card', 'deck', 'holder', 'label', 'spinner' ]);
   jeAddEnumCommands('^.*\\(SET\\) ↦ relation', [ '+', '-', '=', "*", "/",'!' ]);

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1032,13 +1032,13 @@ export class Widget extends StateManaged {
             c = c.filter(w=>w.get('type')!='pile');
           }
 
-          c = c.slice(0, a.max);
+          c = c.slice(0, a.max); // a.mode == 'set'
           if(a.mode == 'intersect')
             c = collections[a.collection] ? collections[a.collection].filter(value => c.includes(value)) : [];
           else if(a.mode == 'remove')
             c = collections[a.collection] ? collections[a.collection].filter(value => !c.includes(value)) : [];
-          else
-            c = c.concat(a.mode == 'add' ? collections[a.collection] || [] : []);
+          else if(a.mode == 'add')
+            c = c.concat(collections[a.collection] || []);
 
           collections[a.collection] = [...new Set(c)];
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1002,7 +1002,7 @@ export class Widget extends StateManaged {
       if(a.func == 'SELECT') {
         setDefaults(a, { type: 'all', property: 'parent', relation: '==', value: null, max: 999999, collection: 'DEFAULT', mode: 'set', source: 'all' });
         if(a.source == 'all' || isValidCollection(a.source)) {
-          if([ 'add', 'set' ].indexOf(a.mode) == -1)
+          if([ 'add', 'set', 'remove', 'intersect' ].indexOf(a.mode) == -1)
             problems.push(`Warning: Mode ${a.mode} interpreted as set.`);
           let c = (a.source == 'all' ? Array.from(widgets.values()) : collections[a.source]).filter(function(w) {
             if(w.isBeingRemoved)
@@ -1032,7 +1032,14 @@ export class Widget extends StateManaged {
             c = c.filter(w=>w.get('type')!='pile');
           }
 
-          c = c.slice(0, a.max).concat(a.mode == 'add' ? collections[a.collection] || [] : []);
+          c = c.slice(0, a.max);
+          if(a.mode == 'intersect')
+            c = collections[a.collection] ? collections[a.collection].filter(value => c.includes(value)) : [];
+          else if(a.mode == 'remove')
+            c = collections[a.collection] ? collections[a.collection].filter(value => !c.includes(value)) : [];
+          else
+            c = c.concat(a.mode == 'add' ? collections[a.collection] || [] : []);
+
           collections[a.collection] = [...new Set(c)];
 
           if(a.sortBy)


### PR DESCRIPTION
Add 'intersect' and 'remove' as modes for SELECT, and update JSON editor appropriately. Implements #587.

Also (unrelated, but discovered in testing) change the default for `mode` in the JSON editor from `add` to `set`.

If this is merged, the description of `mode` in the discussion of `SELECT` in the Wiki will change to something like:

- mode: set / add / remove / intersect - "set" (the default) replaces any previously stored widgets in _collection_ by the selected widgets. "add" extends _collection_ by the selected widgets. "remove" removes from _collection_ any selected widgets that are in _collection_. Finally, _intersect_ replaces _collection_ by the collection of all widgets that both appear in _collection_ and are selected.