### PR TITLE
copy canvas image to enlarged

### DIFF
--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -2,6 +2,7 @@ class Canvas extends Widget {
   constructor(id) {
     super(id);
     this.canvas = document.createElement('canvas');
+    this.canvas.dataset.id = id;
     this.context = this.canvas.getContext('2d');
 
     const defaults = {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1826,6 +1826,13 @@ export class Widget extends StateManaged {
       e.innerHTML = this.domElement.innerHTML;
       e.className = this.domElement.className;
       e.dataset.id = id;
+      for(const clone of e.querySelectorAll('canvas')) {
+        const original = this.domElement.querySelector(`canvas[data-id = '${clone.dataset.id}']`);
+        const context = clone.getContext('2d');
+        clone.width = original.width;
+        clone.height = original.height;
+        context.drawImage(original, 0, 0);
+      }
       e.style.cssText = cssText;
       e.style.display = this.domElement.style.display;
       e.style.transform = `scale(calc(${this.get('enlarge')} * var(--scale)))`;


### PR DESCRIPTION
Fixes #1207 

If a canvas is enlarged, the enlarged widget updates with the canvas. A child canvas is also copied, but like other child widgets, it is not updated live in the enlarged widget.