### PR TITLE
Allow accessing library games' _raw_ assets

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -112,6 +112,23 @@ MinifyRoom().then(function(result) {
     res.send(result);
   });
 
+  router.get('/assets/:game/:name', function(req, res) {
+    const highest_allowed_directory = path.join(Config.directory('library'), "games") + "/";
+    const filepath = path.join(highest_allowed_directory, req.params.game, "assets", req.params.name);
+    // security guard against escaping the highest_allowed_directory
+    if (filepath.indexOf(highest_allowed_directory) !== 0) {
+      res.sendStatus(404);
+    }
+
+    fs.access(filepath, fs.F_OK, (err) => {
+      if (err) {
+        res.sendStatus(404);
+      } else {
+        res.sendFile(filepath);
+      }
+    });
+  });
+
   router.get('/assets/:name', function(req, res) {
     if(!req.params.name.match(/^[0-9_-]+$/) || !Config.resolveAsset(req.params.name)) {
       res.sendStatus(404);


### PR DESCRIPTION
I'm throwing this one out for discussion. This PR allows _direct_ access to _raw_ asset files under `library/games/xxxx/assets/yyyy.zzz` via route `/assets/:game/:name`.

Benefits:
* Assets files can be in their original raw form, e.g. webp, png, etc., as opposed to their hash name. This makes game creation workflow easier (no need to convert files to hash names; file extensions are kept so application can open them more easily).
* faster file serving -- no need to open files to inspect its first bytes
* future-proof -- no need to add byte identifiers for newer file types

We can tune cache control if necessary.

I'm not sure why game assets were converted to hash names in the first place, so there might be reasons that I am unaware. Can we discuss this?