### PR TITLE
added `STOP`

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1326,7 +1326,7 @@ export class Widget extends StateManaged {
       if(!jeRoutineLogging && problems.length)
         console.log(problems);
 
-      if(a.func == 'CALL' && !a.return)
+      if(a.func == 'STOP' || a.func == 'CALL' && !a.return)
         break
 
     } // End iterate over functions in routine


### PR DESCRIPTION
This only terminates the execution of the currently running routine.

I don't think it's useful as is because if used inside a `thenRoutine` it would only stop that `thenRoutine` and not its parent routine.