### PR TITLE
PCIO importer improvements

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -672,7 +672,7 @@ export class Widget extends StateManaged {
                   returnCollection = `(${result.collection.length} widgets)`;
                 jeLoggingRoutineOperationSummary(
                   `${a.routine} ${theWidget} and return variable '${a.variable}' and collection '${a.collection}'`,
-                  `${JSON.stringify(variables[a.variable])}; ${JSON.stringify(result.collection)}`)
+                  `${JSON.stringify(variables[a.variable])}; ${returnCollection}`)
               } else {
                 jeLoggingRoutineOperationSummary( `${a.routine} ${theWidget} and abort caller processing`)
               }

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -746,7 +746,7 @@ export default async function convertPCIO(content) {
             func:   'SORT',
             holder: c.args.sources.value,
             key:    'sortingOrder',
-            reverse: c.args.direction.value != 'za'
+            reverse: !c.args.direction || c.args.direction.value != 'za'
           };
           if(c.holder.length == 1)
             c.holder = c.holder[0];


### PR DESCRIPTION
For now this only prevents a crash when importing a `SORT_CARDS` without `direction`.