### PR TITLE
fix crash when `CALL`ing invalid widget

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -697,7 +697,7 @@ export class Widget extends StateManaged {
         setDefaults(a, { widget: this.get('id'), routine: 'clickRoutine', 'return': true, arguments: {}, variable: 'result', collection: 'result' });
         if(!a.routine.match(/Routine$/)) {
           problems.push('Routine parameters have to end with "Routine".');
-        } else if(this.isValidID(a.widget)) {
+        } else if(this.isValidID(a.widget, problems)) {
           if(!Array.isArray(widgets.get(a.widget).get(a.routine))) {
             problems.push(`Widget ${a.widget} does not contain ${a.routine} (or it is no array).`);
           } else {
@@ -712,7 +712,7 @@ export class Widget extends StateManaged {
             collections[a.collection] = result.collection;
 
             if(jeRoutineLogging) {
-              const theWidget = this.isValidID(a.widget) && a.widget != this.get('id') ? `in ${a.widget}` : '';
+              const theWidget = this.isValidID(a.widget, problems) && a.widget != this.get('id') ? `in ${a.widget}` : '';
               if (a.return) {
                 let returnCollection = result.collection.map(w=>w.get('id')).join(',');
                 if(!result.collection.length || result.collection.length >= 5)

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -816,14 +816,14 @@ export default async function convertPCIO(content) {
         if(c.func == 'CHANGE_TIMER_TIME') {
           if(!c.args.timers)
             continue;
-          if ((c.args.changeType && c.args.changeType.value)=="add"){
-            var mode = "inc"
-          } else if ((c.args.changeType && c.args.changeType.value)=="subtract"){
-            var mode = "dec"
-          } else if ((c.args.changeType && c.args.changeType.value)=="set"){
-            var mode = "set"
+          if ((c.args.changeType && c.args.changeType.value)=='add'){
+            var mode = 'inc'
+          } else if ((c.args.changeType && c.args.changeType.value)=='subtract'){
+            var mode = 'dec'
+          } else if ((c.args.changeType && c.args.changeType.value)=='set'){
+            var mode = 'set'
           } else {
-            var mode = "reset"
+            var mode = 'reset'
           };
           c = {
             func: 'TIMER',


### PR DESCRIPTION
It was already checking for a valid widget ID but `isValidID` requires a second parameter now. Probably a merge error at the time this was added.