### PR TITLE
Fix addVariant

### DIFF
--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -63,7 +63,7 @@ async function addState(e, type, src, id) {
 
   let url = `/addState/${roomID}/${id}/${type}/${src && src.name && encodeURIComponent(src.name)}/`;
   waitingForStateCreation = id;
-  if(e && (e.target.parentNode == $('#addVariant') || e.target.classList.contains('update'))) {
+  if(e && (e.target.parentNode.parentNode == $('#addVariant') || e.target.classList.contains('update'))) {
     waitingForStateCreation = $('#stateEditOverlay').dataset.id;
     url += $('#stateEditOverlay').dataset.id;
   }


### PR DESCRIPTION
Addresses #1001.  Minor change in the structure of buttons was causing the variants to be added as separate games.