### PR TITLE
Only transition widgets which weren't just created.

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -157,7 +157,9 @@ export class Widget extends StateManaged {
     let newParent = undefined;
     if(delta.parent !== undefined) {
       newParent = delta.parent ? widgets.get(delta.parent).domElement : $('#topSurface');
-      fromTransform = getElementTransformRelativeTo(this.domElement, newParent);
+      // If the widget wasn't newly created, transition from its previous location.
+      if (delta.id === undefined)
+        fromTransform = getElementTransformRelativeTo(this.domElement, newParent);
     }
 
     this.applyCSS(delta);


### PR DESCRIPTION
Note this is using a bit of a hack, the delta.id is in fact defined if the widget id changes as well. I'm not sure if we have a signal for the widget having just been created yet but the id trick works unless some programmatic code also changes the id while reparenting. This fixes #1590.