### PR TITLE
fixed GitHub workflows

### DIFF
--- a/.github/workflows/production-environment.yml
+++ b/.github/workflows/production-environment.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@master
+      with:
+        submodules: recursive
     - name: Install Node.js 16.x
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@master
+      with:
+        submodules: recursive
     - name: Install Node.js 16.x
       uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
Looks like the action `textbook/git-checkout-submodule-action@master` we use in the automated tests to checkout the submodule is no longer supported by the maintainer. But the official `actions/checkout@v2` seems to just have an option to checkout submodules.