### PR TITLE
css @rule selectors

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -379,12 +379,12 @@ export class Widget extends StateManaged {
     return css;
   }
 
-  cssAsText(css) {
+  cssAsText(css, nested = false) {
     if(typeof css == 'object') {
       let cssText = '';
       for(const key in css) {
         if(typeof css[key] == 'object')
-          return this.cssToStylesheet(css);
+          return this.cssToStylesheet(css, nested);
         cssText += `; ${key}: ${css[key]}`;
       }
       return cssText;
@@ -426,20 +426,24 @@ export class Widget extends StateManaged {
     return css;
   }
 
-  cssToStylesheet(css) {
+  cssToStylesheet(css, nested = false) {
     const style = document.createElement('style');
     style.id = `STYLES_${escapeID(this.id)}`;
     for(const key in css) {
-      if(key == 'inline')
-        continue;
-
-      let selector = key == 'default' ? '' : key;
-      if(selector.charAt(0) != '@')
-        selector = `#w_${escapeID(this.id)}${selector}`;
-      style.appendChild(document.createTextNode(`${selector} { ${mapAssetURLs(this.cssReplaceProperties(this.cssAsText(css[key])))} }`));
+      let selector = key;
+      if(!nested) {
+        if(key == 'inline')
+          continue;
+        if(key == 'default')
+          selector = '';
+        if(selector.charAt(0) != '@')
+          selector = `#w_${escapeID(this.id)}${selector}`;
+      }
+      style.appendChild(document.createTextNode(`${selector} { ${mapAssetURLs(this.cssReplaceProperties(this.cssAsText(css[key], true)))} }`));
     }
+    if(nested)
+      return style.textContent;
     $('head').appendChild(style);
-
     return this.cssAsText(css.inline || '');
   }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -364,6 +364,7 @@ export class Widget extends StateManaged {
       return applyTransformedOffset(parentCenter, offset, s, rot );
     }
   }
+
   css() {
     this.propertiesUsedInCSS = [];
     if($(`#STYLES_${escapeID(this.id)}`))
@@ -392,6 +393,7 @@ export class Widget extends StateManaged {
       return css;
     }
   }
+
   cssBorderRadius() {
     let br = this.get('borderRadius');
     switch(typeof(br)) {
@@ -427,8 +429,7 @@ export class Widget extends StateManaged {
   }
 
   cssToStylesheet(css, nested = false) {
-    const style = document.createElement('style');
-    style.id = `STYLES_${escapeID(this.id)}`;
+    let styleString = '';
     for(const key in css) {
       let selector = key;
       if(!nested) {
@@ -439,11 +440,17 @@ export class Widget extends StateManaged {
         if(selector.charAt(0) != '@')
           selector = `#w_${escapeID(this.id)}${selector}`;
       }
-      style.appendChild(document.createTextNode(`${selector} { ${mapAssetURLs(this.cssReplaceProperties(this.cssAsText(css[key], true)))} }`));
+      styleString += `${selector} { ${mapAssetURLs(this.cssReplaceProperties(this.cssAsText(css[key], true)))} }\n`;
     }
+
     if(nested)
-      return style.textContent;
+      return styleString;
+
+    const style = document.createElement('style');
+    style.id = `STYLES_${escapeID(this.id)}`;
+    style.appendChild(document.createTextNode(styleString));
     $('head').appendChild(style);
+
     return this.cssAsText(css.inline || '');
   }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -429,9 +429,15 @@ export class Widget extends StateManaged {
   cssToStylesheet(css) {
     const style = document.createElement('style');
     style.id = `STYLES_${escapeID(this.id)}`;
-    for(const key in css)
-      if(key != 'inline')
-        style.appendChild(document.createTextNode(`#w_${escapeID(this.id)}${key == 'default' ? '' : key} { ${mapAssetURLs(this.cssReplaceProperties(this.cssAsText(css[key])))} }`));
+    for(const key in css) {
+      if(key == 'inline')
+        continue;
+
+      let selector = key == 'default' ? '' : key;
+      if(selector.charAt(0) != '@')
+        selector = `#w_${escapeID(this.id)}${selector}`;
+      style.appendChild(document.createTextNode(`${selector} { ${mapAssetURLs(this.cssReplaceProperties(this.cssAsText(css[key])))} }`));
+    }
     $('head').appendChild(style);
 
     return this.cssAsText(css.inline || '');


### PR DESCRIPTION
Provides basic support for widget stylesheets to css `@`rules. Intended use is `@font-face` and `@keyframes`. Multiple `@font-face` rules can be added to a widget if they differ in trailing whitespace. Should work with other `@`rules that typically take blocks (though I can't think of any that would be useful currently - `@property` might be nice when supported in Firefox and Safari).

Support for nested css blocks added.