### PR TITLE
Make it so material icons work in the JSON editor top buttons

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -426,7 +426,7 @@ body.jsonEdit.jeZoomOut #topSurface {
   vertical-align: top;
 }
 
-[id=jeTopButtons] button.material {
+[id=jeTopButtons] button.material-icons {
   font-family: 'Material Icons';
 }
 

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1951,7 +1951,7 @@ function jeShowCommands() {
     if(contextMatch && contextMatch[0] == "") {
       const name = (typeof command.name == 'function' ? command.name() : command.name);
       const icon = (typeof command.icon == 'function' ? command.icon() : command.icon);
-      const isMaterial = String(icon).match(/^[^[]/) ? 'material' : '';
+      const isMaterial = String(icon).match(/^[^[]/) ? 'material-icons' : '';
       commandText += `<button class='top ${isMaterial}' id='${command.id}' title='${name}' ${!command.show || command.show() ? '' : 'disabled'}>${icon}</button>`;
     }
   }


### PR DESCRIPTION
The best way to test this is to put a breakpoint in `jeAddCommands` and modify the icon of one of the top buttons to be the name of a material icon, without the `[]`, e.g. `content_copy`.