### PR TITLE
fix state downloads when using urlPrefix

### DIFF
--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -94,7 +94,7 @@ function addStateFromLibrary(e) {
 
 function downloadState(variantID) {
   const stateID = $('#stateEditOverlay').dataset.id;
-  let url = `/dl/${roomID}`
+  let url = `dl/${roomID}`
   if(variantID !== null)
     url += `/${stateID}`;
   if(variantID)


### PR DESCRIPTION
PR #1087 missed this one.

On my local test server I see a reconnect/reload after downloading a state now. I do not see that on the production server. I want to see if it also happens on the PR test server. I probably want to fix that.