### PR TITLE
Replace "ghetto" by "legacy" in UI

### DIFF
--- a/client/js/connection.js
+++ b/client/js/connection.js
@@ -24,7 +24,7 @@ export function startWebSocket() {
       toServer('room', { playerName, roomID });
       if(urlProperties.trace)
         toServer('enableTrace');
-      $('#ghetto-link').href += `#${roomID}`;
+      $('#legacy-link').href += `#${roomID}`;
     }
   };
 

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -117,7 +117,7 @@ function checkURLproperties() {
     on('#askIDoverlay button', 'click', function() {
       roomID = urlProperties.askID + $('#enteredID').value;
       toServer('room', { playerName, roomID });
-      $('#ghetto-link').href += `#${roomID}`;
+      $('#legacy-link').href += `#${roomID}`;
       showOverlay();
     });
     showOverlay('askIDoverlay');

--- a/client/room.html
+++ b/client/room.html
@@ -147,7 +147,7 @@
       <div id="editJSONoverlay" class="overlay">
         <h1>Edit widget JSON</h1>
         <p>Please check <a href="https://github.com/ArnoldSmith86/virtualtabletop/wiki/Creating-Games">our GitHub wiki for documentation</a>.</p>
-        <p>You can open this room in <a href="https://virtualtabletop.io/ghetto.htm" id="legacy-link">the legacy editor</a>. Be sure to have <b>backups</b> on your harddrive first (of every game in your room)!</p>
+        <p>You can open this room in <a href="https://virtualtabletop.io/legacy-editor.htm" id="legacy-link">the legacy editor</a>. Be sure to have <b>backups</b> on your harddrive first (of every game in your room)!</p>
         <textarea id="editWidgetJSON"></textarea>
         <base-edit-overlay :json-edit="true"></base-edit-overlay>
       </div>

--- a/client/room.html
+++ b/client/room.html
@@ -147,7 +147,7 @@
       <div id="editJSONoverlay" class="overlay">
         <h1>Edit widget JSON</h1>
         <p>Please check <a href="https://github.com/ArnoldSmith86/virtualtabletop/wiki/Creating-Games">our GitHub wiki for documentation</a>.</p>
-        <p>You can open this room in <a href="https://virtualtabletop.io/ghetto.htm" id="ghetto-link">an advanced editor</a>. Be sure to have <b>backups</b> on your harddrive first (of every game in your room)!</p>
+        <p>You can open this room in <a href="https://virtualtabletop.io/ghetto.htm" id="legacy-link">the legacy editor</a>. Be sure to have <b>backups</b> on your harddrive first (of every game in your room)!</p>
         <textarea id="editWidgetJSON"></textarea>
         <base-edit-overlay :json-edit="true"></base-edit-overlay>
       </div>


### PR DESCRIPTION
Change #ghetto-link to #legacy-link in three places; changed the phrase "in an advanced" editor to "in the legacy editor".

Change link in room.html to legacy-editor.htm.