### PR TITLE
fixed "Update variant using current room state"

### DIFF
--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -63,7 +63,7 @@ async function addState(e, type, src, id) {
 
   let url = `/addState/${roomID}/${id}/${type}/${src && src.name && encodeURIComponent(src.name)}/`;
   waitingForStateCreation = id;
-  if(e && (e.target.parentNode == $('#addVariant') || e.target.className == 'update')) {
+  if(e && (e.target.parentNode == $('#addVariant') || e.target.classList.contains('update'))) {
     waitingForStateCreation = $('#stateEditOverlay').dataset.id;
     url += $('#stateEditOverlay').dataset.id;
   }


### PR DESCRIPTION
A comparison was looking for `class == "update"`. Now it checks if it is one of the classes