### PR TITLE
show and tell: state details sidebar in library

### DIFF
--- a/client/css/overlays/states.css
+++ b/client/css/overlays/states.css
@@ -279,14 +279,13 @@ div:nth-of-type(1) > .list > .roomState .star {
   }
 }
 @media (min-width: 200px) {
-  #statesOverlay {
-    padding-right: 600px;
-    --size: calc((var(--roomWidth) * var(--scale) - 610px) / 4 - 22px);
+  #statesOverlay.withDetails {
+    padding-right: calc((var(--size) + 22px) * 3);
   }
-  #statesOverlay > #stateDetailsOverlay {
+  #statesOverlay.withDetails > #stateDetailsOverlay {
     display: block !important;
     position: absolute;
-    width: 600px;
+    width: calc((var(--size) + 22px) * 3);
     right: 0;
     left: unset;
   }

--- a/client/css/overlays/states.css
+++ b/client/css/overlays/states.css
@@ -278,6 +278,22 @@ div:nth-of-type(1) > .list > .roomState .star {
     height: 48px;
   }
 }
+@media (min-width: 200px) {
+  #statesOverlay {
+    padding-right: 600px;
+    --size: calc((var(--roomWidth) * var(--scale) - 610px) / 4 - 22px);
+  }
+  #statesOverlay > #stateDetailsOverlay {
+    display: block !important;
+    position: absolute;
+    width: 600px;
+    right: 0;
+    left: unset;
+  }
+  #mainDetails, #similarDetails {
+    min-height: 190px;
+  }
+}
 
 
 
@@ -555,12 +571,6 @@ div:nth-of-type(1) > .list > .roomState .star {
   width: 100%;
 }
 
-@media not all and (max-width: 957px), not all and (max-height: 600px), not all and (max-width: 1000px) and (max-height: 643px) {
-  #stateDetailsOverlay #helpTexts, #stateDetailsOverlay #similarDetails {
-    display: block !important;
-  }
-}
-@media (max-width: 1260px), (max-height: 787px) {
   #stateDetailsOverlay {
     --mainDetailsHeight: 200px;
     --similarDetailsHeight: 160px;
@@ -582,8 +592,6 @@ div:nth-of-type(1) > .list > .roomState .star {
   #nextState .details, #prevState .details {
     display: none;
   }
-}
-@media (max-width: 1140px), (max-height: 712px) {
   #closeDetails {
     font-size: 0;
     padding: 5px;
@@ -591,13 +599,9 @@ div:nth-of-type(1) > .list > .roomState .star {
   #closeDetails::before {
     margin: 0;
   }
-}
-@media (max-width: 1040px), (max-height: 650px) {
   .variant {
     padding: .11rem .5rem;
   }
-}
-@media (max-width: 957px), (max-height: 600px), (max-width: 1000px) and (max-height: 643px) {
   #stateDetailsOverlay {
     --mainDetailsHeight: 150px;
     --similarDetailsHeight: 150px;
@@ -640,7 +644,6 @@ div:nth-of-type(1) > .list > .roomState .star {
   #helpTexts {
     padding: 0 20px;
   }
-}
 @media (max-width: 500px), (max-height: 312px) {
   #stateDetailsOverlay {
     --mainDetailsHeight: 50px;

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -264,6 +264,10 @@ onLoad(function() {
 
   on('.toolbarButton', 'click', function(e) {
     const overlay = e.currentTarget.dataset.overlay;
+
+    if(e.target.id == 'statesButton')
+      $('#statesOverlay').append($('#stateDetailsOverlay'));
+
     if(overlay)
       showOverlay(overlay);
   });

--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -278,7 +278,7 @@ function fillStatesList(states, starred, returnServer, activePlayers) {
 }
 
 function fillStateDetails(states, state, dom) {
-  showStatesOverlay('stateDetailsOverlay');
+  //showStatesOverlay('stateDetailsOverlay');
   $('#stateDetailsOverlay').dataset.id = state.id;
   for(const dom of $a('#stateDetailsOverlay, #stateDetailsOverlay > *'))
     dom.scrollTop = 0;

--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -279,6 +279,7 @@ function fillStatesList(states, starred, returnServer, activePlayers) {
 
 function fillStateDetails(states, state, dom) {
   //showStatesOverlay('stateDetailsOverlay');
+  toggleClass($('#statesOverlay'), 'withDetails', true);
   $('#stateDetailsOverlay').dataset.id = state.id;
   for(const dom of $a('#stateDetailsOverlay, #stateDetailsOverlay > *'))
     dom.scrollTop = 0;
@@ -388,7 +389,7 @@ function fillStateDetails(states, state, dom) {
 
 
   $('#closeDetails').onclick = function() {
-    showStatesOverlay('statesOverlay');
+    toggleClass($('#statesOverlay'), 'withDetails', false);
   };
   $('#stateDetailsOverlay .buttons [icon=download]').onclick = function() {
     window.open(`dl/${roomID}/${state.id}`);


### PR DESCRIPTION
I already said in meetings that I plan to show the state details next to the library for wide viewports (probably starting with 1080p). I hacked together how this would look:

![image](https://user-images.githubusercontent.com/73538315/178942101-0fe367f1-8ffa-4ab6-9f74-d03a2819892a.png)

This PR breaks pretty much everywhere else and most of the buttons at the top of the sidebar don't work as expected but this should be good enough for us to decide if this is something we want or not.