### PR TITLE
Optimize piles

### DIFF
--- a/client/css/widgets/pile.css
+++ b/client/css/widgets/pile.css
@@ -2,6 +2,10 @@
   will-change: transform;
 }
 
+.pile > :not(.visible-in-pile):not(.handle) {
+  display: none;
+}
+
 .pile .handle {
   position: absolute;
   left: var(--phPosition);

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -23,6 +23,8 @@ class Pile extends Widget {
 
     this.domElement.appendChild(this.handle);
     this.childCount = 0;
+    this.visibleChildren = new Set();
+    this.visibleChildLimit = 5;
     this.updateText();
   }
 
@@ -30,12 +32,21 @@ class Pile extends Widget {
     super.applyChildAdd(child);
     ++this.childCount;
     this.updateText();
+    this.updateVisibleChildren();
+  }
+
+  applyChildZ(child) {
+    super.applyChildZ();
+    this.updateVisibleChildren();
   }
 
   applyChildRemove(child) {
     super.applyChildRemove(child);
     --this.childCount;
     this.updateText();
+    if (this.visibleChildren.has(child)) {
+      this.updateVisibleChildren();
+    }
   }
 
   applyDeltaToDOM(delta) {
@@ -196,6 +207,17 @@ class Pile extends Widget {
   updateText() {
     const text = this.get('text');
     this.handle.textContent = text === null ? this.childCount : text;
+  }
+
+  updateVisibleChildren() {
+    for (let child of this.visibleChildren) {
+      child.domElement.classList.remove('visible-in-pile');
+    }
+    this.visibleChildren.clear();
+    for(const child of this.children().slice(0, this.visibleChildLimit)) {
+      this.visibleChildren.add(child);
+      child.domElement.classList.add('visible-in-pile');
+    }
   }
 
   validDropTargets() {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -118,6 +118,11 @@ export class Widget extends StateManaged {
     this.applyZ();
   }
 
+  applyChildZ(child) {
+    if(this.get('inheritChildZ'))
+      this.applyZ();
+  }
+
   applyCSS(delta) {
     for(const property of this.classesProperties()) {
       if(delta[property] !== undefined) {
@@ -244,11 +249,8 @@ export class Widget extends StateManaged {
   }
 
   applyZ(force) {
-    const thisInheritChildZ = this.get('inheritChildZ');
-    if(force || thisInheritChildZ) {
+    if(force || this.get('inheritChildZ')) {
       this.domElement.style.zIndex = this.calculateZ();
-      if(thisInheritChildZ && this.get('parent'))
-        widgets.get(this.get('parent')).applyZ();
     }
   }
 
@@ -257,10 +259,15 @@ export class Widget extends StateManaged {
   }
 
   calculateZ() {
+    const pZ = this.z;
     this.z = ((this.get('layer') + 10) * 100000) + this.get('z');
     if(this.get('inheritChildZ'))
       for(const child of this.childrenOwned())
         this.z = Math.max(this.z, child.z);
+    if (this.z != pZ) {
+      if(this.get('parent') && widgets.has(this.get('parent')))
+        widgets.get(this.get('parent')).applyChildZ(this);
+    }
     return this.z;
   }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -272,7 +272,7 @@ export class Widget extends StateManaged {
   }
 
   children() {
-    return this.childArray.sort((a,b)=>b.get('z')-a.get('z'));
+    return this.childArray.sort((a,b)=>b.z-a.z);
   }
 
   childrenOwned() {


### PR DESCRIPTION
Optimize rendering of large piles by hiding deep cards
    
Large piles can slow down the game quite a bit as the browser tries to draw all of the obscured piles. This optimizes large piles by hiding every card after the nth.

Note this PR is based on / depends on #1360 which adds the applyChildZ function used here to detect reordering of the cards.

The performance can be compared to https://virtualtabletop.io/oq8o