### PR TITLE
adds css variables to holders

### DIFF
--- a/client/css/widgets/holder.css
+++ b/client/css/widgets/holder.css
@@ -30,7 +30,7 @@
 
 .widget.droppable.droptarget {
   background-color: var(--wcBackgroundDT);
-  border-color: var(--wcBorderDT);
+  border-color: var(--wcBorderDT) !important;
 }
 
 body.edit .widget.droppable.droptarget {

--- a/client/css/widgets/holder.css
+++ b/client/css/widgets/holder.css
@@ -1,9 +1,16 @@
 .holder {
-  background: white;
+  background: var(--wcBackground);
   box-sizing: border-box;
-  border: calc(1px / var(--scale)) solid #333;
-  border-color: #d8d8d8 #ccc #ccc #d8d8d8;
+  border-width: calc(1px / var(--scale));
+  border-style: solid;
+  border-color:var(--wcBorder);
   border-radius: 8px;
+
+  --wcBackground: #ffffff;
+  --wcBackgroundDT: var(--wcBackground);
+  --wcBorderLight: #d8d8d8 #ccc #ccc #d8d8d8;
+  --wcBorder: var(--wcBorderLight);
+  --wcBorderDT: #333;
 }
 
 .holder > .widget, .widget.droppable.droptarget.holder.transparent > .widget {
@@ -22,7 +29,8 @@
 }
 
 .widget.droppable.droptarget {
-  border: calc(1px / var(--scale)) solid #333 !important;
+  background-color: var(--wcBackgroundDT);
+  border-color: var(--wcBorderDT);
 }
 
 body.edit .widget.droppable.droptarget {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -680,6 +680,9 @@ function jeAddCSScommands() {
     'button': [
       '--wcMain: #1f5ca6', '--wcMainOH: #0d2f5e', '--wcBorder: #0d2f5e', '--wcBorderOH: #1f5ca6', '--wcFont: #ffffff', '--wcFontOH: #ffffff'
     ],
+    'holder': [
+      '--wcBackground: #ffffff', '--wcBackgroundDT: var(--wcBackground)', '--wcBorder: #d8d8d8 #ccc #ccc #d8d8d8', '--wcBorderDT: #333'
+    ],
     'seat': [
       '--wcShadowTurn: 0px 0px 20px 5px var(--color)'
     ],


### PR DESCRIPTION
As requested in #597

DT stands for dropTarget

 --wcBackground: #ffffff;
  --wcBackgroundDT: var(--wcBackground);
  --wcBorderLight: #d8d8d8 #ccc #ccc #d8d8d8;
  --wcBorder: var(--wcBorderLight);
  --wcBorderDT: #333;

--wcBorderLight is there because of a future style sheet PR 