### PR TITLE
fix audio with `urlPrefix`

### DIFF
--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -32,7 +32,7 @@ export function domByTemplate(id, type) {
 }
 
 export function mapAssetURLs(str) {
-  return str.replaceAll(/(["' (])\/(assets|i)\//g, '$1$2/');
+  return str.replaceAll(/(^|["' (])\/(assets|i)\//g, '$1$2/');
 }
 
 export function escapeID(id) {


### PR DESCRIPTION
The last minute change to `mapAssetURLs` caused it to no longer remove the initial slash if it just receives an asset string (as opposed to CSS).