### PR TITLE
FIX: borderRadius missing from cssProperties

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -395,7 +395,7 @@ export class Widget extends StateManaged {
   }
 
   cssProperties() {
-    return [ 'css', 'height', 'inheritChildZ', 'layer', 'width' ];
+    return [ 'borderRadius', 'css', 'height', 'inheritChildZ', 'layer', 'width' ];
   }
 
   cssTransform() {


### PR DESCRIPTION
Looks like I failed to add borderRadius to css properties, so updates are sometimes delayed.