### PR TITLE
fixed state migration for duplicate games

### DIFF
--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -462,7 +462,7 @@ function fillStatesList(states, starred, activeState, returnServer, activePlayer
       if(variant.plStateID)
         variant = states[variant.plStateID].variants[variant.plVariantID];
 
-      if(!publicLibraryLinksFound[`${state.id} - ${variantID}`])
+      if(!publicLibraryLinksFound[`${state.id} - ${variantID}`] || state.starred)
         hasVariants = true;
 
       validPlayers.push(...parsePlayers(variant.players));

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -520,8 +520,9 @@ export default class Room {
                   allVariantsFromPL = false;
               if(allVariantsFromPL && compareNameAndImage(state, targetState)) {
                 Logging.log(`migrating ${target} in room ${this.id}`);
+                if(!this.state._meta.starred[targetState.publicLibrary])
+                  Statistics.toggleStateStar(targetState.publicLibrary, true);
                 this.state._meta.starred[targetState.publicLibrary] = true;
-                Statistics.toggleStateStar(targetState.publicLibrary, true);
                 this.removeState(undefined, id);
                 migratedToTargetState = true;
                 break;


### PR DESCRIPTION
If a room had the same public library game 60x before #1223, the migration would remove the duplicates but it would count each one towards the stars.

Also: a public library game is hidden if all its variants get linked to from other games in the room. This PR changes it so it is only hidden if it is not also starred.