### PR TITLE
new `.pinPiece` and `.classicPiece` css

### DIFF
--- a/client/css/widgets/classes.css
+++ b/client/css/widgets/classes.css
@@ -29,6 +29,7 @@ body.edit .legacyClassicPiece::after {
   position: absolute;
   display: block;
   content: "";
+  top: 0;
 }
 .classicPiece::before {
   width: calc(32 / 60 * 100%);
@@ -157,6 +158,8 @@ body.edit .widget.checkersPiece::after {
   display: block;
   box-sizing: border-box;
   content: "";
+  top: 0;
+  height: 0;
   border: calc(var(--borderWidth) * 1px) solid var(--borderColor);
   background-color: var(--color);
 }

--- a/client/css/widgets/classes.css
+++ b/client/css/widgets/classes.css
@@ -148,7 +148,6 @@ body.edit .widget.checkersPiece::after {
   --pinWidth: 40;
   --pinLength: 80;
   --pinAngle: -30;
-  --borderWidth: 3;
 }
 .pinPiece::before,
 .pinPiece::after,

--- a/client/css/widgets/classes.css
+++ b/client/css/widgets/classes.css
@@ -1,20 +1,91 @@
-.classicPiece {
-  --mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cpath d='M38.84 30.94C41.71 32.37 44.44 32.73 46.66 32.62C49.4 32.5 51.95 31.7 54.14 30.37C54.28 30.29 54.42 30.21 54.56 30.13L62.81 65.86L72.96 78.7C73.65 79.57 74 80.61 74 81.81C74 83.01 73.65 84.05 72.96 84.92C72.27 85.8 71.45 86.23 70.5 86.23L63.26 86.23C62.97 86.74 62.67 87 62.33 87L29.67 87C29.33 87 29.03 86.74 28.74 86.23L21.5 86.23C20.55 86.23 19.73 85.8 19.04 84.92C18.35 84.05 18 83.01 18 81.81C18 80.61 18.35 79.57 19.04 78.7L29.19 65.86L37.44 30.13L37.91 30.4C38.05 30.49 38.2 30.57 38.35 30.66L38.84 30.94ZM48.94 32.32C50.51 31.98 51.84 31.67 54.14 30.37C58.6 27.68 61.56 22.84 61.56 17.32C61.56 8.85 54.6 2 46 2C37.4 2 30.44 8.85 30.44 17.32C30.44 22.86 33.43 27.72 37.91 30.4L38.35 30.66C40.61 31.91 43.22 32.63 46 32.63C46.22 32.63 46.44 32.63 46.66 32.62C47.5 32.57 48.26 32.46 48.94 32.32Z' /%3E%3C/svg%3E%0A");
+.classicPiece, .legacyClassicPiece {
   -webkit-mask-image: var(--mask);
   mask-image: var(--mask);
   background: var(--color);
 }
-body.edit .widget.classicPiece {
+.classicPiece {
+  --mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 60 90' preserveAspectRatio='none'%3E%3Cpath d='M2 77A5 5 0 0 0 1 84C4 88 20 90 30 90C40 90 56 88 59 84A5 5 0 0 0 58 77L46 70L38 32A17 17 0 1 0 22 32L14 70Z' /%3E%3C/svg%3E");
+  background-image: radial-gradient(
+      circle at 50% 0%,
+      rgba(0, 0, 0, 0) 90%,
+      rgba(0, 0, 0, 1)
+    ),
+    linear-gradient(
+      110deg,
+      rgba(0, 0, 0, 0) 20%,
+      rgba(255, 255, 255, 0.2) 50%,
+      rgba(0, 0, 0, 0) 70%
+    ),
+    linear-gradient(
+      250deg,
+      rgba(0, 0, 0, 0) 20%,
+      rgba(0, 0, 0, 0.2) 50%,
+      rgba(0, 0, 0, 0) 70%
+    );
+}
+.classicPiece::before,
+.classicPiece::after,
+body.edit .legacyClassicPiece::after {
+  position: absolute;
+  display: block;
+  content: "";
+}
+.classicPiece::before {
+  width: calc(32 / 60 * 100%);
+  height: calc(45 / 90 * 100%);
+  border-radius: 50% / calc(4 / 45 * 100%);
+  top: calc(28 / 90 * 100%);
+  left: calc(14 / 60 * 100%);
+  background-color: var(--color);
+  background-image: linear-gradient(
+      95deg,
+      rgba(0, 0, 0, 0) 10%,
+      rgba(255, 255, 255, 0.1) 35%,
+      rgba(0, 0, 0, 0) 50%
+    ),
+    linear-gradient(
+      -95deg,
+      rgba(0, 0, 0, 0) 10%,
+      rgba(0, 0, 0, 0.1) 35%,
+      rgba(0, 0, 0, 0) 50%
+    );
+}
+.classicPiece::after {
+  width: calc(34 / 60 * 100%);
+  height: calc(34 / 90 * 100%);
+  border-radius: 50%;
+  left: calc(13 / 60 * 100%);
+  background-color: var(--color);
+  background-image: radial-gradient(
+    circle at 25% 30%,
+    rgba(255, 255, 255, 0.3),
+    rgba(0, 0, 0, 0) 50%,
+    rgba(0, 0, 0, 0.3) 80%
+  );
+}
+.legacyClassicPiece {
+  --mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cpath d='M38.84 30.94C41.71 32.37 44.44 32.73 46.66 32.62C49.4 32.5 51.95 31.7 54.14 30.37C54.28 30.29 54.42 30.21 54.56 30.13L62.81 65.86L72.96 78.7C73.65 79.57 74 80.61 74 81.81C74 83.01 73.65 84.05 72.96 84.92C72.27 85.8 71.45 86.23 70.5 86.23L63.26 86.23C62.97 86.74 62.67 87 62.33 87L29.67 87C29.33 87 29.03 86.74 28.74 86.23L21.5 86.23C20.55 86.23 19.73 85.8 19.04 84.92C18.35 84.05 18 83.01 18 81.81C18 80.61 18.35 79.57 19.04 78.7L29.19 65.86L37.44 30.13L37.91 30.4C38.05 30.49 38.2 30.57 38.35 30.66L38.84 30.94ZM48.94 32.32C50.51 31.98 51.84 31.67 54.14 30.37C58.6 27.68 61.56 22.84 61.56 17.32C61.56 8.85 54.6 2 46 2C37.4 2 30.44 8.85 30.44 17.32C30.44 22.86 33.43 27.72 37.91 30.4L38.35 30.66C40.61 31.91 43.22 32.63 46 32.63C46.22 32.63 46.44 32.63 46.66 32.62C47.5 32.57 48.26 32.46 48.94 32.32Z' /%3E%3C/svg%3E%0A");
+}
+body.edit .widget.classicPiece,
+body.edit .widget.legacyClassicPiece {
   border: none;
   background: var(--editColor) !important;
 }
-body.edit .widget.classicPiece::after {
-  content: "";
-  position: absolute;
-  background: var(--color) !important;
-  border-radius: 50%;
+body.edit .widget.classicPiece::before {
+  display: none;
+}
+body.edit .widget.classicPiece::after,
+body.edit .widget.legacyClassicPiece::after {
+  background: var(--color);
   width: 16px;
   height: 16px;
+}
+body.edit .widget.classicPiece::after {
+  left: calc(50% - 8px);
+  top: calc(19% - 8px);
+}
+body.edit .widget.legacyClassicPiece::after {
+  border-radius: 50%;
   left: 38px;
   top: 9px;
 }
@@ -24,8 +95,7 @@ body.edit .widget.classicPiece::after {
   border-radius: 50%;
   background: var(--color);
 }
-
-.checkersPiece::before, .checkersPiece::after, .pinPiece::before, .pinPiece::after {
+.checkersPiece::before, .checkersPiece::after {
   content: "";
   background: rgba(255,255,255,.32);
   background-size: 50px 50px;
@@ -38,7 +108,6 @@ body.edit .widget.classicPiece::after {
   left: 10.5%;
   box-sizing: border-box;
 }
-
 .checkersPiece::after {
   background: var(--color);
   width: 57%;
@@ -46,7 +115,6 @@ body.edit .widget.classicPiece::after {
   top: 21.5%;
   left: 21.5%;
 }
-
 .checkersPiece.crowned::after {
   content: "♛";
   font-size: 40px;
@@ -56,7 +124,6 @@ body.edit .widget.classicPiece::after {
   align-items: center;
   text-align: center;
 }
-
 body.edit .widget.checkersPiece {
   border-width: 10px;
   box-shadow: none;
@@ -72,37 +139,91 @@ body.edit .widget.checkersPiece::after {
   left: 40%;
 }
 
-.pinPiece::before {
-  border: 3px solid #3f3b38;
+.pinPiece, .legacyPinPiece {
+  --borderColor: #3f3b38;
+  --borderWidth: 3;
+}
+.pinPiece {
+  --pinWidth: 40;
+  --pinLength: 80;
+  --pinAngle: -30;
+  --borderWidth: 3;
+}
+.pinPiece::before,
+.pinPiece::after,
+.legacyPinPiece::before,
+.legacyPinPiece::after {
+  position: absolute;
+  display: block;
+  box-sizing: border-box;
+  content: "";
+  border: calc(var(--borderWidth) * 1px) solid var(--borderColor);
   background-color: var(--color);
+}
+.pinPiece::before {
+  width: calc(var(--pinWidth) * 1%);
+  padding-top: calc(var(--pinLength) * 1% - var(--borderWidth) * 2px);
+  border-radius: 50% / calc(var(--pinWidth) / var(--pinLength) * 30%);
+  margin-top: 50%;
+  left: calc(50% - var(--pinWidth) * 0.5%);
+  transform-origin: 50% 0%;
+  transform: rotate(calc(var(--pinAngle) * 1deg));
+  background-image: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0.2),
+    rgba(0, 0, 0, 0) 60%,
+    rgba(0, 0, 0, 0.1)
+  );
+}
+.pinPiece::after {
+  width: 100%;
+  padding-top: calc(100% - var(--borderWidth) * 2px);
+  border-radius: 50%;
+  background-image: radial-gradient(
+    circle at 25% 30%,
+    rgba(255, 255, 255, 0.3),
+    rgba(0, 0, 0, 0) 50%,
+    rgba(0, 0, 0, 0.3) 80%,
+    rgba(0, 0, 0, 0.3)
+  );
+}
+.legacyPinPiece::before,
+.legacyPinPiece::after {
+  background-size: 50px 50px;
+  background-position: -17px -14px;
+}
+.legacyPinPiece::before {
   background-image: linear-gradient(90deg, rgba(255,255,255,.32), rgba(0,0,0,.16));
-  background-position: -17px 14px;
-  border-radius: 0;
+  background-size: 50px 50px;
+  background-position: -17px -14px;
   top: 9px;
   left: 15px;
   width: 14px;
+  height: 79%;
   transform: rotate(-30deg);
 }
-
-.pinPiece::after {
-  border: 3px solid #3f3b38;
-  background-color: var(--color);
+.legacyPinPiece::after {
   background-image: radial-gradient(circle, rgba(255,255,255,.32), rgba(255,255,255,0) 30%, rgba(0,0,0,.16));
   width: 35.85px;
   height: 35.85px;
+  border-radius: 50%;
   left: 0;
   top: 0;
 }
-
-body.edit .widget.pinPiece {
+body.edit .widget.pinPiece,
+body.edit .widget.legacyPinPiece {
   border: none;
   box-shadow: none;
   box-sizing: border-box;
 }
-body.edit .widget.pinPiece::before, body.edit .widget.pinPiece::after {
+body.edit .widget.pinPiece::before,
+body.edit .widget.pinPiece::after,
+body.edit .widget.legacyPinPiece::before,
+body.edit .widget.legacyPinPiece::after {
   border: 3px solid var(--editColor);
   background: none;
 }
-body.edit .widget.pinPiece::after {
+body.edit .widget.pinPiece::after,
+body.edit .widget.legacyPinPiece::after {
   background-image: radial-gradient(circle, var(--color), var(--color) 20%, var(--roomColor) 30%);
 }

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -666,10 +666,10 @@ function populateAddWidgetOverlay() {
     addWidgetToAddWidgetOverlay(new BasicWidget('add-classic-'+color), {
       classes: 'classicPiece',
       color,
-      width: 90,
-      height: 90,
-      x: 510,
-      y: y + (43.83 - 90)/2
+      width: 56,
+      height: 84,
+      x: 528,
+      y: y + (43.83 - 84)/2
     });
     y += 88;
   }

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -300,7 +300,7 @@ function v6cssPieces(properties) {
       properties.classes.replace(pinRE, 'legacyPinPiece');
       return;
     } else {
-      const length = 50 + 30 * math.Round((properties.height - 28.5)/15.33);
+      const length = 50 + 30 * Math.round((properties.height - 28.5)/15.33);
       if(length !=80)
         properties.css = `--pinLength: ${length}`;
       properties.width = 33.85;

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -303,7 +303,7 @@ function v6cssPieces(properties) {
       const length = 50 + 30 * Math.round((properties.height - 28.5)/15.33);
       if(length !=80)
         properties.css = `--pinLength: ${length}`;
-      properties.width = 33.85;
+      properties.width = 35.85;
       return;
     }
   } else if(properties.classes.match(classicRE)) {

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -300,7 +300,7 @@ function v6cssPieces(properties) {
       properties.classes = properties.classes.replace(pinRE, 'legacyPinPiece');
       return;
     } else {
-      const length = 50 + 30 * Math.round((properties.height - 28.5)/15.33);
+      const length = Math.round(50 + 30 * (properties.height - 28.5)/15.33);
       if(length !=80)
         properties.css = `--pinLength: ${length}`;
       properties.width = 35.85;

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -1,4 +1,4 @@
-export const VERSION = 5;
+export const VERSION = 6;
 
 export default function FileUpdater(state) {
   const v = state._meta.version;
@@ -32,6 +32,7 @@ function updateProperties(properties, v) {
 
   v<4 && v4ModifyDropTargetEmptyArray(properties);
   v<5 && v5DynamicFaceProperties(properties);
+  v<6 && v6cssPieces(properties);
 }
 
 function updateRoutine(routine, v) {
@@ -285,6 +286,36 @@ function v5DynamicFaceProperties(properties) {
           delete object.valueType;
         }
       }
+    }
+  }
+}
+
+function v6cssPieces(properties) {
+  const pinRE = /\bpinPiece\b/;
+  const classicRE = /\bclassicPiece\b/;
+  if(!properties.classes || typeof properties.classes != 'string')
+    return;
+  if(properties.classes.match(pinRE)) {
+    if(properties.text || properties.css || !properties.height || properties.height > 60) {
+      properties.classes.replace(pinRE, 'legacyPinPiece');
+      return;
+    } else {
+      const length = 50 + 30 * math.Round((properties.height - 28.5)/15.33);
+      if(length !=80)
+        properties.css = `--pinLength: ${length}`;
+      properties.width = 33.85;
+      return;
+    }
+  } else if(properties.classes.match(classicRE)) {
+    if(properties.text || properties.css || properties.width < 74 || properties.height < 87) {
+      properties.classes.replace(classicRE, 'legacyClassicPiece');
+      return;
+    } else {
+      properties.x += 17;
+      properties.y += 3;
+      properties.width = 56;
+      properties.height = 84;
+      return;
     }
   }
 }

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -297,7 +297,7 @@ function v6cssPieces(properties) {
     return;
   if(properties.classes.match(pinRE)) {
     if(properties.text || properties.css || !properties.height || properties.height > 60) {
-      properties.classes.replace(pinRE, 'legacyPinPiece');
+      properties.classes = properties.classes.replace(pinRE, 'legacyPinPiece');
       return;
     } else {
       const length = 50 + 30 * Math.round((properties.height - 28.5)/15.33);
@@ -308,7 +308,7 @@ function v6cssPieces(properties) {
     }
   } else if(properties.classes.match(classicRE)) {
     if(properties.text || properties.css || properties.width < 74 || properties.height < 87) {
-      properties.classes.replace(classicRE, 'legacyClassicPiece');
+      properties.classes = properties.classes.replace(classicRE, 'legacyClassicPiece');
       return;
     } else {
       properties.x += 17;

--- a/tests/testcafe/tests.js
+++ b/tests/testcafe/tests.js
@@ -337,7 +337,7 @@ publicLibraryButtons('Reward',             0, '7a0e6d7fda1143f21d64552c18f92a75'
 ]);
 publicLibraryButtons('Rummy Tiles',        0, 'c93ac5accd3f22264839675bd8b5321d', [ 'startMix', 'draw14' ]);
 publicLibraryButtons('Undercover',         1, '967a258cffec728391e4b039f4899aae', [ 'Reset', 'Spy Master Button' ]);
-publicLibraryButtons('Functions - CALL',   0, 'bfa7e4fb4a065fa21f820370de7ac734', [
+publicLibraryButtons('Functions - CALL',   0, '493d1f63f35366f82f7573ce04f2126e', [
   'n4cw_8_C', '5a52', '5a52', '66kr', 'qeg1', 'n4cwB', '8r6p', 'qeg1', 'qeg1', 'n5eu'
 ]);
 publicLibraryButtons('Functions - CLICK',  0, 'd44e77e0782cadbc9594494e5a83dde0', [ '7u2q' ]);


### PR DESCRIPTION
Re-sizable replacements for pin and pawn.

Pin scales only according to the width of the widget. Pin also has `--borderColor`, `--borderWidth` (3), `--pinWidth` (40), `--pinLength` (80 - values less that 50 do not extend beyond the pin head), & `--pinAngle` (-30) css variables allowing customization. Old pin available as 'legacyPinPiece' and border variables have been added to it.

Pawn stretches to fill widget (designed aspect ratio is 2:3). Old pawn available as 'legacyClasicPiece'