### PR TITLE
Fix red color on children of offending node

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -194,6 +194,7 @@ body.jsonEdit.jeZoomOut #topSurface {
   font-size: 12px;
   background: #ffffff10;
   margin-left: 20px;
+  color:lightgray;
 }
 
 .jeLogSkipped {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1375,7 +1375,7 @@ function jeLoggingRoutineEnd(variables, collections) {
     // Make expander arrows that are parents of nodes with problems show up red.
     const problems = document.getElementsByClassName('jeLogHasProblems');
     for (i=0; i<problems.length; i++) {
-      let node = problems[i].parentNode;
+      let node = problems[i];
       while (node && !node.classList.contains('jeLog')) {
         if(node.classList.contains('jeLogOperation')) {
           node.firstElementChild.classList.remove('jeExpander');


### PR DESCRIPTION
Fixes #1066. Also fixes a problem where the arrow of the node with a problem was not painted red.

The pr-test room contains a small test taken from the pr-test room of #1040. I'm pretty sure that @bjalder26 had a better test room for that PR, but I don't know where it is now.

http://212.47.248.129:4068/uz1y contains @ArnoldSmith86's original example - sit in a seat and press New Game.

As I had to make a pretty global change to the css, I'd appreciate some real testing. It should be pretty benign, but still.