### PR TITLE
limit recursion depth of routines

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -676,6 +676,12 @@ export class Widget extends StateManaged {
         continue;
       }
 
+      if(depth > 250) {
+        problems.push("Too much recursion (>250). Your routine is probably (directly or indirectly) calling itself.");
+        if(jeRoutineLogging) jeLoggingRoutineOperationEnd(problems, variables, collections, true);
+        break;
+      }
+
       if(typeof a == 'string') {
         const identifier = '(?:[a-zA-Z0-9_-]|\\\\u[0-9a-fA-F]{4})+';
         const string     = `'((?:[ !#-&(-[\\]-~]|\\\\u[0-9a-fA-F]{4})*)'`;


### PR DESCRIPTION
Fixes #1405. This limits the recursion depth to 250 and aborts the routine when that limit is reached.

I feel like that limit should be closer to 1000 but something about the debug output cannot go that deep. Maybe the browser has a limit for how deep HTML elements can be nested?