### PR TITLE
Clear erroneous audio element when invalid audio

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1539,8 +1539,6 @@ export class Widget extends StateManaged {
               audioElement.parentNode.removeChild(audioElement);
           };
           audioElement.onerror = function() {
-            audioElement.pause();
-            clearInterval();
             if(audioElement.parentNode)
               audioElement.parentNode.removeChild(audioElement);
           }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1538,6 +1538,12 @@ export class Widget extends StateManaged {
             if(audioElement.parentNode)
               audioElement.parentNode.removeChild(audioElement);
           };
+          audioElement.onerror = function() {
+            audioElement.pause();
+            clearInterval();
+            if(audioElement.parentNode)
+              audioElement.parentNode.removeChild(audioElement);
+          }
         }
       }
       setInterval(function(){


### PR DESCRIPTION
When an invalid src is input for the AUDIO function it creates an audio element that will not be cleared from the DOM tree.  The reason why it will not be cleared is because currently unless a length is set in the JSON the JavaScript will remove the element once it has finished playing.  Since an invalid audio won't play, the element won't be cleared.

The point of this PR is to clear it immediately.  If there is an error with the AUDIO, then the audio element will be removed.

An invalid src should quickly be cleared from the developer tools.  A valid one should be cleared after the set period (default, when the audio ends).
![image](https://user-images.githubusercontent.com/78324099/146662537-179c98c1-7714-4863-87a8-d0fc032ba474.png)

To see it "work", just open these two rooms.  Open the developer tools to the elements tab, and start clicking the button.
PR: http://212.47.248.129:4039/pr-test 
Production: https://virtualtabletop.io/9t6e