### PR TITLE
fix scrolling issue in iOS Safari

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -4,7 +4,6 @@
   white-space: pre-line;
   font-family: monospace;
   display: none;
-  height: 100%;
   width: 100%;
   z-index: 2;
   position: relative;

--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -23,11 +23,19 @@
   --neutralInput: #1f5ca6;
 }
 
+html {
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
 body {
   background: #484848;
   padding: 0;
   margin: 0;
-  overflow: hidden;
+  height: 100%;
+  overflow: auto;
+  position: relative;
   font-family: 'Roboto', sans-serif;
 }
 


### PR DESCRIPTION
I have no device to test this but according to @mousewax this should fix the issue that Safari on iOS sometimes scrolls the entire page instead of moving the desired widget when in fullscreen mode.