### PR TITLE
Allow customizing a cursor's active duration.

### DIFF
--- a/client/css/overlays/players.css
+++ b/client/css/overlays/players.css
@@ -160,6 +160,7 @@ label.ui-line::before{
   --cursorOpacity: 0;
   --cursorActiveOpacity: 0.3;
   --cursorPressedOpacity: 0.3;
+  --cursorActiveDuration: 100; /* milliseconds */
 }
 .cursor {
   position: absolute;

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -83,7 +83,7 @@ onLoad(function() {
           playerCursors[args.player].classList.add('foreign');
         else
           playerCursors[args.player].classList.remove('foreign');
-        playerCursorsTimeout[args.player] = setTimeout(()=>{playerCursors[args.player].classList.remove('active')}, 100 )
+        playerCursorsTimeout[args.player] = setTimeout(()=>{playerCursors[args.player].classList.remove('active')}, parseInt(getComputedStyle(playerCursors[args.player]).getPropertyValue('--cursorActiveDuration')))
       }
     }
   });


### PR DESCRIPTION
In case a particular game wants to make it easier for players to point to things they may want to increase the cursor active duration so that the cursor stays visible longer before fading away.

The https://test.virtualtabletop.io/PR-1358/pr-test has a test of setting the active duration to 2000 (milliseconds). Note we could parse units to make it accept the same as an animation time (e.g. 2s or 2000ms) but I don't know if this complexity is necessary.