### PR TITLE
Put widget tree in its own area in JSON editor

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -34,7 +34,7 @@
 
 /*** Tree and widget display area ***/
 #jeEditArea {
-  --treeheight: 40%;
+  --treeheight: 70%;
   display: grid;
   grid-template-columns: 60% 40%;
   grid-template-rows: 4% var(--treeheight)  8px auto;

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -105,8 +105,8 @@ ul, .jeTreeDisplay, .jeNestedTree {
 }
 
 li, .jeNestedTree {
-    margin-left: 10px;
-    padding-left: 0;
+  margin-left: 10px;
+  padding-left: 0;
 }
 
 /* Style the caret/arrow */
@@ -155,33 +155,33 @@ li, .jeNestedTree {
 
 /*** CSS to handle search box for tree widget ***/
 #jeWidgetSearchBox {
-    position: relative;
-    top: 1px;
-    width: calc(0.5 * var(--editorPaneWidth));
+  position: relative;
+  top: 1px;
+  width: calc(0.5 * var(--editorPaneWidth));
 }
 
 #jeWidgetSearchResults {
-    display: block;
-    height: 100%;
-    overflow:scroll
+  display: block;
+  height: 100%;
+  overflow:scroll
 }
 
 #jeWidgetSearchResults > table {
-    display: block;
-    width: calc(0.6 * var(--editorPaneWidth));
-    height: 80%;
-    position: relative;
-    left: calc(0.2 * var(--editorPaneWidth));
-    color: black;
-    background-color: gray;
-    border:1 px solid black;
-    opacity: 100%;
-    overflow-x: hidden;
-    overflow-y: scroll;
+  display: block;
+  width: calc(0.6 * var(--editorPaneWidth));
+  height: 80%;
+  position: relative;
+  left: calc(0.2 * var(--editorPaneWidth));
+  color: black;
+  background-color: gray;
+  border:1 px solid black;
+  opacity: 100%;
+  overflow-x: hidden;
+  overflow-y: scroll;
 }
 
 .jeHighlightRow {
-    background-color: gray;
+  background-color: gray;
 }
 
 /**** End tree search CSS ****/
@@ -201,6 +201,10 @@ i.null    { color: blue;    }
 i.default { color: #606060; }
 i.variable{ color: #40e0d0; }
 i.error   { color: red; font-weight: bold; }
+
+body.jsonEdit .selectedInEdit {
+  box-shadow: 0px 0px 0px 5px yellow;
+}
 
 /**** End color formatting ****/
 
@@ -476,7 +480,7 @@ body.jsonEdit.jeZoomOut #topSurface {
   content: '[tag]';
 }
 #widget_css::before{
-    content: '[style]';
+  content: '[style]';
   }
 #widget_rotation::before{
   content: '[rotate_right]';

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -163,6 +163,7 @@ i.error   { color: red; font-weight: bold; }
 
 /*** End formatting for edit area grid regions ***/
 
+/*** CSS to handle search box for compute operations ***/
 #var_results > table {
   table-layout: fixed;
 }
@@ -173,7 +174,24 @@ i.error   { color: red; font-weight: bold; }
   overflow: hidden;
   text-overflow: ellipsis;
 }
+/*** End compute operations CSS ***/
 
+/*** CSS to handle search box for tree widget ***/
+#tree_results > table {
+    table-layout: fixed;
+    position: absolute;
+    top: 25px;
+    left: 25px;
+    color: white;
+    background-color: black;
+}
+
+#tree_results > table > tbody > tr > td:nth-child(1) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/*** End tree widget CSS ***/
 #jeCommands {
   white-space: pre-wrap;
   height: 100%;

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -157,7 +157,8 @@ li, .jeNestedTree {
 #jeWidgetSearchBox {
   position: relative;
   top: 1px;
-  width: calc(0.5 * var(--editorPaneWidth));
+  width: calc(0.4 * var(--editorPaneWidth));
+  left: 0;
 }
 
 #jeWidgetSearchResults {
@@ -168,10 +169,10 @@ li, .jeNestedTree {
 
 #jeWidgetSearchResults > table {
   display: block;
-  width: calc(0.6 * var(--editorPaneWidth));
+  width: calc(0.4 * var(--editorPaneWidth));
   height: 80%;
   position: relative;
-  left: calc(0.2 * var(--editorPaneWidth));
+  left: calc(0.15 * var(--editorPaneWidth));
   color: black;
   background-color: gray;
   border:1 px solid black;

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -32,12 +32,13 @@
   box-sizing: border-box;
 }
 
-/*** Tree and widget display area ***/
+/*** Tree and widget display/edit area ***/
+/**** CSS to set up the grid ****/
 #jeEditArea {
-  --treeheight: 70%;
+  --treeHeight: 70%;
   display: grid;
   grid-template-columns: 60% 40%;
-  grid-template-rows: 4% var(--treeheight)  8px auto;
+  grid-template-rows: 4% 25px var(--treeHeight)  8px auto;
   row-gap: 0px;
   top: 0;
   height: 100%;
@@ -47,29 +48,55 @@
 }
 
 #jeEditHeader {
-  grid-column-start: 1;
-  grid-row-start: 1;
+  grid-column: 1 / span 1;
+  grid-row: 1 / span 1;
   border-bottom: 1px solid white;
 }
 
 #jeMouseCoords {
-  grid-column-start: 2;
-  grid-row-start: 1;
+  grid-column: 2 / span 1;
+  grid-row: 1 /span 1;
   display: block;
   text-align: right;
   right: calc(var(--commandPaneWidth) + 20px);
   border-bottom: 1px solid white;
 }
 
+#jeWidgetSearch {
+  grid-column: 1 / span 2;
+  grid-row: 2 / span 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+
 #jeTree {
-  grid-column-start: 1;
-  grid-column-end: 3;
-  grid-row-start: 2;
+  grid-column: 1 / span 2;
+  grid-row: 3 / span 1;
   overflow-wrap: break-word;
   overflow-y: auto;
   white-space: pre-wrap;
   cursor: pointer;
+  border-top: 1px solid gray;
 }
+
+#jeResize {
+  content: '';
+  grid-column: 1 / span 2;
+  grid-row: 4 / span 1;
+  cursor: ns-resize;
+  background-color: #b8c6db;
+  background-image: linear-gradient(#b8c6db 0%, #f5f7fa 20%, #b8c6db 80%);
+}
+
+#jeText, #jeTextHighlight {
+  grid-column: 1 / span 2;
+  grid-row: 5 / span 1;
+  white-space: pre-wrap;
+  overflow-y: auto;
+  overflow-wrap: break-word;
+}
+/**** End of grid layout ****/
 
 ul, .jeTreeDisplay, .jeNestedTree {
   margin: 0;
@@ -114,38 +141,49 @@ li, .jeNestedTree {
   display: block;
 }
 
-#jeResize {
-  content: '';
-  grid-column-start: 1;
-  grid-column-end: 3;
-  grid-row-start: 3;
-  cursor: ns-resize;
-  background-color: #b8c6db;
-  background-image: linear-gradient(#b8c6db 0%, #f5f7fa 20%, #b8c6db 80%);
-}
-#jeText, #jeTextHighlight {
-  grid-column-start: 1;
-  grid-column-end: 3;
-  grid-row-start: 4;
-  white-space: pre-wrap;
-  overflow-y: auto;
-  overflow-wrap: break-word;
-}
-
 #jeText {
   background: none;
   -webkit-text-fill-color: transparent;
   text-fill-color: transparent;
   outline: none;
 }
+
 #jeText::selection {
   background-color: #808080;
   -webkit-text-fill-color: white;
 }
 
-/*** End setup of edit area grid ***/
+/*** CSS to handle search box for tree widget ***/
+#jeWidgetSearchBox {
+    position: relative;
+    top: 1px;
+    width: calc(0.6 * var(--editorPaneWidth));
+    left: calc(0.2 * var(--editorPaneWidth));
+}
 
-/*** Formatting for edit area grid regions ***/
+#jeWidgetSearchResults {
+    display: block;
+    height: 100%;
+    overflow:scroll
+}
+
+#jeWidgetSearchResults > table {
+    display: block;
+    width: calc(0.6 * var(--editorPaneWidth));
+    height: 80%;
+    position: relative;
+    left: calc(0.2 * var(--editorPaneWidth));
+    color: black;
+    background-color: gray;
+    border:1 px solid black;
+    opacity: 100%;
+    overflow-x: hidden;
+    overflow-y: scroll;
+}
+
+/**** End tree search CSS ****/
+
+/**** Color formatting for widgets ****/
 
 #jsonEditor i {
   font-style: normal;
