### PR TITLE
added missing `await` in `snapToGrid`

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2279,7 +2279,7 @@ export class Widget extends StateManaged {
       }
 
       if(closest) {
-        this.setPosition(closest[0], closest[1], this.get('z'));
+        await this.setPosition(closest[0], closest[1], this.get('z'));
         for(const p in closest[2])
           if([ 'x', 'y', 'minX', 'minY', 'maxX', 'maxY', 'offsetX', 'offsetY', 'alignX', 'alignY' ].indexOf(p) == -1)
             await this.set(p, closest[2][p]);


### PR DESCRIPTION
While working on the undo feature in #1627, I noticed that moving a widget on a `grid` caused extra deltas to be sent. The cause was this missing `await`.