### PR TITLE
fixed problems when changing faces on a basic widget

### DIFF
--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -27,7 +27,7 @@ class BasicWidget extends Widget {
         this.applyDelta(face);
     }
     if(delta.text !== undefined)
-      setText(this.domElement, delta.text);
+      setText(this.domElement, this.get('text'));
 
     for(const property of Object.values(this.get('svgReplaces') || {}))
       if(delta[property] !== undefined)

--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -31,7 +31,7 @@ class BasicWidget extends Widget {
       }
 
       const face = this.faces()[this.get('activeFace')];
-      if(face !== undefined) {
+      if(face && typeof face == 'object') {
         this.applyDeltaToDOM(face);
         this.previouslyActiveFace = face;
       }

--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -22,9 +22,19 @@ class BasicWidget extends Widget {
   applyDeltaToDOM(delta) {
     super.applyDeltaToDOM(delta);
     if(delta.activeFace !== undefined || delta.faces !== undefined) {
-      let face = this.faces()[this.get('activeFace')];
-      if(face !== undefined)
+      if(this.previouslyActiveFace !== undefined) {
+        const undoDelta = {};
+        for(const property in this.previouslyActiveFace)
+          undoDelta[property] = this.state[property] !== undefined ? this.state[property] : null;
+        this.applyDeltaToDOM(undoDelta);
+        delete this.previouslyActiveFace;
+      }
+
+      const face = this.faces()[this.get('activeFace')];
+      if(face !== undefined) {
         this.applyDeltaToDOM(face);
+        this.previouslyActiveFace = face;
+      }
     }
     if(delta.text !== undefined)
       setText(this.domElement, this.get('text'));

--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -24,7 +24,7 @@ class BasicWidget extends Widget {
     if(delta.activeFace !== undefined || delta.faces !== undefined) {
       let face = this.faces()[this.get('activeFace')];
       if(face !== undefined)
-        this.applyDelta(face);
+        this.applyDeltaToDOM(face);
     }
     if(delta.text !== undefined)
       setText(this.domElement, this.get('text'));
@@ -88,13 +88,13 @@ class BasicWidget extends Widget {
     }
   }
 
-  getDefaultValue(property) {
+  get(property) {
     if(property == 'faces' || property == 'activeFace' || !this.faces()[this.get('activeFace')])
-      return super.getDefaultValue(property);
+      return super.get(property);
     const d = this.faces()[this.get('activeFace')][property];
     if(d !== undefined)
       return d;
-    return super.getDefaultValue(property);
+    return super.get(property);
   }
 
   getImage() {


### PR DESCRIPTION
This is very similar to #536 but it was faster to redo it than to resolve all the conflicts. I also wanted a better way to undo the previous face changes.

This fixes #1664. It does change behavior in production but not in a way as discussed in #536. Turns out the properties of the active face were never copied to the widget in the first place. _But_ changing from a face that _has_ an `image` to a face that _does not_, would previously still show the `image` of the previous face. It no longer does. The behavior in production is clearly buggy though because reloading the room would make the `image` of the previous face disappear. Reloading the room should _never_ change anything so this is a clear no-no bug that will be fixed now.