### PR TITLE
fixed re-saving a savegame if the source game is no longer there

### DIFF
--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -450,7 +450,8 @@ function fillStatesList(states, starred, activeState, returnServer, activePlayer
         updateSaveButton.style.display = 'inline-flex';
     }
 
-    $('img', entry).src = mapAssetURLs(state.image);
+    if(state.image)
+      $('img', entry).src = mapAssetURLs(state.image);
 
     fillStateTileTitles(entry, state.name, state.similarName, state.savePlayers, state.saveDate);
 

--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -359,8 +359,8 @@ function sortStatesCallback(stateA, stateB) {
   if(sortBy == 'timePlayed' && stateB.timePlayed != stateA.timePlayed)
     return stateB.timePlayed - stateA.timePlayed;
   if(sortBy == 'similarName' && stateB.similarName != stateA.similarName)
-    return (stateA.similarName||stateA.name).localeCompare(stateB.similarName||stateB.name);
-  return stateA.name.localeCompare(stateB.name);
+    return String(stateA.similarName||stateA.name).localeCompare(String(stateB.similarName||stateB.name));
+  return String(stateA.name).localeCompare(String(stateB.name));
 }
 function resortStatesList() {
   for(const list of $a('#statesList .list')) {
@@ -474,7 +474,7 @@ function fillStatesList(states, starred, activeState, returnServer, activePlayer
       }
     }
 
-    for(const mode of state.mode.split(/[,;] */))
+    for(const mode of String(state.mode).split(/[,;] */))
       modeOptions[mode] = true;
 
     if(hasVariants) {

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -730,7 +730,15 @@ export default class Room {
 
     const id = Math.random().toString(36).substring(3, 7);
 
-    this.state._meta.states[id] = {...this.state._meta.states[this.state._meta.activeState.linkStateID || this.state._meta.activeState.stateID]};
+    let targetState = null;
+    for(const id of [ this.state._meta.activeState.saveStateID, this.state._meta.activeState.stateID, this.state._meta.activeState.linkStateID ])
+      if(this.state._meta.states[id])
+        targetState = this.state._meta.states[id];
+
+    if(!targetState)
+      throw new Logging.UserError(404, 'Could not find base state for saving the game.');
+
+    this.state._meta.states[id] = {...targetState};
     this.state._meta.states[id].variants = [];
     this.state._meta.states[id].saveState = this.state._meta.activeState.stateID;
     this.state._meta.states[id].saveVariant = this.state._meta.activeState.variantID;
@@ -749,7 +757,7 @@ export default class Room {
     this.addState(id, 'room', null, null, id);
 
     this.state._meta.states[id].variants[0].variant = players;
-    this.state._meta.states[id].variants[0].players = this.state._meta.states[this.state._meta.activeState.stateID].variants[this.state._meta.activeState.variantID].players;
+    this.state._meta.states[id].variants[0].players = targetState.variants[this.state._meta.activeState.variantID].players;
 
     this.state._meta.activeState.saveStateID = id;
 


### PR DESCRIPTION
If you transfer a vtts savegame to a different room, its reference to the game it is based on no longer works (because the new room does not have the same game with the same ID). This PR fixes multiple issues that were uncovered by this behavior:

- There are client crashes if certain game metadata does not exist or is not a string (mainly `name` and `mode`).
- If a state has an undefined image, the client would request `/undefined` which triggers loading room `undefined`. Incidentally that room was broken on my local machine which crashed the entire server.
- Saving the game _again_ would try to load the metadata for the new savegame from the game it was based on. That link is invalid so it produced a completely broken state. Now it falls back to the old savegame which also has all the metadata.