### PR TITLE
'palette' input type

### DIFF
--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -1366,7 +1366,7 @@ input:invalid+span:after {
 .inputpalette > div{
   display: flex;
   flex-wrap: wrap;
-  padding: 0 5px;
+  padding: 0 2px;
 }
 .inputpalette > div input{
   display: none;
@@ -1377,10 +1377,8 @@ input:invalid+span:after {
   display: inline-block;
   border-radius: 8px;
   position: relative;
-  border: 3px solid var(--roomColor);
-  padding: 0px;
-  overflow: hidden;
-  
+  border: 3px solid transparent;
+  padding: 0;
 }
 .inputpalette > div input[type="radio"]:checked+label{
   border: 3px solid var(--VTTblue);
@@ -1393,13 +1391,16 @@ input:invalid+span:after {
   width: 1.25em;
   background: var(--VTTblue);
   color: white;
-  border-radius: 100%;
-  border-top-right-radius: 0;
+  border-top-right-radius: 40%;
+  border-top-left-radius: 50%;
+  border-bottom-right-radius: 50%;
+  border-bottom-left-radius: 50%;
   content: 'check';
   position: absolute;
   top: -3px;
   right: -3px;
   border: 2px solid white;
+  z-index: -1;
 }
 .inputpalette > div label > div{
   display: block;
@@ -1414,4 +1415,5 @@ input:invalid+span:after {
   overflow: hidden;
   background-color: inherit;
   border-radius: 5px;
+  z-index: -2;
 }

--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -1414,5 +1414,4 @@ input:invalid+span:after {
   overflow: hidden;
   background-color: inherit;
   border-radius: 5px;
-  box-shadow: 0 0 1px white;
 }

--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -1378,11 +1378,11 @@ input:invalid+span:after {
   display: inline-block;
   border-radius: 5px;
   position: relative;
-  border: 2px solid var(--roomColor);
+  border: 3px solid var(--roomColor);
   overflow: hidden;
 }
 .inputpalette > div input[type="radio"]:checked+label{
-  border: 2px solid var(--VTTblue);
+  border: 3px solid var(--VTTblue);
 }
 .inputpalette > div input[type="radio"]:checked+label::after{
   font-family: 'Material Icons';
@@ -1398,18 +1398,18 @@ input:invalid+span:after {
   position: absolute;
   top: -3px;
   right: -3px;
-  border: 2px solid var(--roomColor);
+  border: 2px solid white;
 }
 .inputpalette > div label::before{
+  display: block;
   content: '';
   position: absolute;
-  
-  top: -1px;
-  right: -1px;
-  bottom: -1px;
-  left: -1px;
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
   position: absolute;
-  border-radius: 5px;
-  border: 3px solid white;
+  border-radius: 2px;
+  border: 2px solid white;
   overflow: hidden;
 }

--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -1366,7 +1366,7 @@ input:invalid+span:after {
 .inputpalette > div{
   display: flex;
   flex-wrap: wrap;
-  padding: 0 2px;
+  padding: 0 3px;
 }
 .inputpalette > div input{
   display: none;
@@ -1379,6 +1379,7 @@ input:invalid+span:after {
   position: relative;
   border: 3px solid transparent;
   padding: 0;
+  margin: -1.5px;
 }
 .inputpalette > div input[type="radio"]:checked+label{
   border: 3px solid var(--VTTblue);

--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -1366,7 +1366,6 @@ input:invalid+span:after {
 .inputpalette > div{
   display: flex;
   flex-wrap: wrap;
-  gap: 5px;
   padding: 0 5px;
 }
 .inputpalette > div input{
@@ -1376,11 +1375,12 @@ input:invalid+span:after {
   height: 35px;
   width: 35px;
   display: inline-block;
-  border-radius: 5px;
+  border-radius: 8px;
   position: relative;
   border: 3px solid var(--roomColor);
-  overflow: hidden;
   padding: 0px;
+  overflow: hidden;
+  
 }
 .inputpalette > div input[type="radio"]:checked+label{
   border: 3px solid var(--VTTblue);
@@ -1401,7 +1401,7 @@ input:invalid+span:after {
   right: -3px;
   border: 2px solid white;
 }
-.inputpalette > div label::before{
+.inputpalette > div label > div{
   display: block;
   content: '';
   position: absolute;
@@ -1410,7 +1410,9 @@ input:invalid+span:after {
   bottom: 0px;
   left: 0px;
   position: absolute;
-  border-radius: 2px;
   border: 2px solid white;
   overflow: hidden;
+  background-color: inherit;
+  border-radius: 5px;
+  box-shadow: 0 0 1px white;
 }

--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -1373,13 +1373,14 @@ input:invalid+span:after {
   display: none;
 }
 .inputpalette > div label{
-  height: 30px;
-  width: 30px;
+  height: 35px;
+  width: 35px;
   display: inline-block;
   border-radius: 5px;
   position: relative;
   border: 3px solid var(--roomColor);
   overflow: hidden;
+  padding: 0px;
 }
 .inputpalette > div input[type="radio"]:checked+label{
   border: 3px solid var(--VTTblue);

--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -1199,7 +1199,8 @@ button:disabled:hover {
 }
 .inputnumber,
 .inputstring,
-.inputselect{
+.inputselect,
+.inputpalette{
   flex-direction: column;
 }
 .inputcheckbox{
@@ -1208,7 +1209,8 @@ button:disabled:hover {
 
 .inputnumber label,
 .inputstring label,
-.inputselect label{
+.inputselect label,
+.inputpalette label{
   padding: 4px 5px 0 5px;
     width: 100%;
     vertical-align: top;
@@ -1361,4 +1363,38 @@ input:invalid+span:after {
   color: red;
   letter-spacing: -1px;
 }
-
+.inputpalette > div{
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  padding: 0 5px;
+}
+.inputpalette > div input{
+  display: none;
+}
+.inputpalette > div label{
+  height: 30px;
+  width: 30px;
+  display: inline-block;
+  border-radius: 5px;
+  position: relative;
+  border: 2px solid transparent;
+  overflow: hidden;
+}
+.inputpalette > div input[type="radio"]:checked+label{
+  border: 2px solid var(--VTTblue);
+}
+.inputpalette > div input[type="radio"]:checked+label::before{
+  font-family: 'Material Icons';
+  line-height: 1.25em;
+  text-align: center;
+  height: 1.25em;
+  width: 1.25em;
+  background: var(--VTTblue);
+  color: white;
+  border-radius: 100%;
+  content: 'check';
+  position: absolute;
+  top: -3px;
+  right: -3px;
+}

--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -1378,13 +1378,13 @@ input:invalid+span:after {
   display: inline-block;
   border-radius: 5px;
   position: relative;
-  border: 2px solid transparent;
+  border: 2px solid var(--roomColor);
   overflow: hidden;
 }
 .inputpalette > div input[type="radio"]:checked+label{
   border: 2px solid var(--VTTblue);
 }
-.inputpalette > div input[type="radio"]:checked+label::before{
+.inputpalette > div input[type="radio"]:checked+label::after{
   font-family: 'Material Icons';
   line-height: 1.25em;
   text-align: center;
@@ -1393,8 +1393,23 @@ input:invalid+span:after {
   background: var(--VTTblue);
   color: white;
   border-radius: 100%;
+  border-top-right-radius: 0;
   content: 'check';
   position: absolute;
   top: -3px;
   right: -3px;
+  border: 2px solid var(--roomColor);
+}
+.inputpalette > div label::before{
+  content: '';
+  position: absolute;
+  
+  top: -1px;
+  right: -1px;
+  bottom: -1px;
+  left: -1px;
+  position: absolute;
+  border-radius: 5px;
+  border: 3px solid white;
+  overflow: hidden;
 }

--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -170,7 +170,7 @@ export function formField(field, dom, id) {
       optionElement.value = option || '';
       optionElement.id = option || '';
       optionElement.name = id;
-      if(option == field.value)
+      if(toHex(option) == field.value)
         optionElement.checked = 'checked';
       input.appendChild(optionElement);
       input.appendChild(optionlabel);

--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -163,7 +163,10 @@ export function formField(field, dom, id) {
       const optionlabel = document.createElement('label');
       optionlabel.htmlFor = option;
       optionlabel.textContent = ' ';
-      optionlabel.style="background-color:"+option+";"
+
+      const optionlabelinterior = document.createElement('div');
+      optionlabelinterior.style="background-color:"+option+";"
+      optionlabel.appendChild(optionlabelinterior);
 
       const optionElement = document.createElement('input');
       optionElement.type = 'radio';

--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -159,7 +159,7 @@ export function formField(field, dom, id) {
 
   if(field.type == 'palette') {
     const input = document.createElement('div');
-    for(const option of field.options) {
+    for(const option of field.colors) {
       const optionlabel = document.createElement('label');
       optionlabel.htmlFor = option;
       optionlabel.textContent = ' ';

--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -157,6 +157,28 @@ export function formField(field, dom, id) {
     input.id = id;
   }
 
+  if(field.type == 'palette') {
+    const input = document.createElement('div');
+    for(const option of field.options) {
+      const optionlabel = document.createElement('label');
+      optionlabel.htmlFor = option;
+      optionlabel.textContent = ' ';
+      optionlabel.style="background-color:"+option+";"
+
+      const optionElement = document.createElement('input');
+      optionElement.type = 'radio';
+      optionElement.value = option || '';
+      optionElement.id = option || '';
+      optionElement.name = id;
+      if(option == field.value)
+        optionElement.checked = 'checked';
+      input.appendChild(optionElement);
+      input.appendChild(optionlabel);
+    }
+    dom.appendChild(input);
+    input.id = id;
+  }
+
   if(field.type == 'string') {
     const input = document.createElement('input');
     input.value = field.value || '';

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -957,9 +957,10 @@ function jeAddCommands() {
   jeAddFieldCommand('label', 'checkbox|color|number|palette|select|string|switch', '');
   jeAddFieldCommand('value', 'checkbox|color|number|palette|select|string|switch', '');
   jeAddFieldCommand('variable', 'checkbox|color|number|palette|select|string|switch', '');
+  jeAddFieldCommand('colors', 'palette', []);
   jeAddFieldCommand('min', 'number', 0);
   jeAddFieldCommand('max', 'number', 10);
-  jeAddFieldCommand('options', 'palette|select', [ { value: 'value', text: 'text' } ]);
+  jeAddFieldCommand('options', 'select', [ { value: 'value', text: 'text' } ]);
 
   jeAddEnumCommands('^[a-z]+ ↦ type', widgetTypes.slice(1));
   jeAddEnumCommands('^.*\\([A-Z]+\\) ↦ value', [ '${}' ]);

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -954,12 +954,12 @@ function jeAddCommands() {
   jeAddLimitCommand('maxY');
 
   jeAddFieldCommand('text', 'subtitle|title|text', '');
-  jeAddFieldCommand('label', 'checkbox|color|number|select|string|switch', '');
-  jeAddFieldCommand('value', 'checkbox|color|number|select|string|switch', '');
-  jeAddFieldCommand('variable', 'checkbox|color|number|select|string|switch', '');
+  jeAddFieldCommand('label', 'checkbox|color|number|palette|select|string|switch', '');
+  jeAddFieldCommand('value', 'checkbox|color|number|palette|select|string|switch', '');
+  jeAddFieldCommand('variable', 'checkbox|color|number|palette|select|string|switch', '');
   jeAddFieldCommand('min', 'number', 0);
   jeAddFieldCommand('max', 'number', 10);
-  jeAddFieldCommand('options', 'select', [ { value: 'value', text: 'text' } ]);
+  jeAddFieldCommand('options', 'palette|select', [ { value: 'value', text: 'text' } ]);
 
   jeAddEnumCommands('^[a-z]+ ↦ type', widgetTypes.slice(1));
   jeAddEnumCommands('^.*\\([A-Z]+\\) ↦ value', [ '${}' ]);
@@ -972,7 +972,7 @@ function jeAddCommands() {
   jeAddEnumCommands('^.*\\(GET\\) ↦ aggregation', [ 'first', 'last', 'array', 'average', 'median', 'min', 'max', 'sum' ]);
   jeAddEnumCommands('^.*\\(IF\\) ↦ relation', [ '<', '<=', '==', '!=', '>', '>=' ]);
   jeAddEnumCommands('^.*\\(IF\\) ↦ (operand1|operand2|condition)', [ '${}' ]);
-  jeAddEnumCommands('^.*\\(INPUT\\) ↦ fields ↦ [0-9]+ ↦ type', [ 'checkbox', 'color', 'number', 'select', 'string', 'subtitle', 'switch', 'text', 'title' ]);
+  jeAddEnumCommands('^.*\\(INPUT\\) ↦ fields ↦ [0-9]+ ↦ type', [ 'checkbox', 'color', 'number', 'palette', 'select', 'string', 'subtitle', 'switch', 'text', 'title' ]);
   jeAddEnumCommands('^.*\\(LABEL\\) ↦ mode', [ 'set', 'dec', 'inc', 'append' ]);
   jeAddEnumCommands('^.*\\(ROTATE\\) ↦ angle', [ 45, 60, 90, 135, 180 ]);
   jeAddEnumCommands('^.*\\(ROTATE\\) ↦ mode', [ 'set', 'add' ]);

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -957,7 +957,7 @@ function jeAddCommands() {
   jeAddFieldCommand('label', 'checkbox|color|number|palette|select|string|switch', '');
   jeAddFieldCommand('value', 'checkbox|color|number|palette|select|string|switch', '');
   jeAddFieldCommand('variable', 'checkbox|color|number|palette|select|string|switch', '');
-  jeAddFieldCommand('colors', 'palette', []);
+  jeAddFieldCommand('colors', 'palette', [ '#000000' ]);
   jeAddFieldCommand('min', 'number', 0);
   jeAddFieldCommand('max', 'number', 10);
   jeAddFieldCommand('options', 'select', [ { value: 'value', text: 'text' } ]);

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -587,6 +587,13 @@ export class Widget extends StateManaged {
           } else {
             result[field.variable] = 'off';
           }
+        } else if(field.type == 'palette') {
+          let thisresult = document.getElementsByName('INPUT_' + escapeID(this.get('id')) + ';' + field.variable);
+          for (var i=0;i<thisresult.length;i++){
+            if ( thisresult[i].checked ) {
+              result[field.variable] = thisresult[i].value;
+            }
+          }
         } else if(field.type == 'number') {
           let thisvalue = document.getElementById('INPUT_' + escapeID(this.get('id')) + ';' + field.variable).value;
           if(thisvalue > field.max)


### PR DESCRIPTION
Added a simplified 'palette' input type that takes a list of colors as options. 

```
        {
          "type": "palette",
          "label": "Color",
          "options": [
            "#897349",
            "#89dd98",
            "#fff",
            "#dbdc00"
          ],
          "variable": "playerColor",
          "value": "${playerColor}"
        }
```
<img width="369" alt="image" src="https://user-images.githubusercontent.com/12822213/218907136-1df30f40-f655-4e94-abb2-a6e3da0a20dc.png">

It uses --VTTblue as the selected outline and checkmark color.

----------------
Proposed wiki update:

* `type`: 
......
    * `palette`_displays colored radio buttons_-stores the selected value. Unlike the `color` field, this offers a consistent viewing experience across browsers and forces the players to choose from a palette of options.
      * `colors`: _array_ - displays the color choices available to the player. Accepts most color formats (html-friendly, hex, rgb, rgba, hsl, hsla).