### PR TITLE
improved asset handling when adding games to the public library

### DIFF
--- a/server/room.mjs
+++ b/server/room.mjs
@@ -167,6 +167,10 @@ export default class Room {
     if(!Config.get('allowPublicLibraryEdits'))
       return;
 
+    for(const usedAsset in this.getAssetListForState(id))
+      if(!fs.existsSync(Config.directory('assets') + '/' + usedAsset))
+        throw new Logging.UserError(404, `Could not find asset /assets/${usedAsset} which is referenced in the state.`);
+
     const variantData = {};
     for(const variantID in this.state._meta.states[id].variants)
       variantData[variantID] = JSON.parse(fs.readFileSync(this.variantFilename(id, variantID)));
@@ -354,6 +358,14 @@ export default class Room {
 
   getAssetList(state) {
     return [...new Set(JSON.stringify(state).match(/\/assets\/-?[0-9]+_[0-9]+/g) || [])];
+  }
+
+  getAssetListForState(stateID) {
+    const usedAssets = {};
+    for(const vID in this.state._meta.states[stateID].variants)
+      for(const asset of this.getAssetList(JSON.parse(fs.readFileSync(this.variantFilename(stateID, vID)))))
+        usedAssets[asset.split('/')[2]] = true;
+    return usedAssets;
   }
 
   getRedirection() {
@@ -988,11 +1000,7 @@ export default class Room {
       return;
 
     const assetsDir = this.variantFilename(stateID, 0).replace(/\/[0-9]+\.json$/, '/assets');
-
-    const usedAssets = {};
-    for(const vID in this.state._meta.states[stateID].variants)
-      for(const asset of this.getAssetList(JSON.parse(fs.readFileSync(this.variantFilename(stateID, vID)))))
-        usedAssets[asset.split('/')[2]] = true;
+    const usedAssets = this.getAssetListForState(stateID);
 
     const savedAssets = {};
     for(const file of fs.readdirSync(assetsDir))

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -168,7 +168,7 @@ export default class Room {
       return;
 
     for(const usedAsset in this.getAssetListForState(id))
-      if(!fs.existsSync(Config.directory('assets') + '/' + usedAsset))
+      if(!Config.resolveAsset(usedAsset))
         throw new Logging.UserError(404, `Could not find asset /assets/${usedAsset} which is referenced in the state.`);
 
     const variantData = {};
@@ -1012,7 +1012,7 @@ export default class Room {
 
     for(const usedAsset in usedAssets)
       if(!savedAssets[usedAsset])
-        fs.copyFileSync(Config.directory('assets') + '/' + usedAsset, assetsDir + '/' + usedAsset);
+        fs.copyFileSync(Config.resolveAsset(usedAsset), assetsDir + '/' + usedAsset);
   }
 
   writePublicLibraryMetaToFilesystem(stateID, meta) {


### PR DESCRIPTION
When adding a game to the public library using the GUI, the server would crash if it could not find an asset used by the game.

This PR fixes two situations where this might happen:

1. If the asset actually does not exist. In this case it now shows a popup to the user before screwing things up.
2. If the asset is used in another public library game and does not exist in the global assets directory. In this case the asset is now copied from the other game.