### PR TITLE
Fixes and enhancements to 15 games

### DIFF
--- a/tests/testcafe/tests.js
+++ b/tests/testcafe/tests.js
@@ -344,7 +344,7 @@ publicLibraryButtons('Reversi',            0, '35e0017570f9ecd206a2317c1528be36'
          [ ()=>Selector("#w_zpiece08"), ()=>Selector("#w_sq53") ]
        ]);
 publicLibraryButtons('Reward',             0, '011671469f1fa8455c1a4123fe7ff313', [
-  'gmex', 'kprc', 'oksq', 'j1wz', 'vfhn', '0i6i', 'Orange Recall', '#buttonInputGo', 'b09z'
+  'gmex', 'kprc', 'oksq', 'j1wz', 'vfhn', 'seat1', 'next'
 ]);
 publicLibraryButtons('Rummy Tiles',        0, '6c5f8896284f52e874076bc60cca6325', [ 'startMix', 'draw14' ]);
 publicLibraryButtons('Undercover',         1, '97725a1d0733ef74dd5e1d0f9f260cb5', [ 'Reset', 'Spy Master Button' ]);

--- a/tests/testcafe/tests.js
+++ b/tests/testcafe/tests.js
@@ -343,7 +343,7 @@ publicLibraryButtons('Reversi',            0, '35e0017570f9ecd206a2317c1528be36'
          [ ()=>Selector("#w_zpiece19"), ()=>Selector("#w_sq35") ],
          [ ()=>Selector("#w_zpiece08"), ()=>Selector("#w_sq53") ]
        ]);
-publicLibraryButtons('Reward',             0, '011671469f1fa8455c1a4123fe7ff313', [
+publicLibraryButtons('Reward',             0, '60c8c548fec57ead23c697b43216544f', [
   'gmex', 'kprc', 'oksq', 'j1wz', 'vfhn', 'seat1', 'next'
 ]);
 publicLibraryButtons('Rummy Tiles',        0, '6c5f8896284f52e874076bc60cca6325', [ 'startMix', 'draw14' ]);


### PR DESCRIPTION
This is essentially a redo of #1100.  I put that one on hold because it was so large and also introduced new things.  This PR just updates existing games.  Most changes are minor or cometic.  A few games got big makeovers.

Public Library:
•	Agra. Fixed minor layering issue and attribution link. Added shuffle on recall to 3/4/5 exchange tokens.
•	Alleys. Added seats. Changed pawns so they inherit seat color. Updated restart button code.
•	Chinese Checkers. Added seats. Combined all variants into one using an option button to pick style of marble.
•	Connex.  Added seats and next turn button
•	Dix Dice. Added seats and restart button.
•	Dominoes. Changed rotation method. Changed cards to SVGs. Add 15 pip dominoes and colors. Added seats. Expanded number of players. Added options for scoring increments of 1 or 5. Improved shift view feature.
•	Flora. Changed card images to SVGs. Combined all variants into one using an option button to pick types of cards. Added seats. Improved shift view feature. Added detail to the attributions. Updated the library image with the new cards.
•	Forces of Nature. Update color of #6 card type.
•	Reward. Added seats. Changed cards to css. Updated menu system code. Updated attribution and changed library image.
•	Spin 5. Reduced and combined number of variants.  Added seats.  Added animation to rotating boards to enhance appearance.
•	Stratagem. Added seats.
•	Tangrams.  Updated recall and shuffle button.
•	Tantrums. Added seats and revised layout slightly.
•	Tittle. Added seats and revised layout slightly. Improved shift view feature.
•	Wordy. Added seats and reset button. Combined 3 language variants into one with option to choose language.  Will make future language updates much easier.

In library.json, corrected typo in "similar to" for Stardust Butterfly.

Successfully added all revised games using library.json file.