### PR TITLE
Prevent dropping to obscured drop targets fixes #1353

### DIFF
--- a/client/js/geometry.js
+++ b/client/js/geometry.js
@@ -14,6 +14,14 @@ export function overlap(a, b) {
   return !(aR.top+aR.height <= bR.top || aR.top >= bR.top+bR.height || aR.left+aR.width <= bR.left || aR.left >= bR.left+bR.width);
 }
 
+export function containScore(obj, container) {
+  const oR = obj.getBoundingClientRect();
+  const cR = container.getBoundingClientRect();
+  const intersectionArea = Math.max(Math.min(oR.right, cR.right) - Math.max(oR.left, cR.left), 0) * Math.max(Math.min(oR.bottom, cR.bottom) - Math.max(oR.top, cR.top), 0);
+  const oA = (oR.width * oR.height);
+  return oA ? intersectionArea / oA : 0;
+}
+
 export function overlapScore(a, b) {
   const aR = a.getBoundingClientRect();
   const bR = b.getBoundingClientRect();


### PR DESCRIPTION
Drop targets in front of other drop targets should be used even if the drop location is not as close to the center. This allows for cases like a player mat above other drop targets.