### PR TITLE
fix widget stylesheets when using `urlPrefix`

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -431,7 +431,7 @@ export class Widget extends StateManaged {
     style.id = `STYLES_${escapeID(this.id)}`;
     for(const key in css)
       if(key != 'inline')
-        style.appendChild(document.createTextNode(`#w_${escapeID(this.id)}${key == 'default' ? '' : key} { ${this.cssReplaceProperties(this.cssAsText(css[key]))} }`));
+        style.appendChild(document.createTextNode(`#w_${escapeID(this.id)}${key == 'default' ? '' : key} { ${mapAssetURLs(this.cssReplaceProperties(this.cssAsText(css[key])))} }`));
     $('head').appendChild(style);
 
     return this.cssAsText(css.inline || '');


### PR DESCRIPTION
PR #1087 did not map asset URLs in widget stylesheets. This PR fixes that.

So this:

```JSON
{
  "id": "background",

  "css": {
    "default": {
      "background-image": "url(/assets/-607361757_73020)"
    }
  }
}
```

works with this PR (https://test.virtualtabletop.io/PR-1142/pr-test) but does not without it (https://test.virtualtabletop.io/PR-1141/owpw).

It does however work in production and on the beta servers because they do serve the asset under `/assets/-607361757_73020`.