### PR TITLE
the default for custom properties should be `null` instead of `undefined`

### DIFF
--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -36,7 +36,7 @@ export class StateManaged {
     for(const [ id, properties ] of Object.entries(this.inheritFrom()))
       if(this.inheritFromIsValid(properties, key) && widgets.has(id) && widgets.get(id).get(key) !== undefined)
         return widgets.get(id).get(key);
-    return this.defaults[key];
+    return this.defaults[key] === undefined ? null : this.defaults[key];
   }
 
   get(property) {

--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -16,7 +16,7 @@ export class StateManaged {
     for(const i in delta) {
       if(delta[i] === null) {
         delete this.state[i];
-        deltaForDOM[i] = this.getDefaultValue(i);
+        deltaForDOM[i] = this.get(i);
       } else {
         deltaForDOM[i] = this.state[i] = delta[i];
       }
@@ -36,7 +36,7 @@ export class StateManaged {
     for(const [ id, properties ] of Object.entries(this.inheritFrom()))
       if(this.inheritFromIsValid(properties, key) && widgets.has(id) && widgets.get(id).get(key) !== undefined)
         return widgets.get(id).get(key);
-    return this.defaults[key] === undefined ? null : this.defaults[key];
+    return this.defaults[key];
   }
 
   get(property) {


### PR DESCRIPTION
If a property gets set to `null`, it reverts to its default value. For custom properties the function `getDefaultValue` returned `undefined` instead of `null`. No other part of the VTT code expects `undefined` in the delta though so it gets treated as "property was not changed at all".

I am pretty surprised that this did not come up earlier and I am a bit afraid that this might break subtle things in a game or two.

I am also pretty sure that this should be changed though.