@@ -161,7 +199,9 @@ i.default { color: #606060; }
 i.variable{ color: #40e0d0; }
 i.error   { color: red; font-weight: bold; }
 
-/*** End formatting for edit area grid regions ***/
+/**** End color formatting ****/
+
+/*** End setup of edit area ***/
 
 /*** CSS to handle search box for compute operations ***/
 #var_results > table {
@@ -176,22 +216,6 @@ i.error   { color: red; font-weight: bold; }
 }
 /*** End compute operations CSS ***/
 
-/*** CSS to handle search box for tree widget ***/
-#tree_results > table {
-    table-layout: fixed;
-    position: absolute;
-    top: 25px;
-    left: 25px;
-    color: white;
-    background-color: black;
-}
-
-#tree_results > table > tbody > tr > td:nth-child(1) {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-/*** End tree widget CSS ***/
 #jeCommands {
   white-space: pre-wrap;
   height: 100%;

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -161,6 +161,7 @@ li, .jeNestedTree {
 /*** CSS to handle search box for tree widget ***/
 #jeWidgetSearchBox {
   margin-top: 1px;
+  width: 50%;
 }
 
 #jeSearchTable {

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -68,6 +68,50 @@
   overflow-wrap: break-word;
   overflow-y: auto;
   white-space: pre-wrap;
+  cursor: pointer;
+}
+
+ul, .jeTreeDisplay, .jeNestedTree {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+li, .jeNestedTree {
+    margin-left: 10px;
+    padding-left: 0;
+}
+
+/* Style the caret/arrow */
+.jeTreeExpander, .jeTreeExpander-down {
+  user-select: none; /* Prevent text selection */
+}
+
+/* Create the caret/arrow with a unicode, and style it */
+.jeTreeExpander::before {
+  content: "\25B6";
+  color: white;
+  display: inline-block;
+  margin-right: 6px;
+}
+
+/* Rotate the caret/arrow icon when clicked on (using JavaScript) */
+.jeTreeExpander-down::before {
+  content: "\25B6";
+  color: white;
+  display: inline-block;
+  margin-right: 6px;
+  transform: rotate(90deg);
+}
+
+/* Hide the nested list */
+.nested {
+  display: none;
+}
+
+/* Show the nested list when the user clicks on the caret/arrow (with JavaScript) */
+.active {
+  display: block;
 }
 
 #jeResize {

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -157,8 +157,7 @@ li, .jeNestedTree {
 #jeWidgetSearchBox {
     position: relative;
     top: 1px;
-    width: calc(0.6 * var(--editorPaneWidth));
-    left: calc(0.2 * var(--editorPaneWidth));
+    width: calc(0.5 * var(--editorPaneWidth));
 }
 
 #jeWidgetSearchResults {

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -164,21 +164,20 @@ li, .jeNestedTree {
 #jeWidgetSearchResults {
   display: block;
   height: 100%;
-  overflow:scroll
+  overflow:scroll;
 }
 
 #jeWidgetSearchResults > table {
   display: block;
-  width: calc(0.4 * var(--editorPaneWidth));
-  height: 80%;
+  width: var(--editorPaneWidth);
+  height: 100%;
+  left: 0;
   position: relative;
-  left: calc(0.15 * var(--editorPaneWidth));
-  color: black;
-  background-color: gray;
-  border:1 px solid black;
+  background-color: #484848;
   opacity: 100%;
   overflow-x: hidden;
   overflow-y: scroll;
+  z-index: 1;
 }
 
 .jeHighlightRow {

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -77,7 +77,7 @@
   overflow-y: auto;
   white-space: pre-wrap;
   cursor: pointer;
-  border-top: 1px solid gray;
+  border-top: 1px dashed gray;
 }
 
 #jeResize {
@@ -179,6 +179,10 @@ li, .jeNestedTree {
     opacity: 100%;
     overflow-x: hidden;
     overflow-y: scroll;
+}
+
+.jeHighlightRow {
+    background-color: gray;
 }
 
 /**** End tree search CSS ****/

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -38,7 +38,7 @@
   --treeHeight: 70%;
   display: grid;
   grid-template-columns: 60% 40%;
-  grid-template-rows: 4% 25px var(--treeHeight)  8px auto;
+  grid-template-rows: min-content 25px var(--treeHeight)  8px auto;
   row-gap: 0px;
   top: 0;
   height: 100%;

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -196,6 +196,7 @@ li, .jeNestedTree {
 i.key     { color: yellow;  }
 i.custom  { color: orange;  }
 i.extern  { color: red;     }
+.extern   { color: red;     }
 i.string  { color: #7ed07e; }
 i.number  { color: #dda0dd; }
 i.null    { color: blue;    }

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -203,7 +203,11 @@ i.default { color: #606060; }
 i.variable{ color: #40e0d0; }
 i.error   { color: red; font-weight: bold; }
 
-body.jsonEdit .selectedInEdit {
+body.jsonEdit .selectedInEdit:not(.pile) {
+  box-shadow: 0px 0px 0px 5px yellow;
+}
+
+body.jsonEdit .selectedInEdit.pile .handle {
   box-shadow: 0px 0px 0px 5px yellow;
 }
 

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -211,6 +211,11 @@ body.jsonEdit .selectedInEdit.pile .handle {
   box-shadow: 0px 0px 0px 5px yellow;
 }
 
+body.jsonEdit:not(.edit) .selectedInEdit.deck {
+  display: block;
+  font-size: 0;
+}
+
 /**** End color formatting ****/
 
 /*** End setup of edit area ***/

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -32,12 +32,47 @@
   box-sizing: border-box;
 }
 
-#jeText, #jeTextHighlight {
-  white-space: pre-wrap;
-  overflow-y: auto;
+/*** Tree and widget display area ***/
+#jeEditArea {
+  --treeheight: 40%;
+  display: grid;
+  grid-template-columns: 60% 40%;
+  grid-template-rows: 5% var(--treeheight) auto;
+  row-gap: 5px;
+  top: 0;
   height: 100%;
   width: var(--editorPaneWidth);
   right: var(--commandPaneWidth);
+}
+
+#jeEditHeader {
+  grid-column-start: 1;
+  grid-row-start: 1;
+}
+
+#jeMouseCoords {
+  grid-column-start: 2;
+  grid-row-start: 1;
+  display: block;
+  text-align: right;
+  right: calc(var(--commandPaneWidth) + 20px);
+}
+
+#jeTree {
+  grid-column-start: 1;
+  grid-column-end: 3;
+  grid-row-start: 2;
+  overflow-wrap: break-word;
+  overflow-y: auto;
+  white-space: pre-wrap;
+}
+
+#jeText, #jeTextHighlight {
+  grid-column-start: 1;
+  grid-column-end: 3;
+  grid-row-start: 3;
+  white-space: pre-wrap;
+  overflow-y: auto;
   overflow-wrap: break-word;
 }
 
@@ -52,16 +87,9 @@
   -webkit-text-fill-color: white;
 }
 
-#var_results > table {
-  table-layout: fixed;
-}
+/*** End setup of edit area grid ***/
 
-#var_results > table > tbody > tr > td:nth-child(1) {
-  min-width: 60px;
-  max-width: 60px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+/*** Formatting for edit area grid regions ***/
 
 #jsonEditor i {
   font-style: normal;
@@ -76,6 +104,19 @@ i.null    { color: blue;    }
 i.default { color: #606060; }
 i.variable{ color: #40e0d0; }
 i.error   { color: red; font-weight: bold; }
+
+/*** End formatting for edit area grid regions ***/
+
+#var_results > table {
+  table-layout: fixed;
+}
+
+#var_results > table > tbody > tr > td:nth-child(1) {
+  min-width: 60px;
+  max-width: 60px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
 #jeCommands {
   white-space: pre-wrap;
@@ -138,11 +179,6 @@ body.jsonEdit.jeZoomOut #roomArea {
 
 body.jsonEdit.jeZoomOut #topSurface {
   overflow: visible;
-}
-
-#jeMouseCoords {
-  display: block;
-  right: calc(var(--commandPaneWidth) + 20px);
 }
 
 #jeLogWrapper {

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -37,17 +37,19 @@
   --treeheight: 40%;
   display: grid;
   grid-template-columns: 60% 40%;
