### PR TITLE
added commands for exporting and importing assets

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -463,7 +463,7 @@ const jeCommands = [
               const propertyName = keys.shift();
               const property = JSON.parse(JSON.stringify(widget.get(propertyName)));
 
-              if(keys.length > 1) {
+              if(keys.length > 0) {
                 let pointer = property;
                 while(keys.length > 1)
                   pointer = pointer[keys.shift()];

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -463,12 +463,16 @@ const jeCommands = [
               const propertyName = keys.shift();
               const property = JSON.parse(JSON.stringify(widget.get(propertyName)));
 
-              let pointer = property;
-              while(keys.length > 1)
-                pointer = pointer[keys.shift()];
-              pointer[keys[0]] = newAsset;
+              if(keys.length > 1) {
+                let pointer = property;
+                while(keys.length > 1)
+                  pointer = pointer[keys.shift()];
+                pointer[keys[0]] = newAsset;
 
-              await widget.set(propertyName, property);
+                await widget.set(propertyName, property);
+              } else {
+                await widget.set(propertyName, newAsset);
+              }
             } catch(e) {
               console.error(`Failed to update ${filename}. Please make sure the filename corresponds to a valid widget property.`);
             }


### PR DESCRIPTION
The main JSON editor toolbar now has a button that downloads all room assets as a zip file with the files named after their widget ID and property.

You can then extract and edit those images on your machine and use the second new button to upload one or more of the edited files. The new assets will then be uploaded and based on the filename, the new asset URL will be updated in the room state.


If you use the same asset in multiple places, this would decouple them unless you upload the same new asset for each of the properties it is used in. Because of that the download can optionally create files named after their asset URL. After editing and re-uploading them, the filename is used to find the old asset URL and it gets replaced by the newly created one.

- [ ] This needs to escape special characters like `/` in filenames.