### PR TITLE
fixed Medieval VNO direction indicator and NEXT button

### DIFF
--- a/library/games/Medieval VNO/0.json
+++ b/library/games/Medieval VNO/0.json
@@ -1486,7 +1486,7 @@
     "id": "playerSitIn",
     "activePlayers": [],
     "dropTarget": {
-      "not": "allowed"
+      "id": "u7h3"
     },
     "dropOffsetX": 0,
     "dropOffsetY": 0,
@@ -3512,7 +3512,7 @@
     "width": 100,
     "height": 80,
     "dropTarget": {
-      "not": "allowed"
+      "id": "marker"
     },
     "parent": "player1Zone",
     "dropOffsetX": 0,
@@ -6185,7 +6185,7 @@
       "similarName": "UNO",
       "description": "Play cards onto discard stack matching color or number.  Use cards with powers to influence play.  First to get rid of all cards wins.",
       "showName": true,
-      "lastUpdate": 1624286591000
+      "lastUpdate": 1673381158873
     }
   }
 }

--- a/library/games/Medieval VNO/1.json
+++ b/library/games/Medieval VNO/1.json
@@ -1482,7 +1482,7 @@
     "id": "playerSitIn",
     "activePlayers": [],
     "dropTarget": {
-      "not": "allowed"
+      "id": "u7h3"
     },
     "dropOffsetX": 0,
     "dropOffsetY": 0,
@@ -3563,7 +3563,7 @@
     "width": 100,
     "height": 80,
     "dropTarget": {
-      "not": "allowed"
+      "id": "marker"
     },
     "parent": "player1Zone",
     "dropOffsetX": 0,
@@ -6234,7 +6234,7 @@
       "similarName": "UNO",
       "description": "Play cards onto discard stack matching color or number.  Use cards with powers to influence play.  First to get rid of all cards wins.",
       "showName": true,
-      "lastUpdate": 1624286591000
+      "lastUpdate": 1673381158873
     }
   }
 }

--- a/library/games/Medieval VNO/2.json
+++ b/library/games/Medieval VNO/2.json
@@ -1505,7 +1505,7 @@
     "id": "playerSitIn",
     "activePlayers": [],
     "dropTarget": {
-      "not": "allowed"
+      "id": "u7h3"
     },
     "dropOffsetX": 0,
     "dropOffsetY": 0,
@@ -3586,7 +3586,7 @@
     "width": 100,
     "height": 80,
     "dropTarget": {
-      "not": "allowed"
+      "id": "marker"
     },
     "parent": "player1Zone",
     "dropOffsetX": 0,
@@ -6342,7 +6342,7 @@
       "similarName": "UNO",
       "description": "Play cards onto discard stack matching color or number.  Use cards with powers to influence play.  First to get rid of all cards wins.",
       "showName": true,
-      "lastUpdate": 1624286591000
+      "lastUpdate": 1673381158873
     }
   },
   "buyPile": {


### PR DESCRIPTION
It used `"dropTarget": { "not": "allowed" }` which prevented several routine operations to operate on the children.