### PR TITLE
Change `fixedParent` Default to True for Most Widgets

### DIFF
--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -6,6 +6,7 @@ class BasicWidget extends Widget {
 
     this.addDefaults({
       typeClasses: 'widget basic',
+      fixedParent: false,
 
       faces: [ {} ],
       faceCycle: 'forward',

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -3,6 +3,7 @@ class Card extends Widget {
     super(id);
 
     this.addDefaults({
+      fixedParent: false,
       width: 103,
       height: 160,
       typeClasses: 'widget card',

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -6,6 +6,7 @@ class Pile extends Widget {
 
     this.addDefaults({
       typeClasses: 'widget pile',
+      fixedParent: false,
       x: 4,
       y: 4,
       width: 1,

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -60,7 +60,7 @@ export class Widget extends StateManaged {
       ignoreOnLeave: false,
 
       parent: null,
-      fixedParent: false,
+      fixedParent: true,
       inheritFrom: null,
       owner: null,
       dragging: null,

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -437,10 +437,9 @@ function v12HandDropShadow(properties) {
 }
 
 function v13fixedParentDefaults(properties) {
-  if (properties.type == 'card' || properties.type == 'pile' || properties.type == null){
-    if (properties.fixedParent=true)
-      properties.fixedParent=true;
-  } else if (properties.fixedParent=false){
-    properties.fixedparent=false;
+  if (!(properties.type == 'card' || properties.type == 'pile' || properties.type == null)){
+    if (typeof properties.fixedParent === 'undefined' && (properties.movable == true)){
+    properties.fixedParent = false;
+    }
   }
 }

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -1,4 +1,4 @@
-export const VERSION = 12;
+export const VERSION = 13;
 
 export default function FileUpdater(state) {
   const v = state._meta.version;
@@ -95,6 +95,7 @@ function updateProperties(properties, v, globalProperties) {
   v<8 && v8HoverInheritVisibleForSeat(properties);
   v<10 && v10GridOffset(properties);
   v<12 && globalProperties.v12DropShadowAllowed && v12HandDropShadow(properties);
+  v<13 && v13fixedParentDefaults(properties);
 }
 
 function updateRoutine(routine, v, globalProperties) {
@@ -432,5 +433,14 @@ function v11OwnerMOVEXY(routine) {
 function v12HandDropShadow(properties) {
   if (properties.type == 'holder' && properties.childrenPerOwner && !properties.enterRoutine && !properties.leaveRoutine && !properties.changeRoutine) {
     properties.dropShadow = true;
+  }
+}
+
+function v13fixedParentDefaults(properties) {
+  if (properties.type == 'card' || properties.type == 'pile' || properties.type == null){
+    if (properties.fixedParent=true)
+      properties.fixedParent=true;
+  } else if (properties.fixedParent=false){
+    properties.fixedparent=false;
   }
 }


### PR DESCRIPTION
This implements a request from Discord to make the default for `fixedParent` be true for everything except: basic widgets, cards, and piles.

I'm feeling pretty stupid and I can't figure out whether this needs a file updater or not.  I don't think so because the value is currently either true or false and not null or undefined for all widgets.  So changing the default shouldn't change anything for existing widgets but only set the default for new ones, right?