### PR TITLE
fix that moving a card half out the hand does not update owner

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1679,6 +1679,9 @@ export class Widget extends StateManaged {
         lastHoverTarget.domElement.classList.remove('droptarget');
       if(this.hoverTarget)
         this.hoverTarget.domElement.classList.add('droptarget');
+
+      if(lastHoverTarget != this.hoverTarget && this.hoverTarget != this.currentParent)
+        await this.checkParent(true);
     }
   }
 


### PR DESCRIPTION
PR #903 changed the way drop targets work but did not update the `owner` behavior of cards. As a result it caused #1072. See that issue for the problem description. This PR should fix the situation by triggering the holder leave behavior as soon as the drop target for the dragged card changes.