### PR TITLE
adds color picker for JSON editor

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -38,7 +38,7 @@ const jeCommands = [
     id: 'je_colorPicker',
     name: 'change color',
     options: [ { type: 'color', label: 'color' } ],
-    context: '.*#([0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})|^.* ↦ color$' + String.fromCharCode(36),
+    context: '.*#([0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})|^.* ↦ color',
     call: async function(options) {
       if(options['color']) {
         jeInsert(null, jeGetLastKey(), options['color']);


### PR DESCRIPTION
Created code based on other commands

context based on image upload
options based on duplicate
setting property based on toggle boolean

No example available for populating input (color always start at #ff0000)