### PR TITLE
fixed that cloning displays certain children in the wrong position

### DIFF
--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -108,7 +108,7 @@ export function batchEnd() {
 function receiveDelta(delta) {
   // the order of widget changes is not necessarily correct and in order to avoid cyclic children, this first moves affected widgets to the top level
   for(const widgetID in delta.s) {
-    if(delta.s[widgetID] && delta.s[widgetID].parent !== undefined && widgets.has(widgetID)) {
+    if(delta.s[widgetID] && delta.s[widgetID].parent !== undefined && delta.s[widgetID].id === undefined) {
       const domElement = widgets.get(widgetID).domElement;
       const topTransform = getElementTransformRelativeTo(domElement, $('#topSurface')) || 'none';
       $('#topSurface').appendChild(domElement);


### PR DESCRIPTION
This fixes #1686. When adding new widgets locally (through cloning or the Add Widget overlay), it receives its initial state twice - once because it is created locally first so following routine operations can already interact with it and then it receives the normal delta with the same properties again.

The new code, that makes it possible to apply animation to parent changes, sets temporary transforms to the widget when its parent property changes. But because this would trigger all sorts of animations when loading the room, it only does this when the widget is not a newly created widget.

This is done in two areas in the code (where widgets are unparented to avoid cyclic parents and where widgets are reparented to their actual parent. They both follow the same logic but one path used `widgets.has(id)` to check if it is a new widget and the other path used `delta.id !== undefined` to check if it is a new widget.

Both checks work fine unless there is an `id` in a delta after the widget was already added to `widgets` which is exactly the case when locally adding a new widget.

Now both code paths check for `delta.id === undefined` so they both execute at the same times, undoing each other's changes.