### PR TITLE
fixed crash with invalid widgets

### DIFF
--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -68,7 +68,11 @@ export function addWidget(widget, instance) {
     w.applyInitialDelta(widget);
   } catch(e) {
     console.error(`Could not add widget!`, widget, e);
-    removeWidget(widget.id);
+    try {
+      removeWidget(widget.id);
+    } catch(e) {
+      console.error(`Could not remove invalid widget!`, widget, e);
+    }
     return;
   }
   if(w.get('dropTarget'))

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -68,11 +68,7 @@ export function addWidget(widget, instance) {
     w.applyInitialDelta(widget);
   } catch(e) {
     console.error(`Could not add widget!`, widget, e);
-    try {
-      removeWidget(widget.id);
-    } catch(e) {
-      console.error(`Could not remove invalid widget!`, widget, e);
-    }
+    removeWidget(widget.id);
     return;
   }
   if(w.get('dropTarget'))
@@ -147,7 +143,11 @@ function receiveStateFromServer(args) {
 }
 
 function removeWidget(widgetID) {
-  widgets.get(widgetID).applyRemove();
+  try {
+    widgets.get(widgetID).applyRemove();
+  } catch(e) {
+    console.error(`Could not remove widget!`, widgetID, e);
+  }
   widgets.delete(widgetID);
   dropTargets.delete(widgetID);
 }

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -34,7 +34,12 @@ export function addWidget(widget, instance) {
     w = instance;
   } else if(widget.type == 'card') {
     if(widgets.has(widget.deck)) {
-      w = new Card(id);
+      if(widgets.get(widget.deck).get('type') == 'deck') {
+        w = new Card(id);
+      } else {
+        console.error(`Could not add widget!`, widget, 'card with invalid deck');
+        return;
+      }
     } else {
       if(!deferredCards[widget.deck])
         deferredCards[widget.deck] = [];


### PR DESCRIPTION
Invalid widgets will not be added. Examples are widgets without `id`, with non-existant `parent` or cards without `deck` or `cardType`. They will produce error messages in the browser console (except for non-existant `parent`, I think).

When adding the widget failed, it is removed "properly" by calling `removeWidget`. _But_ if that _also_ fails, it currently crashes the client. An example are cards with their `deck` set to an existing widget that is not a deck.