### PR TITLE
Fix two minor issues with JSON editor

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -372,10 +372,16 @@ body.jsonEdit.jeZoomOut #topSurface {
   transform: rotate(90deg);
 }
 
+/* .jeLogHasProblems and .jeLogHasNoProblems control the text color of the first item displayed. */
 .jeLogHasProblems, .jeLogProblems {
   color: red;
 }
 
+.jeLogHasNoProblems {
+  color: white;
+}
+
+/* .jeLogProblems controls the color and display of the problem text */
 .jeLogProblems {
   display: none;
 }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -708,7 +708,6 @@ function jeAddRoutineOperationCommands(command, defaults) {
     show: jeRoutineCall((_, routine)=>Array.isArray(routine), true)
   });
 
-  defaults.skip = false;
   for(const property in defaults) {
     jeCommands.push({
       id: 'default_' + command + '_' + property,
@@ -1892,7 +1891,7 @@ function jeLoggingRoutineOperationEnd(problems, variables, collections, skipped)
 
   jeLoggingHTML =  `
     ${savedHTML[0]}
-    <div class="jeLogOperation ${skipped ? 'jeLogSkipped' : ''} ${problems.length ? 'jeLogHasProblems' : ''}">
+    <div class="jeLogOperation ${skipped ? 'jeLogSkipped' : ''} ${problems.length ? 'jeLogHasProblems' : 'jeLogHasNoProblems'}">
       <div class="jeExpander">
         <span class="jeLogName">${opFunction}</span> ${jeRoutineResult} <span class="jeLogTime">(${+new Date() - startTime}ms)</span>
       </div>


### PR DESCRIPTION
1. Removes `skip` as a default option for every function - it has long since been deprecated.
2. Red color indicating errors in the debug info now works better: a red arrow with not-red text following indicates that the current statement is OK but that one of its descendants has an error. A red arrow with red text following indicates that this statement itself is in error; the `Problems` section under the designator will explain the error.