### PR TITLE
parallelize testcafe tests on GitHub

### DIFF
--- a/.github/workflows/testcafe-chrome.yml
+++ b/.github/workflows/testcafe-chrome.yml
@@ -1,4 +1,4 @@
-name: TestCafe (loads games, clicks buttons, checks the results)
+name: TestCafe Chrome (loads games, clicks buttons, checks the results)
 
 on:
   push:
@@ -27,11 +27,7 @@ jobs:
         npm run debug &
         sleep 5
         curl -I http://localhost:8272
-    - name: Run TestCafe tests (Firefox)
-      uses: DevExpress/testcafe-action@latest
-      with:
-        args: "firefox:headless tests/testcafe/tests.js"
-    - name: Run TestCafe tests (Chrome)
+    - name: Run TestCafe tests
       uses: DevExpress/testcafe-action@latest
       with:
         args: "chrome:headless tests/testcafe/tests.js"

--- a/.github/workflows/testcafe-firefox.yml
+++ b/.github/workflows/testcafe-firefox.yml
@@ -1,0 +1,33 @@
+name: TestCafe Firefox (loads games, clicks buttons, checks the results)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+
+jobs:
+  build:
+    name: Run TestCafe Tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install Node.js 16.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 16.x
+    - name: Install dependencies
+      run: npm ci
+    - name: Start virtualtabletop server
+      run: |
+        npm run debug &
+        sleep 5
+        curl -I http://localhost:8272
+    - name: Run TestCafe tests
+      uses: DevExpress/testcafe-action@latest
+      with:
+        args: "firefox:headless tests/testcafe/tests.js"


### PR DESCRIPTION
This PR splits Firefox and Chrome TestCafé tests in separate workflows. That should hopefully make it run in parallel.