### PR TITLE
Revert "Move to seat sets `owner` before moving to `hand`"

### DIFF
--- a/client/js/widgets/holder.js
+++ b/client/js/widgets/holder.js
@@ -66,7 +66,7 @@ class Holder extends Widget {
     if(child.get('type') == 'deck')
       return;
 
-    if(child.get('owner') == null && this.get('childrenPerOwner'))
+    if(this.get('childrenPerOwner'))
       await child.set('owner', playerName);
 
     if(this != child.currentParent) { // FIXME: this isn't exactly pretty

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1125,9 +1125,9 @@ export class Widget extends StateManaged {
                     if(widgets.has(target.get('hand'))) {
                       const targetHand = widgets.get(target.get('hand'));
                       await applyFlip();
+                      await c.moveToHolder(targetHand);
                       if(targetHand.get('childrenPerOwner'))
                         await c.set('owner', target.get('player'));
-                      await c.moveToHolder(targetHand);
                       c.bringToFront()
                       if(targetHand.get('type') == 'holder')
                         targetHand.updateAfterShuffle(); // this arranges the cards in the new owner's hand


### PR DESCRIPTION
Reverts ArnoldSmith86/virtualtabletop#1139

I think this PR breaks MOVE to seat (and then from seat to hand) behavior.  But only sometimes.  Not sure exactly why or how or when, but now when you MOVE to a seat, sometimes the player pressing the button gets all of the cards.  I noticed this in Hearts, which I'm still tweaking.  So I tested it in Spades which was definitely working and in the 3rd variant (seats) of the Hands tutorial.  Intermittently but not every time, sitting in a seat and MOVEing to that seat gives that player all the cards. 