### PR TITLE
fix crashes with invalid values for `svgReplaces` and `faces`

### DIFF
--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -112,7 +112,7 @@ function receiveDelta(delta) {
     if(delta.s[widgetID] === null) {
       if(widgets.has(widgetID))
         removeWidget(widgetID);
-    } else {
+    } else if(widgets.has(widgetID)) { // addWidget above MIGHT have failed
       widgets.get(widgetID).applyDelta(delta.s[widgetID]);
     }
   }

--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -23,7 +23,7 @@ class BasicWidget extends Widget {
   applyDeltaToDOM(delta) {
     super.applyDeltaToDOM(delta);
     if(delta.activeFace !== undefined || delta.faces !== undefined) {
-      let face = this.get('faces')[this.get('activeFace')];
+      let face = this.faces()[this.get('activeFace')];
       if(face !== undefined)
         this.applyDelta(face);
     }
@@ -72,22 +72,27 @@ class BasicWidget extends Widget {
     return p;
   }
 
+  faces() {
+    const faces = this.get('faces');
+    return Array.isArray(faces) ? faces : [];
+  }
+
   async flip(setFlip, faceCycle) {
     if(setFlip !== undefined && setFlip !== null)
       await this.set('activeFace', setFlip);
     else {
       const fC = (faceCycle !== undefined && faceCycle !== null) ? faceCycle : this.get('faceCycle');
       if (fC == 'backward')
-        await this.set('activeFace', this.get('activeFace') == 0 ? this.get('faces').length-1 : this.get('activeFace') -1);
+        await this.set('activeFace', this.get('activeFace') == 0 ? this.faces().length-1 : this.get('activeFace') -1);
       else
-        await this.set('activeFace', Math.floor(this.get('activeFace') + (fC == 'random' ? Math.random()*99999 : 1)) % this.get('faces').length);
+        await this.set('activeFace', Math.floor(this.get('activeFace') + (fC == 'random' ? Math.random()*99999 : 1)) % this.faces().length);
     }
   }
 
   getDefaultValue(property) {
-    if(property == 'faces' || property == 'activeFace' || !this.get('faces') || !this.get('faces')[this.get('activeFace')])
+    if(property == 'faces' || property == 'activeFace' || !this.faces() || !this.faces()[this.get('activeFace')])
       return super.getDefaultValue(property);
-    const d = this.get('faces')[this.get('activeFace')][property];
+    const d = this.faces()[this.get('activeFace')][property];
     if(d !== undefined)
       return d;
     return super.getDefaultValue(property);

--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -94,7 +94,7 @@ class BasicWidget extends Widget {
   }
 
   getImage() {
-    if(!Object.keys(this.get('svgReplaces')).length)
+    if(!Object.keys(this.get('svgReplaces') || {}).length)
       return this.get('image');
 
     const replaces = {};

--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -90,7 +90,7 @@ class BasicWidget extends Widget {
   }
 
   getDefaultValue(property) {
-    if(property == 'faces' || property == 'activeFace' || !this.faces() || !this.faces()[this.get('activeFace')])
+    if(property == 'faces' || property == 'activeFace' || !this.faces()[this.get('activeFace')])
       return super.getDefaultValue(property);
     const d = this.faces()[this.get('activeFace')][property];
     if(d !== undefined)

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -69,7 +69,7 @@ export class Button extends Widget {
   }
 
   getImage() {
-    if(!Object.keys(this.get('svgReplaces')).length)
+    if(!Object.keys(this.get('svgReplaces') || {}).length)
       return this.get('image');
 
     const replaces = {};

--- a/client/js/widgets/timer.js
+++ b/client/js/widgets/timer.js
@@ -77,7 +77,7 @@ export class Timer extends Widget {
   }
 
   getImage() {
-    if(!Object.keys(this.get('svgReplaces')).length)
+    if(!Object.keys(this.get('svgReplaces') || {}).length)
       return this.get('image');
 
     const replaces = {};

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -520,7 +520,7 @@ export class Widget extends StateManaged {
           return match[9] ? false : undefined;
 
         let indexName = evaluateIdentifier(match[3], match[4]);
-        return indexName !== undefined ? varContent[indexName] : varContent;
+        return varContent !== null && indexName !== undefined ? varContent[indexName] : varContent;
       }
 
       // property

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -520,6 +520,8 @@ export class Widget extends StateManaged {
           return match[9] ? false : undefined;
 
         let indexName = evaluateIdentifier(match[3], match[4]);
+        if(varContent === null && indexName !== undefined)
+          problems.push(`Cannot index a variable that evaluates to 'null'.`);
         return varContent !== null && indexName !== undefined ? varContent[indexName] : varContent;
       }
 


### PR DESCRIPTION
It is not easy to make `svgReplaces` evaluate to `null` but it is possible with `inheritFrom`. This causes a crash which this PR fixes.

Similar behavior happens for `faces` where the code assumed it is an array. The resulting crash should now also be fixed.

Additionally this PR fixes a crash when indexing a variable that evaluates to `null` in a dynamic expression.