### PR TITLE
missing settings are read from `config.template.json`

### DIFF
--- a/server/config.mjs
+++ b/server/config.mjs
@@ -7,17 +7,21 @@ class Config {
       fs.copyFileSync(path.resolve() + '/config.template.json', path.resolve() + '/config.json');
 
     this.config = JSON.parse(fs.readFileSync(path.resolve() + '/config.json'));
+    this.configFallback = JSON.parse(fs.readFileSync(path.resolve() + '/config.template.json'));
   }
 
   directory(index) {
-    if(this.config.directories[index][0] == '/')
-      return this.config.directories[index];
+    if(this.get('directories')[index][0] == '/')
+      return this.get('directories')[index];
     else
-      return path.resolve() + '/' + this.config.directories[index];
+      return path.resolve() + '/' + this.get('directories')[index];
   }
 
   get(index) {
-    return this.config[index];
+    if(this.config[index] !== undefined)
+      return this.config[index];
+    else
+      return this.configFallback[index];
   }
 }
 

--- a/server/config.mjs
+++ b/server/config.mjs
@@ -6,22 +6,19 @@ class Config {
     if(!fs.existsSync(path.resolve() + '/config.json'))
       fs.copyFileSync(path.resolve() + '/config.template.json', path.resolve() + '/config.json');
 
-    this.config = JSON.parse(fs.readFileSync(path.resolve() + '/config.json'));
-    this.configFallback = JSON.parse(fs.readFileSync(path.resolve() + '/config.template.json'));
+    this.config = JSON.parse(fs.readFileSync(path.resolve() + '/config.template.json'));
+    this.config = Object.assign(this.config, JSON.parse(fs.readFileSync(path.resolve() + '/config.json')));
   }
 
   directory(index) {
-    if(this.get('directories')[index][0] == '/')
-      return this.get('directories')[index];
+    if(this.config.directories[index][0] == '/')
+      return this.config.directories[index];
     else
-      return path.resolve() + '/' + this.get('directories')[index];
+      return path.resolve() + '/' + this.config.directories[index];
   }
 
   get(index) {
-    if(this.config[index] !== undefined)
-      return this.config[index];
-    else
-      return this.configFallback[index];
+    return this.config[index];
   }
 }
 


### PR DESCRIPTION
When #1087 added the new config parameter `urlPrefix`, everyone had to add it to their `config.json` or the server would immediately crash.

This PR now adds a fallback so that config parameters that are not defined in `config.json` will be read from `config.template.json` instead. This means you now only have to set stuff in `config.json` if it is not the default.