### PR TITLE
fix sort logging; updateAfterShuffle for collections

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1502,6 +1502,10 @@ export class Widget extends StateManaged {
         } else if(collection = getCollection(a.collection)) {
           if(collections[collection].length) {
             await shuffleWidgets(collections[collection]);
+            await w(collections[collection].map(i=>i.get('parent')), async holder=>{
+              if(holder.get('type') == 'holder')
+                await holder.updateAfterShuffle();
+            });
           } else {
             problems.push(`Collection ${a.collection} is empty.`);
           }
@@ -1526,9 +1530,9 @@ export class Widget extends StateManaged {
               if(holder.get('type') == 'holder')
                 await holder.updateAfterShuffle();
             });
+            if(jeRoutineLogging)
+              jeLoggingRoutineOperationSummary(`widgets in '${a.holder}' by ${key}${reverse}`);
           }
-          if(jeRoutineLogging)
-            jeLoggingRoutineOperationSummary(`widgets in '${a.holder}' by ${key}${reverse}`);
         } else if(collection = getCollection(a.collection)) {
           if(collections[collection].length) {
             await sortWidgets(collections[collection], a.key, a.reverse, a.locales, a.options, a.rearrange);


### PR DESCRIPTION
two small bug fixes:

* add updateAfterShuffle when shuffling a collection
* sort-logging only when holder is valid