### PR TITLE
JSON editor tree view no longer steals focus

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1171,7 +1171,7 @@ function jeDisplayTree() {
   jeMode = 'tree';
   jeWidget = null;
   jeStateNow = null;
-  jeSet(jeStateBefore = result);
+  jeSet(jeStateBefore = result, true);
   jeGetContext();
   jeShowCommands();
 }


### PR DESCRIPTION
Please test if this fixes the same stuff that #1031 fixes.

This would be a less hacky solution but if the other PR fixes more stuff, I have no problem merging it instead.