### PR TITLE
Long variant name display fix

### DIFF
--- a/client/css/overlays/states.css
+++ b/client/css/overlays/states.css
@@ -155,3 +155,15 @@
 #stateEditOverlay .input{
   display: flex;
 }
+.variantsList .prettyButton.play{
+  flex-wrap: wrap;
+}
+
+.variantsList .prettyButton.play .variant{
+  padding-top: 4px;
+  border-top: 1px solid #ffffffaa;
+  width: 100%;
+}
+.variantsList .prettyButton.play .variant:empty{
+  display: none;
+}


### PR DESCRIPTION
Update to make long variant names appear below the play symbol.
From:
![image](https://user-images.githubusercontent.com/12822213/144919643-732f6164-ee62-4d25-b33d-02d409e7627d.png)

To:
![image](https://user-images.githubusercontent.com/12822213/144919576-2297c49d-ad9c-4fa3-ba04-aa8ac6919440.png)
