### PR TITLE
Use gitpod/workspace-full-vnc

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,16 +1,20 @@
+image: gitpod/workspace-full-vnc
 tasks:
   - init: nvm install 16; nvm use 16; npm install
     command: (sleep 2; gp preview $(gp url 8272)/test) & npm run debug
 ports:
   - port: 8272
+    name: virtualtabletop
     visibility: public
     onOpen: ignore
-  - port: 9229
+  - port: 6080
+    name: noVNC
     visibility: private
-    onOpen: ignore
-  - port: 9239
+  - port: 9229
+    name: Node.JS Debugger
     visibility: private
     onOpen: ignore
   - port: 5900
+    name: vnc
     visibility: private
     onOpen: ignore


### PR DESCRIPTION
This switches Gitpod workspaces created from this repository to use the gitpod/workspace-full-vnc image instead of the default gitpod/workspace-full image. Starting up a Gitpod workspace takes about the same time, but the image comes with a visual desktop served to noVNC on port 6080 and Chrome built in. This means that testcafe can run visually (or headless) in Chrome in the workspace with no additional setup.