### PR TITLE
added toggle for wide/narrow sidebar to JSON editor

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -86,8 +86,7 @@ i.error   { color: red; font-weight: bold; }
 }
 
 #jeWidgetLayers {
-  width: calc(100% - var(--commandPaneWidth) - var(--editorPaneWidth));
-  white-space: pre;
+  width: 9001px;
   font-size: 0;
   padding: 0;
   background: transparent;
@@ -96,9 +95,9 @@ i.error   { color: red; font-weight: bold; }
 #jeWidgetLayers > div {
   display: inline-block;
   padding: 2px;
-  overflow: hidden;
   vertical-align: top;
   font-size: 12px;
+  margin-right: 4px;
 }
 
 #jeWidgetLayers > div:empty {

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -82,19 +82,19 @@ i.error   { color: red; font-weight: bold; }
 }
 
 #jeWidgetLayers {
-  height: 10%;
   width: calc(100% - var(--commandPaneWidth) - var(--editorPaneWidth));
   white-space: pre;
-  overflow: hidden;
+  font-size: 0;
+  padding: 0;
   background: transparent;
 }
 
 #jeWidgetLayers > div {
   display: inline-block;
-  width: 125px;
-  margin-bottom: 10px;
-  padding: 4px;
+  padding: 2px;
   overflow: hidden;
+  vertical-align: top;
+  font-size: 12px;
 }
 
 #jeWidgetLayers > div:empty {

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -166,6 +166,10 @@ body.jsonEdit.jeZoomOut #topSurface {
   border: 3px solid white;
 }
 
+#jeLogWrapper > h1 {
+  margin: 0;
+}
+
 #jeLogWrapper:hover #jeLog {
   display: block;
 }

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -1,6 +1,6 @@
 #jsonEditor {
-  --commandPaneWidth: 320px;
-  --editorPaneWidth: 600px; /* the sum of these two has to be changed in main.js => setScale => jeEnabled branch */
+  --commandPaneWidth: 180px;
+  --editorPaneWidth: 320px; /* the sum of these two has to be changed in main.js => setScale => jeEnabled branch */
   white-space: pre-line;
   font-family: monospace;
   display: none;
@@ -8,6 +8,11 @@
   width: 100%;
   z-index: 2;
   position: relative;
+}
+
+#jsonEditor.wide {
+  --commandPaneWidth: 320px;
+  --editorPaneWidth: 600px; /* the sum of these two has to be changed in main.js => setScale => jeEnabled branch */
 }
 
 #jsonEditor > *, .jsonEdit, #jeWidgetLayers > div, #jeLog {
@@ -139,7 +144,7 @@ body.jsonEdit.jeZoomOut #topSurface {
 }
 
 #jeMouseCoords {
-  display: block; 
+  display: block;
   right: calc(var(--commandPaneWidth) + 20px);
 }
 

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -15,6 +15,10 @@
   --editorPaneWidth: 600px;
 }
 
+#jsonEditor.notHighEnough #jeWidgetLayers, #jsonEditor.notHighEnough #jeLogWrapper {
+  display: none;
+}
+
 #jsonEditor > *, .jsonEdit, #jeWidgetLayers > div, #jeLog {
   background: #08090a;
 }

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -122,10 +122,7 @@ body.jsonEdit #jeCommands > .jeTopButton > button {
 }
 
 body.jsonEdit #jeCommands > .jeTopButton > span.top {
-  display: inline-block;
-  color: #aaa;
-  font-size: x-small;
-  margin-bottom: 10px;
+  display: none;
 }
 
 body.jsonEdit #toolbar {

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -1,6 +1,6 @@
 #jsonEditor {
   --commandPaneWidth: 180px;
-  --editorPaneWidth: 320px; /* the sum of these two has to be changed in main.js => setScale => jeEnabled branch */
+  --editorPaneWidth: 320px;
   white-space: pre-line;
   font-family: monospace;
   display: none;
@@ -12,7 +12,7 @@
 
 #jsonEditor.wide {
   --commandPaneWidth: 320px;
-  --editorPaneWidth: 600px; /* the sum of these two has to be changed in main.js => setScale => jeEnabled branch */
+  --editorPaneWidth: 600px;
 }
 
 #jsonEditor > *, .jsonEdit, #jeWidgetLayers > div, #jeLog {

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -160,10 +160,22 @@ body.jsonEdit.jeZoomOut #topSurface {
   left: 0;
   display: none;
   height: 90vh;
-  width: 50vw;
+  right: calc(var(--commandPaneWidth) + var(--editorPaneWidth));
   overflow: auto;
   box-sizing: border-box;
   border: 3px solid white;
