### PR TITLE
Improve testcafe-gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,3 +11,6 @@ ports:
   - port: 9239
     visibility: private
     onOpen: ignore
+  - port: 5900
+    visibility: private
+    onOpen: ignore

--- a/tests/testcafe/gitpod-vnc/install.sh
+++ b/tests/testcafe/gitpod-vnc/install.sh
@@ -2,7 +2,7 @@
 sudo apt update
 sudo apt install -y xvfb x11vnc xterm openjfx libopenjfx-java openbox firefox
 
-sudo sed -ri "s/<number>4<\/number>/<number>1<\/number>" /etc/xdg/openbox/rc.xml
+sudo sed -ri "s/<number>4<\/number>/<number>1<\/number>/" /etc/xdg/openbox/rc.xml
 
 sudo git clone --depth 1 https://github.com/novnc/noVNC.git /opt/novnc \
   && sudo git clone --depth 1 https://github.com/novnc/websockify /opt/novnc/utils/websockify
@@ -12,4 +12,4 @@ sudo cp /workspace/virtualtabletop/tests/testcafe/gitpod-vnc/start-vnc-session.s
 sudo chmod +x /usr/bin/start-vnc-session.sh
 
 echo "export DISPLAY=:0" >> /home/gitpod/.bashrc.d/300-vnc
-echo "[ ! -e /tmp/X0-lock ] && (/usr/bin/start-vnc-session.sh &> /tmp/display-\&{DISPLAY}.log)" >> /home/gitpod/.bashrc.d/300-vnc
+echo "[ ! -e /tmp/X0-lock ] && (/usr/bin/start-vnc-session.sh &> /tmp/display-\${DISPLAY}.log)" >> /home/gitpod/.bashrc.d/300-vnc

--- a/tests/testcafe/gitpod-vnc/install.sh
+++ b/tests/testcafe/gitpod-vnc/install.sh
@@ -13,3 +13,5 @@ sudo chmod +x /usr/bin/start-vnc-session.sh
 
 echo "export DISPLAY=:0" >> /home/gitpod/.bashrc.d/300-vnc
 echo "[ ! -e /tmp/X0-lock ] && (/usr/bin/start-vnc-session.sh &> /tmp/display-\${DISPLAY}.log)" >> /home/gitpod/.bashrc.d/300-vnc
+
+. /home/gitpod/.bashrc.d/300-vnc

--- a/tests/testcafe/gitpod-vnc/install.sh
+++ b/tests/testcafe/gitpod-vnc/install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+sudo apt update
+sudo apt install -y xvfb x11vnc xterm openjfx libopenjfx-java openbox firefox
+
+sudo sed -ri "s/<number>4<\/number>/<number>1<\/number>" /etc/xdg/openbox/rc.xml
+
+sudo git clone --depth 1 https://github.com/novnc/noVNC.git /opt/novnc \
+  && sudo git clone --depth 1 https://github.com/novnc/websockify /opt/novnc/utils/websockify
+sudo cp /workspace/virtualtabletop/tests/testcafe/gitpod-vnc/novnc-index.html /opt/novnc/index.html
+
+sudo cp /workspace/virtualtabletop/tests/testcafe/gitpod-vnc/start-vnc-session.sh /usr/bin/
+sudo chmod +x /usr/bin/start-vnc-session.sh
+
+echo "export DISPLAY=:0" >> /home/gitpod/.bashrc.d/300-vnc
+echo "[ ! -e /tmp/X0-lock ] && (/usr/bin/start-vnc-session.sh &> /tmp/display-\&{DISPLAY}.log)" >> /home/gitpod/.bashrc.d/300-vnc

