### PR TITLE
Use DOMMatrix transforms to convert points between spaces.

### DIFF
--- a/client/js/geometry.js
+++ b/client/js/geometry.js
@@ -18,12 +18,58 @@ export function getOffset(origin, target) {
   return {x: target.x - origin.x, y: target.y - origin.y}
 }
 
-export function applyTransformedOffset(origin, offset, scale, rotation) {
-  if(rotation % 360 == 0) {
-    return {x: origin.x + offset.x * scale, y: origin.y + offset.y * scale}
-  } else {
-    const dist = distance({x:0,y:0},offset) * scale;
-    const angle = Math.atan2(offset.y ,offset.x) + rotation * Math.PI / 180;
-    return {x: origin.x + dist * Math.cos(angle), y: origin.y + dist * Math.sin(angle)};
+export function getScreenTransform(elem) {
+  let transform = new DOMMatrix();
+  let t = new DOMPoint(10, 10);
+  while (elem) {
+    transform.preMultiplySelf(getElementTransform(elem));
+    elem = elem.offsetParent;
   }
+  return transform;
+}
+
+function parseLengths(str) {
+  return str.match(/^(-?[0-9.]*)px (-?[0-9.]*)px$/).slice(1, 3).map(s => parseFloat(s))
+}
+
+export function dehomogenize(point) {
+  return new DOMPoint(point.x / point.w, point.y / point.w, point.z / point.w);
+}
+
+export function getPointOnPlane(transform, x, y) {
+  const inv = transform.inverse();
+  const p0 = dehomogenize(inv.transformPoint(new DOMPoint(x, y, 0)));
+  // Get transformed direction vector of ray in (0, 0, 1) direction.
+  let dir = dehomogenize(inv.transformPoint(new DOMPoint(x, y, 1)));
+  dir.x -= p0.x;
+  dir.y -= p0.y;
+  dir.z -= p0.z;
+  // If the projected line is parallel with the plane, no intersection point can be determined.
+  if (dir.z == 0)
+    return null;
+  // Find point of intersection with plane.
+  const t = -p0.z / dir.z;
+  return new DOMPoint(p0.x + dir.x * t, p0.y + dir.y * t, p0.z + dir.z * t);
+}
+
+export function getElementTransform(elem) {
+  let transform = new DOMMatrix();
+  const computedPerspective = getComputedStyle(elem).perspective;
+  if (computedPerspective != 'none' && computedPerspective != '0px') {
+    const perspective = parseFloat(computedPerspective);
+    const perspectiveOrigin = parseLengths(getComputedStyle(elem).perspectiveOrigin);
+    // From https://w3c.github.io/csswg-drafts/css-transforms-2/#PerspectiveDefined
+    transform.translateSelf(perspectiveOrigin[0], perspectiveOrigin[1]);
+    transform.multiplySelf(new DOMMatrix([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, -1/perspective, 0, 0, 0, 1]));
+    transform.translateSelf(-perspectiveOrigin[0], -perspectiveOrigin[1]);
+  }
+  const computedTransform = getComputedStyle(elem).transform;
+  if (computedTransform !='none') {
+    const transformOrigin = parseLengths(getComputedStyle(elem).transformOrigin);
+    transform.translateSelf(transformOrigin[0], transformOrigin[1]);
+    transform.multiplySelf(new DOMMatrix(getComputedStyle(elem).transform));
+    transform.translateSelf(-transformOrigin[0], -transformOrigin[1]);
+  }
+  transform.translateSelf(elem.offsetLeft, elem.offsetTop);
+  return transform;
 }

--- a/client/js/geometry.js
+++ b/client/js/geometry.js
@@ -29,7 +29,7 @@ export function getScreenTransform(elem) {
 }
 
 function parseLengths(str) {
-  return str.match(/^(-?[0-9.]*)px (-?[0-9.]*)px$/).slice(1, 3).map(s => parseFloat(s))
+  return str.split(' ').map(s => parseFloat(s))
 }
 
 export function dehomogenize(point) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -367,13 +367,15 @@ export class Widget extends StateManaged {
     return coordLocal.x >= 0 && coordLocal.y >= 0 && coordLocal.x <= this.get('width') && coordLocal.y <= this.get('height');
   }
   coordLocalFromCoordClient(coord) {
-    return getPointOnPlane(getScreenTransform(this.domElement), coord.x, coord.y);
+    const result = getPointOnPlane(getScreenTransform(this.domElement), coord.x, coord.y);
+    return result || new DOMPoint();
   }
   coordLocalFromCoordGlobal(coord) {
     return this.coordLocalFromCoordParent(this.coordParentFromCoordGlobal(coord));
   }
   coordLocalFromCoordParent(coord) {
-    return getPointOnPlane(getElementTransform(this.domElement), coord.x, coord.y);
+    const result = getPointOnPlane(getElementTransform(this.domElement), coord.x, coord.y);
+    return result || new DOMPoint();
   }
   coordParentFromCoordGlobal(coord) {
     const p = this.get('parent');

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -4,7 +4,7 @@ import { playerName, playerColor, activePlayers } from '../overlays/players.js';
 import { batchStart, batchEnd, widgetFilter, widgets } from '../serverstate.js';
 import { showOverlay, shuffleWidgets, sortWidgets } from '../main.js';
 import { tracingEnabled } from '../tracing.js';
-import { center, distance, overlap, getOffset, applyTransformedOffset } from '../geometry.js';
+import { center, distance, overlap, getOffset, getElementTransform, getScreenTransform, getPointOnPlane, dehomogenize } from '../geometry.js';
 
 const readOnlyProperties = new Set([
   '_absoluteRotation',
@@ -367,42 +367,21 @@ export class Widget extends StateManaged {
     return coordLocal.x >= 0 && coordLocal.y >= 0 && coordLocal.x <= this.get('width') && coordLocal.y <= this.get('height');
   }
   coordLocalFromCoordClient(coord) {
-    const s = this.get('_absoluteScale') * scale;
-    const rot = this.get('_absoluteRotation') % 360;
-    const localCenter = {x: this.get('width') / 2, y: this.get('height') / 2};
-    const offset = getOffset(center(this.domElement), coord);
-    return applyTransformedOffset(localCenter, offset, 1 / s, -rot );
+    return getPointOnPlane(getScreenTransform(this.domElement), coord.x, coord.y);
   }
   coordLocalFromCoordGlobal(coord) {
     return this.coordLocalFromCoordParent(this.coordParentFromCoordGlobal(coord));
   }
   coordLocalFromCoordParent(coord) {
-    const s = this.get('scale');
-    const rot = this.get('rotation') % 360;
-    if(s == 1 && rot == 0) {
-      return {x: coord.x - this.get('x'), y: coord.y - this.get('y')};
-    } else {
-      const localCenter = {x: this.get('width') / 2, y: this.get('height') / 2};
-      const parentCenter = {x: localCenter.x + this.get('x') , y: localCenter.y + this.get('y') };
-      const offset = getOffset(parentCenter, coord);
-      return applyTransformedOffset(localCenter, offset, 1 / s, -rot );
-    }
+    return getPointOnPlane(getElementTransform(this.domElement), coord.x, coord.y);
   }
   coordParentFromCoordGlobal(coord) {
     const p = this.get('parent');
     return (widgets.has(p)) ? widgets.get(p).coordLocalFromCoordGlobal(coord) : coord;
   }
   coordParentFromCoordLocal(coord) {
-    let s = this.get('scale');
-    let rot = this.get('rotation') % 360;
-    if(s == 1 && rot == 0) {
-      return {x: coord.x + this.get('x'), y: coord.y + this.get('y')};
-    } else {
-      const localCenter = {x: this.get('width') / 2, y: this.get('height') / 2};
-      const parentCenter = {x: localCenter.x + this.get('x') , y: localCenter.y + this.get('y') };
-      const offset = getOffset(localCenter, coord);
-      return applyTransformedOffset(parentCenter, offset, s, rot );
-    }
+    const transform = getElementTransform(this.domElement);
+    return dehomogenize(transform.transformPoint(new DOMPoint(coord.x, coord.y)));
   }
 
   css() {


### PR DESCRIPTION
This supports arbitrarily complex transformations including perspective and also leans on the browser to do the conversion between coordinate spaces. Fixes #1420.