### PR TITLE
added inverted properties to `inheritFrom`

### DIFF
--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -72,7 +72,7 @@ export class StateManaged {
     if([ 'id', 'type', 'deck', 'cardType' ].indexOf(key) != -1)
       return false;
 
-    if(Array.isArray(properties) && properties[0][0] == '!')
+    if(Array.isArray(properties) && properties.length && properties[0].length && properties[0][0] == '!')
       return properties.indexOf('!'+key) == -1;
     else
       return properties.indexOf(key) != -1;

--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -67,7 +67,15 @@ export class StateManaged {
   }
 
   inheritFromIsValid(properties, key) {
-    return (properties == '*' || properties.indexOf(key) != -1) && [ 'id', 'type', 'deck', 'cardType' ].indexOf(key) == -1;
+    if(properties == '*')
+      return true;
+    if([ 'id', 'type', 'deck', 'cardType' ].indexOf(key) != -1)
+      return false;
+
+    if(Array.isArray(properties) && properties[0][0] == '!')
+      return properties.indexOf('!'+key) == -1;
+    else
+      return properties.indexOf(key) != -1;
   }
 
   inheritFromUnregister() {


### PR DESCRIPTION
Instead of `["x","y"]` you can now use `["!x","!y"]` to inherit everything EXCEPT `x` and `y`.

Completely untested. As in: I did not even check if the site still loads.