### PR TITLE
Move jeGetContext to bottom to ensure it is called after cursor state

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1153,14 +1153,14 @@ function jeSelectWidget(widget, dontFocus, addToSelection, restoreCursorPosition
       jeStateNow[cursorState.defaultValueToAdd] = jeWidget.getDefaultValue(cursorState.defaultValueToAdd);
     jeSet(jeStateBefore = jePreProcessText(JSON.stringify(jePreProcessObject(jeStateNow), null, '  ')), dontFocus);
     editPanel.style.setProperty('--treeHeight', "20%");
-
-    jeGetContext();
   }
 
   jeCenterSelection();
-
+  
   if(restoreCursorPosition)
     jeCursorStateSet(cursorState);
+  
+  jeGetContext();
 }
 
 function jeSelectWidgetMulti(widget, dontFocus) {


### PR DESCRIPTION
This is intended to address @96LawDawg's comment to PR #1306, where dragging a widget causes context to be lost in the JSON editor. This causes weird behavior (and differently in different browsers). 

Needs testing.