--- a/tests/testcafe/gitpod-vnc/novnc-index.html
+++ b/tests/testcafe/gitpod-vnc/novnc-index.html
@@ -1,0 +1,8 @@
+<!--
+This static HTML file simply redirects to /vnc.html, and configures the following options:
+* autoconnect - Automatically connect as soon as the page has finished loading.
+* reconnect - Automatically reconnect if the connection is dropped.
+* resize=scale - Automatically resize the remote session to fit inside the preview window.
+Source: https://github.com/novnc/noVNC/blob/master/docs/EMBEDDING.md
+-->
+<html><head><meta http-equiv="Refresh" content="0; url=vnc.html?autoconnect=true&reconnect=true&resize=scale"></head></html>

--- a/tests/testcafe/gitpod-vnc/start-vnc-session.sh
+++ b/tests/testcafe/gitpod-vnc/start-vnc-session.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# see https://en.wikipedia.org/wiki/Xvfb#Remote_control_over_SSH
+
+DISP=${DISPLAY:1}
+
+Xvfb -screen "$DISP" "${CUSTOM_XVFB_WxHxD:=1920x1080x16}" -ac -pn -noreset &
+
+openbox &
+
+VNC_PORT=$((5900 + "$DISP"))
+NOVNC_PORT=$((6080 + "$DISP"))
+
+x11vnc -localhost -shared -display :"$DISP" -forever -rfbport ${VNC_PORT} -bg -o "/tmp/x11vnc-${DISP}.log"
+cd /opt/novnc/utils && ./novnc_proxy --vnc "localhost:${VNC_PORT}" --listen "${NOVNC_PORT}" &

--- a/tests/testcafe/gitpod-vnc/start-vnc-session.sh
+++ b/tests/testcafe/gitpod-vnc/start-vnc-session.sh
@@ -6,7 +6,7 @@ DISP=${DISPLAY:1}
 
 Xvfb -screen "$DISP" "${CUSTOM_XVFB_WxHxD:=1920x1080x16}" -ac -pn -noreset &
 
-openbox &
+${WINDOW_MANAGER:-openbox} &
 
 VNC_PORT=$((5900 + "$DISP"))
 NOVNC_PORT=$((6080 + "$DISP"))

--- a/tests/testcafe/gitpod.sh
+++ b/tests/testcafe/gitpod.sh
@@ -3,4 +3,4 @@ if ! which firefox >/dev/null 2>&1; then
   sudo apt update
   sudo apt install -y firefox
 fi
-npm run testcafe-firefox-headless
+npm run testcafe-firefox-headless "$@"

--- a/tests/testcafe/gitpod.sh
+++ b/tests/testcafe/gitpod.sh
@@ -3,4 +3,4 @@ if ! which firefox >/dev/null 2>&1; then
   sudo apt update
   sudo apt install -y firefox
 fi
-npm run testcafe-firefox-headless "$@"
+npm run testcafe-firefox-headless -- "$@"

--- a/tests/testcafe/tests.js
+++ b/tests/testcafe/tests.js
@@ -97,7 +97,7 @@ test('Create game using edit mode', async t => {
     .click('#add-holder')
     .click('#addButton')
     .click('#addHand')
-    .drag('[id="hand"]', 100, 100) // this shouldn't change anything because it's not movable
+    .drag('[id="hand"]', 100, -100) // this shouldn't change anything because it's not movable
     .click('#editButton')
     .click('[id="hand"]')
     .click('#transparentHolder')


### PR DESCRIPTION
Allows arguments to be passed to testcafe-gitpod similar to other testcafe scripts.

Also adds files for setting up a VNC environment needed to run testcafe in graphical mode with gitpod. This can be set up using this branch then another branch can be checked out for testing (the script installs the tools needed outside the container's /workspace directory - changes do not persist when the container is stopped, but they are also not removed when switching branches).

To run graphical tests in gitpod using VNC, simply use `source tests/testcafe/gitpod-vnc/install.sh` to install and start VNC (also installs firefox). Open a browser to the suggested port 6080 to see the graphical desktop. Then use `npm run testcafe-firefox` to run tests.