### PR TITLE
fixed wrong logo height on oldish Android

### DIFF
--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -141,6 +141,7 @@ body.aspectTooGood.hiddenToolbar {
       body.wideToolbar #toolbar > img {
         display: block;
         margin: 10px 20px 3px 20px;
+        height: 52px;
       }
       body.wideToolbar #toolbar .divider:nth-child(2) {
         display: block;


### PR DESCRIPTION
My wife's phone uses Android 9 and its WebView 85.0.4183.101 somehow displays the logo in the wide toolbar really tall (the `img` but not the image), making lower buttons inaccessible.

This PR simply sets a fixed height on the `img`.