### PR TITLE
Move to seat sets `owner` before moving to `hand`

### DIFF
--- a/client/js/widgets/holder.js
+++ b/client/js/widgets/holder.js
@@ -66,7 +66,7 @@ class Holder extends Widget {
     if(child.get('type') == 'deck')
       return;
 
-    if(this.get('childrenPerOwner'))
+    if(child.get('owner') == null && this.get('childrenPerOwner'))
       await child.set('owner', playerName);
 
     if(this != child.currentParent) { // FIXME: this isn't exactly pretty

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1124,9 +1124,9 @@ export class Widget extends StateManaged {
                   if(target.get('hand') && target.get('player')) {
                     if(widgets.has(target.get('hand'))) {
                       await applyFlip();
-                      await c.moveToHolder(widgets.get(target.get('hand')));
                       if(widgets.get(target.get('hand')).get('childrenPerOwner'))
                         await c.set('owner', target.get('player'));
+                      await c.moveToHolder(widgets.get(target.get('hand')));
                       c.bringToFront()
                       widgets.get(target.get('hand')).updateAfterShuffle(); // this arranges the cards in the new owner's hand
                     } else {


### PR DESCRIPTION
Fixes #1116 

This could change the behavior of some games that make use of owner arrays. Currently a player in an owner array can move a card into the hand to become the sole owner of the card, but this PR changes that behavior. All players in the owner array would continue to see the card.