-  grid-template-rows: 5% var(--treeheight) auto;
-  row-gap: 5px;
+  grid-template-rows: 4% var(--treeheight)  8px auto;
+  row-gap: 0px;
   top: 0;
   height: 100%;
   width: var(--editorPaneWidth);
   right: var(--commandPaneWidth);
+  border: 1px solid white;
 }
 
 #jeEditHeader {
   grid-column-start: 1;
   grid-row-start: 1;
+  border-bottom: 1px solid white;
 }
 
 #jeMouseCoords {
@@ -56,6 +58,7 @@
   display: block;
   text-align: right;
   right: calc(var(--commandPaneWidth) + 20px);
+  border-bottom: 1px solid white;
 }
 
 #jeTree {
@@ -67,10 +70,19 @@
   white-space: pre-wrap;
 }
 
-#jeText, #jeTextHighlight {
+#jeResize {
+  content: '';
   grid-column-start: 1;
   grid-column-end: 3;
   grid-row-start: 3;
+  cursor: ns-resize;
+  background-color: #b8c6db;
+  background-image: linear-gradient(#b8c6db 0%, #f5f7fa 20%, #b8c6db 80%);
+}
+#jeText, #jeTextHighlight {
+  grid-column-start: 1;
+  grid-column-end: 3;
+  grid-row-start: 4;
   white-space: pre-wrap;
   overflow-y: auto;
   overflow-wrap: break-word;

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -593,7 +593,9 @@ function addCompositeWidgetToAddWidgetOverlay(widgetsToAdd, onClick) {
     w.domElement.id = w.id;
     if(!wi.parent) {
       w.domElement.addEventListener('click', async _=>{
+        batchStart();
         overlayDone(await onClick());
+        batchEnd();
       });
       $('#addOverlay').appendChild(w.domElement);
     }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -449,9 +449,7 @@ const jeCommands = [
     call: async function() {
       for(const id of jeSelectedIDs())
         await removeWidgetLocal(id);
-      jeStateNow = null;
-      jeWidget = null;
-      jeDisplayTree();
+      jeEmpty();
     }
   },
   {
@@ -951,7 +949,7 @@ function jeApplyDelta(delta, widgetWasAdded) {
     for(const field of [ 'id', 'deck' ]) {
       if(!jeDeltaIsOurs && jeStateNow && jeStateNow[field] && delta.s[jeStateNow[field]] !== undefined) {
         if(delta.s[jeStateNow[field]] === null) {
-          jeDisplayTree();
+          jeEmpty();
         } else {
           if(jeKeyIsDown) {
             jeKeyIsDownDeltas.push(delta.s[jeStateNow[field]]);
@@ -1900,12 +1898,9 @@ function jeShowCommands() {
 
 function jeToggle() {
   if(jeEnabled === null) {
-    $('#jeEditHeader').innerHTML = 'CTRL-click a widget on\nthe left to edit it.';
-    jeAddCommands();
-    jeDisplayTree();
+    jeEmpty();
     $('#jeText').addEventListener('input', jeColorize);
     $('#jeText').onscroll = e=>$('#jeTextHighlight').scrollTop = e.target.scrollTop;
-    jeColorize();
   }
   jeEnabled = !jeEnabled;
   jeRoutineLogging = jeEnabled;
@@ -1918,9 +1913,21 @@ function jeToggle() {
   setScale();
 }
 
+function jeEmpty() {
+  jeMode = 'empty';
+  jeContext = [ 'No widget selected.' ];
+  jeStateNow = null;
+  jeWidget = null;
+
+  jeSet('');
+  jeAddCommands();
+  jeDisplayTree();
+  jeShowCommands();
+}
+
 const clickButton = async function(event) {
   await jeCallCommand(jeCommands.find(o => o.id == event.currentTarget.id));
-  if (jeContext != 'macro') {
+  if(jeMode != 'macro' && jeMode != 'empty') {
     jeGetContext();
     if((jeWidget || jeMode == 'multi') && !jeJSONerror)
       await jeApplyChanges();

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1268,7 +1268,7 @@ function jeDisplayTree() {
   const allWidgets = Array.from(widgets.values());
   $('#jeTree').innerHTML = '<ul class=jeTreeDisplay>' + jeDisplayTreeAddWidgets(allWidgets, null) + '</ul>';
 
-  $('#jeWidgetSearch').innerHTML = '<label for="jeWidgetSearchBox" class=extern>Search Room: </label><input id="jeWidgetSearchBox" type="text"><div id="jeWidgetSearchResults"></div>';
+  $('#jeWidgetSearch').innerHTML = '<label for="jeWidgetSearchBox" class=extern>Search Room: </label><input id="jeWidgetSearchBox" type="text" style="margin-bottom: 4px;"><div id="jeWidgetSearchResults"></div>';
 
   // Add handlers to tree elements to display widget contents
   on('.jeTreeExpander', 'click', function(e) {
@@ -1323,11 +1323,18 @@ function jeDisplayTreeAddWidgets(allWidgets, parent) {
 
 function jeDisplayFilteredWidgets() {
   const subtext = $('#jeWidgetSearchBox').value.toLowerCase();
-  const widgetIds = (Array.from(widgets.keys())).sort();
-  let results = widgetIds.filter(o => o.toLowerCase().includes(subtext));
+  const results = widgetFilter(o => o.get('id').toLowerCase().includes(subtext) ||
+          o.get('type') && o.get('type').toLowerCase().includes(subtext) ||
+          !o.get('type') && 'basic'.includes(subtext)).sort(
+            function(a,b) {
+              const na = a.get('id').toLowerCase();
+              const nb = b.get('id').toLowerCase();
+              return na < nb ? -1 : na > nb ? 1 : 0
+            }
+          );
   let resultTable = '<table id="jeSearchTable">';
   for(const w of results)
-    resultTable += '<tr valign=top><td class="jeInSearchWindow"><b>' + html(w) + '</b></td></tr>';
+    resultTable += '<tr valign=top><td class="jeInSearchWindow"><i class=key>' + html(w.get('id')) + '</i> - <i class=string>' + html(w.get('type') || 'basic') + '</i></td></tr>';
   resultTable += '</table>';
   $('#jeWidgetSearchResults').innerHTML = resultTable;
 }
@@ -1955,9 +1962,9 @@ window.addEventListener('mouseup', async function(e) {
     if(e.target.parentElement && e.target.parentElement.classList.contains('jeTreeWidget'))
       newWidget = e.target.parentElement.children[0];
     else if (e.target.classList.contains("jeInSearchWindow"))
-      newWidget = e.target;
+      newWidget = e.target.children[0];
     else if (e.target.parentElement && e.target.parentElement.classList.contains("jeInSearchWindow"))
-      newWidget = e.target.parentElement;
+      newWidget = e.target.parentElement.children[0];
 
     if(newWidget) {
       jeContext = [ 'Tree', `"${newWidget.textContent}"`];

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1268,7 +1268,7 @@ function jeDisplayTree() {
   const allWidgets = Array.from(widgets.values());
   $('#jeTree').innerHTML = '<ul class=jeTreeDisplay>' + jeDisplayTreeAddWidgets(allWidgets, null) + '</ul>';
 
-  $('#jeWidgetSearch').innerHTML = '<label for="jeWidgetSearchBox">Search Room: </label><input id="jeWidgetSearchBox" type="text"><div id="jeWidgetSearchResults"></div>';
+  $('#jeWidgetSearch').innerHTML = '<label for="jeWidgetSearchBox" class=extern>Search Room: </label><input id="jeWidgetSearchBox" type="text"><div id="jeWidgetSearchResults"></div>';
 
   // Add handlers to tree elements to display widget contents
   on('.jeTreeExpander', 'click', function(e) {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1277,6 +1277,7 @@ function jeDisplayTree() {
     if(e.target.classList.contains('jeTreeExpander')) {
       $('.nested', e.target.parentElement).classList.toggle('active');
       e.target.classList.toggle('jeTreeExpander-down');
+      e.stopImmediatePropagation();
     }
   });
 
@@ -1288,6 +1289,11 @@ function jeDisplayTree() {
   jeMode = 'tree';
   jeContext = ['Tree'];
   jeShowCommands();
+
+  on('.jeTreeWidget', 'click', function(e) {
+    jeSelectWidget(widgets.get($('.key', e.currentTarget).innerText));
+    e.stopPropagation();
+  });
 }
 
 function jeDisplayTreeAddWidgets(allWidgets, parent) {
@@ -1339,6 +1345,10 @@ function jeDisplayFilteredWidgets() {
     resultTable += '<tr valign=top><td class="jeInSearchWindow"><i class=key>' + html(w.get('id')) + '</i> - <i class=string>' + html(w.get('type') || 'basic') + '</i></td></tr>';
   resultTable += '</table>';
   $('#jeWidgetSearchResults').innerHTML = resultTable;
+
+  on('.jeInSearchWindow', 'click', function(e) {
+    jeSelectWidget(widgets.get($('.key', e.currentTarget).innerText));
+  });
 }
 
 /* End of tree subpane control */
@@ -1954,27 +1964,9 @@ window.addEventListener('mouseup', async function(e) {
   if(!jeEnabled)
     return;
   jeRoutineResetOnNextLog = true;
-  if(e.target.id!="jeWidgetSearchBox") {
-    // Clear the search results
-    $('#jeWidgetSearchBox').value = '';
-    $('#jeWidgetSearchResults').innerHTML = '';
 
-    /* Check to see if user is selecting a widget for display */
-    let newWidget = null;
-    if(e.target.parentElement && e.target.parentElement.classList.contains('jeTreeWidget'))
-      newWidget = e.target.parentElement.children[0];
-    else if (e.target.classList.contains("jeInSearchWindow"))
-      newWidget = e.target.children[0];
-    else if (e.target.parentElement && e.target.parentElement.classList.contains("jeInSearchWindow"))
-      newWidget = e.target.parentElement.children[0];
-
-    if(newWidget) {
-      jeContext = [ 'Tree', `"${newWidget.textContent}"`];
-      jeCallCommand(jeCommands.find(o => o.id == 'je_openWidgetById'));
-    } else if(e.target == $('#jeText') && jeContext != 'macro') {// Click in widget text, fix context
-      jeGetContext();
-    }
-  }
+  if(e.target == $('#jeText') && jeContext != 'macro') // Click in widget text, fix context
+    jeGetContext();
 });
 
 onLoad(function() {
@@ -2042,6 +2034,13 @@ on('#jsonEditor', 'keydown', function(e) {
   if(e.key == 'Enter') {
     jeNewline();
     e.preventDefault();
+  }
+});
+
+on('body', 'click', function(e) {
+  if(jeEnabled) {
+    $('#jeWidgetSearchBox').value = '';
+    $('#jeWidgetSearchResults').innerHTML = '';
   }
 });
 

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1291,7 +1291,7 @@ function jeDisplayTree() {
   jeShowCommands();
 
   on('.jeTreeWidget', 'click', function(e) {
-    jeSelectWidget(widgets.get($('.key', e.currentTarget).innerText));
+    jeSelectWidget(widgets.get($('.key', e.currentTarget).innerText), false, e.shiftKey);
     e.stopPropagation();
   });
 }
@@ -1347,7 +1347,9 @@ function jeDisplayFilteredWidgets() {
   $('#jeWidgetSearchResults').innerHTML = resultTable;
 
   on('.jeInSearchWindow', 'click', function(e) {
-    jeSelectWidget(widgets.get($('.key', e.currentTarget).innerText));
+    jeSelectWidget(widgets.get($('.key', e.currentTarget).innerText), false, e.shiftKey);
+    if(e.shiftKey)
+      e.stopPropagation();
   });
 }
 

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1274,16 +1274,12 @@ function jeDisplayTree() {
   $('#jeWidgetSearch').innerHTML = '<i class=extern>Search Room:  </i><input id="jeWidgetSearchBox" type="text"><div id="jeWidgetSearchResults"></div>';
 
   // Add handlers to tree elements to display widget contents
-  let toggler = document.getElementsByClassName("jeTreeExpander");
-  let i;
-  for (i = 0; i < toggler.length; i++) {
-    toggler[i].addEventListener("click", function(e) {
-      if(e.target.classList.contains("jeTreeExpander")) {
-        e.target.parentElement.querySelector(".nested").classList.toggle("active");
-        e.target.classList.toggle("jeTreeExpander-down");
-      }
-    });
-  }
+  on('.jeTreeExpander', 'click', function(e) {
+    if(e.target.classList.contains('jeTreeExpander')) {
+      $('.nested', e.target.parentElement).classList.toggle('active');
+      e.target.classList.toggle('jeTreeExpander-down');
+    }
+  });
 
   // Add handler to search box to display widget list
   on('#jeWidgetSearchBox', 'input', jeDisplayFilteredWidgets);

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1245,28 +1245,20 @@ function jeColorize() {
 
 /* Displaying and controlling tree subpane of edit area */
 
-const editPanel = document.getElementById("jeEditArea");
+const editPanel = $('#jeEditArea');
 
-let mouse_pos;
+let mouse_reference;
+let resizer_reference;
 
 function resize(e){
-  function pad(w) {
-    return parseInt(window.getComputedStyle(document.getElementById("jeEditArea")).getPropertyValue(w).slice(0,-2))
-  };
-  const panelHeight = editPanel.clientHeight;
-  const resizeHeight = document.getElementById("jeResize").clientHeight;
-  const headerHeight = document.getElementById("jeEditHeader").clientHeight;
-  const treeHeight = document.querySelector('#jeTree').clientHeight;
-  const padding = pad('padding-top') + pad('padding-bottom');
-
-  const height = Math.max(0,Math.min(panelHeight - resizeHeight - headerHeight - padding, treeHeight + e.y - mouse_pos));
-  editPanel.style.setProperty('--treeHeight', height + "px"); 
-  mouse_pos = e.y;
+  const height = Math.min(editPanel.offsetHeight - 200, Math.max(0, resizer_reference - mouse_reference + e.y));
+  editPanel.style.setProperty('--treeHeight', height + "px");
 }
 
 editPanel.addEventListener("mousedown", function(e){
   if(e.target == $('#jeResize')) {
-    mouse_pos = e.y;
+    mouse_reference = e.y;
+    resizer_reference = $('#jeTree').offsetHeight;
     document.addEventListener("mousemove", resize, false);
   }
 });
@@ -1280,7 +1272,7 @@ function jeDisplayTree() {
   $('#jeTree').innerHTML = '<ul class=jeTreeDisplay>' + jeDisplayTreeAddWidgets(allWidgets, null) + '</ul>';
 
   $('#jeWidgetSearch').innerHTML = '<i class=extern>Search Room:  </i><input id="jeWidgetSearchBox" type="text"><div id="jeWidgetSearchResults"></div>';
-  
+
   // Add handlers to tree elements to display widget contents
   let toggler = document.getElementsByClassName("jeTreeExpander");
   let i;
@@ -1330,7 +1322,7 @@ function jeDisplayTreeAddWidgets(allWidgets, parent) {
     if(children)
       result += `<ul class="jeNestedTree nested ${widget.get('type')=='pile' ? '' : 'active'}">${children}</ul>`;
     result += '</li>';
-      
+
     delete allWidgets[allWidgets.indexOf(widget)];
   }
   return result;
@@ -1935,7 +1927,7 @@ window.addEventListener('mousemove', function(e) {
       w2.calculateZ() - w1.calculateZ() :
       ((w1card && !w2card) || (w1foreign && w2normal)) ? 1 : -1;
   });
-  
+
   for(let i=1; i<=11; ++i) {
     const hotkey = i>=4 ? i+1 : i;
     if(hoveredWidgets[i-1]) {
@@ -1967,7 +1959,7 @@ window.addEventListener('mouseup', async function(e) {
 
     /* Check to see if user is selecting a widget for display */
     let newWidget = null;
-    if(e.target.parentElement && e.target.parentElement.classList.contains('jeTreeWidget')) 
+    if(e.target.parentElement && e.target.parentElement.classList.contains('jeTreeWidget'))
       newWidget = e.target.parentElement.children[0];
     else if (e.target.classList.contains("jeInSearchWindow"))
       newWidget = e.target;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1260,13 +1260,15 @@ function resize(e){
 }
 
 editPanel.addEventListener("mousedown", function(e){
-  mouse_pos = e.y;
-  document.addEventListener("mousemove", resize, false);
-}, false);
+  if(e.target == $('#jeResize')) {
+    mouse_pos = e.y;
+    document.addEventListener("mousemove", resize, false);
+  }
+});
 
 document.addEventListener("mouseup", function(){
   document.removeEventListener("mousemove", resize, false);
-}, false);
+});
 
 function jeDisplayTree() {
   const allWidgets = Array.from(widgets.values());

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1112,6 +1112,13 @@ function jeSelectWidget(widget, dontFocus, addToSelection, restoreCursorPosition
     let selection = widgetList.filter( w => w.textContent == widget.get('id'))[0];
     selection.scrollIntoView({block: "center"});
     selection.parentElement.classList.toggle("jeHighlightRow");
+    widgetList = Array.from(document.getElementsByClassName("widget"));
+    widgetList.forEach( w => w.classList.toggle("selectedInEdit", false) );
+    console.log(widgetList);
+    selection = widgetList.filter( w => w.id == 'w_' + widget.get('id') )[0];
+    console.log(selection);
+    selection.classList.toggle("selectedInEdit", true);
+    console.log(selection);
 
     jeGetContext();
   }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1270,9 +1270,9 @@ document.addEventListener("mouseup", function(){
 
 function jeDisplayTree() {
   const allWidgets = Array.from(widgets.values());
-  $('#jeTree').innerHTML = '<ul class=jeTreeDisplay><i class=extern>Room</i>' + jeDisplayTreeAddWidgets(allWidgets, null) + '</ul>';
+  $('#jeTree').innerHTML = '<ul class=jeTreeDisplay>' + jeDisplayTreeAddWidgets(allWidgets, null) + '</ul>';
 
-  $('#jeWidgetSearch').innerHTML = '<input id="jeWidgetSearchBox" type="text"><div id="jeWidgetSearchResults"></div>';
+  $('#jeWidgetSearch').innerHTML = '<i class=extern>Search Room:  </i><input id="jeWidgetSearchBox" type="text"><div id="jeWidgetSearchResults"></div>';
   
   // Add handlers to tree elements to display widget contents
   let toggler = document.getElementsByClassName("jeTreeExpander");
@@ -1338,24 +1338,6 @@ function jeDisplayFilteredWidgets() {
     resultTable += '<tr valign=top><td class="jeInSearchWindow"><b>' + w + '</b></td></tr>';
   resultTable += '</table>';
   $('#jeWidgetSearchResults').innerHTML = resultTable;
-}
-
-function jeShowSelectedWidget(widget) {
-  jeContext = [ 'Tree', `"${widget.textContent}"`];
-  jeCallCommand(jeCommands.find(o => o.id == 'je_openWidgetById'));
-  editPanel.style.setProperty('--treeHeight', "20%");
-  let widgetList = Array.from(document.getElementsByClassName("key"));
-  widgetList.forEach( w => w.parentElement.classList.toggle("jeHighlightRow", false) );
-  let selection = widgetList.filter( w => w.textContent == widget.textContent)[0];
-  selection.scrollIntoView({block: "center"});
-  selection.parentElement.classList.toggle("jeHighlightRow");
-
-  jeGetContext();
-}
-
-function jeRemoveSearchResults() {
-  $('#jeWidgetSearchBox').value = '';
-  $('#jeWidgetSearchResults').innerHTML = '';
 }
 
 /* End of tree subpane control */
@@ -1972,7 +1954,10 @@ window.addEventListener('mouseup', async function(e) {
     return;
   jeRoutineResetOnNextLog = true;
   if(e.target.id!="jeWidgetSearchBox") {
-    jeRemoveSearchResults(); // Clear the search results
+    // Clear the search results
+    $('#jeWidgetSearchBox').value = '';
+    $('#jeWidgetSearchResults').innerHTML = '';
+
     /* Check to see if user is selecting a widget for display */
     let newWidget = null;
     if(e.target.parentElement && e.target.parentElement.classList.contains('jeTreeWidget')) 

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1248,7 +1248,7 @@ let mouse_reference;
 let resizer_reference;
 
 function resize(e){
-  const height = Math.min(editPanel.offsetHeight - 200, Math.max(0, resizer_reference - mouse_reference + e.y));
+  const height = Math.min(editPanel.offsetHeight - 75, Math.max(0, resizer_reference - mouse_reference + e.y));
   editPanel.style.setProperty('--treeHeight', height + "px");
 }
 

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1352,7 +1352,7 @@ function jeUpdateTree(delta) {
   }
 }
 
-function jeDisplayFilteredWidgets() {
+function jeDisplayFilteredWidgets(e) {
   const subtext = $('#jeWidgetSearchBox').value.toLowerCase();
   const results = widgetFilter(o => o.get('id').toLowerCase().includes(subtext) ||
           o.get('type') && o.get('type').toLowerCase().includes(subtext) ||
@@ -1371,9 +1371,10 @@ function jeDisplayFilteredWidgets() {
 
   on('.jeInSearchWindow', 'click', function(e) {
     jeSelectWidget(widgets.get($('.key', e.currentTarget).innerText), false, e.shiftKey);
-    if(e.shiftKey)
-      e.stopPropagation();
+    e.stopPropagation();
   });
+
+  e.stopPropagation();
 }
 
 /* End of tree subpane control */
@@ -2062,8 +2063,8 @@ on('#jsonEditor', 'keydown', function(e) {
   }
 });
 
-on('body', 'click', function(e) {
-  if(jeEnabled) {
+window.addEventListener('click', function(e) {
+  if(jeEnabled && e.target != $('#jeSearchTable')) {
     $('#jeWidgetSearchBox').value = '';
     $('#jeWidgetSearchResults').innerHTML = '';
   }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1344,8 +1344,12 @@ function jeShowSelectedWidget(widget) {
   jeContext = [ 'Tree', `"${widget.textContent}"`];
   jeCallCommand(jeCommands.find(o => o.id == 'je_openWidgetById'));
   editPanel.style.setProperty('--treeHeight', "20%");
-  let entry = Array.from(document.getElementsByClassName("key")).filter( w => w.textContent == widget.textContent);
-  entry[0].scrollIntoView();
+  let widgetList = Array.from(document.getElementsByClassName("key"));
+  widgetList.forEach( w => w.parentElement.classList.toggle("jeHighlightRow", false) );
+  let selection = widgetList.filter( w => w.textContent == widget.textContent)[0];
+  selection.scrollIntoView({block: "center"});
+  selection.parentElement.classList.toggle("jeHighlightRow");
+
   jeGetContext();
 }
 

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1268,7 +1268,7 @@ function jeDisplayTree() {
   const allWidgets = Array.from(widgets.values());
   $('#jeTree').innerHTML = '<ul class=jeTreeDisplay>' + jeDisplayTreeAddWidgets(allWidgets, null) + '</ul>';
 
-  $('#jeWidgetSearch').innerHTML = '<i class=extern>Search Room:  </i><input id="jeWidgetSearchBox" type="text"><div id="jeWidgetSearchResults"></div>';
+  $('#jeWidgetSearch').innerHTML = '<label for="jeWidgetSearchBox">Search Room: </label><input id="jeWidgetSearchBox" type="text"><div id="jeWidgetSearchResults"></div>';
 
   // Add handlers to tree elements to display widget contents
   on('.jeTreeExpander', 'click', function(e) {
@@ -1327,7 +1327,7 @@ function jeDisplayFilteredWidgets() {
   let results = widgetIds.filter(o => o.toLowerCase().includes(subtext));
   let resultTable = '<table id="jeSearchTable">';
   for(const w of results)
-    resultTable += '<tr valign=top><td class="jeInSearchWindow"><b>' + w + '</b></td></tr>';
+    resultTable += '<tr valign=top><td class="jeInSearchWindow"><b>' + html(w) + '</b></td></tr>';
   resultTable += '</table>';
   $('#jeWidgetSearchResults').innerHTML = resultTable;
 }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1270,8 +1270,9 @@ document.addEventListener("mouseup", function(){
 
 function jeDisplayTree() {
   const allWidgets = Array.from(widgets.values());
-  $('#jeTree').innerHTML = '<ul class=jeTreeDisplay><i class=extern>Room</i>\n' + jeDisplayTreeAddWidgets(allWidgets, null) + '</ul>';
-  
+  $('#jeTree').innerHTML = '<ul class=jeTreeDisplay><i class=extern>Room</i><input id="tree_search" name="tree_search" type="text"><div id="tree_results"></div>\n' + jeDisplayTreeAddWidgets(allWidgets, null) + '</ul>';
+
+  // Add handlers to tree elements to display widget contents
   let toggler = document.getElementsByClassName("jeTreeExpander");
   let i;
   for (i = 0; i < toggler.length; i++) {
@@ -1281,7 +1282,13 @@ function jeDisplayTree() {
         e.target.classList.toggle("jeTreeExpander-down");
       }
     });
-  } 
+  }
+
+  // Add handler to search box to display widget list
+  on('#tree_search', 'input', jeDisplayFilteredWidgets);
+  on('#tree_search', 'click', jeDisplayFilteredWidgets);
+
+  // Show commands panel
   jeMode = 'tree';
   jeContext = ['Tree'];
   jeShowCommands();
@@ -1319,6 +1326,16 @@ function jeDisplayTreeAddWidgets(allWidgets, parent) {
   return result;
 }
 
+function jeDisplayFilteredWidgets() {
+  const subtext = $('#tree_search').value.toLowerCase();
+  const widgetIds = (Array.from(widgets.keys())).sort();
+  let results = widgetIds.filter(o => o.toLowerCase().includes(subtext));
+  let resultTable = '<table>';
+  for(const w of results)
+    resultTable += '<tr valign=top><td><b>' + w + '</b></td></tr>';
+  resultTable += '</table>';
+  $('#tree_results').innerHTML = resultTable;
+}
 /* End of tree subpane control */
 
 function jeGetContext() {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1342,6 +1342,8 @@ function jeUpdateTree(delta) {
       treeNodes[id].innerHTML = jeTreeGetWidgetHTML(widgets.get(id));
     } else {
       jeDisplayTree();
+      if(delta[id] != null && typeof delta[id].id == 'string')
+        jeSelectWidget(widgets.get(delta[id].id));
       break;
     }
   }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1107,18 +1107,15 @@ function jeSelectWidget(widget, dontFocus, addToSelection, restoreCursorPosition
       jeStateNow[cursorState.defaultValueToAdd] = jeWidget.getDefaultValue(cursorState.defaultValueToAdd);
     jeSet(jeStateBefore = jePreProcessText(JSON.stringify(jePreProcessObject(jeStateNow), null, '  ')), dontFocus);
     editPanel.style.setProperty('--treeHeight', "20%");
-    let widgetList = Array.from(document.getElementsByClassName("key"));
-    widgetList.forEach( w => w.parentElement.classList.toggle("jeHighlightRow", false) );
-    let selection = widgetList.filter( w => w.textContent == widget.get('id'))[0];
-    selection.scrollIntoView({block: "center"});
-    selection.parentElement.classList.toggle("jeHighlightRow");
-    widgetList = Array.from(document.getElementsByClassName("widget"));
-    widgetList.forEach( w => w.classList.toggle("selectedInEdit", false) );
-    console.log(widgetList);
-    selection = widgetList.filter( w => w.id == 'w_' + widget.get('id') )[0];
-    console.log(selection);
-    selection.classList.toggle("selectedInEdit", true);
-    console.log(selection);
+
+    for(const widgetDOM of $a('#jeTree .key')) {
+      widgetDOM.parentElement.classList.toggle('jeHighlightRow', widgetDOM.textContent == widget.id);
+      if(widgetDOM.textContent == widget.get('id'))
+        widgetDOM.scrollIntoView({ block: 'center' });
+    }
+
+    for(const widgetDOM of $a('.widget'))
+      widgetDOM.classList.toggle('selectedInEdit', widgetDOM == widget.domElement);
 
     jeGetContext();
   }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -944,7 +944,7 @@ async function jeApplyChangesMulti() {
   }
 }
 
-function jeApplyDelta(delta, widgetWasAdded) {
+function jeApplyDelta(delta) {
   if(jeMode == 'widget') {
     for(const field of [ 'id', 'deck' ]) {
       if(!jeDeltaIsOurs && jeStateNow && jeStateNow[field] && delta.s[jeStateNow[field]] !== undefined) {
@@ -978,10 +978,7 @@ function jeApplyDelta(delta, widgetWasAdded) {
     }
   }
 
-  if(widgetWasAdded || Object.values(delta.s).filter(s=>s===null).length)
-    jeDisplayTree();
-  else
-    jeUpdateTree(delta.s);
+  jeUpdateTree(delta.s);
 }
 
 async function jeApplyExternalChanges(state) {
@@ -1343,7 +1340,7 @@ function jeTreeGetWidgetHTML(widget) {
 
 function jeUpdateTree(delta) {
   for(const id in delta) {
-    if(typeof treeNodes[id] != 'undefined' && typeof delta[id].parent == 'undefined') {
+    if(typeof treeNodes[id] != 'undefined' && delta[id] != null && typeof delta[id].parent == 'undefined') {
       treeNodes[id].innerHTML = jeTreeGetWidgetHTML(widgets.get(id));
     } else {
       jeDisplayTree();

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1304,9 +1304,10 @@ function jeDisplayTreeAddWidgets(allWidgets, parent) {
     const children = jeDisplayTreeAddWidgets(allWidgets, widget.get('id'));
     const isSelected = selectedIDs.indexOf(widget.get('id')) != -1 ? 'jeHighlightRow' : '';
 
-    result += `<li class="jeTreeWidget ${isSelected}">`;
     if(children)
-      result += `<span class="jeTreeWidget jeTreeExpander ${(widget.get('type')=='pile') ? '' : 'jeTreeExpander-down'}">`;
+      result += `<li class="jeTreeWidget"><span class="jeTreeWidget ${isSelected} jeTreeExpander ${(widget.get('type')=='pile') ? '' : 'jeTreeExpander-down'}">`;
+    else
+      result += `<li class="jeTreeWidget ${isSelected}">`;
 
     result += jeTreeGetWidgetHTML(widget);
 

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1237,16 +1237,44 @@ function jeColorize() {
   $('#jeTextHighlight').innerHTML = out.join('\n');
 }
 
+/* Displaying and controlling tree subpane of edit area */
+
+const editPanel = document.getElementById("jeEditArea");
+
+let mouse_pos;
+
+function resize(e){
+  const panelHeight = editPanel.clientHeight;
+  const resizeHeight = document.getElementById("jeResize").clientHeight;
+  const headerHeight = document.getElementById("jeEditHeader").clientHeight;
+  const treeHeight = document.querySelector('#jeTree').clientHeight;
+  const height = Math.max(0,Math.min(panelHeight - resizeHeight - headerHeight, treeHeight + e.y - mouse_pos));
+  editPanel.style.setProperty('--treeheight', height + "px"); 
+  mouse_pos = e.y;
+}
+
+editPanel.addEventListener("mousedown", function(e){
+  mouse_pos = e.y;
+  document.addEventListener("mousemove", resize, false);
+}, false);
+
+document.addEventListener("mouseup", function(){
+  document.removeEventListener("mousemove", resize, false);
+}, false);
+
 function jeDisplayTree() {
   const allWidgets = Array.from(widgets.values());
   let result = '<i class=extern>Room</i>\n';
   result += jeDisplayTreeAddWidgets(allWidgets, null, '  ');
   $('#jeTree').innerHTML = result;
   jeMode = 'tree';
+/*
   jeWidget = null;
   jeStateNow = null;
   jeSet(jeStateBefore = result, true);
   jeGetContext();
+*/
+  jeContext = ["Tree"];
   jeShowCommands();
 }
 
@@ -1273,6 +1301,8 @@ function jeDisplayTreeAddWidgets(allWidgets, parent, indent) {
   }
   return result;
 }
+
+/* End of tree subpane control */
 
 function jeGetContext() {
   const aO = getSelection().anchorOffset;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -2060,7 +2060,7 @@ on('#jsonEditor', 'keydown', function(e) {
 });
 
 window.addEventListener('click', function(e) {
-  if(jeEnabled && e.target != $('#jeSearchTable')) {
+  if(jeEnabled && e.target != $('#jeWidgetSearchResults')) {
     $('#jeWidgetSearchBox').value = '';
     $('#jeWidgetSearchResults').style.display = 'none';
   }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -493,8 +493,7 @@ const jeCommands = [
       $('#jsonEditor').classList.toggle('wide');
       setScale();
       $('#jeTextHighlight').scrollTop = $('#jeText').scrollTop;
-      if(jeMode == 'tree')
-        jeDisplayTree();
+      jeDisplayTree();
     }
   },
   {
@@ -981,8 +980,7 @@ function jeApplyDelta(delta) {
     }
   }
 
-  if(jeMode == 'tree')
-    jeDisplayTree();
+  jeDisplayTree();
 }
 
 async function jeApplyExternalChanges(state) {
@@ -1285,11 +1283,6 @@ function jeDisplayTree() {
   on('#jeWidgetSearchBox', 'input', jeDisplayFilteredWidgets);
   on('#jeWidgetSearchBox', 'click', jeDisplayFilteredWidgets);
 
-  // Show commands panel
-  jeMode = 'tree';
-  jeContext = ['Tree'];
-  jeShowCommands();
-
   on('.jeTreeWidget', 'click', function(e) {
     jeSelectWidget(widgets.get($('.key', e.currentTarget).innerText), false, e.shiftKey);
     e.stopPropagation();
@@ -1302,11 +1295,14 @@ function jeDisplayTreeAddWidgets(allWidgets, parent) {
   }
   let result = '';
 
+  const selectedIDs = jeSelectedIDs();
   for(const widget of (allWidgets.filter(w=>w.get('parent')==parent)).sort((w1,w2)=>w1.get('id').localeCompare(w2.get('id'), 'en', {numeric: true, ignorePunctuation: true}))) {
     const type = widget.get('type');
     const children = jeDisplayTreeAddWidgets(allWidgets, widget.get('id'));
+    const isSelected = selectedIDs.indexOf(widget.get('id')) != -1 ? 'jeHighlightRow' : '';
 
-    result += '<li class="jeTreeWidget">';
+
+    result += `<li class="jeTreeWidget ${isSelected}">`;
     if(children)
       result += `<span class="jeTreeWidget jeTreeExpander ${(widget.get('type')=='pile') ? '' : 'jeTreeExpander-down'}">`;
     result += `${colored(widget.get('id'), 'key')} (${colored(type || 'basic','string')} - `;
@@ -1365,15 +1361,6 @@ function jeGetContext() {
 
   const select = v.substr(s, Math.min(e-s, 100)).replace(/\n/g, '\\n');
   const line = v.split('\n')[v.substr(0, s).split('\n').length-1];
-
-  if(jeMode == 'tree') {
-    jeContext = [ 'Tree' ];
-    const match = line.match(/^(  )+(.*?) \([a-z]+ - /);
-    if(match)
-      jeContext.push(`"${match[2]}"`);
-    jeShowCommands();
-    return jeContext;
-  }
 
   if(jeMode == 'macro') {
     jeContext = [ 'Macro' ];

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1116,7 +1116,7 @@ function jeSelectWidget(widget, dontFocus, addToSelection, restoreCursorPosition
   }
 
   for(const [ id, w ] of widgets)
-    w.domElement.classList.toggle('selectedInEdit', selectedIDs.indexOf(id) != -1);
+    w.setHighlighted(selectedIDs.indexOf(id) != -1);
 
   if(restoreCursorPosition)
     jeCursorStateSet(cursorState);

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1367,7 +1367,8 @@ function jeDisplayFilteredWidgets(e) {
 
   on('.jeInSearchWindow', 'click', function(e) {
     jeSelectWidget(widgets.get($('.key', e.currentTarget).innerText), false, e.shiftKey);
-    e.stopPropagation();
+    if(e.shiftKey)
+      e.stopPropagation();
   });
 
   e.stopPropagation();

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1839,6 +1839,22 @@ window.addEventListener('mousemove', function(e) {
       if(jeState.mouseY >= widget.absoluteCoord('y') && jeState.mouseY <= widget.absoluteCoord('y')+widget.get('height'))
         hoveredWidgets.push(widget);
 
+  hoveredWidgets.sort(function(w1,w2) {
+    const hiddenParent =  function(widget) {
+      return widget ? widget.classes().includes('foreign') || hiddenParent(widget.parent) : false
+    };
+
+    const w1card = w1.get('type') == 'card';
+    const w2card = w2.get('type') == 'card';
+    const w1foreign = !w1card && hiddenParent(w1);
+    const w2foreign =  !w2card && hiddenParent(w2);
+    const w1normal = !w1foreign && !w1card;
+    const w2normal = !w2foreign && !w2card;
+    return ((w1card && w2card) || (w1foreign && w2foreign) || (w1normal && w2normal)) ?
+      w2.calculateZ() - w1.calculateZ() :
+      ((w1card && !w2card) || (w1foreign && w2normal)) ? 1 : -1;
+  });
+  
   for(let i=1; i<=11; ++i) {
     const hotkey = i>=4 ? i+1 : i;
     if(hoveredWidgets[i-1]) {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -27,7 +27,7 @@ const jeState = {
 const jeMacroPreset = `
 // this code will be called for
 // every widget as variable w
-
+s
 // variable v is a persistent object you
 // can use to store other information
 
@@ -504,6 +504,7 @@ const jeCommands = [
       $('#jeTextHighlight').scrollTop = $('#jeText').scrollTop;
       if(jeMode == 'tree')
         jeDisplayTree();
+
     }
   },
   {
@@ -1244,11 +1245,16 @@ const editPanel = document.getElementById("jeEditArea");
 let mouse_pos;
 
 function resize(e){
+  function pad(w) {
+    return parseInt(window.getComputedStyle(document.getElementById("jeEditArea")).getPropertyValue(w).slice(0,-2))
+  };
   const panelHeight = editPanel.clientHeight;
   const resizeHeight = document.getElementById("jeResize").clientHeight;
   const headerHeight = document.getElementById("jeEditHeader").clientHeight;
   const treeHeight = document.querySelector('#jeTree').clientHeight;
-  const height = Math.max(0,Math.min(panelHeight - resizeHeight - headerHeight, treeHeight + e.y - mouse_pos));
+  const padding = pad('padding-top') + pad('padding-bottom');
+
+  const height = Math.max(0,Math.min(panelHeight - resizeHeight - headerHeight - padding, treeHeight + e.y - mouse_pos));
   editPanel.style.setProperty('--treeheight', height + "px"); 
   mouse_pos = e.y;
 }
@@ -1268,13 +1274,7 @@ function jeDisplayTree() {
   result += jeDisplayTreeAddWidgets(allWidgets, null, '  ');
   $('#jeTree').innerHTML = result;
   jeMode = 'tree';
-/*
-  jeWidget = null;
-  jeStateNow = null;
-  jeSet(jeStateBefore = result, true);
-  jeGetContext();
-*/
-  jeContext = ["Tree"];
+  jeContext = ['Tree'];
   jeShowCommands();
 }
 
@@ -1916,7 +1916,9 @@ window.addEventListener('mouseup', async function(e) {
     return;
   jeRoutineResetOnNextLog = true;
   if(e.target.parentElement.className == 'jeTreeWidget') {
-    jeSelectWidget(widgets.get(e.target.parentElement.children[0].textContent));
+    jeContext = [ 'Tree', `"${e.target.parentElement.children[0].textContent}"`];
+    await jeCallCommand(jeCommands.find(o => o.id == 'je_openWidgetById'));
+    jeGetContext();
   } else if(e.target == $('#jeText') && jeContext != 'macro') {
     jeGetContext();
   }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -384,7 +384,7 @@ const jeCommands = [
       jeShowCommands();
     }
   },
-  {
+/*  {
     id: 'je_tree',
     name: 'Show Tree',
     icon: '[to_top]',
@@ -392,7 +392,7 @@ const jeCommands = [
     call: async function() {
       jeDisplayTree();
     }
-  },
+  },*/
   {
     id: 'je_removeProperty',
     name: _=>`remove property ${jeContext && jeContext[jeContext.length-1]}`,
@@ -411,15 +411,6 @@ const jeCommands = [
     },
     show: function() {
       return jeGetValue(jeContext.slice(0, -1))[jeContext[jeContext.length-1]] !== undefined;
-    }
-  },
-  {
-    id: 'je_addNewWidget',
-    name: 'Add new widget',
-    icon: '[add_circle]',
-    forceKey: 'A',
-    call: async function() {
-      showOverlay("addOverlay")
     }
   },
   {
@@ -447,6 +438,15 @@ const jeCommands = [
           jeStateNow.id = clonedWidget.id;
         }
       }
+    }
+  },
+  {
+    id: 'je_addNewWidget',
+    name: 'Add new widget',
+    icon: '[add_circle]',
+    forceKey: 'A',
+    call: async function() {
+      showOverlay("addOverlay")
     }
   },
   {

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -167,7 +167,7 @@ function setScale() {
   if(jeEnabled) {
     const targetWidth = jeZoomOut ? 3200 : 1600;
     const targetHeight = jeZoomOut ? 2000 : 1000;
-    const availableWidth = $('#jeText').offsetLeft;
+    const availableWidth = $('#jeEditArea').offsetLeft;
     if(availableWidth/(h-70) < 1600/1000)
       scale = availableWidth/targetWidth;
     else

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -104,13 +104,9 @@ function receiveDelta(delta) {
     if(delta.s[widgetID] && delta.s[widgetID].parent !== undefined && widgets.has(widgetID))
       $('#topSurface').appendChild(widgets.get(widgetID).domElement);
 
-  let widgetWasAdded = false;
-  for(const widgetID in delta.s) {
-    if(delta.s[widgetID] !== null && !widgets.has(widgetID)) {
+  for(const widgetID in delta.s)
+    if(delta.s[widgetID] !== null && !widgets.has(widgetID))
       addWidget(delta.s[widgetID]);
-      widgetWasAdded = true;
-    }
-  }
 
   for(const widgetID in delta.s)
     if(delta.s[widgetID] !== null && widgets.has(widgetID)) // check widgets.has because addWidget above MIGHT have failed
@@ -121,7 +117,7 @@ function receiveDelta(delta) {
       removeWidget(widgetID);
 
   if(typeof jeEnabled != 'undefined' && jeEnabled)
-    jeApplyDelta(delta, widgetWasAdded);
+    jeApplyDelta(delta);
 }
 
 function receiveDeltaFromServer(delta) {

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -104,9 +104,13 @@ function receiveDelta(delta) {
     if(delta.s[widgetID] && delta.s[widgetID].parent !== undefined && widgets.has(widgetID))
       $('#topSurface').appendChild(widgets.get(widgetID).domElement);
 
-  for(const widgetID in delta.s)
-    if(delta.s[widgetID] !== null && !widgets.has(widgetID))
+  const widgetWasAdded = false;
+  for(const widgetID in delta.s) {
+    if(delta.s[widgetID] !== null && !widgets.has(widgetID)) {
       addWidget(delta.s[widgetID]);
+      widgetWasAdded = true;
+    }
+  }
 
   for(const widgetID in delta.s)
     if(delta.s[widgetID] !== null && widgets.has(widgetID)) // check widgets.has because addWidget above MIGHT have failed
@@ -117,7 +121,7 @@ function receiveDelta(delta) {
       removeWidget(widgetID);
 
   if(typeof jeEnabled != 'undefined' && jeEnabled)
-    jeApplyDelta(delta);
+    jeApplyDelta(delta, widgetWasAdded);
 }
 
 function receiveDeltaFromServer(delta) {

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -104,7 +104,7 @@ function receiveDelta(delta) {
     if(delta.s[widgetID] && delta.s[widgetID].parent !== undefined && widgets.has(widgetID))
       $('#topSurface').appendChild(widgets.get(widgetID).domElement);
 
-  const widgetWasAdded = false;
+  let widgetWasAdded = false;
   for(const widgetID in delta.s) {
     if(delta.s[widgetID] !== null && !widgets.has(widgetID)) {
       addWidget(delta.s[widgetID]);

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -700,7 +700,7 @@ export class Widget extends StateManaged {
             // ignore (but log) blank and comment only lines
             if(jeRoutineLogging) jeLoggingRoutineOperationSummary(comment[1]||'');
           } else {
-            problems.push('String could not be interpreted as expression. Please check your syntax and note that many characters have to be escaped.');
+            problems.push(`String '${a}' could not be interpreted as a valid expression. Please check your syntax and note that many characters have to be escaped.`);
           }
         }
       }
@@ -1846,7 +1846,7 @@ export class Widget extends StateManaged {
         e.classList.add('right');
       if(cursor.top < window.innerHeight/2)
         e.classList.add('bottom');
-      
+
       const wStyle = $(`#STYLES_${escapeID(id)}`);
       if(wStyle) {
         if($('#enlargeStyle'))

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -290,6 +290,9 @@ export class Widget extends StateManaged {
       if(!widgetFilter(w=>asArray(this.get('linkedToSeat')).indexOf(w.get('id')) != -1 && w.get('player')).length)
         className += ' foreign';
 
+    if(this.isHighlighted)
+      className += ' selectedInEdit';
+
     return className;
   }
 
@@ -1786,6 +1789,11 @@ export class Widget extends StateManaged {
       await this.set('rotation', (this.get('rotation') + degrees) % 360);
     else
       await this.set('rotation', degrees);
+  }
+
+  setHighlighted(isHighlighted) {
+    this.isHighlighted = isHighlighted;
+    this.domElement.className = this.classes();
   }
 
   async setText(text, mode, problems) {

--- a/client/room.html
+++ b/client/room.html
@@ -421,6 +421,7 @@
     <div id="jeEditArea">
       <div id="jeEditHeader"></div>
       <div id="jeMouseCoords"></div>
+      <div id="jeWidgetSearch"></div>
       <div id="jeTree"></div>
       <div id="jeResize"></div>
       <div id="jeTextHighlight"></div>

--- a/client/room.html
+++ b/client/room.html
@@ -419,7 +419,7 @@
     </div>
 
     <div id="jeEditArea">
-      <div id="jeEditHeader">CTRL-click a widget on\nthe left to edit it.</div>
+      <div id="jeEditHeader">CTRL-click a widget on<br>the left to edit it.</div>
       <div id="jeMouseCoords"></div>
       <div id="jeWidgetSearch"></div>
       <div id="jeTree"></div>

--- a/client/room.html
+++ b/client/room.html
@@ -419,7 +419,7 @@
     </div>
 
     <div id="jeEditArea">
-      <div id="jeEditHeader"></div>
+      <div id="jeEditHeader">CTRL-click a widget on\nthe left to edit it.</div>
       <div id="jeMouseCoords"></div>
       <div id="jeWidgetSearch"></div>
       <div id="jeTree"></div>

--- a/client/room.html
+++ b/client/room.html
@@ -417,9 +417,14 @@
       <div id="jeWidgetLayer11"></div>
       <div id="jeWidgetLayer12"></div>
     </div>
-    <div id="jeTextHighlight"></div>
-    <div id="jeText" contenteditable="true" spellcheck="false"></div>
-    <div id="jeMouseCoords"></div>
+
+    <div id="jeEditArea">
+      <div id="jeEditHeader"></div>
+      <div id="jeMouseCoords"></div>
+      <div id="jeTree"></div>
+      <div id="jeTextHighlight"></div>
+      <div id="jeText" contenteditable="true" spellcheck="false"></div>
+    </div>
     <div id="jeCommands"></div>
     <div id="jeLogWrapper">
       <div id="jeLog"><h1>No debug information yet.</h1></div>

--- a/client/room.html
+++ b/client/room.html
@@ -422,6 +422,7 @@
       <div id="jeEditHeader"></div>
       <div id="jeMouseCoords"></div>
       <div id="jeTree"></div>
+      <div id="jeResize"></div>
       <div id="jeTextHighlight"></div>
       <div id="jeText" contenteditable="true" spellcheck="false"></div>
     </div>


### PR DESCRIPTION
Allocates part of the edit pane in the JSON editor to hold the tree. Clicking on a widget in the tree opens that widget in the lower portion of the pane. Eventually I'd like to extend this to close #382.

Comments and help are solicited!

Remains to be done:
- [x] The appearance of the edit pane should probably be changed. At present there is no delineation between the two area, so it is perhaps a bit confusing. Also, should the colors be the same in the tree and widget displays? (Added a draggable separator to adjust the spacing as desired.)
- [x] Someone needs to take a look at the new css, and the code to process it in `jeDisplayTree`. There is probably a better way to do all of this.
- [x] Add collapse/expand arrow in the tree area.
- [x] Add a search box next to "Room" to filter the tree display by a text string entered by the user, or perhaps display a drop-down box.
- [x] Fix that no context commands are displayed when clicking on a widget in the tree area.
- [x] Probably remove the "display tree" button.
- [x] Highlight selected widget in tree display when widget is displayed in lower pane.
- [x] Highlight widget in room when widget is selected in tree.
- [x] In initial tree display, collapse piles by default.
- [x] When widget is selected in tree, ensure that space allocated to tree gets small, giving more space to see widget.

Still a couple of unimplemented things, and various small bugs and UI enhancements, but this is getting there. I'd appreciate a code review.