### PR TITLE
Make expander arrows in the JSON editor red if one of their descendants has a problem

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -221,6 +221,19 @@ body.jsonEdit.jeZoomOut #topSurface {
   transform: rotate(90deg);
 }
 
+/* Create the red caret/arrow with a unicode, and style it */
+.jeRedExpander::before {
+  content: "\25B6";
+  color: red;
+  display: inline-block;
+  margin-right: 6px;
+}
+
+/* Rotate the red caret/arrow icon when clicked on (using JavaScript) */
+.jeRedExpander-down::before {
+  transform: rotate(90deg);
+}
+
 .jeLogHasProblems, .jeLogProblems {
   color: red;
 }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1356,14 +1356,27 @@ function jeLoggingRoutineEnd(variables, collections) {
   --jeLoggingDepth;
   if(!jeLoggingDepth) {
     $('#jeLog').innerHTML = jeLoggingHTML + '</div></div>';
-    var expanders = document.getElementsByClassName('jeExpander');
-    var i;
+    // Make it so clicking on the arrows expands the subtree
+    const expanders = document.getElementsByClassName('jeExpander');
+    let i;
     for (i=0; i < expanders.length; i++) {
       expanders[i].addEventListener('click', function() {
         this.classList.toggle('jeExpander-down');
-        this.parentElement.querySelector('.jeLogNested').classList.toggle('active');
+        this.parentNode.querySelector('.jeLogNested').classList.toggle('active');
       });
     }
+    // Make expander arrows that are parents of nodes with problems show up red.
+    const problems = document.getElementsByClassName('jeLogHasProblems');
+    for (i=0; i<problems.length; i++) {
+      let node = problems[i].parentNode;
+      while (node && !node.classList.contains('jeLog')) {
+        if(node.classList.contains('jeLogOperation')) {
+          node.firstElementChild.classList.remove('jeExpander');
+          node.firstElementChild.classList.add('jeRedExpander')
+        }
+        node = node.parentNode;
+      }
+    }    
   }
 }
 


### PR DESCRIPTION
Currently it can be hard to figure out if there was an error in a complicated routine call, as only the erroneous statement shows up red. This PR bubbles the error up, so that the expandable arrow on any node will be red if one of its descendants had an error.