### PR TITLE
improved debug output for invalid expressions

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -700,7 +700,7 @@ export class Widget extends StateManaged {
             // ignore (but log) blank and comment only lines
             if(jeRoutineLogging) jeLoggingRoutineOperationSummary(comment[1]||'');
           } else {
-            problems.push('String could not be interpreted as expression. Please check your syntax and note that many characters have to be escaped.');
+            problems.push(`String '${a}' could not be interpreted as a valid expression. Please check your syntax and note that many characters have to be escaped.`);
           }
         }
       }
@@ -1846,7 +1846,7 @@ export class Widget extends StateManaged {
         e.classList.add('right');
       if(cursor.top < window.innerHeight/2)
         e.classList.add('bottom');
-      
+
       const wStyle = $(`#STYLES_${escapeID(id)}`);
       if(wStyle) {
         if($('#enlargeStyle'))


### PR DESCRIPTION
The debugger would just print a red `var`. Now the message includes the complete string so it is easier to find.