### PR TITLE
fixed slow JSON editor when editing widgets with many children

### DIFF
--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -870,12 +870,16 @@ async function updateWidget(currentState, oldState, applyChangesFromUI) {
       if(widget[key] === undefined)
         widget[key] = null;
   }
+
   const id = await addWidgetLocal(widget);
 
-  for(const child of children)
-    sendPropertyUpdate(child.get('id'), 'parent', id);
-  for(const card of cards)
-    sendPropertyUpdate(card.get('id'), 'deck', id);
+  if(widget.id !== previousState.id) {
+    for(const child of children)
+      sendPropertyUpdate(child.get('id'), 'parent', id);
+    for(const card of cards)
+      sendPropertyUpdate(card.get('id'), 'deck', id);
+  }
+
   batchEnd();
 }
 

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -832,11 +832,14 @@ function uploadWidget(preset) {
 }
 
 async function updateWidget(currentState, oldState, applyChangesFromUI) {
+  batchStart();
+
   const previousState = JSON.parse(oldState);
   try {
     var widget = JSON.parse(currentState);
   } catch(e) {
     alert(e.toString());
+    batchEnd();
     return;
   }
 
@@ -846,6 +849,7 @@ async function updateWidget(currentState, oldState, applyChangesFromUI) {
 
   if(widget.parent !== undefined && !widgets.has(widget.parent)) {
     alert(`Parent widget ${widget.parent} does not exist.`);
+    batchEnd();
     return;
   }
 
@@ -872,6 +876,7 @@ async function updateWidget(currentState, oldState, applyChangesFromUI) {
     sendPropertyUpdate(child.get('id'), 'parent', id);
   for(const card of cards)
     sendPropertyUpdate(card.get('id'), 'deck', id);
+  batchEnd();
 }
 
 async function onClickUpdateWidget(applyChangesFromUI) {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -362,9 +362,7 @@ const jeCommands = [
             const s = JSON.stringify(w.state);
             const newState = JSON.parse(s);
             macro(newState, variableState);
-            batchStart();
             await updateWidget(JSON.stringify(newState), s);
-            batchEnd();
           }
         } catch(e) {
           jeJSONerror = e;


### PR DESCRIPTION
This should fix #1280. See https://github.com/ArnoldSmith86/virtualtabletop/issues/1280#issuecomment-1196392512 for a description of what caused the problem.