### PR TITLE
add support for GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+    "updateContentCommand": "npm install",
+    "postStartCommand": "npm run debug",
+    "portsAttributes": {
+        "8272": {
+            "label": "virtualtabletop",
+            "onAutoForward": "notify"
+        },
+        "9229":{
+            "label": "VTT-websocket",
+            "onAutoForward": "silent"
+        }
+    }
+}


### PR DESCRIPTION
`testcafe-gitpod` script works without modification; however, functions.js test fails on 2-core VM (succeeds on 4-core VM). 

Overall Gitpod performance feels better. Codespaces does have the advantage of saving the whole container when stopped, not just the workspaces folder. gitpod-vnc scripts do not work for watching testcafe tests (but the basic concept does work the same).