### PR TITLE
Caret is now placed properly in most cases

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -535,21 +535,6 @@ const jeCommands = [
     }
   },
   {
-    id: 'je_selectSortBy',
-    name: 'sortBy',
-    context: '^button ↦ clickRoutine ↦ [0-9]+ ↦ \\(SELECT\\) ↦ ',
-    show: jeRoutineCall(function(routineIndex) {
-      return !Object.keys(jeGetValue(jeContext.slice(1, routineIndex+2))).includes("sortBy");
-    }, true),
-    call: async function() {
-      jeStateNow.clickRoutine[+jeContext[2]].sortBy = {
-        "key": "###SELECT ME###",
-        "reverse": false
-      };
-      jeSetAndSelect('z');
-    }
-  },
-  {
     id: 'widget_holder_dropTarget',
     name: "dropTarget",
     class: 'property',
@@ -629,9 +614,17 @@ function jeAddRoutineOperationCommands(command, defaults) {
       id: 'default_' + command + '_' + property,
       name: property,
       context: `^.* ↦ \\(${command}\\) ↦ `,
-      call: jeRoutineCall(function(routineIndex, routine, operationIndex, operation) {
-        jeInsert(jeContext.slice(1, routineIndex+2), property, defaults[property]);
-      }),
+      call: property != 'sortBy' ? // Special case for sortBy; emulate jeInsert w/special replacement
+        jeRoutineCall(function(routineIndex, routine, operationIndex, operation) {
+          jeInsert(jeContext.slice(1, routineIndex+2), property, defaults[property]);
+        }) :
+        jeRoutineCall(function(routineIndex, routine, operationIndex, operation) {
+          jeGetValue(jeContext.slice(1,routineIndex+2)).sortBy = {
+            "key": "###SELECT ME###",
+            "reverse": false
+          };
+          jeSetAndSelect('z');
+        }),
       show: jeRoutineCall(function(routineIndex, routine, operationIndex, operation) {
         return operation && operation[property] === undefined;
       }, true)
@@ -672,7 +665,7 @@ function jeAddCommands() {
   jeAddRoutineOperationCommands('MOVEXY', { count: 1, face: null, from: null, x: 0, y: 0, snapToGrid: true });
   jeAddRoutineOperationCommands('RECALL', { owned: true, holder: null });
   jeAddRoutineOperationCommands('ROTATE', { count: 1, angle: 90, mode: 'add', holder: null, collection: 'DEFAULT' });
-  jeAddRoutineOperationCommands('SELECT', { type: 'all', property: 'parent', relation: '==', value: null, max: 999999, collection: 'DEFAULT', mode: 'set', source: 'all'});
+  jeAddRoutineOperationCommands('SELECT', { type: 'all', property: 'parent', relation: '==', value: null, max: 999999, collection: 'DEFAULT', mode: 'set', source: 'all', sortBy: '###SEE jeAddRoutineOperation###'});
   jeAddRoutineOperationCommands('SET', { collection: 'DEFAULT', property: 'parent', relation: '=', value: null });
   jeAddRoutineOperationCommands('SORT', { key: 'value', reverse: false, locales: null, options: null, holder: null, collection: 'DEFAULT' });
   jeAddRoutineOperationCommands('SHUFFLE', { holder: null, collection: 'DEFAULT' });

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -533,21 +533,6 @@ const jeCommands = [
       }
       jeUpdateMulti();
     }
-  },
-  {
-    id: 'widget_holder_dropTarget',
-    name: "dropTarget",
-    class: 'property',
-    context: '^holder',
-    show: jeRoutineCall(function(routineIndex) {
-      return !Object.keys(jeGetValue(jeContext.slice(1, routineIndex+2))).includes("dropTarget");
-    }, true),
-    call: async function() {
-      jeStateNow.dropTarget = {
-        "type": "###SELECT ME###"
-      };
-      jeSetAndSelect('card');
-    }
   }
 ];
 
