### PR TITLE
fixed moving a room to a beta server

### DIFF
--- a/server/room.mjs
+++ b/server/room.mjs
@@ -641,7 +641,7 @@ export default class Room {
     }
     if(zipBody && zipBody.length) {
       await this.addState('serverMove', 'file', zipBody, 'source', false);
-      await this.loadState(null, 'serverMove', 'serverMove');
+      await this.loadState(null, 'serverMove', 0);
       this.removeState(null, 'serverMove');
     }
   }


### PR DESCRIPTION
I missed this when I turned variant IDs into numbers. The target server tried to load variant ID `"serverMove"` instead of `0`.