### PR TITLE
listen for touchcancel

### DIFF
--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -3,7 +3,7 @@ const mouseStatus = {};
 
 function eventCoords(name, e) {
   let coords;
-  if(name == 'touchend')
+  if(name == 'touchend' || name == 'touchcancel')
     coords = e.changedTouches[0];
   else if(name == 'touchstart' || name == 'touchmove')
     coords = e.targetTouches[0];
@@ -51,7 +51,7 @@ async function inputHandler(name, e) {
     if(!edit && (!jeEnabled || !e.ctrlKey) && widget.passthroughMouse) {
       if(name == 'mousedown' || name == 'touchstart') {
         await widget.mouseRaw('down', coords);
-      } else if (name == 'mouseup' || name == 'touchend') {
+      } else if (name == 'mouseup' || name == 'touchend' || name == 'touchcancel') {
         await widget.mouseRaw('up', coords);
       } else if (name == 'mousemove' || name == 'touchmove') {
         await widget.mouseRaw('move', coords);
@@ -78,7 +78,7 @@ async function inputHandler(name, e) {
       if (movable) {
         ms.localAnchor = ms.moveTarget.coordLocalFromCoordClient({x: coords.clientX, y: coords.clientY});
       }
-    } else if(name == 'mouseup' || name == 'touchend' && mouseStatus[target.id]) {
+    } else if(name == 'mouseup' || (name == 'touchend' || name == 'touchcancel') && mouseStatus[target.id]) {
       const ms = mouseStatus[target.id];
       const timeSinceStart = +new Date() - ms.start;
       const pixelsMoved = ms.coords ? Math.abs(ms.coords.x - ms.downCoords.x) + Math.abs(ms.coords.y - ms.downCoords.y) : 0;
@@ -122,7 +122,7 @@ async function inputHandler(name, e) {
 }
 
 onLoad(function() {
-  [ 'touchstart', 'touchend', 'touchmove', 'mousedown', 'mousemove', 'mouseup', 'contextmenu' ].forEach(function(event) {
+  [ 'touchstart', 'touchend', 'touchmove', 'touchcancel', 'mousedown', 'mousemove', 'mouseup', 'contextmenu' ].forEach(function(event) {
     window.addEventListener(event, e => inputHandler(event, e));
   });
 });


### PR DESCRIPTION
This problem is similar to #1144 but has a different origin.

The hand holder is usually at the bottom of the room. Phones nowadays trigger system gestures when swiping from the bottom. When dragging a card from the hand, you could trigger the system gesture to switch apps or go to the home screen and the card being dragged would just stop in mid air causing the same issues as described in #1072 (the parent is set to null but the owner is not).

This PR listens for the `touchcancel` event which is triggered in situations like this and handles it like it handles a normal `touchend` event. So it will pretend that the player let go of the card in that place.