### PR TITLE
Assign function keys using descending Z-order.

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1840,10 +1840,14 @@ window.addEventListener('mousemove', function(e) {
         hoveredWidgets.push(widget);
 
   hoveredWidgets.sort(function(w1,w2) {
+    const hiddenParent =  function(widget) {
+      return widget ? widget.classes().includes('foreign') || hiddenParent(widget.parent) : false
+    };
+
     const w1card = w1.get('type') == 'card';
     const w2card = w2.get('type') == 'card';
-    const w1foreign = w1.classes().includes('foreign') && !w1card;
-    const w2foreign = w2.classes().includes('foreign') && !w2card;
+    const w1foreign = !w1card && hiddenParent(w1);
+    const w2foreign =  !w2card && hiddenParent(w2);
     const w1normal = !w1foreign && !w1card;
     const w2normal = !w2foreign && !w2card;
     return ((w1card && w2card) || (w1foreign && w2foreign) || (w1normal && w2normal)) ?

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1839,7 +1839,17 @@ window.addEventListener('mousemove', function(e) {
       if(jeState.mouseY >= widget.absoluteCoord('y') && jeState.mouseY <= widget.absoluteCoord('y')+widget.get('height'))
         hoveredWidgets.push(widget);
 
-  hoveredWidgets.sort(function(w1,w2){return w2.calculateZ() - w1.calculateZ()});
+  hoveredWidgets.sort(function(w1,w2) {
+    const w1card = w1.get('type') == 'card';
+    const w2card = w2.get('type') == 'card';
+    const w1foreign = w1.classes().includes('foreign') && !w1card;
+    const w2foreign = w2.classes().includes('foreign') && !w2card;
+    const w1normal = !w1foreign && !w1card;
+    const w2normal = !w2foreign && !w2card;
+    return ((w1card && w2card) || (w1foreign && w2foreign) || (w1normal && w2normal)) ?
+      w2.calculateZ() - w1.calculateZ() :
+      ((w1card && !w2card) || (w1foreign && w2normal)) ? 1 : -1;
+  });
   
   for(let i=1; i<=11; ++i) {
     const hotkey = i>=4 ? i+1 : i;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1839,6 +1839,8 @@ window.addEventListener('mousemove', function(e) {
       if(jeState.mouseY >= widget.absoluteCoord('y') && jeState.mouseY <= widget.absoluteCoord('y')+widget.get('height'))
         hoveredWidgets.push(widget);
 
+  hoveredWidgets.sort(function(w1,w2){return w2.calculateZ() - w1.calculateZ()});
+  
   for(let i=1; i<=11; ++i) {
     const hotkey = i>=4 ? i+1 : i;
     if(hoveredWidgets[i-1]) {


### PR DESCRIPTION
Sort widgets under mouse so that widget on top gets F1 and function keys are assigned in descending order. Fixes #401 