### PR TITLE
only remove Guests from players if no player has the name

### DIFF
--- a/server/room.mjs
+++ b/server/room.mjs
@@ -330,8 +330,9 @@ export default class Room {
     Logging.log(`removing player ${player.name} from room ${this.id}`);
 
     this.players = this.players.filter(e => e != player);
-    if(player.name.match(/^Guest/) && !Object.values(this.state).filter(w=>w.player==player.name||w.owner==player.name||Array.isArray(w.owner)&&w.owner.indexOf(player.name)!=-1).length)
-      delete this.state._meta.players[player.name];
+    if(player.name.match(/^Guest/) && !this.players.filter(e => e.name == player.name).length)
+      if(!Object.values(this.state).filter(w=>w.player==player.name||w.owner==player.name||Array.isArray(w.owner)&&w.owner.indexOf(player.name)!=-1).length)
+        delete this.state._meta.players[player.name];
 
     if(this.players.length == 0) {
       this.unload();


### PR DESCRIPTION
When adding the feature that guests are removed from the list, I did not think about the fact that other clients might still be connected with the same name. Now there is a check.

I hope that this is the cause for the problems Roger, Raphael and I had in a pr-test room recently.