### PR TITLE
increase asset limit from 2 MiB to 10 MiB

### DIFF
--- a/client/js/main.js
+++ b/client/js/main.js
@@ -320,7 +320,10 @@ onLoad(function() {
   startWebSocket();
 
   onMessage('warning', alert);
-  onMessage('error', alert);
+  onMessage('error', function(message) {
+    waitingForStateCreation = null;
+    alert(message);
+  });
   onMessage('internal_error', function() {
     preventReconnect();
     showOverlay('internalErrorOverlay');

--- a/server.mjs
+++ b/server.mjs
@@ -192,7 +192,7 @@ MinifyRoom().then(function(result) {
     }).catch(next);
   });
 
-  app.put('/asset', bodyParser.raw({ limit: '100mb' }), function(req, res) {
+  app.put('/asset', bodyParser.raw({ limit: '10mb' }), function(req, res) {
     const filename = `/${CRC32.buf(req.body)}_${req.body.length}`;
     if(!fs.existsSync(assetsdir + filename))
       fs.writeFileSync(assetsdir + filename, req.body);

--- a/server/fileloader.mjs
+++ b/server/fileloader.mjs
@@ -19,23 +19,23 @@ async function downloadLink(link) {
     requestEtag = linkStatus[link].etag;
     if(requestEtag === null || linkStatus[link].time > +(new Date()) - 2*60*60*1000)
       return;
-  } else {
-    linkStatus[link] = {
-      filename: Math.random().toString(36).substring(3, 9)
-    };
   }
+  const currentLinkStatus = linkStatus[link] || {
+    filename: Math.random().toString(36).substring(3, 9)
+  };
 
   const response = await fetch(link, requestEtag ? { headers: { 'If-None-Match': requestEtag } } : {});
 
-  linkStatus[link].time = +new Date();
-  linkStatus[link].status = response.status;
+  currentLinkStatus.time = +new Date();
+  currentLinkStatus.status = response.status;
 
   if(response.status != 304) {
-    linkStatus[link].etag = response.headers.get('etag');
+    currentLinkStatus.etag = response.headers.get('etag');
     const states = await readStatesFromBuffer(await response.buffer());
-    fs.writeFileSync(`${dirname}/${linkStatus[link].filename}`, JSON.stringify(states));
+    fs.writeFileSync(`${dirname}/${currentLinkStatus.filename}`, JSON.stringify(states));
   }
 
+  linkStatus[link] = currentLinkStatus;
   fs.writeFileSync(filename, JSON.stringify(linkStatus));
 }
 

--- a/server/fileloader.mjs
+++ b/server/fileloader.mjs
@@ -99,7 +99,9 @@ async function readVariantsFromBuffer(buffer) {
         variants[filename] = variant;
       }
 
-      if(filename.match(/^\/?assets/) && zip.files[filename]._data && zip.files[filename]._data.uncompressedSize < 2097152) {
+      if(filename.match(/^\/?assets/) && zip.files[filename]._data) {
+        if(zip.files[filename]._data.uncompressedSize >= 10485760)
+          throw new Logging.UserError(403, `${filename} is bigger than 10 MiB.`);
         const targetFile = '/assets/' + zip.files[filename]._data.crc32 + '_' + zip.files[filename]._data.uncompressedSize;
         if(targetFile.match(/^\/assets\/[0-9_-]+$/) && !fs.existsSync(path.resolve() + '/save' + targetFile))
           fs.writeFileSync(path.resolve() + '/save' + targetFile, await zip.files[filename].async('nodebuffer'));


### PR DESCRIPTION
When uploading assets directly, the limit was 100MiB but when reading from a vtt file, the limit was 2MiB (and anything bigger was just silently ignored).

Now the limit for both is 10MiB and if an asset in an uploaded game is bigger, it gets rejected with an appropriate error message.