### PR TITLE
return 404 for invalid asset names

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -81,8 +81,10 @@ MinifyRoom().then(function(result) {
   });
 
   router.get('/assets/:name', function(req, res) {
-    if(!req.params.name.match(/^[0-9_-]+$/))
+    if(!req.params.name.match(/^[0-9_-]+$/)) {
+      res.sendStatus(404);
       return;
+    }
     fs.readFile(assetsdir + '/' + req.params.name, function(err, content) {
       if(!content) {
         res.sendStatus(404);


### PR DESCRIPTION
Loading `https://virtualtabletop.io/assets/833604844_1066812,` would not finish the request until some kind of timeout. Now it should return 404.