### PR TITLE
CALL can return falsy value

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1510,7 +1510,7 @@ export class Widget extends StateManaged {
       playerName = variables.playerName;
     }
 
-    return { variable: variables.result || null, collection: collections.result || [] };
+    return { variable: variables.result === undefined ? null : variables.result, collection: collections.result || [] };
   }
 
   get(property) {


### PR DESCRIPTION
Fixes #1070 

This could result in games breaking if they rely on all falsy results of CALLed routines being converted to `null`.