### PR TITLE
Optimize DOM reads and modifications

### DIFF
--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -11,7 +11,7 @@ export class StateManaged {
     Object.assign(this.defaults, defaults);
   }
 
-  applyDelta(delta) {
+  applyDelta(delta, modifyDOM, afterModify) {
     const deltaForDOM = {};
     for(const i in delta) {
       if(delta[i] === null) {
@@ -21,15 +21,15 @@ export class StateManaged {
         deltaForDOM[i] = this.state[i] = delta[i];
       }
     }
-    this.applyDeltaToDOM(deltaForDOM);
+    this.applyDeltaToDOM(deltaForDOM, modifyDOM, afterModify);
 
     if(delta.z)
       updateMaxZ(this.get('layer'), delta.z);
   }
 
-  applyInitialDelta(delta) {
-    this.applyDeltaToDOM(this.defaults);
-    this.applyDelta(delta);
+  applyInitialDelta(delta, modifyDOM, afterModify) {
+    this.applyDeltaToDOM(this.defaults, modifyDOM, afterModify);
+    this.applyDelta(delta, modifyDOM, afterModify);
   }
 
   getDefaultValue(key) {

--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -19,19 +19,21 @@ class BasicWidget extends Widget {
     });
   }
 
-  applyDeltaToDOM(delta) {
-    super.applyDeltaToDOM(delta);
+  applyDeltaToDOM(delta, modifyDOM, afterModify) {
+    super.applyDeltaToDOM(delta, modifyDOM, afterModify);
     if(delta.activeFace !== undefined || delta.faces !== undefined) {
       let face = this.faces()[this.get('activeFace')];
       if(face !== undefined)
-        this.applyDelta(face);
+        this.applyDelta(face, modifyDOM, afterModify);
     }
-    if(delta.text !== undefined)
-      setText(this.domElement, delta.text);
+    modifyDOM.then(() => {
+      if(delta.text !== undefined)
+        setText(this.domElement, delta.text);
 
-    for(const property of Object.values(this.get('svgReplaces') || {}))
-      if(delta[property] !== undefined)
-        this.domElement.style.cssText = mapAssetURLs(this.css());
+      for(const property of Object.values(this.get('svgReplaces') || {}))
+        if(delta[property] !== undefined)
+          this.domElement.style.cssText = mapAssetURLs(this.css());
+    });
   }
 
   classes() {

--- a/client/js/widgets/button.js
+++ b/client/js/widgets/button.js
@@ -28,14 +28,16 @@ export class Button extends Widget {
     });
   }
 
-  applyDeltaToDOM(delta) {
-    super.applyDeltaToDOM(delta);
-    if(delta.text !== undefined)
-      setText(this.domElement, delta.text);
+  applyDeltaToDOM(delta, modifyDOM, afterModify) {
+    super.applyDeltaToDOM(delta, modifyDOM, afterModify);
+    modifyDOM.then(() => {
+      if(delta.text !== undefined)
+        setText(this.domElement, delta.text);
 
-    for(const property of Object.values(this.get('svgReplaces') || {}))
-      if(delta[property] !== undefined)
-        this.domElement.style.cssText = mapAssetURLs(this.css());
+      for(const property of Object.values(this.get('svgReplaces') || {}))
+        if(delta[property] !== undefined)
+          this.domElement.style.cssText = mapAssetURLs(this.css());
+    });
   }
 
   css() {

--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -26,8 +26,8 @@ class Canvas extends Widget {
     this.domElement.appendChild(this.canvas);
   }
 
-  applyDeltaToDOM(delta) {
-    super.applyDeltaToDOM(delta);
+  applyDeltaToDOM(delta, modifyDOM, afterModify) {
+    super.applyDeltaToDOM(delta, modifyDOM, afterModify);
 
     if(this.context) {
       if(delta.resolution !== undefined) {

--- a/client/js/widgets/deck.js
+++ b/client/js/widgets/deck.js
@@ -22,8 +22,8 @@ class Deck extends Widget {
     ++this.domElement.textContent;
   }
 
-  applyDeltaToDOM(delta) {
-    super.applyDeltaToDOM(delta);
+  applyDeltaToDOM(delta, modifyDOM, afterModify) {
+    super.applyDeltaToDOM(delta, modifyDOM, afterModify);
     if(delta.cardDefaults !== undefined || delta.cardTypes !== undefined || delta.faceTemplates !== undefined) {
       for(const cardID in this.cards) {
         const card = this.cards[cardID];
@@ -42,7 +42,7 @@ class Deck extends Widget {
         for(const key in card.state)
           deltaForCard[key] = card.get(key);
 
-        card.applyDeltaToDOM(deltaForCard);
+        card.applyDeltaToDOM(deltaForCard, modifyDOM, afterModify);
       }
       this.previousCardDefaults = this.get('cardDefaults');
       this.previousCardTypes = this.get('cardTypes');

--- a/client/js/widgets/label.js
+++ b/client/js/widgets/label.js
@@ -25,35 +25,37 @@ export class Label extends Widget {
     });
   }
 
-  applyDeltaToDOM(delta) {
-    super.applyDeltaToDOM(delta);
-    if(delta.text !== undefined || delta.twoRowBottomAlign !== undefined) {
-      this.input.value = this.get('text');
-      if(this.get('twoRowBottomAlign')) {
-        this.input.style.height = '20px';
-        this.input.style.minHeight = 'unset';
-        this.input.style.paddingTop = '0';
-        const contentHeight = this.input.scrollHeight;
-        if(contentHeight < this.get('height')) {
-          this.input.style.paddingTop = `${this.get('height')-contentHeight}px`;
-          this.input.style.height = 'auto';
-          this.input.style.minHeight = `${contentHeight}px`;
+  applyDeltaToDOM(delta, modifyDOM, afterModify) {
+    super.applyDeltaToDOM(delta, modifyDOM, afterModify);
+    modifyDOM.then(() => {
+      if(delta.text !== undefined || delta.twoRowBottomAlign !== undefined) {
+        this.input.value = this.get('text');
+        if(this.get('twoRowBottomAlign')) {
+          this.input.style.height = '20px';
+          this.input.style.minHeight = 'unset';
+          this.input.style.paddingTop = '0';
+          const contentHeight = this.input.scrollHeight;
+          if(contentHeight < this.get('height')) {
+            this.input.style.paddingTop = `${this.get('height')-contentHeight}px`;
+            this.input.style.height = 'auto';
+            this.input.style.minHeight = `${contentHeight}px`;
+          } else {
+            this.input.style.minHeight = '100%';
+          }
         } else {
           this.input.style.minHeight = '100%';
+          this.input.style.paddingTop = 'unset';
         }
-      } else {
-        this.input.style.minHeight = '100%';
-        this.input.style.paddingTop = 'unset';
       }
-    }
-    if(delta.editable !== undefined) {
-      if(delta.editable)
-        this.input.removeAttribute("readonly");
-      else
-        this.input.setAttribute("readonly", !delta.editable);
-    }
-    if(delta.spellCheck !== undefined) {
-      this.input.setAttribute('spellcheck', this.get('spellCheck') === true)
-    }
+      if(delta.editable !== undefined) {
+        if(delta.editable)
+          this.input.removeAttribute("readonly");
+        else
+          this.input.setAttribute("readonly", !delta.editable);
+      }
+      if(delta.spellCheck !== undefined) {
+        this.input.setAttribute('spellcheck', this.get('spellCheck') === true)
+      }
+    });
   }
 }

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -38,38 +38,40 @@ class Pile extends Widget {
     this.updateText();
   }
 
-  applyDeltaToDOM(delta) {
-    super.applyDeltaToDOM(delta);
-    if(this.handle && delta.handleCSS !== undefined)
-      this.handle.style = mapAssetURLs(this.cssAsText(this.get('handleCSS'),null,true));
-    if(this.handle && delta.text !== undefined)
-      this.updateText();
-    if(this.handle && (delta.width !== undefined || delta.height !== undefined || delta.handleSize !== undefined)) {
-      if(this.get('handleSize') == 'auto' && (this.get('width') < 50 || this.get('height') < 50))
-        this.handle.classList.add('small');
-      else
-        this.handle.classList.remove('small');
-    }
+  applyDeltaToDOM(delta, modifyDOM, afterModify) {
+    super.applyDeltaToDOM(delta, modifyDOM, afterModify);
+    modifyDOM.then(() => {
+      if(this.handle && delta.handleCSS !== undefined)
+        this.handle.style = mapAssetURLs(this.cssAsText(this.get('handleCSS'),null,true));
+      if(this.handle && delta.text !== undefined)
+        this.updateText();
+      if(this.handle && (delta.width !== undefined || delta.height !== undefined || delta.handleSize !== undefined)) {
+        if(this.get('handleSize') == 'auto' && (this.get('width') < 50 || this.get('height') < 50))
+          this.handle.classList.add('small');
+        else
+          this.handle.classList.remove('small');
+      }
 
-    const threshold = this.get('handleOffset')+5;
-    for(const e of [ [ 'x', 'right', 1600-this.get('width'), 'center' ], [ 'y', 'bottom', 1000-this.get('height'), 'middle' ] ]) {
-      if(this.handle && (delta[e[0]] !== undefined || delta.parent !== undefined || delta.handlePosition !== undefined || delta.handleOffset !== undefined)) {
-        if(this.get('handlePosition') == 'static') {
-          this.handle.classList.remove(e[1]);
-          this.handle.classList.remove(e[3]);
-        } else if(this.get('handlePosition').match(e[3])) {
-          this.handle.classList.remove(e[1]);
-          this.handle.classList.add(e[3]);
-        } else {
-          this.handle.classList.remove(e[3]);
-          const isRightOrBottom = this.get('handlePosition').match(e[1]);
-          if(isRightOrBottom && this.absoluteCoord(e[0]) < e[2]-threshold || !isRightOrBottom && this.absoluteCoord(e[0]) < threshold)
-            this.handle.classList.add(e[1]);
-          else
+      const threshold = this.get('handleOffset')+5;
+      for(const e of [ [ 'x', 'right', 1600-this.get('width'), 'center' ], [ 'y', 'bottom', 1000-this.get('height'), 'middle' ] ]) {
+        if(this.handle && (delta[e[0]] !== undefined || delta.parent !== undefined || delta.handlePosition !== undefined || delta.handleOffset !== undefined)) {
+          if(this.get('handlePosition') == 'static') {
             this.handle.classList.remove(e[1]);
+            this.handle.classList.remove(e[3]);
+          } else if(this.get('handlePosition').match(e[3])) {
+            this.handle.classList.remove(e[1]);
+            this.handle.classList.add(e[3]);
+          } else {
+            this.handle.classList.remove(e[3]);
+            const isRightOrBottom = this.get('handlePosition').match(e[1]);
+            if(isRightOrBottom && this.absoluteCoord(e[0]) < e[2]-threshold || !isRightOrBottom && this.absoluteCoord(e[0]) < threshold)
+              this.handle.classList.add(e[1]);
+            else
+              this.handle.classList.remove(e[1]);
+          }
         }
       }
-    }
+    });
   }
 
   async click(mode='respect') {

--- a/client/js/widgets/scoreboard.js
+++ b/client/js/widgets/scoreboard.js
@@ -30,9 +30,13 @@ class Scoreboard extends Widget {
     });
   }
 
-  applyDeltaToDOM(delta) {
-    super.applyDeltaToDOM(delta);
-    this.updateTable();
+  applyDeltaToDOM(delta, modifyDOM, afterModify) {
+    super.applyDeltaToDOM(delta, modifyDOM, afterModify);
+    modifyDOM.then(() => {
+      // Scoreboard currently makes a lot of getComputedStyle calls during construction.
+      // Ideally we could do these ahead of time before the major dom modifications.
+      this.updateTable();
+    });
   }
 
   classes() {

--- a/client/js/widgets/seat.js
+++ b/client/js/widgets/seat.js
@@ -24,22 +24,26 @@ class Seat extends Widget {
     });
   }
 
-  applyDeltaToDOM(delta) {
-    super.applyDeltaToDOM(delta);
-    if(delta.index !== undefined || delta.player !== undefined || delta.display !== undefined || delta.displayEmpty !== undefined) {
-      const display = this.get('player') != '' ? this.get('display') : this.get('displayEmpty');
-      let displayedText = String(display || '')
-      displayedText = displayedText.replaceAll('seatIndex',this.get('index'))
-      displayedText = displayedText.replaceAll('playerName',this.get('player'))
-      setText(this.domElement, displayedText);
-    }
+  applyDeltaToDOM(delta, modifyDOM, afterModify) {
+    super.applyDeltaToDOM(delta, modifyDOM, afterModify);
+    modifyDOM.then(() => {
+      if(delta.index !== undefined || delta.player !== undefined || delta.display !== undefined || delta.displayEmpty !== undefined) {
+        const display = this.get('player') != '' ? this.get('display') : this.get('displayEmpty');
+        let displayedText = String(display || '')
+        displayedText = displayedText.replaceAll('seatIndex',this.get('index'))
+        displayedText = displayedText.replaceAll('playerName',this.get('player'))
+        setText(this.domElement, displayedText);
+      }
 
-    this.updateLinkedWidgets(delta.player !== undefined);
+      this.updateLinkedWidgets(delta.player !== undefined);
+    });
   }
 
-  applyInitialDelta(delta) {
-    super.applyInitialDelta(delta);
-    this.updateLinkedWidgets(true);
+  applyInitialDelta(delta, modifyDOM, afterModify) {
+    super.applyInitialDelta(delta, modifyDOM, afterModify);
+    modifyDOM.then(() => {
+      this.updateLinkedWidgets(true);
+    });
   }
 
   classes() {

--- a/client/js/widgets/spinner.js
+++ b/client/js/widgets/spinner.js
@@ -20,22 +20,24 @@ class Spinner extends Widget {
     });
   }
 
-  applyDeltaToDOM(delta) {
-    super.applyDeltaToDOM(delta);
+  applyDeltaToDOM(delta, modifyDOM, afterModify) {
+    super.applyDeltaToDOM(delta, modifyDOM, afterModify);
 
-    if(delta.options !== undefined || delta.backgroundCSS !== undefined || delta.spinnerCSS !== undefined || delta.valueCSS !== undefined)
-      this.createChildNodes();
+    modifyDOM.then(() => {
+      if(delta.options !== undefined || delta.backgroundCSS !== undefined || delta.spinnerCSS !== undefined || delta.valueCSS !== undefined)
+        this.createChildNodes();
 
-    if(delta.angle !== undefined && this.spinner || delta.value !== undefined && this.value) {
-      this.spinner.style.transform = `rotate(${delta.angle}deg)`;
-      this.value.classList.add('hidden');
-      if(this.timeout)
-        clearTimeout(this.timeout);
-      this.timeout = setTimeout(_=>{
-        this.value.textContent = this.get('value');
-        this.value.classList.remove('hidden')
-      }, 1300);
-    }
+      if(delta.angle !== undefined && this.spinner || delta.value !== undefined && this.value) {
+        this.spinner.style.transform = `rotate(${delta.angle}deg)`;
+        this.value.classList.add('hidden');
+        if(this.timeout)
+          clearTimeout(this.timeout);
+        this.timeout = setTimeout(_=>{
+          this.value.textContent = this.get('value');
+          this.value.classList.remove('hidden')
+        }, 1300);
+      }
+    });
   }
 
   async click(mode='respect') {

--- a/client/js/widgets/timer.js
+++ b/client/js/widgets/timer.js
@@ -20,22 +20,24 @@ export class Timer extends Widget {
     });
   }
 
-  applyDeltaToDOM(delta) {
-    super.applyDeltaToDOM(delta);
-    if(delta.milliseconds !== undefined) {
-      const s = Math.floor(Math.abs(delta.milliseconds)/1000);
-      setText(this.domElement, `${delta.milliseconds < 0 ? '-' : ''}${Math.floor(s/60)}:${Math.floor(s%60)}`.replace(/:(\d)$/, ':0$1'));
-    }
+  applyDeltaToDOM(delta, modifyDOM, afterModify) {
+    super.applyDeltaToDOM(delta, modifyDOM, afterModify);
+    modifyDOM.then(() => {
+      if(delta.milliseconds !== undefined) {
+        const s = Math.floor(Math.abs(delta.milliseconds)/1000);
+        setText(this.domElement, `${delta.milliseconds < 0 ? '-' : ''}${Math.floor(s/60)}:${Math.floor(s%60)}`.replace(/:(\d)$/, ':0$1'));
+      }
 
-    if(this.interval && (delta.paused !== undefined || delta.precision !== undefined)) {
-      this.stopTimer();
-      if(!this.get('paused'))
-        this.startTimer();
-    }
+      if(this.interval && (delta.paused !== undefined || delta.precision !== undefined)) {
+        this.stopTimer();
+        if(!this.get('paused'))
+          this.startTimer();
+      }
+    });
   }
 
-  applyInitialDelta(delta) {
-    super.applyInitialDelta(delta);
+  applyInitialDelta(delta, modifyDOM, afterModify) {
+    super.applyInitialDelta(delta, modifyDOM, afterModify);
     if(delta.paused === false && activePlayers.length == 1)
       this.startTimer();
   }


### PR DESCRIPTION
This is a pretty big change and currently still broken but I wanted to get it out there to see if anyone has any alternate suggestions or if there's a better way to do this. The TLDR is one of the biggest performance hits in virtualtabletop on my slow computer is forced synchronous style and layout. You can read more about the general issue at:

https://web.dev/avoid-large-complex-layouts-and-layout-thrashing/#avoid-forced-synchronous-layouts

This patch splits up `applyDelta` and `applyDeltaToDOM` into three phases in order to reduce forced layouts as much as possible.
1. A measure phase - the initial phase. During this phase it is fine to read style and layout because nothing has invalidated it yet.
2. DOM modification phase. During this phase any modifications can be made to style and layout. Reading back during this should be avoided and moved to the measure phase if possible.
3. A post modification phase. This is really only for initiating transitions which require a separate style change, but could be used for other tasks that want to happen after all dom modification - e.g. maybe measuring the result of the modified dom.

On my slow machine this brought a game initialization which used to take about 30s down to a couple seconds.

- [ ] Fix populateAddWidgetOverlay crash
- [ ] Get it more robust...