### PR TITLE
lights off

### DIFF
--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -350,6 +350,16 @@ body.aspectTooGood #options {
   transform: translateY(273px) translateX(46px);
 }
 
+body.lightsOff, body.lightsOff #toolbar, body.lightsOff #toolbar .tooltip {
+  background: black;
+}
+body.lightsOff #toolbar {
+  opacity: 0.1;
+}
+body.lightsOff #toolbar:hover {
+  opacity: 1;
+}
+
 #options.hidden {
   visibility: hidden;
 }
@@ -507,6 +517,10 @@ html:not(:-webkit-full-screen) #fullscreenButton .tooltip::before {
 
 html:-webkit-full-screen #fullscreenButton .tooltip::before {
   content: 'Exit ';
+}
+
+#lightsButton::before {
+  content: '[auto_awesome]';
 }
 
 #hideToolbarButton::before {

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -265,6 +265,13 @@ onLoad(function() {
     muted = !muted
   });
 
+  on('#lightsButton', 'click', function(){
+    if($('body').classList.contains('lightsOff'))
+      $('body').classList.remove('lightsOff');
+    else
+      $('body').classList.add('lightsOff');
+  });
+
   on('#optionsButton', 'click', function(){
     if(optionsHidden) {
       document.getElementById('options').classList.remove('hidden');

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -247,17 +247,15 @@ onLoad(function() {
 
   on('#muteButton', 'click', function(){
     if(muted) {
-      document.getElementById('volume').value = unmuteVol;
-      document.getElementById('muteButton').classList.remove('muted');
-      var allAudios = document.querySelectorAll('audio');
-      allAudios.forEach(function(audio){
+      $('#volume').value = unmuteVol;
+      $('#muteButton').classList.remove('muted');
+      $a('audio').forEach(function(audio){
         audio.volume = Math.min(audio.getAttribute('maxVolume') * (((10 ** (unmuteVol / 96.025)) / 10) - 0.1), 1);
       });
     } else {
       unmuteVol = document.getElementById('volume').value;
-      document.getElementById("volume").value = 0;
-      var allAudios = document.querySelectorAll('audio');
-      allAudios.forEach(function(audio){
+      $('#volume').value = 0;
+      $a('audio').forEach(function(audio){
         audio.volume = 0;
       });
       document.getElementById('muteButton').classList.add('muted');
@@ -274,9 +272,9 @@ onLoad(function() {
 
   on('#optionsButton', 'click', function(){
     if(optionsHidden) {
-      document.getElementById('options').classList.remove('hidden');
+      $('#options').classList.remove('hidden');
     } else {
-      document.getElementById('options').classList.add('hidden');
+      $('#options').classList.add('hidden');
     }
     optionsHidden = !optionsHidden
   });
@@ -358,15 +356,14 @@ window.onkeyup = function(event) {
   }
 }
 
-if(document.getElementById("volume")) {
-    document.getElementById("volume").addEventListener("input", function(){ // allows volume to be adjusted in real time
-      if(muted) {
-        document.getElementById('muteButton').classList.remove('muted');
-        muted = !muted
-      }
-    var allAudios = document.querySelectorAll('audio');
-    allAudios.forEach(function(audio){
-      audio.volume = Math.min(audio.getAttribute('maxVolume') * (((10 ** (document.getElementById('volume').value / 96.025)) / 10) - 0.1), 1);
+if($('#volume')) {
+  on('#volume', 'input', function(){ // allows volume to be adjusted in real time
+    if(muted) {
+      $('#muteButton').classList.remove('muted');
+      muted = !muted
+    }
+    $a('audio').forEach(function(audio){
+      audio.volume = Math.min(audio.getAttribute('maxVolume') * (((10 ** ($('#volume').value / 96.025)) / 10) - 0.1), 1);
     });
   });
 }

--- a/client/room.html
+++ b/client/room.html
@@ -25,8 +25,10 @@
     <div class="divider">&nbsp;</div>
     <button id="editButton" class="toolbarButton"><span class="tooltip">Edit Mode</span></button>
     <button id="addButton" data-overlay="addOverlay" class="toolbarButton"><span class="tooltip">Add Widget</span></button>
+    <div class="divider">&nbsp;</div>
     <button id="optionsButton" class="toolbarButton"><span class="tooltip">Sound</span></button>
     <span id="options" class="hidden"><button id="muteButton" class="toolbarButton"></button><div class='volumeWrap'><input id="volume" type='range'min="0" max="100" value="30" ></div></span>
+    <button id="lightsButton" class="toolbarButton"><span class="tooltip">Lights</span></button>
     <div class="divider">&nbsp;</div>
     <button id="fullscreenButton" class="toolbarButton"><span class="tooltip">Fullscreen</span></button>
     <button id="hideToolbarButton" class="toolbarButton"><span class="tooltip">Hide Toolbar</span></button>


### PR DESCRIPTION
I had this idea yesterday that this might look nice on phones with AMOLED screens when using fullscreen.

This PR adds a new toolbar button after the sound button that toggles between the normal background and toolbar and black versions with dimmed images.

Please make suggestions about where to put this. The players overlay is already called "Players & Settings" - maybe this is the point where we move sound and lights there?