### PR TITLE
add internalURL to support bypassing the authentication layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,39 @@ If you use "GitHub Desktop" you should follow these steps:
 4. Go to Repository -> Open in Command Prompt.
 5. Do `npm install` so Node.js downloads all the dependencies of the project.
 
+## Configure the server
+
+If you just want to run VirtualTabletop locally, you likely don't need to change anything. You can skip this section.
+
+However, if you have some custom setup, for example:
+
+1. Your virtualtabletop server is behind [a reverse proxy](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/)
+2. Your virtualtabletop server is not at the root path, e.g. `https://example.domain.com/games/virtualtabletop`
+3. You use a different port.
+4. Your web stack has an authentication layer.
+5. You are using different paths for `library`, `save`, or `assets`.
+
+then you can edit the configuration file.
+
+1. Make a copy of `config.template.json` and name it `config.json`. (If `config.json` already exists, you can just edit it.)
+2. Change the values in `config.json`.
+
+Most fields are obvious.
+
+`externalURL` is the URL seen by the world. `internalURL` is the URL seen from your VirtualTabletop server environment. For example, a typical cloud setup may be like this:
+
+* Your server is sitting behind an NGINX reverse proxy, so that public users can visit your virtualtabletop server at https://example.domain.com/games/virtualtabletop
+* You are running VirtualTabletop in a docker container and it's port is set to 8272. NGINX sees your server at http://localhost:8272
+* You have an authentication layer in front of NGINX, e.g. OpenID or Google OAuth, so your users need to login to see https://example.domain.com/games/virtualtabletop Because of this authentication layer, VirtualTabletop cannot fetch files within https://example.domain.com/games/virtualtabletop (it will be blocked by OpenID or Google OAuth). In this case, you need to provide `internalURL` for file fetching.
+
+Example configuration (partial):
+```
+"port": 8272,
+"externalURL": "https://example.domain.com",
+"internalURL": "http://localhost:8272",
+"urlPrefix": "/games/virtualtabletop/",
+```
+
 ## Starting the server
 
 Now you can start the server by typing:

--- a/config.template.json
+++ b/config.template.json
@@ -1,6 +1,7 @@
 {
   "port": 8272,
   "externalURL": "http://localhost:8272",
+  "internalURL": "http://localhost:8272",
   "urlPrefix": "",
   "minifyJavascript": false,
   "forceTracing": false,

--- a/server/fileloader.mjs
+++ b/server/fileloader.mjs
@@ -24,7 +24,12 @@ async function downloadLink(link) {
     filename: Math.random().toString(36).substring(3, 9)
   };
 
-  const response = await fetch(link, requestEtag ? { headers: { 'If-None-Match': requestEtag } } : {});
+  // if the link is to our own server, use the local link instead so we can skip external auth, if any
+  var actual_link = link;
+  if (Config.get("externalURL") && link.startsWith(Config.get("externalURL"))) {
+    actual_link = link.replace(Config.get("externalURL"), Config.get("internalURL"));
+  }
+  const response = await fetch(actual_link, requestEtag ? { headers: { 'If-None-Match': requestEtag } } : {});
 
   currentLinkStatus.time = +new Date();
   currentLinkStatus.status = response.status;


### PR DESCRIPTION
When there is an authentication layer in front of the server (a common setup in the cloud), `fileloader` will be blocked from fetching the file at the public URL. This PR adds an `internalURL` setting so VirtualTabletop server can bypass the authentication to download internal vtt files.

Please see changes in `README.md` for more explanation.

This feature was mentioned [here](https://github.com/ArnoldSmith86/virtualtabletop/pull/731#issuecomment-1022168070).