### PR TITLE
Add property to inherit onlyVisibleForSeat while dragging.

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -66,6 +66,7 @@ export class Widget extends StateManaged {
 
       linkedToSeat: null,
       onlyVisibleForSeat: null,
+      childrenInheritVisibleForSeat: false,
 
       clickRoutine: null,
       changeRoutine: null,
@@ -1730,8 +1731,15 @@ export class Widget extends StateManaged {
       if(this.hoverTarget)
         this.hoverTarget.domElement.classList.add('droptarget');
 
-      if(lastHoverTarget != this.hoverTarget && this.hoverTarget != this.currentParent)
-        await this.checkParent(true);
+      if (lastHoverTarget != this.hoverTarget) {
+        if (this.hoverTarget && this.hoverTarget.get('childrenInheritVisibleForSeat'))
+          await this.set('onlyVisibleForSeat', this.hoverTarget.get('onlyVisibleForSeat'));
+        else if (lastHoverTarget && lastHoverTarget.get('childrenInheritVisibleForSeat'))
+          await this.set('onlyVisibleForSeat', null);
+
+        if(this.hoverTarget != this.currentParent)
+          await this.checkParent(true);
+      }
     }
   }
 


### PR DESCRIPTION
While dragging, inherit the onlyVisibleForSeat property from the current hover target to hide visibility for changes made over a hidden widget. Fixes #1356.