### PR TITLE
Use the offset from the transform origin to calculate move delta.

### DIFF
--- a/client/js/geometry.js
+++ b/client/js/geometry.js
@@ -55,6 +55,11 @@ export function getPointOnPlane(transform, x, y) {
   return new DOMPoint(p0.x + dir.x * t, p0.y + dir.y * t, p0.z + dir.z * t);
 }
 
+export function getTransformOrigin(elem) {
+  const lengths = parseLengths(getComputedStyle(elem).transformOrigin);
+  return {x: lengths[0], y: lengths[1]};
+}
+
 export function getElementTransform(elem) {
   let transform = new DOMMatrix();
   const computedStyle = getComputedStyle(elem);

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -5,7 +5,7 @@ import { batchStart, batchEnd, widgetFilter, widgets } from '../serverstate.js';
 import { showOverlay, shuffleWidgets, sortWidgets } from '../main.js';
 import { tracingEnabled } from '../tracing.js';
 import { toHex } from '../color.js';
-import { center, distance, overlap, getOffset, getElementTransform, getScreenTransform, getPointOnPlane, dehomogenize, getElementTransformRelativeTo } from '../geometry.js';
+import { center, distance, overlap, getOffset, getElementTransform, getScreenTransform, getPointOnPlane, dehomogenize, getElementTransformRelativeTo, getTransformOrigin } from '../geometry.js';
 
 const readOnlyProperties = new Set([
   '_absoluteRotation',
@@ -1852,9 +1852,11 @@ export class Widget extends StateManaged {
 
   async move(coordGlobal, localAnchor) {
     const coordParent = this.coordParentFromCoordGlobal(coordGlobal);
-    const offset = getOffset(this.coordParentFromCoordLocal(localAnchor), this.coordParentFromCoordLocal({x: 0, y: 0}));
-    let newX = Math.round(coordParent.x + offset.x);
-    let newY = Math.round(coordParent.y + offset.y);
+    const transformOrigin = getTransformOrigin(this.domElement);
+    let positionCoord = this.coordParentFromCoordLocal(transformOrigin);
+    const offset = getOffset(this.coordParentFromCoordLocal(localAnchor), positionCoord);
+    let newX = Math.round(coordParent.x + offset.x - transformOrigin.x);
+    let newY = Math.round(coordParent.y + offset.y - transformOrigin.y);
 
     //Keeps widget's top left corner within coordinates set by dragLimit object
     const limit = this.get('dragLimit');


### PR DESCRIPTION
When cards are transformed they are effectively positioned relative to their transform origin. Fixes #1582.