### PR TITLE
fixed save states without version

### DIFF
--- a/server/room.mjs
+++ b/server/room.mjs
@@ -741,7 +741,7 @@ export default class Room {
     if(updateCurrentSave) {
       const stateID = this.state._meta.activeState.saveStateID;
       const newContent = {...this.state};
-      delete newContent._meta;
+      newContent._meta = { version: this.state._meta.version };
       this.state._meta.states[stateID].saveDate = +new Date();
       fs.writeFileSync(this.variantFilename(stateID, 0), JSON.stringify(newContent));
       return this.sendMetaUpdate();

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -423,6 +423,7 @@ export default class Room {
       this.state._meta.states = Object.assign(this.state._meta.states, this.getPublicLibraryGames());
 
       this.migrateOldPublicLibraryLinks();
+      this.migrateBrokenSaveWithoutVersion();
       await this.updateLinkedStates();
       this.removeInvalidPublicLibraryLinks(player);
 
@@ -477,6 +478,33 @@ export default class Room {
       this.state._meta.activeState = { stateID, variantID };
 
     this.sendMetaUpdate();
+  }
+
+  migrateBrokenSaveWithoutVersion() {
+    // a bug caused some savegames to be written to disk without file version
+    // this guesses and adds the missing version by looking at the save date and comparing it to the commit time of version bumps
+    if(this.state._meta.metaVersion < 2) {
+      this.state._meta.metaVersion = 2;
+      for(const [ id, state ] of Object.entries(this.state._meta.states)) {
+        if(state.savePlayers) {
+          const content = JSON.parse(fs.readFileSync(this.variantFilename(id, 0)));
+          if(!content._meta || !content._meta.version) {
+            if(state.saveDate >= 1676062683000)
+              content._meta = { version: 12 };
+            else if(state.saveDate >= 1674097185000)
+              content._meta = { version: 11 };
+            else if(state.saveDate >= 1674011502000)
+              content._meta = { version: 10 };
+            else if(state.saveDate >= 1672556492000)
+              content._meta = { version: 9 };
+            else
+              content._meta = { version: 8 };
+            Logging.log(`setting missing file version to ${content._meta.version} for ${id} in room ${this.id}`);
+            fs.writeFileSync(this.variantFilename(id, 0), JSON.stringify(content));
+          }
+        }
+      }
+    }
   }
 
   migrateOldPublicLibraryLinks() {


### PR DESCRIPTION
This fixes #1635. When updating the currently loaded save game, the button deleted `_meta` from the saved file which also removes version information. This PR fixes that.

To mitigate broken states now saved on the server, this PR also looks at all save games the next time when a room is loaded. If it finds states without version information, it looks at the date when the state was saved, compares it to the most recent version changes and sets the version in the file accordingly, fixing it for the future.

If a file was broken, loaded before a version bump and then resaved afterwards, it might still be broken, because it might have skipped one or more file updaters.

Also: this assumes that the server updated to new commits as soon as they went live. This should be true for the production server but other servers probably only update on demand. @mousewax, this could affect your server, for example.