### PR TITLE
Fix selectability issue for label textareas that are read-only

### DIFF
--- a/client/css/widgets/label.css
+++ b/client/css/widgets/label.css
@@ -1,10 +1,10 @@
-.label {
+.widget.label {
   font-size: 16px;
   color: #6d6d6d;
   text-align: center;
 }
 
-.label > textarea {
+.widget.label > textarea {
   border: none;
   background: none;
   padding: 0;
@@ -27,3 +27,8 @@ body.edit .widget.label > * {
   left: 0;
   top: 0;
 }
+
+.widget.label > textarea:read-only {
+  pointer-events: none;
+}
+


### PR DESCRIPTION
Contains fix for https://github.com/ArnoldSmith86/virtualtabletop/issues/20

Still ctrl+click selectable in JSON editor.