@@ -906,7 +891,7 @@ function jeAddNumberCommand(name, key, callback) {
 
 function jeAddWidgetPropertyCommands(object) {
   for(const property in object.defaults)
-    if(property != 'typeClasses' && property != 'dropTarget' && !property.match(/^c[0-9]{2}$/))
+    if(property != 'typeClasses' && !property.match(/^c[0-9]{2}$/))
       jeAddWidgetPropertyCommand(object, property);
   const type = object.defaults.typeClasses.replace(/widget /, '');
   return type == 'basic' ? null : type;
@@ -918,9 +903,16 @@ function jeAddWidgetPropertyCommand(object, property) {
     name: property,
     class: 'property',
     context: `^${object.getDefaultValue('typeClasses').replace('widget ', '')}`,
-    call: async function() {
-      jeInsert([], property, property.match(/Routine$/) ? [] : object.getDefaultValue(property));
-    },
+    call: property!='dropTarget' ?
+      async function() {
+        jeInsert([], property, property.match(/Routine$/) ? [] : object.getDefaultValue(property));
+      } :
+      async function() {
+        jeStateNow.dropTarget = {
+          "type": "###SELECT ME###"
+        };
+        jeSetAndSelect('card');
+      },
     show: function() {
       return jeStateNow[property] === undefined;
     }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -599,16 +599,16 @@ function jeAddRoutineOperationCommands(command, defaults) {
       id: 'default_' + command + '_' + property,
       name: property,
       context: `^.* ↦ \\(${command}\\) ↦ `,
-      call: property != 'sortBy' ? // Special case for sortBy; emulate jeInsert w/special replacement
-        jeRoutineCall(function(routineIndex, routine, operationIndex, operation) {
-          jeInsert(jeContext.slice(1, routineIndex+2), property, defaults[property]);
-        }) :
+      call: property == 'sortBy' ? // Special case for sortBy; emulate jeInsert w/special replacement
         jeRoutineCall(function(routineIndex, routine, operationIndex, operation) {
           jeGetValue(jeContext.slice(1,routineIndex+2)).sortBy = {
             "key": "###SELECT ME###",
             "reverse": false
           };
           jeSetAndSelect('z');
+        }) :
+        jeRoutineCall(function(routineIndex, routine, operationIndex, operation) {
+          jeInsert(jeContext.slice(1, routineIndex+2), property, defaults[property]);
         }),
       show: jeRoutineCall(function(routineIndex, routine, operationIndex, operation) {
         return operation && operation[property] === undefined;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -903,16 +903,26 @@ function jeAddWidgetPropertyCommand(object, property) {
     name: property,
     class: 'property',
     context: `^${object.getDefaultValue('typeClasses').replace('widget ', '')}`,
-    call: property!='dropTarget' ?
-      async function() {
-        jeInsert([], property, property.match(/Routine$/) ? [] : object.getDefaultValue(property));
-      } :
-      async function() {
-        jeStateNow.dropTarget = {
-          "type": "###SELECT ME###"
-        };
-        jeSetAndSelect('card');
-      },
+    call: property=='dropTarget'? // Special case for dropTarget, faces, and spinner options
+            async function() {
+              jeStateNow.dropTarget = {
+                "type": "###SELECT ME###"
+              };
+              jeSetAndSelect('card');
+            }
+        : property=='faces' ?
+            async function() {
+              jeStateNow.faces = ["###SELECT ME###"];
+              jeSetAndSelect({});
+            }
+        : object.getDefaultValue('typeClasses').replace('widget ', '') + '_' + property == 'spinner_options' ?
+            async function() {
+              jeStateNow.options = "###SELECT ME###";
+              jeSetAndSelect([]);
+            }
+        :  async function() {
+             jeInsert([], property, property.match(/Routine$/) ? [] : object.getDefaultValue(property));
+           },
     show: function() {
       return jeStateNow[property] === undefined;
     }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1840,8 +1840,8 @@ function jeSet(text, dontFocus) {
 // display the results in the text area by calling jeSet, and select the replaced text by calling jeSelect.
 function jeSetAndSelect(replaceBy, insideString) {
 
-  const emptyBrackets = replaceBy && ((Array.isArray(replaceBy) && replaceBy.length==0) || (typeof replaceBy === 'object' && Object.keys(replaceBy).length === 0)); // ###SELECT ME### should be replaced by [] or {}
-  const dollar = replaceBy && replaceBy == '${}'; // ###SELECT ME### should be replaced by ${} (and this will be in a string)
+  const emptyBrackets = replaceBy && (typeof replaceBy === 'object' && Object.keys(replaceBy).length === 0); // ###SELECT ME### should be replaced by [] or {}
+  const dollar = replaceBy == '${}'; // ###SELECT ME### should be replaced by ${} (and this will be in a string)
 
   if(jeMode == 'widget')
     var jsonString = jePreProcessText(JSON.stringify(jePreProcessObject(jeStateNow), null, '  '));

--- a/client/js/widgets/spinner.js
+++ b/client/js/widgets/spinner.js
@@ -8,7 +8,7 @@ class Spinner extends Widget {
       typeClasses: 'widget spinner',
       clickable: true,
 
-      options: [],
+      options: [ 1, 2, 3, 4, 5, 6 ],
       value: '🎲',
       angle: 0,
 

--- a/client/js/widgets/spinner.js
+++ b/client/js/widgets/spinner.js
@@ -8,7 +8,7 @@ class Spinner extends Widget {
       typeClasses: 'widget spinner',
       clickable: true,
 
-      options: [ 1, 2, 3, 4, 5, 6 ],
+      options: [],
       value: '🎲',
       angle: 0,
 


### PR DESCRIPTION
This is intended to fix #763.

Except for the `faces` property of `basicwidget` and the `dropTarget` property of `holder`, I believe that the caret is placed properly. Basically this involves changes to `jeInsert` to figure out what is being done, and changes to `jeSetAndSelect` to get the selection boundaries correct.

- The code seems somewhat special-cased to me, but this is a pretty fiddly thing to get right. I'd appreciate a code review.
- For the two remaining cases, the issue is that the offsets of where to put the selection are computed using an incompletely formatted version of the JSON (specifically, it uses `{ "type": "card"}` instead of the version including newlines and leading spaces produced by `stringify`. I don't see a simple way to solve this problem; perhaps someone else does.