### PR TITLE
Add 'range' option to FOREACH

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -756,7 +756,7 @@ function jeAddCommands() {
   jeAddRoutineOperationCommands('CLONE', { source: 'DEFAULT', collection: 'DEFAULT', xOffset: 0, yOffset: 0, count: 1, properties: null });
   jeAddRoutineOperationCommands('DELETE', { collection: 'DEFAULT'});
   jeAddRoutineOperationCommands('FLIP', { count: 0, face: null, faceCycle: 'forward', holder: null, collection: 'DEFAULT' });
-  jeAddRoutineOperationCommands('FOREACH', { loopRoutine: [], in: [], collection: 'DEFAULT' });
+  jeAddRoutineOperationCommands('FOREACH', { loopRoutine: [], in: [], range: [], collection: 'DEFAULT' });
   jeAddRoutineOperationCommands('GET', { variable: 'id', collection: 'DEFAULT', property: 'id', aggregation: 'first', skipMissing: false });
   jeAddRoutineOperationCommands('IF', { condition: null, operand1: null, relation: '==', operand2: null, thenRoutine: [], elseRoutine: [] });
   jeAddRoutineOperationCommands('INPUT', { cancelButtonIcon: null, cancelButtonText: "Cancel", confirmButtonIcon: null, confirmButtonText: "OK", fields: [] } );

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1027,19 +1027,29 @@ export class Widget extends StateManaged {
           if(jeRoutineLogging)
             jeLoggingRoutineOperationSummary( `elements in '${JSON.stringify(a.in)}'`);
         } else if(a.range) {
-          let range = a.range;
-          if(!Array.isArray(range))
-            range = [1,range];
-          if(range.length < 2 || range[1]<0 ||(range[1] && range[1]<0)) {
-            problems.push(`Range ${JSON.stringify(range)} should be either an array with at least two elements, or a positive number, [1,1] used.`);
-            range = [1,1]
+          let range = asArray(a.range);
+          if(range.length == 1)
+            range.unshift(1);
+          if(range.length == 2)
+            range.push(1);
+          let start = parseFloat(range[0]);
+          let end = parseFloat(range[1]);
+          let step = parseFloat(range[2]);
+          if(isNaN(start)) {
+            problems.push(`Invalid start of range ${JSON.stringify(range[0])}, 1 used`);
+            start = 1;
           }
-          let start = range[0];
-          let end = range[1];
-          let step = range[2] || (start < end ? 1 : -1);
-          if( isNaN(parseFloat(start)) || isNaN(parseFloat(end)) || isNaN(parseFloat(step)) || (start < end && step < 0) || (start > end && step > 0) ) {
-            problems.push(`Invalid range ${JSON.stringify(range)}, [1,1,1] used`);
-            start = end = step = 1;
+          if(isNaN(end)) {
+            problems.push(`Invalid end of range ${JSON.stringify(range[1])}, 1 used`);
+            end = 1;
+          }
+          if(isNaN(step) || step == 0) {
+            problems.push(`Invalid step value ${JSON.stringify(range[2])}, 1 used`);
+            step = 1;
+          }
+          if(start>end && step>0 || start<end && step<0) {
+            step = -step;
+            problems.push(`Step ${JSON.stringify(range[2])} changed to ${step}`)
           }
           for (let index=start; (step > 0) ? index <= end : index >= end; index += step)
             await callWithAdditionalValues({ value: index });

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1025,12 +1025,29 @@ export class Widget extends StateManaged {
           for(const key in a.in)
             await callWithAdditionalValues({ key, value: a.in[key] }, {});
           if(jeRoutineLogging)
-            jeLoggingRoutineOperationSummary( `element in '${JSON.stringify(a.in)}'`);
+            jeLoggingRoutineOperationSummary( `elements in '${JSON.stringify(a.in)}'`);
+        } else if(a.range) {
+          const range = a.range;
+          if(range.length < 2) {
+            problems.push(`Range ${JSON.stringify(range)} should be an array with at least two elements.`);
+            range = [1,1]
+          }
+          let start = range[0];
+          let end = range[1];
+          let step = range[2] || (start < end ? 1 : -1);
+          if((start < end && step < 0) || (start > end && step > 0)) {
+            problems.push(`Invalid range ${JSON.stringify(range)}, [1,1,1] used`);
+            start = end = step = 1;
+          }
+          for (let index=start; (step > 0) ? index <= end : index >= end; index += step)
+            await callWithAdditionalValues({ value: index });
+          if(jeRoutineLogging)
+            jeLoggingRoutineOperationSummary( `values in range '${JSON.stringify(a.range)}'`);
         } else if(collection = getCollection(a.collection)) {
           for(const widget of collections[collection])
             await callWithAdditionalValues({ widgetID: widget.get('id') }, { DEFAULT: [ widget ] });
           if(jeRoutineLogging)
-            jeLoggingRoutineOperationSummary( `widget in '${a.collection}'`);
+            jeLoggingRoutineOperationSummary( `widgets in '${a.collection}'`);
         }
       }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1027,15 +1027,17 @@ export class Widget extends StateManaged {
           if(jeRoutineLogging)
             jeLoggingRoutineOperationSummary( `elements in '${JSON.stringify(a.in)}'`);
         } else if(a.range) {
-          const range = a.range;
-          if(range.length < 2) {
-            problems.push(`Range ${JSON.stringify(range)} should be an array with at least two elements.`);
+          let range = a.range;
+          if(!Array.isArray(range))
+            range = [1,range];
+          if(range.length < 2 || range[1]<0 ||(range[1] && range[1]<0)) {
+            problems.push(`Range ${JSON.stringify(range)} should be either an array with at least two elements, or a positive number, [1,1] used.`);
             range = [1,1]
           }
           let start = range[0];
           let end = range[1];
           let step = range[2] || (start < end ? 1 : -1);
-          if((start < end && step < 0) || (start > end && step > 0)) {
+          if( isNaN(parseFloat(start)) || isNaN(parseFloat(end)) || isNaN(parseFloat(step)) || (start < end && step < 0) || (start > end && step > 0) ) {
             problems.push(`Invalid range ${JSON.stringify(range)}, [1,1,1] used`);
             start = end = step = 1;
           }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1027,20 +1027,20 @@ export class Widget extends StateManaged {
           if(jeRoutineLogging)
             jeLoggingRoutineOperationSummary( `elements in '${JSON.stringify(a.in)}'`);
         } else if(a.range) {
-          let range = asArray(a.range);
+          let range = [...asArray(a.range)];
 
           if(range.length == 0) {
             problems.push(`Empty range given, [1] used.`);
             range = [1]
           }
+          if(range.length == 1)
+            range.unshift(1);
           let start = parseFloat(range[0]);
           if(isNaN(start)) {
             problems.push(`Invalid start of range ${JSON.stringify(range[0])}, 1 used`);
             start = 1;
           }
 
-          if(range.length == 1)
-            range.unshift(1);
           let end = parseFloat(range[1]);
           if(isNaN(end)) {
             problems.push(`Invalid end of range ${JSON.stringify(range[1])}, 1 used`);

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1007,7 +1007,7 @@ export class Widget extends StateManaged {
             jeLoggingRoutineOperationStart( "loopRoutine", "loopRoutine" );
           await this.evaluateRoutine(a.loopRoutine, variables, collections, (depth || 0) + 1, true);
           if(jeRoutineLogging)
-            jeLoggingRoutineOperationEnd(problems, variables, collections, false);
+            jeLoggingRoutineOperationEnd([], variables, collections, false);
           for(const add in addVariables) {
             if(variableBackups[add] !== undefined)
               variables[add] = variableBackups[add];

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1027,43 +1027,41 @@ export class Widget extends StateManaged {
           if(jeRoutineLogging)
             jeLoggingRoutineOperationSummary( `elements in '${JSON.stringify(a.in)}'`);
         } else if(a.range) {
-          const rangeProblems = []; // To avoid repeated error messages in each loop iteration
           let range = asArray(a.range);
-          
+
           if(range.length == 0) {
-            rangeProblems.push(`Empty range given, [1] used.`);
+            problems.push(`Empty range given, [1] used.`);
             range = [1]
           }
           let start = parseFloat(range[0]);
           if(isNaN(start)) {
-            rangeProblems.push(`Invalid start of range ${JSON.stringify(range[0])}, 1 used`);
+            problems.push(`Invalid start of range ${JSON.stringify(range[0])}, 1 used`);
             start = 1;
           }
-          
+
           if(range.length == 1)
             range.unshift(1);
           let end = parseFloat(range[1]);
           if(isNaN(end)) {
-            rangeProblems.push(`Invalid end of range ${JSON.stringify(range[1])}, 1 used`);
+            problems.push(`Invalid end of range ${JSON.stringify(range[1])}, 1 used`);
             end = 1;
           }
-          
+
           if(range.length == 2)
             range.push(end > start ? 1 : -1);
           let step = parseFloat(range[2]);
           if(isNaN(step) || step == 0) {
             step = end > start ? 1 : -1;
-            rangeProblems.push(`Invalid step value ${JSON.stringify(range[2])}, ${step} used`);
+            problems.push(`Invalid step value ${JSON.stringify(range[2])}, ${step} used`);
           }
-          
+
           if(start>end && step>0 || start<end && step<0) {
             step = -step;
-            rangeProblems.push(`Step ${-step} changed to ${step}`)
+            problems.push(`Step ${-step} changed to ${step}`)
           }
-          
+
           for (let index=start; (step > 0) ? index <= end : index >= end; index += step)
             await callWithAdditionalValues({ value: index });
-          problems = rangeProblems;
           if(jeRoutineLogging)
             jeLoggingRoutineOperationSummary( `values in range '${JSON.stringify(a.range)}'`);
         } else if(collection = getCollection(a.collection)) {


### PR DESCRIPTION
Fixes #1431.

This adds `range` in addition to the existing `in` and `collection` parameters to `FOREACH`. `in` takes precedence over `range`, which takes precedence over `collection` if more than one is specified.

The value to `range` is a range of the form `[start, end, step]`. If `step` is omitted, it is assumed to be 1 if `start` < `end` and -1 if `start` > `end`. The `loopRoutine` is called once for each element of the resulting range, passing the range element as `value`.