### PR TITLE
Fix multiple calls to tree display in multi-widget deletion.

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -513,8 +513,7 @@ const jeCommands = [
     show: _=>jeStateNow,
     call: async function() {
       batchStart();
-      const selectedIDs = jeSelectedIDs();
-      for(const id of selectedIDs)
+      for(const id of jeSelectedIDs())
         await removeWidgetLocal(id);
       batchEnd();
       jeEmpty();
@@ -538,8 +537,7 @@ const jeCommands = [
       { label: '# Copies Y',             type: 'number',   value: 0,   min:     0, max:  100 }
     ],
     call: async function(options) {
-      const selectedIDs = jeSelectedIDs();
-      for(const id of selectedIDs) {
+      for(const id of jeSelectedIDs()) {
         const problems = [];
         const clonedWidget = await duplicateWidget(widgets.get(id), options['Copy recursively'], options['Copy using inheritFrom'], options['Inherit properties'].split(',').map(e => e.trim()),options['Increment IDs'], options['Increment In'].split(','), options['X offset'], options['Y offset'], options['# Copies X'], options['# Copies Y'], problems);
         if(problems.length)
@@ -1579,7 +1577,6 @@ function jeTreeGetWidgetHTML(widget) {
 
 function jeUpdateTree(delta) {
   for(const id in delta) {
-    // If modifying an existing widget without changing its parent, just substitute new HTML for that widget.
     if(typeof treeNodes[id] != 'undefined' && delta[id] != null && typeof delta[id].parent == 'undefined') {
       treeNodes[id].innerHTML = jeTreeGetWidgetHTML(widgets.get(id));
     } else if(!jeInMacroExecution) {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -2170,9 +2170,9 @@ function jeToggle() {
   jeLoggingHTML = '';
   if(jeEnabled) {
     $('body').classList.add('jsonEdit');
-    jeDisplayTree();
     if(jeWidget && !widgets.has(jeWidget.id))
       jeEmpty();
+    jeDisplayTree();
   } else {
     $('body').classList.remove('jsonEdit');
   }
@@ -2186,7 +2186,6 @@ function jeEmpty() {
   jeWidget = null;
 
   jeSet('');
-  jeDisplayTree();
   jeShowCommands();
 }
 

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -513,7 +513,8 @@ const jeCommands = [
     show: _=>jeStateNow,
     call: async function() {
       batchStart();
-      for(const id of jeSelectedIDs())
+      const selectedIDs = jeSelectedIDs();
+      for(const id of selectedIDs)
         await removeWidgetLocal(id);
       batchEnd();
       jeEmpty();
@@ -537,7 +538,8 @@ const jeCommands = [
       { label: '# Copies Y',             type: 'number',   value: 0,   min:     0, max:  100 }
     ],
     call: async function(options) {
-      for(const id of jeSelectedIDs()) {
+      const selectedIDs = jeSelectedIDs();
+      for(const id of selectedIDs) {
         const problems = [];
         const clonedWidget = await duplicateWidget(widgets.get(id), options['Copy recursively'], options['Copy using inheritFrom'], options['Inherit properties'].split(',').map(e => e.trim()),options['Increment IDs'], options['Increment In'].split(','), options['X offset'], options['Y offset'], options['# Copies X'], options['# Copies Y'], problems);
         if(problems.length)
@@ -1577,6 +1579,7 @@ function jeTreeGetWidgetHTML(widget) {
 
 function jeUpdateTree(delta) {
   for(const id in delta) {
+    // If modifying an existing widget without changing its parent, just substitute new HTML for that widget.
     if(typeof treeNodes[id] != 'undefined' && delta[id] != null && typeof delta[id].parent == 'undefined') {
       treeNodes[id].innerHTML = jeTreeGetWidgetHTML(widgets.get(id));
     } else if(!jeInMacroExecution) {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -512,8 +512,10 @@ const jeCommands = [
     forceKey: 'R',
     show: _=>jeStateNow,
     call: async function() {
+      batchStart();
       for(const id of jeSelectedIDs())
         await removeWidgetLocal(id);
+      batchEnd();
       jeEmpty();
     }
   },

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -269,7 +269,7 @@ const jeCommands = [
         const selectedKey = elements[0];
         elements[0] = "###SELECT ME###";
         jeStateNow[cssKind] = {};
-        for( let i=0; i<Math.floor(elements.length/2); i++) 
+        for( let i=0; i<Math.floor(elements.length/2); i++)
           jeStateNow[cssKind][elements[2*i].trim()] = elements[2*i+1].trim();
         jeSetAndSelect(selectedKey.trim())
       } else {
@@ -1503,7 +1503,7 @@ document.addEventListener("mouseup", function(){
 
 function jeDisplayTree() {
   const allWidgets = Array.from(widgets.values());
-  $('#jeTree').innerHTML = '<ul class=jeTreeDisplay>' + jeDisplayTreeAddWidgets(allWidgets, null) + '</ul>';
+  $('#jeTree').innerHTML = '<ul class=jeTreeDisplay>' + jeDisplayTreeAddWidgets(allWidgets, null, jeSelectedIDs()) + '</ul>';
 
   treeNodes = {};
   for(const dom of $a('#jeTree .key'))
@@ -1528,15 +1528,14 @@ function jeDisplayTree() {
   });
 }
 
-function jeDisplayTreeAddWidgets(allWidgets, parent) {
+function jeDisplayTreeAddWidgets(allWidgets, parent, selectedIDs) {
   function colored(str, kind) {
     return `<i class=${kind}>${html(str)}</i>`
   }
   let result = '';
 
-  const selectedIDs = jeSelectedIDs();
   for(const widget of (allWidgets.filter(w=>w.get('parent')==parent)).sort((w1,w2)=>w1.get('id').localeCompare(w2.get('id'), 'en', {numeric: true, ignorePunctuation: true}))) {
-    const children = jeDisplayTreeAddWidgets(allWidgets, widget.get('id'));
+    const children = jeDisplayTreeAddWidgets(allWidgets, widget.get('id'), selectedIDs);
     const isSelected = selectedIDs.indexOf(widget.get('id')) != -1 ? 'jeHighlightRow' : '';
 
     if(children)


### PR DESCRIPTION
Fixes #1351.

`jeDisplayTree` wass being called by `removeWidgetLocal` for each widget in the selection. This PR wraps the  for loop in `je_removeWidget` with `batchStart` and `batchEnd`.