### PR TITLE
Add maxX and maxY to JSON Editor Grid Options

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -784,6 +784,8 @@ function jeAddCommands() {
 
   jeAddGridCommand('x', 0);
   jeAddGridCommand('y', 0);
+  jeAddGridCommand('maxX', 0);
+  jeAddGridCommand('maxY', 0);
   jeAddGridCommand('minX', 0);
   jeAddGridCommand('minY', 0);
   jeAddGridCommand('offsetX', 0);


### PR DESCRIPTION
Fixes #1461.  I probably would have put minX and minY first and then max, but it doesn't matter since the editor seems to automatically alphabetize them.