### PR TITLE
Fix source not displaying properly default collections in JSON editor

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -576,7 +576,7 @@ function jeAddCommands() {
 
   jeAddEnumCommands('^.*\\((CLICK|COUNT|DELETE|FLIP|GET|LABEL|ROTATE|SET|SORT|SHUFFLE)\\) ↦ collection', collectionNames.slice(1));
   jeAddEnumCommands('^.*\\(CLONE\\) ↦ source', collectionNames.slice(1));
-  jeAddEnumCommands('^.*\\(SELECT|TURN\\) ↦ source', collectionNames);
+  jeAddEnumCommands('^.*\\((SELECT|TURN)\\) ↦ source', collectionNames);
 
   jeAddNumberCommand('increment number', '+', x=>x+1);
   jeAddNumberCommand('decrement number', '-', x=>x-1);


### PR DESCRIPTION
Missing ( ) were making the "source" parameter in TURN and SELECT not display properly in JSON editor