### PR TITLE
always show uploading games

### DIFF
--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -265,13 +265,17 @@ function updateLibraryFilter() {
 
   function applyFilters(filters, callback) {
     for(const [ dom, dataset ] of states) {
-      const textMatch     = dataset.text.match(filters.text);
-      const typeMatch     = filters.type     == 'Any' || dataset.type.split(/[,;] */).indexOf(filters.type) != -1;
-      const playersMatch  = filters.players  == 'Any' || dataset.players.split(/[,;] */).indexOf(filters.players) != -1;
-      const durationMatch = filters.duration == 'Any' || dataset.duration >= filters.duration.split('-')[0] && dataset.duration <= filters.duration.split('-')[1];
-      const languageMatch = filters.language == 'Any' || dataset.languages.split(/[,;] */).indexOf(filters.language.replace(/ \+ None/, '')) != -1 || filters.language.match(/None$/) && dataset.languages.split(/[,;] */).indexOf('') != -1;
-      const modeMatch     = filters.mode     == 'Any' || dataset.modes.split(/[,;] */).indexOf(filters.mode) != -1;
-      callback(dom, textMatch && typeMatch && playersMatch && durationMatch && languageMatch && modeMatch);
+      if(dom.classList.contains('uploading')) {
+        callback(dom, true);
+      } else {
+        const textMatch     = dataset.text.match(filters.text);
+        const typeMatch     = filters.type     == 'Any' || dataset.type.split(/[,;] */).indexOf(filters.type) != -1;
+        const playersMatch  = filters.players  == 'Any' || dataset.players.split(/[,;] */).indexOf(filters.players) != -1;
+        const durationMatch = filters.duration == 'Any' || dataset.duration >= filters.duration.split('-')[0] && dataset.duration <= filters.duration.split('-')[1];
+        const languageMatch = filters.language == 'Any' || dataset.languages.split(/[,;] */).indexOf(filters.language.replace(/ \+ None/, '')) != -1 || filters.language.match(/None$/) && dataset.languages.split(/[,;] */).indexOf('') != -1;
+        const modeMatch     = filters.mode     == 'Any' || dataset.modes.split(/[,;] */).indexOf(filters.mode) != -1;
+        callback(dom, textMatch && typeMatch && playersMatch && durationMatch && languageMatch && modeMatch);
+      }
     }
   }
 


### PR DESCRIPTION
Uploading states are now always displayed no matter what filters are applied in the library.

This was the easiest way to fix a crash where uploading states were missing metadata for the filtering.