### PR TITLE
Fix uneditable labels so they scroll

### DIFF
--- a/client/css/widgets/label.css
+++ b/client/css/widgets/label.css
@@ -30,6 +30,6 @@ body.edit .widget.label > * {
 }
 
 .widget.label > textarea:read-only {
-  pointer-events: none;
+  outline: none;
 }
 


### PR DESCRIPTION
Fixes #1064 by changing `pointer-events: none` to `outline: none`.  This allows scrolling without allowing the textarea to become the focus and interfere with other actions.