### PR TITLE
Round y coordinates of checkers and classic pieces.

### DIFF
--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -673,7 +673,7 @@ function populateAddWidgetOverlay() {
       width: 73.5,
       height: 73.5,
       x: 440,
-      y: y + (43.83 - 73.5)/2
+      y: Math.round(y + (43.83 - 73.5)/2)
     });
 
     addWidgetToAddWidgetOverlay(new BasicWidget('add-classic-'+color), {
@@ -682,7 +682,7 @@ function populateAddWidgetOverlay() {
       width: 56,
       height: 84,
       x: 528,
-      y: y + (43.83 - 84)/2
+      y: Math.round(y + (43.83 - 84)/2)
     });
     y += 88;
   }


### PR DESCRIPTION
The y-coordinates are computed by centering them around the pins. This PR just rounds the result to avoid random decimals. Fixes #1307 