+}
+
+@media (max-width: 1000px) {
+  #jeLog {
+    right: var(--commandPaneWidth);
+  }
+}
+
+@media (max-width: 600px) {
+  #jeLog {
+    right: 0;
+  }
 }
 
 #jeLogWrapper > h1 {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -407,6 +407,15 @@ const jeCommands = [
     }
   },
   {
+    id: 'je_toggleWide',
+    name: '↔️ toggle wide',
+    forceKey: 'ArrowRight',
+    call: async function() {
+      $('#jsonEditor').classList.toggle('wide');
+      setScale();
+    }
+  },
+  {
     id: 'je_addMultiProperty',
     name: 'add property',
     context: '^Multi-Selection',

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -413,6 +413,7 @@ const jeCommands = [
     call: async function() {
       $('#jsonEditor').classList.toggle('wide');
       setScale();
+      $('#jeTextHighlight').scrollTop = $('#jeText').scrollTop;
     }
   },
   {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1639,11 +1639,13 @@ window.addEventListener('mousemove', function(e) {
         hoveredWidgets.push(widget);
 
   for(let i=1; i<=12; ++i) {
+    if(i==4)
+      ++i;
     if(hoveredWidgets[i-1]) {
       jeWidgetLayers[i] = hoveredWidgets[i-1];
       var deck = `${hoveredWidgets[i-1].get('type')}` == 'card' ? `\ndeck: ${hoveredWidgets[i-1].get('deck')}` : "";
       var cardType = `${hoveredWidgets[i-1].get('type')}` == 'card' ? `\ncardType: ${hoveredWidgets[i-1].get('cardType')}` : "";
-      $(`#jeWidgetLayer${i}`).textContent = `F${i}:\nid: ${hoveredWidgets[i-1].get('id')}\ntype: ${hoveredWidgets[i-1].get('type') || 'basic'} ${deck} ${cardType}`;
+      $(`#jeWidgetLayer${i}`).textContent = `F${i}: ${hoveredWidgets[i-1].get('id')}\ntype: ${hoveredWidgets[i-1].get('type') || 'basic'} ${deck} ${cardType}`;
     } else {
       delete jeWidgetLayers[i];
       $(`#jeWidgetLayer${i}`).textContent = '';

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1108,7 +1108,7 @@ function jeColorize() {
 
 function jeDisplayTree() {
   const allWidgets = Array.from(widgets.values());
-  let result = 'CTRL-click a widget on the left to edit it.\n\nRoom\n';
+  let result = 'CTRL-click a widget on\nthe left to edit it.\n\nRoom\n';
   result += jeDisplayTreeAddWidgets(allWidgets, null, '  ');
   jeMode = 'tree';
   jeWidget = null;

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -142,14 +142,10 @@ function setScale() {
     const targetWidth = jeZoomOut ? 3200 : 1600;
     const targetHeight = jeZoomOut ? 2000 : 1000;
     const availableWidth = $('#jeText').offsetLeft;
-    if(availableWidth/h < 1600/1000)
+    if(availableWidth/(h-70) < 1600/1000)
       scale = availableWidth/targetWidth;
     else
-      scale = h/targetHeight;
-    if(h - scale * targetHeight < 60)
-      $('#jsonEditor').classList.add('notHighEnough');
-    else
-      $('#jsonEditor').classList.remove('notHighEnough');
+      scale = (h-70)/targetHeight;
   } else {
     scale = w/h < 1600/1000 ? w/1600 : h/1000;
   }

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -139,8 +139,9 @@ function setScale() {
   let vh = window.innerHeight * 0.01;
   document.documentElement.style.setProperty('--vh', `${vh}px`);
   if(jeEnabled) {
+    const sidebarWidth = $('#jsonEditor.wide') ? 920 : 500;
     const targetWidth = jeZoomOut ? 3200 : 1600;
-    scale = (w-920)/targetWidth;
+    scale = (w-sidebarWidth)/targetWidth;
   } else {
     scale = w/h < 1600/1000 ? w/1600 : h/1000;
   }

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -140,7 +140,16 @@ function setScale() {
   document.documentElement.style.setProperty('--vh', `${vh}px`);
   if(jeEnabled) {
     const targetWidth = jeZoomOut ? 3200 : 1600;
-    scale = $('#jeText').offsetLeft/targetWidth;
+    const targetHeight = jeZoomOut ? 2000 : 1000;
+    const availableWidth = $('#jeText').offsetLeft;
+    if(availableWidth/h < 1600/1000)
+      scale = availableWidth/targetWidth;
+    else
+      scale = h/targetHeight;
+    if(h - scale * targetHeight < 60)
+      $('#jsonEditor').classList.add('notHighEnough');
+    else
+      $('#jsonEditor').classList.remove('notHighEnough');
   } else {
     scale = w/h < 1600/1000 ? w/1600 : h/1000;
   }

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -139,9 +139,8 @@ function setScale() {
   let vh = window.innerHeight * 0.01;
   document.documentElement.style.setProperty('--vh', `${vh}px`);
   if(jeEnabled) {
-    const sidebarWidth = $('#jsonEditor.wide') ? 920 : 500;
     const targetWidth = jeZoomOut ? 3200 : 1600;
-    scale = (w-sidebarWidth)/targetWidth;
+    scale = $('#jeText').offsetLeft/targetWidth;
   } else {
     scale = w/h < 1600/1000 ? w/1600 : h/1000;
   }

--- a/client/js/tracing.js
+++ b/client/js/tracing.js
@@ -183,7 +183,7 @@ function updateTraceInput(e) {
 }
 
 window.addEventListener('keydown', function(e) {
-  if(e.key == 'F9') {
+  if(!jeEnabled && e.key == 'F9') {
     if(e.ctrlKey)
       selectFile('TEXT').then(loadTraceFile);
     else if(!tracingEnabled)

--- a/client/room.html
+++ b/client/room.html
@@ -359,7 +359,6 @@
       <div id="jeWidgetLayer1"></div>
       <div id="jeWidgetLayer2"></div>
       <div id="jeWidgetLayer3"></div>
-      <div id="jeWidgetLayer4"></div>
       <div id="jeWidgetLayer5"></div>
       <div id="jeWidgetLayer6"></div>
       <div id="jeWidgetLayer7"></div>


### PR DESCRIPTION
The sidebars on the right of the JSON editor are pretty wide right now. When writing complicated routines that is useful but the rest of the time it is basically a giant waste of space that can make the room look tiny depending on your resolution.

This PR adds a new button to the top row of commands that toggles the width between two presets.

We might have to tweak the values a bit but I think a toggle between a narrow and a wide preset is good enough. Adding a way to set the size freely is also possible but a lot more work and then people will ask for saving their sizes etc.

This PR should work fine as is but please use it as a base for further discussion.