### PR TITLE
fixed TestCafé

### DIFF
--- a/tests/testcafe/test-util.js
+++ b/tests/testcafe/test-util.js
@@ -58,11 +58,15 @@ export async function compareState(t, md5) {
     state = await getState();
     hash = crypto.createHash('md5').update(state).digest('hex');
 
-    if(hash == md5) {
+    // hardcoded hash difference because of https://github.com/ArnoldSmith86/virtualtabletop/issues/1553 - can hopefully be removed if Chrome changes this back
+    if(hash == md5 || hash == 'a1c9e538ab6e1bf3296e4e90cffa0cfb' && md5 == '4403a094826913c3d883dedc619e4924') {
       if(!fs.existsSync(refFile))
         fs.writeFileSync(refFile, state);
 
-      await t.expect(hash).eql(md5);
+      if(hash == 'a1c9e538ab6e1bf3296e4e90cffa0cfb' && md5 == '4403a094826913c3d883dedc619e4924')
+        await t.expect(md5).eql(md5);
+      else
+        await t.expect(hash).eql(md5);
       return;
     }
 


### PR DESCRIPTION
Issue #1553 documents why the compute check for `toLocaleLowerCase` currently fails for Chrome 109. This PR makes TestCafé accept the changed hash although I hope that this is temporary and will be fixed in Chrome.