### PR TITLE
pile customization

### DIFF
--- a/client/css/widgets/pile.css
+++ b/client/css/widgets/pile.css
@@ -39,9 +39,24 @@
   right: var(--phX);
 }
 
+.pile .handle.center {
+  left: 50%;
+  transform: translateX(-50%);
+}
+
 .pile .handle.bottom {
   top: unset;
   bottom: var(--phY);
+}
+
+.pile .handle.middle {
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.pile .handle.center.middle {
+  top: 50%;
+  transform: translateX(-50%) translateY(-50%);
 }
 
 body.edit .pile {

--- a/client/css/widgets/pile.css
+++ b/client/css/widgets/pile.css
@@ -1,8 +1,4 @@
 .pile {
-  will-change: transform;
-}
-
-.pile .handle {
   --phPosition: -15px;
   --phSize: 40px;
 
@@ -12,6 +8,10 @@
   --phWidth: var(--phSize);
   --FontSize: calc(var(--phSize)/2);
 
+  will-change: transform;
+}
+
+.pile .handle {
   position: absolute;
   left: var(--phX);
   top: var(--phY);

--- a/client/css/widgets/pile.css
+++ b/client/css/widgets/pile.css
@@ -1,23 +1,14 @@
 .pile {
-  --phPosition: -15px;
-  --phSize: 40px;
-
-  --phX: var(--phPosition);
-  --phY: var(--phPosition);
-  --phHeight: var(--phSize);
-  --phWidth: var(--phSize);
-  --FontSize: calc(var(--phSize)/2);
-
   will-change: transform;
 }
 
 .pile .handle {
   position: absolute;
-  left: var(--phX);
-  top: var(--phY);
-  width: var(--phHeight);
-  height: var(--phWidth);
-  font-size: var(--FontSize);
+  left: var(--phPosition);
+  top: var(--phPosition);
+  width: var(--phSize);
+  height: var(--phSize);
+  font-size: calc(var(--phSize)/2);
   background: #e4e4e4;
   color: #6d6d6d;
   border-radius: 50%;
@@ -29,14 +20,14 @@
 }
 
 .pile .handle.small {
-  width: calc(var(--phWidth)/2);
-  height: calc(var(--phHeight)/2);
-  font-size: calc(var(--phFontSize)/2);
+  width: calc(var(--phSize)/2);
+  height: calc(var(--phSize)/2);
+  font-size: calc(var(--phSize)/4);
 }
 
 .pile .handle.right {
   left: unset;
-  right: var(--phX);
+  right: var(--phPosition);
 }
 
 .pile .handle.center {
@@ -46,7 +37,7 @@
 
 .pile .handle.bottom {
   top: unset;
-  bottom: var(--phY);
+  bottom: var(--phPosition);
 }
 
 .pile .handle.middle {

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -12,7 +12,8 @@ class Card extends Widget {
       activeFace: 0,
 
       deck: null,
-      cardType: null
+      cardType: null,
+      onPileCreation: {}
     });
 
     this.deck = null;

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -11,7 +11,8 @@ class Pile extends Widget {
       width: 1,
       height: 1,
       alignChildren: true,
-      inheritChildZ: true
+      inheritChildZ: true,
+      clickable: true
     });
 
     this.domElement.appendChild(this.handle);
@@ -47,65 +48,67 @@ class Pile extends Widget {
   }
 
   async click(mode='respect') {
-    $('#pileOverlay').innerHTML = `<p>${this.handle.textContent} cards</p><p>Drag the handle with the number to drag the entire pile.</p>`;
+    if(!await super.click(mode)) {
+      $('#pileOverlay').innerHTML = `<p>${this.handle.textContent} cards</p><p>Drag the handle with the number to drag the entire pile.</p>`;
 
-    const flipButton = document.createElement('button');
-    flipButton.textContent = 'Flip pile';
-    let z=1;
-    flipButton.addEventListener('click', async e=>{
-      batchStart();
-      for(const c of this.children()) {
-        await c.set('z', z++);
-        if(c.flip)
-          await c.flip();
-      };
-      showOverlay();
-      batchEnd();
-    });
-    $('#pileOverlay').appendChild(flipButton);
+      const flipButton = document.createElement('button');
+      flipButton.textContent = 'Flip pile';
+      let z=1;
+      flipButton.addEventListener('click', async e=>{
+        batchStart();
+        for(const c of this.children()) {
+          await c.set('z', z++);
+          if(c.flip)
+            await c.flip();
+        };
+        showOverlay();
+        batchEnd();
+      });
+      $('#pileOverlay').appendChild(flipButton);
 
-    const shuffleButton = document.createElement('button');
-    shuffleButton.textContent = 'Shuffle pile';
-    shuffleButton.addEventListener('click', async e=>{
-      batchStart();
-      for(const c of this.children())
-        await c.set('z', Math.floor(Math.random()*10000));
-      showOverlay();
-      batchEnd();
-    });
-    $('#pileOverlay').appendChild(shuffleButton);
+      const shuffleButton = document.createElement('button');
+      shuffleButton.textContent = 'Shuffle pile';
+      shuffleButton.addEventListener('click', async e=>{
+        batchStart();
+        for(const c of this.children())
+          await c.set('z', Math.floor(Math.random()*10000));
+        showOverlay();
+        batchEnd();
+      });
+      $('#pileOverlay').appendChild(shuffleButton);
 
-    const childCount = this.children().length;
-    const countDiv = document.createElement('div');
-    countDiv.textContent = `/ ${childCount}`;
-    $('#pileOverlay').appendChild(countDiv);
-    const splitInput = document.createElement('input');
-    splitInput.type = 'number';
-    splitInput.value = Math.floor(childCount/2);
-    splitInput.min = 0;
-    splitInput.max = childCount;
-    countDiv.prepend(splitInput);
-    const splitLabel = document.createElement('label');
-    splitLabel.textContent = 'Split: ';
-    countDiv.prepend(splitLabel);
-    const splitButton = document.createElement('button');
-    splitButton.textContent = 'Split pile';
-    splitButton.addEventListener('click', async e=>{
-      batchStart();
-      for(const c of this.children().reverse().slice(childCount-splitInput.value)) {
-        await c.set('parent', null);
-        await c.set('x', this.absoluteCoord('x'));
-        const y = this.absoluteCoord('y');
-        await c.set('y', y < 100 ? y+60 : y-60);
-        await c.updatePiles();
-        await c.bringToFront();
-      };
-      showOverlay();
-      batchEnd();
-    });
-    $('#pileOverlay').appendChild(splitButton);
+      const childCount = this.children().length;
+      const countDiv = document.createElement('div');
+      countDiv.textContent = `/ ${childCount}`;
+      $('#pileOverlay').appendChild(countDiv);
+      const splitInput = document.createElement('input');
+      splitInput.type = 'number';
+      splitInput.value = Math.floor(childCount/2);
+      splitInput.min = 0;
+      splitInput.max = childCount;
+      countDiv.prepend(splitInput);
+      const splitLabel = document.createElement('label');
+      splitLabel.textContent = 'Split: ';
+      countDiv.prepend(splitLabel);
+      const splitButton = document.createElement('button');
+      splitButton.textContent = 'Split pile';
+      splitButton.addEventListener('click', async e=>{
+        batchStart();
+        for(const c of this.children().reverse().slice(childCount-splitInput.value)) {
+          await c.set('parent', null);
+          await c.set('x', this.absoluteCoord('x'));
+          const y = this.absoluteCoord('y');
+          await c.set('y', y < 100 ? y+60 : y-60);
+          await c.updatePiles();
+          await c.bringToFront();
+        };
+        showOverlay();
+        batchEnd();
+      });
+      $('#pileOverlay').appendChild(splitButton);
 
-    showOverlay('pileOverlay');
+      showOverlay('pileOverlay');
+    }
   }
 
   async onChildRemove(child) {

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -15,7 +15,10 @@ class Pile extends Widget {
       clickable: true,
 
       handleCSS: '',
-      handleText: null
+      handleText: null,
+      handleSize: 'auto',
+      handleOffset: 15,
+      handlePosition: 'top right'
     });
 
     this.domElement.appendChild(this.handle);
@@ -41,15 +44,18 @@ class Pile extends Widget {
       this.handle.style = this.get('handleCSS');
     if(this.handle && delta.handleText !== undefined)
       this.updateText();
-    if(this.handle && (delta.width !== undefined || delta.height !== undefined)) {
-      if(this.get('width') < 50 || this.get('height') < 50)
+    if(this.handle && (delta.width !== undefined || delta.height !== undefined || delta.handleSize !== undefined)) {
+      if(this.get('handleSize') == 'auto' && (this.get('width') < 50 || this.get('height') < 50))
         this.handle.classList.add('small');
       else
         this.handle.classList.remove('small');
     }
-    for(const e of [ [ 'x', 'right', 1600-this.get('width')-20 ], [ 'y', 'bottom', 20 ] ]) {
-      if(this.handle && (delta[e[0]] !== undefined || delta.parent !== undefined)) {
-        if(this.absoluteCoord(e[0]) < e[2])
+
+    const threshold = this.get('handleOffset')+5;
+    for(const e of [ [ 'x', 'right', 1600-this.get('width') ], [ 'y', 'bottom', 1000-this.get('height') ] ]) {
+      if(this.handle && (delta[e[0]] !== undefined || delta.parent !== undefined || delta.handlePosition !== undefined || delta.handleOffset !== undefined)) {
+        const isRightOrBottom = this.get('handlePosition').match(e[1]);
+        if(isRightOrBottom && this.absoluteCoord(e[0]) < e[2]-threshold || !isRightOrBottom && this.absoluteCoord(e[0]) < threshold)
           this.handle.classList.add(e[1]);
         else
           this.handle.classList.remove(e[1]);
@@ -119,6 +125,22 @@ class Pile extends Widget {
 
       showOverlay('pileOverlay');
     }
+  }
+
+  css() {
+    let css = super.css();
+
+    if(this.get('handleSize') != 'auto')
+      css += '; --phSize:' + this.get('handleSize') + 'px';
+    css += '; --phPosition:-' + this.get('handleOffset') + 'px';
+
+    return css;
+  }
+
+  cssProperties() {
+    const p = super.cssProperties();
+    p.push('handleSize', 'handleOffset');
+    return p;
   }
 
   getDefaultValue(property) {

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -13,27 +13,33 @@ class Pile extends Widget {
       alignChildren: true,
       inheritChildZ: true,
       clickable: true,
-      handleCSS: ''
+      handleCSS: '',
+      text: null
     });
 
     this.domElement.appendChild(this.handle);
-    this.handle.textContent = 0;
+    this.childCount = 0;
+    this.updateText();
   }
 
   applyChildAdd(child) {
     super.applyChildAdd(child);
-    ++this.handle.textContent;
+    ++this.childCount;
+    this.updateText();
   }
 
   applyChildRemove(child) {
     super.applyChildRemove(child);
-    --this.handle.textContent;
+    --this.childCount;
+    this.updateText();
   }
 
   applyDeltaToDOM(delta) {
     super.applyDeltaToDOM(delta);
     if(this.handle && delta.handleCSS !== undefined)
       this.handle.style = this.get('handleCSS');
+    if(this.handle && delta.text !== undefined)
+      this.updateText();
     if(this.handle && (delta.width !== undefined || delta.height !== undefined)) {
       if(this.get('width') < 50 || this.get('height') < 50)
         this.handle.classList.add('small');
@@ -152,6 +158,11 @@ class Pile extends Widget {
 
   supportsPiles() {
     return false;
+  }
+
+  updateText() {
+    const text = this.get('text');
+    this.handle.textContent = text === null ? this.childCount : text;
   }
 
   validDropTargets() {

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -33,7 +33,7 @@ class Pile extends Widget {
   applyDeltaToDOM(delta) {
     super.applyDeltaToDOM(delta);
     if(this.handle && delta.handleCSS)
-      this.handle.style = delta.handleCSS;
+      this.handle.style = this.get('handleCSS');
     if(this.handle && (delta.width !== undefined || delta.height !== undefined)) {
       if(this.get('width') < 50 || this.get('height') < 50)
         this.handle.classList.add('small');

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -12,7 +12,8 @@ class Pile extends Widget {
       height: 1,
       alignChildren: true,
       inheritChildZ: true,
-      clickable: true
+      clickable: true,
+      handleCSS: ''
     });
 
     this.domElement.appendChild(this.handle);
@@ -31,6 +32,8 @@ class Pile extends Widget {
 
   applyDeltaToDOM(delta) {
     super.applyDeltaToDOM(delta);
+    if(this.handle && delta.handleCSS)
+      this.handle.style = delta.handleCSS;
     if(this.handle && (delta.width !== undefined || delta.height !== undefined)) {
       if(this.get('width') < 50 || this.get('height') < 50)
         this.handle.classList.add('small');

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -13,8 +13,9 @@ class Pile extends Widget {
       alignChildren: true,
       inheritChildZ: true,
       clickable: true,
+
       handleCSS: '',
-      text: null
+      handleText: null
     });
 
     this.domElement.appendChild(this.handle);
@@ -38,7 +39,7 @@ class Pile extends Widget {
     super.applyDeltaToDOM(delta);
     if(this.handle && delta.handleCSS !== undefined)
       this.handle.style = this.get('handleCSS');
-    if(this.handle && delta.text !== undefined)
+    if(this.handle && delta.handleText !== undefined)
       this.updateText();
     if(this.handle && (delta.width !== undefined || delta.height !== undefined)) {
       if(this.get('width') < 50 || this.get('height') < 50)
@@ -161,7 +162,7 @@ class Pile extends Widget {
   }
 
   updateText() {
-    const text = this.get('text');
+    const text = this.get('handleText');
     this.handle.textContent = text === null ? this.childCount : text;
   }
 

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -140,7 +140,9 @@ class Pile extends Widget {
   css() {
     let css = super.css();
 
-    if(this.get('handleSize') != 'auto')
+    if(this.get('handleSize') == 'auto')
+      css += '; --phSize:40px';
+    else
       css += '; --phSize:' + this.get('handleSize') + 'px';
     css += '; --phPosition:-' + this.get('handleOffset') + 'px';
 

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -114,6 +114,12 @@ class Pile extends Widget {
     }
   }
 
+  getDefaultValue(property) {
+    if(property == 'onPileCreation')
+      return this.children()[0].get('onPileCreation');
+    return super.getDefaultValue(property);
+  }
+
   async onChildRemove(child) {
     await super.onChildRemove(child);
     if(this.children().length == 1) {

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -14,8 +14,9 @@ class Pile extends Widget {
       inheritChildZ: true,
       clickable: true,
 
+      text: null,
+
       handleCSS: '',
-      handleText: null,
       handleSize: 'auto',
       handleOffset: 15,
       handlePosition: 'top right'
@@ -42,7 +43,7 @@ class Pile extends Widget {
     super.applyDeltaToDOM(delta);
     if(this.handle && delta.handleCSS !== undefined)
       this.handle.style = this.get('handleCSS');
-    if(this.handle && delta.handleText !== undefined)
+    if(this.handle && delta.text !== undefined)
       this.updateText();
     if(this.handle && (delta.width !== undefined || delta.height !== undefined || delta.handleSize !== undefined)) {
       if(this.get('handleSize') == 'auto' && (this.get('width') < 50 || this.get('height') < 50))
@@ -193,7 +194,7 @@ class Pile extends Widget {
   }
 
   updateText() {
-    const text = this.get('handleText');
+    const text = this.get('text');
     this.handle.textContent = text === null ? this.childCount : text;
   }
 

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -52,13 +52,22 @@ class Pile extends Widget {
     }
 
     const threshold = this.get('handleOffset')+5;
-    for(const e of [ [ 'x', 'right', 1600-this.get('width') ], [ 'y', 'bottom', 1000-this.get('height') ] ]) {
+    for(const e of [ [ 'x', 'right', 1600-this.get('width'), 'center' ], [ 'y', 'bottom', 1000-this.get('height'), 'middle' ] ]) {
       if(this.handle && (delta[e[0]] !== undefined || delta.parent !== undefined || delta.handlePosition !== undefined || delta.handleOffset !== undefined)) {
-        const isRightOrBottom = this.get('handlePosition').match(e[1]);
-        if(isRightOrBottom && this.absoluteCoord(e[0]) < e[2]-threshold || !isRightOrBottom && this.absoluteCoord(e[0]) < threshold)
-          this.handle.classList.add(e[1]);
-        else
+        if(this.get('handlePosition') == 'static') {
           this.handle.classList.remove(e[1]);
+          this.handle.classList.remove(e[3]);
+        } else if(this.get('handlePosition').match(e[3])) {
+          this.handle.classList.remove(e[1]);
+          this.handle.classList.add(e[3]);
+        } else {
+          this.handle.classList.remove(e[3]);
+          const isRightOrBottom = this.get('handlePosition').match(e[1]);
+          if(isRightOrBottom && this.absoluteCoord(e[0]) < e[2]-threshold || !isRightOrBottom && this.absoluteCoord(e[0]) < threshold)
+            this.handle.classList.add(e[1]);
+          else
+            this.handle.classList.remove(e[1]);
+        }
       }
     }
   }

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -32,7 +32,7 @@ class Pile extends Widget {
 
   applyDeltaToDOM(delta) {
     super.applyDeltaToDOM(delta);
-    if(this.handle && delta.handleCSS)
+    if(this.handle && delta.handleCSS !== undefined)
       this.handle.style = this.get('handleCSS');
     if(this.handle && (delta.width !== undefined || delta.height !== undefined)) {
       if(this.get('width') < 50 || this.get('height') < 50)

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1688,14 +1688,14 @@ export class Widget extends StateManaged {
 
         // if a card gets dropped onto a card, they create a new pile and are added to it
         if(thisType == 'card' && widgetType == 'card') {
-          const pile = {
+          const pile = Object.assign({
             type: 'pile',
             parent: this.get('parent'),
             x: widget.get('x'),
             y: widget.get('y'),
             width: this.get('width'),
             height: this.get('height')
-          };
+          }, this.get('onPileCreation'));
           if(thisOwner !== null)
             pile.owner = thisOwner;
           const pileId = addWidgetLocal(pile);

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1673,6 +1673,7 @@ export class Widget extends StateManaged {
     const thisX = this.get('x');
     const thisY = this.get('y');
     const thisOwner = this.get('owner');
+    const thisOnPileCreation = this.get('onPileCreation');
     for(const [ widgetID, widget ] of widgets) {
       if(widget == this)
         continue;
@@ -1682,7 +1683,7 @@ export class Widget extends StateManaged {
 
       // check if this widget is closer than 10px from another widget in the same parent
       if(widget.get('parent') == thisParent && Math.abs(widget.get('x')-thisX) < 10 && Math.abs(widget.get('y')-thisY) < 10) {
-        if(widget.isBeingRemoved || widget.get('owner') !== thisOwner)
+        if(widget.isBeingRemoved || widget.get('owner') !== thisOwner || JSON.stringify(widget.get('onPileCreation')) !== thisOnPileCreation)
           continue;
 
         // if a card gets dropped onto a card, they create a new pile and are added to it

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1673,7 +1673,7 @@ export class Widget extends StateManaged {
     const thisX = this.get('x');
     const thisY = this.get('y');
     const thisOwner = this.get('owner');
-    const thisOnPileCreation = this.get('onPileCreation');
+    const thisOnPileCreation = JSON.stringify(this.get('onPileCreation'));
     for(const [ widgetID, widget ] of widgets) {
       if(widget == this)
         continue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "virtualtabletop",
       "version": "0.5.0",
       "license": "GPL-3.0",
       "dependencies": {

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -278,11 +278,7 @@ export default async function convertPCIO(content) {
         w.faceTemplates.push(widget.backTemplate);
       if(widget.faceTemplate)
         w.faceTemplates.push(widget.faceTemplate);
-      w.cardDefaults = {
-        pilesWith: {
-          type: 'card'
-        }
-      };
+      w.cardDefaults = {};
       if(widget.cardWidth && widget.cardWidth != 103)
         w.cardDefaults.width = widget.cardWidth;
       if(widget.cardHeight && widget.cardHeight != 160)


### PR DESCRIPTION
This supersedes #852 after a discussion and collaboration with @RaphaelAlvez. It adds two properties (one to cards, one to piles):

`onPileCreation` - Whenever this card forms a new pile, all properties from `onPileCreation` will be copied to the pile. A pile will only form if both cards have the same value for `onPileCreation`.

`handleCSS` - The CSS is added to the handle of the pile allowing arbitrary customization.

This PR also introduces css variables for the handle CSS

Setting --phPosition and --phSize should be enough for 90% of the customizations needed.

--phPosition: -15px;
--phSize: 40px;
 
the follow CSS variables are created based on --phPosition and --phSize. For further customization you can set them directly
--phX: var(--phPosition);
--phY: var(--phPosition);
--phHeight: var(--phSize);
--phWidth: var(--phSize);
--FontSize: calc(var(--phSize)/2);

  --phHeight, --phWidth and --FontSize are used in "small" class. this class divides the seize by 2 and is triggered when the cards are smaller then 50px.
  
  --phX and --phY are used in relation to the corner the handle is on

Adding the property "text" within the `onPileCreation` property will override the widget count and put the specified text on the pile.