### PR TITLE
prevent redirecting to an existing room

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -115,7 +115,10 @@ MinifyRoom().then(function(result) {
   });
 
   app.get('/', function(req, res) {
-    res.redirect(Math.random().toString(36).substring(3, 7));
+    let id = null;
+    while(!id || fs.existsSync(savedir + '/rooms/' + id + '.json'))
+      id = Math.random().toString(36).substring(3, 7);
+    res.redirect(id);
   });
 
   app.get('/dl/:room/:state/:variant', function(req, res, next) {


### PR DESCRIPTION
When generating a new room (by going to virtualtabletop.io directly), this PR should prevent the rare case where the generated room ID already exists. It just regenerates random room IDs until it finds an empty one.