### PR TITLE
Allow inheriting of a subset of properties.

### DIFF
--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -903,7 +903,7 @@ async function onClickUpdateWidget(applyChangesFromUI) {
   showOverlay();
 }
 
-async function duplicateWidget(widget, recursive, inheritFrom, incrementKind, incrementIn, xOffset, yOffset, xCopies, yCopies, problems) { // incrementKind: '', 'Letters', 'Numbers'
+async function duplicateWidget(widget, recursive, inheritFrom, inheritProperties, incrementKind, incrementIn, xOffset, yOffset, xCopies, yCopies, problems) { // incrementKind: '', 'Letters', 'Numbers'
 
   const incrementCaps = function(l) {
     const m = l.match(/Z+$/);
@@ -918,9 +918,14 @@ async function duplicateWidget(widget, recursive, inheritFrom, incrementKind, in
     let currentWidget = JSON.parse(JSON.stringify(widget.state))
 
     if(inheritFrom) {
-      const inheritWidget = { inheritFrom: widget.get('id') };
-      for(const key of [ 'id', 'type', 'deck', 'cardType' ])
-        if(currentWidget[key] !== undefined)
+      const inheritAll = JSON.stringify(inheritProperties) == '[""]';
+      const inheritWidget = {};
+      inheritWidget['inheritFrom'] = {};
+      inheritWidget['inheritFrom'][widget.get('id')] = inheritAll ? "*" : inheritProperties;
+
+      // Copy properties from source to new object unless inheritAll is set or the property is in the inherit list.
+      for(const key of Object.keys(currentWidget))
+        if(currentWidget[key] != undefined && (['id','type','deck','cardType'].includes(key) || !(inheritAll || inheritProperties.includes(key))))
           inheritWidget[key] = currentWidget[key];
       currentWidget = inheritWidget;
     }
@@ -998,7 +1003,7 @@ async function onClickDuplicateWidget() {
   const widget = widgets.get(JSON.parse($('#editWidgetJSON').dataset.previousState).id);
   const xOffset = widget.absoluteCoord('x') > 1500 ? -20 : 20;
   const yOffset = widget.absoluteCoord('y') >  900 ? -20 : 20;
-  await duplicateWidget(widget, true, false, 'Numbers', [], xOffset, yOffset, 1, 0);
+  await duplicateWidget(widget, true, false, [], 'Numbers', [], xOffset, yOffset, 1, 0);
   showOverlay();
 }
 

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -463,6 +463,7 @@ const jeCommands = [
       { label: 'Increment IDs',          type: 'select', options: [ { value: 'Numbers', text: 'Numbers' }, { value: 'Letters', text: 'Letters' }, { value: '', text: 'None'  } ] },
       { label: 'Increment In',           type: 'string',   value: 'dropTarget,hand,index,inheritFrom,linkedToSeat,onlyVisibleForSeat,text' },
       { label: 'Copy using inheritFrom', type: 'checkbox', value: false },
+      { label: 'Inherit properties',     type: 'string', value: '' },
       { label: 'Copy recursively',       type: 'checkbox', value: true  },
       { label: 'X offset',               type: 'number',   value: 0,   min: -1600, max: 1600 },
       { label: 'Y offset',               type: 'number',   value: 0,   min: -1000, max: 1000 },
@@ -472,7 +473,7 @@ const jeCommands = [
     call: async function(options) {
       for(const id of jeSelectedIDs()) {
         const problems = [];
-        const clonedWidget = await duplicateWidget(widgets.get(id), options['Copy recursively'], options['Copy using inheritFrom'], options['Increment IDs'], options['Increment In'].split(','), options['X offset'], options['Y offset'], options['# Copies X'], options['# Copies Y'], problems);
+        const clonedWidget = await duplicateWidget(widgets.get(id), options['Copy recursively'], options['Copy using inheritFrom'], options['Inherit properties'].split(',').map(e => e.trim()),options['Increment IDs'], options['Increment In'].split(','), options['X offset'], options['Y offset'], options['# Copies X'], options['# Copies Y'], problems);
         if(problems.length)
           jeJSONerror = problems.join('\n');
         if(clonedWidget) {


### PR DESCRIPTION
This adds a new text box below the "use inheritFrom checkbox" to allow the user to enter a set of properties to be inherited. Leaving it blank will result in all properties being inherited (as before).