### PR TITLE
add support for floats with `LABEL`

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1569,9 +1569,15 @@ export class Widget extends StateManaged {
 
   async setText(text, mode, problems) {
     if (this.get('text') !== undefined) {
-      if(mode == 'inc' || mode == 'dec')
-        await this.set('text', (parseInt(this.get('text')) || 0) + (mode == 'dec' ? -1 : 1) * text);
-      else if(mode == 'append')
+      if(mode == 'inc' || mode == 'dec') {
+        let newText = (parseFloat(this.get('text')) || 0) + (mode == 'dec' ? -1 : 1) * text;
+        const decimalPlaces = text.toString().match(/\..*$/);
+        if(decimalPlaces) {
+          const factor = 10**(decimalPlaces[0].length-1);
+          newText = Math.round(newText*factor)/factor;
+        }
+        await this.set('text', newText);
+      } else if(mode == 'append')
         await this.set('text', this.get('text') + text);
       else if(Array.isArray(text))
         await this.set('text', text.join(', '));

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1571,11 +1571,11 @@ export class Widget extends StateManaged {
     if (this.get('text') !== undefined) {
       if(mode == 'inc' || mode == 'dec') {
         let newText = (parseFloat(this.get('text')) || 0) + (mode == 'dec' ? -1 : 1) * text;
-        const decimalPlaces = text.toString().match(/\..*$/);
-        if(decimalPlaces) {
-          const factor = 10**(decimalPlaces[0].length-1);
-          newText = Math.round(newText*factor)/factor;
-        }
+        const decimalPlacesOld = this.get('text').toString().match(/\..*$/);
+        const decimalPlacesChange = text.toString().match(/\..*$/);
+        const decimalPlaces = Math.max(decimalPlacesOld ? decimalPlacesOld[0].length-1 : 0, decimalPlacesChange ? decimalPlacesChange[0].length-1 : 0);
+        const factor = 10**decimalPlaces;
+        newText = Math.round(newText*factor)/factor;
         await this.set('text', newText);
       } else if(mode == 'append')
         await this.set('text', this.get('text') + text);


### PR DESCRIPTION
This is a bit more complicated because of float rounding issues. You do not want `0.100000001` to show on your labels. So this looks at how many decimal places your `LABEL` `value` has and then rounds the result to that many decimal places.

Please test and give feedback.