### PR TITLE
Prevent owner change when childrenPerOwner false

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -244,9 +244,9 @@ export class Widget extends StateManaged {
 
   async checkParent(forceDetach) {
     if(this.currentParent && (forceDetach || !overlap(this.domElement, this.currentParent.domElement))) {
+      await this.set('parent', null);
       if(this.currentParent.get('childrenPerOwner') == true)
         await this.set('owner',  null);
-      await this.set('parent', null);
       if(this.currentParent.dispenseCard)
         await this.currentParent.dispenseCard(this);
       delete this.currentParent;

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -244,8 +244,9 @@ export class Widget extends StateManaged {
 
   async checkParent(forceDetach) {
     if(this.currentParent && (forceDetach || !overlap(this.domElement, this.currentParent.domElement))) {
+      if(this.currentParent.get('childrenPerOwner') == true)
+        await this.set('owner',  null);
       await this.set('parent', null);
-      await this.set('owner',  null);
       if(this.currentParent.dispenseCard)
         await this.currentParent.dispenseCard(this);
       delete this.currentParent;

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -245,7 +245,7 @@ export class Widget extends StateManaged {
   async checkParent(forceDetach) {
     if(this.currentParent && (forceDetach || !overlap(this.domElement, this.currentParent.domElement))) {
       await this.set('parent', null);
-      if(this.currentParent.get('childrenPerOwner') == true)
+      if(this.currentParent.get('childrenPerOwner'))
         await this.set('owner',  null);
       if(this.currentParent.dispenseCard)
         await this.currentParent.dispenseCard(this);


### PR DESCRIPTION
Addresses issue descripted in #820.  Prevents an automatic owner change when a widget is being removed from a holder if childrenPerOwner is not set to true.

Proposed wiki changes:
| childrenPerOwner | false        | If set to true, a new child will have its _owner_ set to the player that drags the child into the holder.  It will also remove the owner when the card is dragged out of the holder. <br />This is set to true when you add a new hand. |