### PR TITLE
Update fix for Chrome favicon to use the SVG version.

### DIFF
--- a/client/room.html
+++ b/client/room.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8">
   <title>VirtualTabletop.io</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+  <link rel="alternate icon" sizes="16x16" href="/i/branding/favicon-32.png"/>
   <link rel="icon" type="image/svg+xml" href="/i/branding/favicon.svg"/>
   <link rel="apple-touch-icon" sizes="180x180" href="/i/branding/ios-icon.png">
   <link rel="manifest" href="/i/branding/manifest.json">

--- a/client/room.html
+++ b/client/room.html
@@ -7,7 +7,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
   <link rel="icon" type="image/svg+xml" href="/i/branding/favicon.svg"/>
   <link rel="apple-touch-icon" sizes="180x180" href="/i/branding/ios-icon.png">
-  <link rel="alternate icon" href="/i/branding/favicon-32.png"/>
   <link rel="manifest" href="/i/branding/manifest.json">
   <link rel="mask-icon" href="/i/branding/mask-icon.svg">
   <script src="https://cdn.jsdelivr.net/combine/npm/vue@3.0.7/dist/vue.global.prod.js,npm/jszip@3.6.0/dist/jszip.min.js"></script>

--- a/client/room.html
+++ b/client/room.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>VirtualTabletop.io</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
-  <link rel="alternate icon" sizes="16x16" href="/i/branding/favicon-32.png"/>
+  <link rel="icon" sizes="any" href="/i/branding/favicon-32.png"/>
   <link rel="icon" type="image/svg+xml" href="/i/branding/favicon.svg"/>
   <link rel="apple-touch-icon" sizes="180x180" href="/i/branding/ios-icon.png">
   <link rel="manifest" href="/i/branding/manifest.json">


### PR DESCRIPTION
`alternate icon` is not a valid `rel` value for a `link` and caused Chrome to use the PNG favicon instead of the SVG version.