### PR TITLE
New function: `CHOOSE`

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -855,23 +855,22 @@ export class Widget extends StateManaged {
       }
 
       if(a.func == 'CHOOSE') {  
-        let numFaces;
         const faceDetails = {};
         for (const [key, value] of Object.entries(this.get('faces'))) {
           faceDetails[key] = value;
         }
-        numFaces = this.faces().length;
-        console.log(faceDetails)
+        let numFaces = this.faces().length;
         setDefaults(a, { source: 'DEFAULT', count: numFaces, xOffset: 0, yOffset: 0, properties: {}, collection: 'CHOOSER' });
+        // Somehow, need to change the collection so that it know the collection is this.id. Right now, have to put a SELECT in the routine to make it work.
         const source = getCollection(a.source);
         if(source) {
           var c=[];
           const numRows = Math.ceil(Math.sqrt(numFaces));
           const numColumns = Math.ceil(numFaces / numRows);
-          const xSpacing = 100; // The distance between each column
-          const ySpacing = 100; // The distance between each row
-          let x = -numColumns / 2 * xSpacing; // The starting x coordinate
-          let y = -numRows / 2 * ySpacing; // The starting y coordinate
+          const xSpacing = this.get('width');
+          const ySpacing = this.get('height');
+          let x = -numColumns / 2 * xSpacing + this.get('width') / 2;
+          let y = -numRows / 2 * ySpacing + this.get('height') / 2;
       
           for(const w of collections[source]) {
             for(let i=1; i<=a.count; ++i) {
@@ -885,12 +884,13 @@ export class Widget extends StateManaged {
                   problems.push(`There is already a widget with id:${a.properties.id}, generating new ID.`);
               }
               delete clone.faces;
-              delete clone.clickRoutine;
-              // clone.movable = false  ADD This back in later
+              delete clone.clickRoutine; // Need to add in a special clickRoutine to do the choosing part.
+              clone.movable = false
               clone.parent = this.id;
               clone.x = x;
               clone.y = y;
-              for (const [key, value] of Object.entries(faceDetails)) {
+ 
+              for (const [key, value] of Object.entries(faceDetails)) { //This is not working to put unique faces properties on each widget
                 clone[key] = value;
               }
               const cWidget = widgets.get(await addWidgetLocal(clone));
@@ -899,7 +899,7 @@ export class Widget extends StateManaged {
       
               x += xSpacing;
               if(x >= numColumns / 2 * xSpacing) {
-                x = -numColumns / 2 * xSpacing;
+                x = -numColumns / 2 * xSpacing + this.get('width') / 2;
                 y += ySpacing;
               }
             }


### PR DESCRIPTION
This partially implements #770, although not in the way suggested there.

The idea is to create a chooser type of process like PCIO has for bidding, suits, dice, etc.  PCIO uses cards.  But cards are much harder to work with than basic widgets.  We could go 2 ways with this.  One way is to just cycle through each of the choices on a separate face.  Very easy to implement.  Just need the PCIO importer to take the values, text, images, etc. on the cards and put them on the face of a basic widget.

The other way is to do it like PCIO does when there are more than 2 choices: have a little menu of all the choices pop up.  That is what this very early draft starts to do.  The idea is to clone with widgets, put a unique face on each one, put them in a grid, then delete all the clones when the user clicks on them and set the proper face on the original widget.  This is only about 25% done, but I'm throwing it out there so you can tell me we need to do it a different way, if that is what you think.