### PR TITLE
PCIO importer improvements

### DIFF
--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -746,7 +746,7 @@ export default async function convertPCIO(content) {
             func:   'SORT',
             holder: c.args.sources.value,
             key:    'sortingOrder',
-            reverse: c.args.direction.value != 'za'
+            reverse: !c.args.direction || c.args.direction.value != 'za'
           };
           if(c.holder.length == 1)
             c.holder = c.holder[0];


### PR DESCRIPTION
For now this only prevents a crash when importing a `SORT_CARDS` without `direction`.