### PR TITLE
moveToHolder only moves if not already in holder

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1854,8 +1854,9 @@ export class Widget extends StateManaged {
     const curAncestor = this.get('_ancestor');
     if(curAncestor && !this.currentParent)
       this.currentParent = widgets.get(curAncestor);
-    if(this.currentParent != holder) {
+    if(this.currentParent != holder)
       await this.checkParent(true);
+    if(this.currentParent != holder || this.get('owner') || holder.get('childrenPerOwner')) {
       await this.set('owner',  null);
       await this.set('parent', holder.get('id'));
     }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1851,13 +1851,14 @@ export class Widget extends StateManaged {
       return;
 
     await this.bringToFront();
-    if(this.get('parent') && !this.currentParent)
-      this.currentParent = widgets.get(this.get('parent'));
-    if(this.currentParent != holder)
+    const curAncestor = this.get('_ancestor');
+    if(curAncestor && !this.currentParent)
+      this.currentParent = widgets.get(curAncestor);
+    if(this.currentParent != holder) {
       await this.checkParent(true);
-
-    await this.set('owner',  null);
-    await this.set('parent', holder.get('id'));
+      await this.set('owner',  null);
+      await this.set('parent', holder.get('id'));
+    }
   }
 
   async moveStart() {

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -63,5 +63,5 @@ test('Create game using edit mode', async t => {
     .click('#addScoreboard')
     .click('#w_m06r');
   await t.resizeWindow(width,height);
-  await compareState(t, '90763067f59a7d65ca134cdc9266858c');
+  await compareState(t, '1ec0b52e161aaffce367d792f7f840f9');
 });

--- a/tests/testcafe/publiclibrary.js
+++ b/tests/testcafe/publiclibrary.js
@@ -46,12 +46,12 @@ function publicLibraryButtons(game, variant, md5, tests) {
   });
 }
 
-publicLibraryButtons('Blue',               0, '50a9596d38d0d5edc5d6c3eecc3c5b5d', ["player1Seat","player2Seat","player3Seat","player4Seat",
+publicLibraryButtons('Blue',               0, 'b88c08031939d5f982992fc958978ba6', ["player1Seat","player2Seat","player3Seat","player4Seat",
   'Deal_button', 'e36b',
   'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_incrementButton', 'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_decrementButton',
   'reset_button', '#buttonInputGo', 'visibility_button'
 ]);
-publicLibraryButtons('Bhukhar',            0, 'c32671a16623cc91202fbba4d62f3371', [ 'btnMenuSettings', 'btn8Players', 'btn4Packs', 'btnCloseSettings', 'btnSelectPlayer', 'btnDeal', 'btnPile4', 'btnStartGame', 'btnTakeOne', 'btnNextPlayer', 'btnPickUp' ]);
+publicLibraryButtons('Bhukhar',            0, '5595ffc3b876086fbc65dc38a103939a', [ 'btnMenuSettings', 'btn8Players', 'btn4Packs', 'btnCloseSettings', 'btnSelectPlayer', 'btnDeal', 'btnPile4', 'btnStartGame', 'btnTakeOne', 'btnNextPlayer', 'btnPickUp' ]);
 publicLibraryButtons('Dice',               0, 'a68d28c20b624d6ddf87149bae230598', [ 'k18u', 'hy65', 'gghr', 'dsfa', 'f34a', 'fusq' ]);
 publicLibraryButtons('Dots',               0, '23894df38f786cb014fa1cd79f2345db', [ 'reset', '#buttonInputGo', 'col11', 'col21', 'col12', 'col22', 'row11', 'row31', 'row21', 'row32', 'row12', 'row42', 'row22', 'row23', 'col23' ]);
 publicLibraryButtons('Solitaire',          0, 'e83b2d21474496df86cd3dd2540efe58', [ 'reset', 'jemz', 'reset' ]);
@@ -70,14 +70,14 @@ publicLibraryButtons('Reward',             0, '965cc73a5dc1048c3203ab23935b4abf'
   'gmex', 'kprc', 'oksq', 'j1wz', 'vfhn', 'seat1', 'next'
 ]);
 publicLibraryButtons('Rummy Tiles',        0, 'ab2a2638cdb61809a644c5ca73770f77', [ 'startMix', 'draw14' ]);
-publicLibraryButtons('Undercover',         1, '8512b8cb117a694ee7e201869999e571', [ 'Reset', 'Spy Master Button' ]);
-publicLibraryButtons('Functions - CALL',   0, '15bc313f5adc00d310adb07ee2d6059a', [
+publicLibraryButtons('Undercover',         1, 'dccab2340f9bff4b4126141abc742aca', [ 'Reset', 'Spy Master Button' ]);
+publicLibraryButtons('Functions - CALL',   0, 'dc872fd616321be8cab07cd36e7aeac6', [
   'n4cw_8_C', '5a52', '5a52', '66kr', 'qeg1', 'n4cwB', '8r6p', 'qeg1', 'qeg1', 'n5eu'
 ]);
 publicLibraryButtons('Functions - CLICK',  0, 'd44e77e0782cadbc9594494e5a83dde0', [ '7u2q' ]);
 publicLibraryButtons('Functions - ROTATE', 0, '241d87e4b6b825f8835893a2dd5dbdcc', [ 'c44c', '9kdj', 'w53c', 'w53c' ]);
-publicLibraryButtons('Functions - SELECT', 2, '3e4652080a097cce27106579afa90e50', [ 'jkmt1']);
-publicLibraryButtons('Functions - SORT',   1, '9e83c7e238dcab8a28f59f8d1ccc5b97', [
+publicLibraryButtons('Functions - SELECT', 2, '65881371547e86a6837d28c6640be9fe', [ 'jkmt1']);
+publicLibraryButtons('Functions - SORT',   1, '266026ebd74dd0d752e3a505b4063d48', [
   'ingw', 'k131', 'cnfu', 'i6yz', 'z394', '0v3h', '1h8o', 'v5ra', 'ingw-copy001', 'k131-copy001', 'cnfu-copy001',
   'i6yz-copy001', 'z394-copy001', '0v3h-copy001'
 ]);


### PR DESCRIPTION
Previously, Widget.moveToHolder(holder) force detached the widget from it's parent if the parent was not holder, even if the parent was a pile in the holder. This now checks if the widget's _ancestor is the holder instead. This significantly improves RECALL for large decks that are mostly still in the pile in the deck's holder. 

Testing results: On production, Start button in Cards Against Humanity took 336ms for the RECALL step immediately after loading the game. With this PR the step took 6ms.

I'm pretty sure that the efficiency is from removing a lot of extraneous DOM tree manipulation.