### PR TITLE
Add parameter to control snap distance when cards make piles

### DIFF
--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -12,6 +12,7 @@ class Card extends Widget {
 
       deck: null,
       cardType: null,
+      pileSnapRange: 10,
       onPileCreation: {}
     });
 

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -14,7 +14,6 @@ class Pile extends Widget {
       inheritChildZ: true,
 
       text: null,
-
       pileSnapRange: 10,
 
       handleCSS: '',
@@ -41,7 +40,6 @@ class Pile extends Widget {
   }
 
    applyDeltaToDOM(delta) {
-
     super.applyDeltaToDOM(delta);
     if(this.handle && delta.handleCSS !== undefined)
       this.handle.style = mapAssetURLs(this.cssAsText(this.get('handleCSS'),null,true));

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -15,7 +15,7 @@ class Pile extends Widget {
 
       text: null,
 
-      snapRadius: 10,
+      pileSnapRange: 10,
 
       handleCSS: '',
       handleSize: 'auto',
@@ -41,8 +41,6 @@ class Pile extends Widget {
   }
 
    applyDeltaToDOM(delta) {
-
-    this.handle.snapRadius = this.get('snapRadius');
 
     super.applyDeltaToDOM(delta);
     if(this.handle && delta.handleCSS !== undefined)

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -15,6 +15,8 @@ class Pile extends Widget {
 
       text: null,
 
+      snapRadius: 10,
+
       handleCSS: '',
       handleSize: 'auto',
       handleOffset: 15,
@@ -38,7 +40,10 @@ class Pile extends Widget {
     this.updateText();
   }
 
-  applyDeltaToDOM(delta) {
+   applyDeltaToDOM(delta) {
+
+    this.handle.snapRadius = this.get('snapRadius');
+
     super.applyDeltaToDOM(delta);
     if(this.handle && delta.handleCSS !== undefined)
       this.handle.style = mapAssetURLs(this.cssAsText(this.get('handleCSS'),null,true));

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -39,7 +39,7 @@ class Pile extends Widget {
     this.updateText();
   }
 
-   applyDeltaToDOM(delta) {
+  applyDeltaToDOM(delta) {
     super.applyDeltaToDOM(delta);
     if(this.handle && delta.handleCSS !== undefined)
       this.handle.style = mapAssetURLs(this.cssAsText(this.get('handleCSS'),null,true));

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2222,9 +2222,8 @@ export class Widget extends StateManaged {
       if(widgetType != 'card' && widgetType != 'pile')
         continue;
 
-      // check if this widget is closer than 10px from another widget in the same parent
-      let snapRadius = 50;
-      if(widget.get('parent') == thisParent && Math.abs(widget.get('x')-thisX) < snapRadius && Math.abs(widget.get('y')-thisY) < snapRadius) {
+      // check if this widget is closer than the pileSnapRange from another widget in the same parent
+      if(widget.get('parent') == thisParent && Math.abs(widget.get('x')-thisX) < this.get('pileSnapRange') && Math.abs(widget.get('y')-thisY) < this.get('pileSnapRange')) {
         if(widget.isBeingRemoved || widget.get('owner') !== thisOwner || JSON.stringify(widget.get('onPileCreation')) !== thisOnPileCreation)
           continue;
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2223,7 +2223,8 @@ export class Widget extends StateManaged {
         continue;
 
       // check if this widget is closer than 10px from another widget in the same parent
-      if(widget.get('parent') == thisParent && Math.abs(widget.get('x')-thisX) < 10 && Math.abs(widget.get('y')-thisY) < 10) {
+      let snapRadius = 50;
+      if(widget.get('parent') == thisParent && Math.abs(widget.get('x')-thisX) < snapRadius && Math.abs(widget.get('y')-thisY) < snapRadius) {
         if(widget.isBeingRemoved || widget.get('owner') !== thisOwner || JSON.stringify(widget.get('onPileCreation')) !== thisOnPileCreation)
           continue;
 


### PR DESCRIPTION
This would implement #201 if it worked right.  Requesting help.

I could get this to work if I just created a property on cards.  But it seems to make sense to add this to the deck's cardDefaults onPileCreation settings.  That is what I'm having trouble with.

Here is the issue.  In pile.js I added a new default of snapRadius: 10 (it is currently 10px). And I got that to apply to the pile, so it shows up like handleCSS, handleSize, etc.

But in widget.js, around line 2226, I can't figure out a way to read the property from the handle.snapRadius.  Pile.js uses a constructor with this.handle.xxx format and widget.js doesn't.  I've tried every combination of this.get and widget.get I can think of.  I tried exporting and importing.  Somebody knows an easy fix for this.  Help.

By the way, the code in this PR currently forces a snapRadius of 50, just so you can see how it works different.  That line will obviously be removed.