### PR TITLE
fix crash with empty piles

### DIFF
--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -156,7 +156,7 @@ class Pile extends Widget {
   }
 
   getDefaultValue(property) {
-    if(property == 'onPileCreation')
+    if(property == 'onPileCreation' && this.children().length)
       return this.children()[0].get('onPileCreation');
     return super.getDefaultValue(property);
   }
@@ -201,6 +201,6 @@ class Pile extends Widget {
   }
 
   validDropTargets() {
-    return getValidDropTargets(this.children()[0]);
+    return this.children().length ? getValidDropTargets(this.children()[0]) : [];
   }
 }


### PR DESCRIPTION
Apparently real-world games crash now because of empty piles. This introduces a sanity check.