### PR TITLE
make `directories.save` and `directories.assets` in `config.json` work

### DIFF
--- a/server/fileloader.mjs
+++ b/server/fileloader.mjs
@@ -1,13 +1,13 @@
 import fs from 'fs';
-import path from 'path';
 import fetch from 'node-fetch';
 import JSZip from 'jszip';
 
 import { VERSION } from './fileupdater.mjs';
 import PCIO from './pcioimport.mjs';
 import Logging from './logging.mjs';
+import Config from './config.mjs';
 
-const dirname = path.resolve() + '/save/links';
+const dirname = Config.directory('save') + '/links';
 const filename = dirname + '.json';
 const linkStatus = fs.existsSync(filename) ? JSON.parse(fs.readFileSync(filename)) : {};
 
@@ -101,8 +101,8 @@ async function readVariantsFromBuffer(buffer) {
 
       if(filename.match(/^\/?assets/) && zip.files[filename]._data && zip.files[filename]._data.uncompressedSize < 2097152) {
         const targetFile = '/assets/' + zip.files[filename]._data.crc32 + '_' + zip.files[filename]._data.uncompressedSize;
-        if(targetFile.match(/^\/assets\/[0-9_-]+$/) && !fs.existsSync(path.resolve() + '/save' + targetFile))
-          fs.writeFileSync(path.resolve() + '/save' + targetFile, await zip.files[filename].async('nodebuffer'));
+        if(targetFile.match(/^\/assets\/[0-9_-]+$/) && !fs.existsSync(Config.directory('assets') + targetFile.substr(7)))
+          fs.writeFileSync(Config.directory('assets') + targetFile.substr(7), await zip.files[filename].async('nodebuffer'));
       }
 
     }

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -1,6 +1,7 @@
 import fs from 'fs';
-import path from 'path';
 import JSZip from 'jszip';
+
+import Config from './config.mjs';
 
 const pieceColors = {
   default: '#000000',
@@ -29,8 +30,8 @@ export default async function convertPCIO(content) {
     if(filename.match(/^\/?userassets/) && zip.files[filename]._data && zip.files[filename]._data.uncompressedSize < 2097152) {
       const targetFile = '/assets/' + zip.files[filename]._data.crc32 + '_' + zip.files[filename]._data.uncompressedSize;
       nameMap['package://' + filename] = targetFile;
-      if(targetFile.match(/^\/assets\/[0-9_-]+$/) && !fs.existsSync(path.resolve() + '/save' + targetFile))
-        fs.writeFileSync(path.resolve() + '/save' + targetFile, await zip.files[filename].async('nodebuffer'));
+      if(targetFile.match(/^\/assets\/[0-9_-]+$/) && !fs.existsSync(Config.directory('assets') + targetFile.substr(7)))
+        fs.writeFileSync(Config.directory('assets') + targetFile.substr(7), await zip.files[filename].async('nodebuffer'));
     }
   }
 

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import path from 'path';
 
 import JSZip from 'jszip';
 import fetch from 'node-fetch';
@@ -66,7 +65,7 @@ export default class Room {
     } catch(e) {
       Logging.log(`ERROR LOADING FILE: ${e.toString()}`);
       try {
-        fs.writeFileSync(path.resolve() + '/save/errors/' + Math.random().toString(36).substring(3, 7), src);
+        fs.writeFileSync(Config.directory('save') + '/errors/' + Math.random().toString(36).substring(3, 7), src);
       } catch(e) {}
       throw e;
     }
@@ -194,8 +193,8 @@ export default class Room {
       zip.file(`${vID}.json`, JSON.stringify(state, null, '  '));
       if(includeAssets)
         for(const asset of this.getAssetList(state))
-          if(fs.existsSync(path.resolve() + '/save' + asset))
-            zip.file(asset.substr(1), fs.readFileSync(path.resolve() + '/save' + asset));
+          if(fs.existsSync(Config.directory('assets') + asset.substr(7)))
+            zip.file(asset.substr(1), fs.readFileSync(Config.directory('assets') + asset.substr(7)));
     }
 
     const zipBuffer = await zip.generateAsync({type:'nodebuffer', compression: 'DEFLATE'});
@@ -395,7 +394,7 @@ export default class Room {
   }
 
   roomFilename() {
-    return path.resolve() + '/save/rooms/' + this.id + '.json';
+    return Config.directory('save') + '/rooms/' + this.id + '.json';
   }
 
   sendMetaUpdate() {
@@ -464,7 +463,7 @@ export default class Room {
   trace(source, payload) {
     if(!this.enableTracing && source == 'client' && payload.type == 'enable') {
       this.enableTracing = true;
-      this.tracingFilename = `${path.resolve()}/save/${this.id}-${+new Date}.trace`;
+      this.tracingFilename = `${Config.directory('save')}/${this.id}-${+new Date}.trace`;
       this.broadcast('tracing', 'enable');
       payload.initialState = this.state;
       fs.writeFileSync(this.tracingFilename, '[\n');
@@ -507,6 +506,6 @@ export default class Room {
   }
 
   variantFilename(stateID, variantID) {
-    return path.resolve() + '/save/states/' + this.id + '-' + stateID.replace(/[^a-z0-9]/g, '_') + '-' + variantID.replace(/[^a-z0-9]/g, '_') + '.json';
+    return Config.directory('save') + '/states/' + this.id + '-' + stateID.replace(/[^a-z0-9]/g, '_') + '-' + variantID.replace(/[^a-z0-9]/g, '_') + '.json';
   }
 }


### PR DESCRIPTION
I added those options when I introduced the `config.json` file but I never actually made them work. I am pretty sure that they do now, though.