### PR TITLE
fixed JSON editor client crash when setting grids inside cardDefaults

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -410,7 +410,7 @@ const jeCommands = [
   {
     id: 'je_grid',
     name: 'grid element',
-    context: '^.* ↦ grid',
+    context: '^[^ ]* ↦ grid',
     call: async function() {
       const w = widgets.get(jeStateNow.id);
       jeStateNow.grid.push({
@@ -1057,7 +1057,7 @@ function jeAddGridCommand(key, value) {
   jeCommands.push({
     id: 'grid_' + key,
     name: key,
-    context: '^.* ↦ grid ↦ [0-9]+',
+    context: '^[^ ]* ↦ grid ↦ [0-9]+',
     show: _=>!(key in jeStateNow.grid[+jeContext[2]]),
     call: async function() {
       jeStateNow.grid[+jeContext[2]][key] = '###SELECT ME###';


### PR DESCRIPTION
Fixes #1376. The grid commands assume that the `grid` property is a top-level widget property but their contexts match a `grid` property even if it is nested inside another property.

This PR changes the context so that the commands are only displayed on the top-level `grid`. A proper fix would make them work everywhere instead.