### PR TITLE
add `clickable` support and `artist` to canvas

### DIFF
--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -9,6 +9,7 @@ class Canvas extends Widget {
       height: 400,
       typeClasses: 'widget canvas',
       clickable: true,
+      artist: null,
 
       resolution: 100,
       activeColor: 1,
@@ -103,6 +104,9 @@ class Canvas extends Widget {
 
   async mouseRaw(state, x, y) {
     if(!this.get('clickable'))
+      return;
+
+    if(this.get('artist') && asArray(this.get('artist')).indexOf(playerName) == -1)
       return;
 
     const resolution = this.getResolution();

--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -8,6 +8,7 @@ class Canvas extends Widget {
       width: 400,
       height: 400,
       typeClasses: 'widget canvas',
+      clickable: true,
 
       resolution: 100,
       activeColor: 1,
@@ -101,6 +102,9 @@ class Canvas extends Widget {
   }
 
   async mouseRaw(state, x, y) {
+    if(!this.get('clickable'))
+      return;
+
     const resolution = this.getResolution();
     const regionRes = Math.floor(resolution/10);
 


### PR DESCRIPTION
Since canvas uses a raw mouse mode, it did not respect its `clickable` property. Now it does. Also added:

`artist`- default `null` - If set to a player name or array of player names only those players can draw on the canvas.

Please suggest better names than `artist`. @bjalder26 suggested `writable` but that feels like a boolean property to me.

Completely untested.