### PR TITLE
Default values in INPUT select field

### DIFF
--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -116,7 +116,7 @@ export function formField(field, dom, id) {
       const optionElement = document.createElement('option');
       optionElement.value = option.value || '';
       optionElement.textContent = option.text || option.value || '';
-      if(option.value == field.value || field.value === undefined && option.selected)
+      if(option.value == field.value || (field.value === undefined || field.value === null) && option.selected)
         optionElement.selected = true;
       input.appendChild(optionElement);
     }

--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -116,7 +116,7 @@ export function formField(field, dom, id) {
       const optionElement = document.createElement('option');
       optionElement.value = option.value || '';
       optionElement.textContent = option.text || option.value || '';
-      if(option.value == field.value || (field.value === undefined || field.value === null) && option.selected)
+      if(option.value == field.value || field.value == null && option.selected)
         optionElement.selected = true;
       input.appendChild(optionElement);
     }

--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -116,6 +116,8 @@ export function formField(field, dom, id) {
       const optionElement = document.createElement('option');
       optionElement.value = option.value || '';
       optionElement.textContent = option.text || option.value || '';
+      if(option.value == field.value || option.selected)
+        optionElement.selected = true;
       input.appendChild(optionElement);
     }
     dom.appendChild(input);

--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -116,7 +116,7 @@ export function formField(field, dom, id) {
       const optionElement = document.createElement('option');
       optionElement.value = option.value || '';
       optionElement.textContent = option.text || option.value || '';
-      if(option.value == field.value || option.selected)
+      if(option.value == field.value || field.value === undefined && option.selected)
         optionElement.selected = true;
       input.appendChild(optionElement);
     }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -622,7 +622,7 @@ function jeAddCommands() {
 
   jeAddFieldCommand('text', 'subtitle|title|text', '');
   jeAddFieldCommand('label', 'checkbox|color|number|select|string|switch', '');
-  jeAddFieldCommand('value', 'checkbox|color|number|string|switch', '');
+  jeAddFieldCommand('value', 'checkbox|color|number|select|string|switch', '');
   jeAddFieldCommand('variable', 'checkbox|color|number|select|string|switch', '');
   jeAddFieldCommand('min', 'number', 0);
   jeAddFieldCommand('max', 'number', 10);


### PR DESCRIPTION
Fixes #1123 

Default value for an INPUT select field can be set in two ways. Setting the field value to the value of one of the options, or setting `selected: true` within the option to select.