### PR TITLE
group custom and routine properties in JSON editor

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1551,13 +1551,17 @@ function jePreProcessObject(o) {
   }
 
   for(const key of Object.keys(o).sort())
-    if(copy[key] === undefined && !key.match(/Routine$/) && jeWidget.getDefaultValue(key) !== undefined)
+    if(copy[key] === undefined && !key.match(/^c[0-9]{2}$/) && !key.match(/Routine$/) && jeWidget.getDefaultValue(key) !== undefined)
       copy[key] = o[key];
   copy[`LINEBREAKcustom`] = null;
   for(const key of Object.keys(o).sort())
-    if(copy[key] === undefined && !key.match(/Routine$/))
+    if(copy[key] === undefined && !key.match(/^c[0-9]{2}$/) && !key.match(/Routine$/))
       copy[key] = o[key];
   copy[`LINEBREAKroutines`] = null;
+  for(const key of Object.keys(o).sort())
+    if(copy[key] === undefined && !key.match(/^c[0-9]{2}$/))
+      copy[key] = o[key];
+  copy[`LINEBREAKcanvas`] = null;
   for(const key of Object.keys(o).sort())
     if(copy[key] === undefined)
       copy[key] = o[key];

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -837,7 +837,7 @@ function jeAddNumberCommand(name, key, callback) {
 
 function jeAddWidgetPropertyCommands(object) {
   for(const property in object.defaults)
-    if(property != 'typeClasses')
+    if(property != 'typeClasses' && !property.match(/^c[0-9]{2}$/))
       jeAddWidgetPropertyCommand(object, property);
   const type = object.defaults.typeClasses.replace(/widget /, '');
   return type == 'basic' ? null : type;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1579,7 +1579,7 @@ function jePreProcessObject(o) {
 }
 
 function jePreProcessText(t) {
-  return t.replace(/(\n +"LINEBREAK.*": null,)+/g, '\n').replace(/(,\n +"LINEBREAK.*": null)+/g, '');
+  return t.replace(/(\n +"LINEBREAK.*": null,)+/g, '\n').replace(/(,\n?\n +"LINEBREAK.*": null)+/g, '');
 }
 
 // Select the characters in a given range in the text area.

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1551,6 +1551,14 @@ function jePreProcessObject(o) {
   }
 
   for(const key of Object.keys(o).sort())
+    if(copy[key] === undefined && !key.match(/Routine$/) && jeWidget.getDefaultValue(key) !== undefined)
+      copy[key] = o[key];
+  copy[`LINEBREAKcustom`] = null;
+  for(const key of Object.keys(o).sort())
+    if(copy[key] === undefined && !key.match(/Routine$/))
+      copy[key] = o[key];
+  copy[`LINEBREAKroutines`] = null;
+  for(const key of Object.keys(o).sort())
     if(copy[key] === undefined)
       copy[key] = o[key];
 


### PR DESCRIPTION
This PR does not change the fixed order at the top of the JSON (type, id, ...). All other properties were just shown in alphabetic order. With this PR this bottom block will be split into three parts: all other known widget properties (the yellow ones), then a block with all custom properties (the orange ones) and then another block with all the routine properties.