### PR TITLE
generate new IDs based on widget type

### DIFF
--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -1,16 +1,23 @@
 let edit = false;
 
-function generateUniqueWidgetID() {
+function generateUniqueWidgetID(widget) {
   let id;
+  let i = 1;
   do {
-    id = Math.random().toString(36).substring(3, 7);
+    if(widget && widget.type == 'card')
+      id = widget.deck + ' - ' + widget.cardType + ' - ' + i;
+    else if(widget)
+      id = (widget.type || 'basic') + ' - ' + i;
+    else
+      id = Math.random().toString(36).substring(3, 7);
+    ++i;
   } while (widgets.has(id));
   return id;
 }
 
 function addWidgetLocal(widget) {
   if (!widget.id)
-    widget.id = generateUniqueWidgetID();
+    widget.id = generateUniqueWidgetID(widget);
   sendPropertyUpdate(widget.id, widget);
   sendDelta(true);
 }

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -1,15 +1,13 @@
 let edit = false;
 
-function generateUniqueWidgetID(widget) {
+function generateUniqueWidgetID(widget, type) {
   let id;
   let i = 1;
   do {
-    if(widget && widget.type == 'card')
-      id = widget.deck + ' - ' + widget.cardType + ' - ' + i;
-    else if(widget)
-      id = (widget.type || 'basic') + ' - ' + i;
+    if(type || widget)
+      id = (type || widget.type || 'basic')[0] + i;
     else
-      id = Math.random().toString(36).substring(3, 7);
+      id = Math.random().toString(36).substring(3, 6);
     ++i;
   } while (widgets.has(id));
   return id;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1117,7 +1117,7 @@ function jeDisplayTreeAddWidgets(allWidgets, parent, indent) {
     if(type == 'card')
       result += `${widget.get('cardType')} - `;
     if(type == 'button' && widget.get('text'))
-      result += `${widget.get('text')} - `;
+      result += `${widget.get('text').replaceAll('\n', '\\n')} - `;
     if(type == null && widget.get('classes'))
       result += `${widget.get('classes')} - `;
     result += `${Math.floor(widget.get('x'))},${Math.floor(widget.get('y'))})\n`;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1054,7 +1054,7 @@ function jeColorize() {
     [ /^(Room)$/, 'extern' ],
     [ /^( +"var )(.*)( = )(-?[0-9.]+)?(null|true|false)?(\$\{[^}]+\})?('(?:[a-zA-Z0-9,.() _-]|\\\\u[0-9a-fA-F]{4})*')?( )?([0-9a-zA-Z_-]+|[=+*/%<!>&|-]{1,3})?(🧮(?:[0-9a-zA-Z_-]+|[=+*/%<!>&|-]{1,2}))?( )?(-?[0-9.]+)?(null|true|false)?(\$\{[^}]+\})?('(?:[a-zA-Z0-9,.() _-]|\\\\u[0-9a-fA-F]{4})*')?( )?(-?[0-9.]+)?(null|true|false)?(\$\{[^}]+\})?('(?:[a-zA-Z0-9,.() _-]|\\\\u[0-9a-fA-F]{4})*')?( )?(-?[0-9.]+)?(null|true|false)?(\$\{[^}]+\})?('(?:[a-zA-Z0-9,.() _-]|\\\\u[0-9a-fA-F]{4})*')?(.*)(",?)$/, 'default', 'custom', null, 'number', 'null', 'variable', 'string', null, null, 'variable', null, 'number', 'null', 'variable', 'string', null, 'number', 'null', 'variable', 'string', null, 'number', 'null', 'variable', 'string', null, 'default' ],
     [ /^( +")(.*)(",?)$/, null, 'string', null ],
-    [ /^( +)(.*)( \()([a-z]+)( - )([0-9-]+)(,)([0-9-]+)(.*)$/, null, 'key', null, 'string', null, 'number', null, 'number', null ]
+    [ /^( +)(.*)( \()([a-z]+)( - )(?:(.*?)( - ))?([0-9-]+)(,)([0-9-]+)(.*)$/, null, 'key', null, 'string', null, 'extern', null, 'number', null, 'number', null ]
   ];
   let out = [];
   for(let line of $('#jeText').textContent.split('\n')) {
@@ -1112,7 +1112,15 @@ function jeDisplayTree() {
 function jeDisplayTreeAddWidgets(allWidgets, parent, indent) {
   let result = '';
   for(const widget of (allWidgets.filter(w=>w.get('parent')==parent)).sort((w1,w2)=>w1.get('id').localeCompare(w2.get('id'), 'en', {numeric: true, ignorePunctuation: true}))) {
-    result += `${indent}${widget.get('id')} (${widget.get('type') || 'basic'} - ${Math.floor(widget.get('x'))},${Math.floor(widget.get('y'))})\n`;
+    const type = widget.get('type');
+    result += `${indent}${widget.get('id')} (${type || 'basic'} - `;
+    if(type == 'card')
+      result += `${widget.get('cardType')} - `;
+    if(type == 'button' && widget.get('text'))
+      result += `${widget.get('text')} - `;
+    if(type == null && widget.get('classes'))
+      result += `${widget.get('classes')} - `;
+    result += `${Math.floor(widget.get('x'))},${Math.floor(widget.get('y'))})\n`;
     result += jeDisplayTreeAddWidgets(allWidgets, widget.get('id'), indent+'  ');
     delete allWidgets[allWidgets.indexOf(widget)];
   }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1111,7 +1111,7 @@ function jeDisplayTree() {
 
 function jeDisplayTreeAddWidgets(allWidgets, parent, indent) {
   let result = '';
-  for(const widget of (allWidgets.filter(w=>w.get('parent')==parent)).sort((w1,w2)=>w1.get('id') > w2.get('id'))) {
+  for(const widget of (allWidgets.filter(w=>w.get('parent')==parent)).sort((w1,w2)=>w1.get('id').localeCompare(w2.get('id'), 'en', {numeric: true, ignorePunctuation: true}))) {
     result += `${indent}${widget.get('id')} (${widget.get('type') || 'basic'} - ${Math.floor(widget.get('x'))},${Math.floor(widget.get('y'))})\n`;
     result += jeDisplayTreeAddWidgets(allWidgets, widget.get('id'), indent+'  ');
     delete allWidgets[allWidgets.indexOf(widget)];


### PR DESCRIPTION
This PR changes the function `generateUniqueWidgetID` to just use the widget type and a counter as the new ID.

This does not work for everything yet because in some places the ID is generated before the rest of the widget has even been created (so the type is not known yet). I will fix that but in the meantime this PR is a base for further discussion.