### PR TITLE
Adds text-transform: inherit; to label textarea

### DIFF
--- a/client/css/widgets/label.css
+++ b/client/css/widgets/label.css
@@ -15,6 +15,7 @@
   width: 100%;
   min-height: 100%;
   resize: none;
+  text-transform: inherit;
 }
 
 body.edit .widget.label {


### PR DESCRIPTION
The textareas of labels do not inherit text-transform.  So using things like `text-transform: uppercase;` will not work in a label's css.  This PR will cause the textarea to inherit text-transform from the label (div), thus make that possible.