### PR TITLE
modify default player colors

### DIFF
--- a/server/room.mjs
+++ b/server/room.mjs
@@ -309,7 +309,7 @@ export default class Room {
     const f = n => {
       const k = (n + hue / 30) % 12;
       const c = .5 - .5 * Math.max(Math.min(k - 3, 9 - k, 1), -1);
-      return Math.round(255 * c).toString(16).padStart(2, '0');
+      return Math.round((180 - 40 * Math.cos(hue/60*Math.PI)) * c).toString(16).padStart(2, '0');
     }
     return `#${f(0)}${f(8)}${f(4)}`;
   }

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -306,10 +306,12 @@ export default class Room {
       const gap = Math.max(...gaps);
       hue = (Math.random() * gap / 3 + hues[gaps.indexOf(gap)] + gap / 3) % 360;
     }
+    const v = [240, 220, 120, 200, 240, 240];
+    const value = v[Math.floor(hue/60)] * (60 - hue%60) / 60 + v[Math.ceil(hue/60) % 6] * (hue%60) / 60;
     const f = n => {
       const k = (n + hue / 30) % 12;
       const c = .5 - .5 * Math.max(Math.min(k - 3, 9 - k, 1), -1);
-      return Math.round((180 - 40 * Math.cos(hue/60*Math.PI)) * c).toString(16).padStart(2, '0');
+      return Math.round(value * c).toString(16).padStart(2, '0');
     }
     return `#${f(0)}${f(8)}${f(4)}`;
   }


### PR DESCRIPTION
I've never really been thrilled with the default player colors. This PR changes the default colors selected for new players (somewhat reducing the value component of the color).

The value is reduced the most for the primary colors (pure red, green, blue: value reduced from 255/255 to 140/255) and the least for the secondary colors (yellow, cyan, magenta: value reduced from 255/255 to 220/255). This [CodePen demo](https://codepen.io/robartsd/pen/LYOEZrX?editors=1100) shows the existing spectrum of colors chosen, an approximation of the new spectrum chosen (gradient points at 15 degree hue angles are accurate, but colors between those points may be slightly different), and sample spectrums of colors that are desaturated enough to be ignored when choosing the hue for a new player color (this is not a change from what is currently in main). While technically this reduces the color space used by the default player colors, I think colors in this range are more distinquishable (particularly the colors containing green components). I very much prefer the darker green (and didn't want to darken the yellow any more than I did). I might prefer the reds and blues a bit brighter.