### PR TITLE
Behave as if fixedParent is true if only movable in edit

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1867,7 +1867,7 @@ export class Widget extends StateManaged {
     await this.bringToFront();
     await this.set('dragging', playerName);
 
-    if(!this.get('fixedParent' && this.get('movable'))) {
+    if(!this.get('fixedParent') && this.get('movable')) {
       this.dropTargets = this.validDropTargets();
       this.currentParent = widgets.get(this.get('_ancestor'));
       this.hoverTarget = null;
@@ -1994,7 +1994,7 @@ export class Widget extends StateManaged {
     await this.set('dragging', null);
     await this.set('hoverTarget', null);
 
-    if(!this.get('fixedParent' && this.get('movable'))) {
+    if(!this.get('fixedParent') && this.get('movable')) {
       for(const t of this.dropTargets)
         t.domElement.classList.remove('droppable');
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1867,7 +1867,7 @@ export class Widget extends StateManaged {
     await this.bringToFront();
     await this.set('dragging', playerName);
 
-    if(!this.get('fixedParent')) {
+    if(!this.get('fixedParent' && this.get('movable'))) {
       this.dropTargets = this.validDropTargets();
       this.currentParent = widgets.get(this.get('_ancestor'));
       this.hoverTarget = null;
@@ -1910,7 +1910,7 @@ export class Widget extends StateManaged {
     await this.setPosition(newX, newY, this.get('z'));
     await this.snapToGrid();
 
-    if(!this.get('fixedParent')) {
+    if(!this.get('fixedParent') && this.get('movable')) {
       await this.checkParent();
 
       const lastHoverTarget = this.hoverTarget;
@@ -1994,7 +1994,7 @@ export class Widget extends StateManaged {
     await this.set('dragging', null);
     await this.set('hoverTarget', null);
 
-    if(!this.get('fixedParent')) {
+    if(!this.get('fixedParent' && this.get('movable'))) {
       for(const t of this.dropTargets)
         t.domElement.classList.remove('droppable');
 


### PR DESCRIPTION
It is very easy to accidentally remove the parent of a widget when in edit mode. This makes all widgets that have movable set to false behave as if fixedParent is set to true when being moved in edit mode.