### PR TITLE
added 5 key keyboard input

### DIFF
--- a/client/css/keyboardmode.css
+++ b/client/css/keyboardmode.css
@@ -1,0 +1,19 @@
+.widget.keyboardHighlight.ArrowUp {
+  box-shadow: 0px 0px 0px 5px red;
+}
+
+.widget.keyboardHighlight.ArrowRight {
+  box-shadow: 0px 0px 0px 5px yellow;
+}
+
+.widget.keyboardHighlight.ArrowDown {
+  box-shadow: 0px 0px 0px 5px blue;
+}
+
+.widget.keyboardHighlight.ArrowLeft {
+  box-shadow: 0px 0px 0px 5px green;
+}
+
+.widget.keyboardHighlight.Enter {
+  box-shadow: 0px 0px 0px 5px purple;
+}

--- a/client/css/keyboardmode.css
+++ b/client/css/keyboardmode.css
@@ -17,3 +17,11 @@
 .widget.keyboardHighlight.Enter {
   box-shadow: 0px 0px 0px 5px purple;
 }
+
+body.keyboardMode #buttonInputGo {
+  background: yellow;
+  color: black;
+}
+body.keyboardMode #buttonInputCancel {
+  background: green;
+}

--- a/client/css/keyboardmode.css
+++ b/client/css/keyboardmode.css
@@ -1,21 +1,25 @@
 .widget.keyboardHighlight.ArrowUp {
-  box-shadow: 0px 0px 0px 5px red;
+  --highlightColor: red;
 }
 
 .widget.keyboardHighlight.ArrowRight {
-  box-shadow: 0px 0px 0px 5px yellow;
+  --highlightColor: yellow;
 }
 
 .widget.keyboardHighlight.ArrowDown {
-  box-shadow: 0px 0px 0px 5px blue;
+  --highlightColor: blue;
 }
 
 .widget.keyboardHighlight.ArrowLeft {
-  box-shadow: 0px 0px 0px 5px green;
+  --highlightColor: green;
 }
 
 .widget.keyboardHighlight.Enter {
-  box-shadow: 0px 0px 0px 5px purple;
+  --highlightColor: purple;
+}
+
+.widget:not(.pile).keyboardHighlight, .widget.pile.keyboardHighlight > .handle {
+  box-shadow: 0px 0px 0px 5px var(--highlightColor);
 }
 
 body.keyboardMode #buttonInputGo {

--- a/client/css/keyboardmode.css
+++ b/client/css/keyboardmode.css
@@ -1,9 +1,9 @@
 .widget.keyboardHighlight.ArrowUp {
-  --highlightColor: red;
+  --highlightColor: yellow;
 }
 
 .widget.keyboardHighlight.ArrowRight {
-  --highlightColor: yellow;
+  --highlightColor: green;
 }
 
 .widget.keyboardHighlight.ArrowDown {
@@ -11,7 +11,7 @@
 }
 
 .widget.keyboardHighlight.ArrowLeft {
-  --highlightColor: green;
+  --highlightColor: red;
 }
 
 .widget.keyboardHighlight.Enter {
@@ -23,9 +23,8 @@
 }
 
 body.keyboardMode #buttonInputGo {
-  background: yellow;
-  color: black;
+  background: green;
 }
 body.keyboardMode #buttonInputCancel {
-  background: green;
+  background: red;
 }

--- a/client/js/keyboardmode.js
+++ b/client/js/keyboardmode.js
@@ -26,7 +26,7 @@ function isForeign(widget) {
 }
 
 function allValidTargets() {
-  return widgetFilter(function(w) {
+  const valid = widgetFilter(function(w) {
     if(w.get('movable') || w.get('clickable')) {
       const isInPile = w.get('parent') && widgets.get(w.get('parent')).get('type') == 'pile';
       if(w.get('movable'))
@@ -35,6 +35,9 @@ function allValidTargets() {
     }
     return false;
   });
+  for(const pile of valid.filter(w=>w.get('type') == 'pile'))
+    valid.push(widgetFilter(w=>w.get('parent')==pile.id).sort((a,b)=>a.get('z')-b.get('z'))[0]);
+  return valid;
 }
 
 function allValidDropTargets(widget) {

--- a/client/js/keyboardmode.js
+++ b/client/js/keyboardmode.js
@@ -13,8 +13,6 @@ function isClickable(widget) {
     return true;
   if(widget.get('type') == 'card' && widgets.get(widget.get('deck')).get('faceTemplates').length > 1)
     return true;
-  if(widget.get('type') == 'card' && widgets.get(widget.get('deck')).get('faceTemplates').length > 1)
-    return true;
   if(!widget.get('type') && widget.faces().length > 1)
     return true;
   if([ 'dice', 'seat', 'spinner' ].indexOf(widget.get('type')) != -1)

--- a/client/js/keyboardmode.js
+++ b/client/js/keyboardmode.js
@@ -20,7 +20,8 @@ function isClickable(widget) {
 }
 
 function isForeign(widget) {
-  return getComputedStyle(widget.domElement).getPropertyValue('--foreign') == 'true';
+  const style = getComputedStyle(widget.domElement);
+  return (style.display == "none") || (style.visibility == "hidden") || (style.getPropertyValue('--foreign') == 'true') || !overlap(widget.domElement, $('#roomArea'));
 }
 
 function allValidTargets() {

--- a/client/js/keyboardmode.js
+++ b/client/js/keyboardmode.js
@@ -37,6 +37,10 @@ function allValidTargets() {
   });
 }
 
+function allValidDropTargets(widget) {
+  return widget.validDropTargets().filter(w=>!isForeign(w));
+}
+
 function emulateAnchor(widget) {
   const rect = widget.domElement.getBoundingClientRect();
   return widget.coordLocalFromCoordClient({x: rect.left, y: rect.top});
@@ -75,9 +79,9 @@ async function widgetSelected(widget) {
 
   if(selectingDropTargetFor) {
     if(isClickable(widget))
-      showKeyboardHighlights(widget.validDropTargets(), widget);
+      showKeyboardHighlights(allValidDropTargets(widget), widget);
     else
-      showKeyboardHighlights(widget.validDropTargets());
+      showKeyboardHighlights(allValidDropTargets(widget));
   } else {
     showKeyboardHighlights(allValidTargets());
   }

--- a/client/js/keyboardmode.js
+++ b/client/js/keyboardmode.js
@@ -144,7 +144,13 @@ window.addEventListener('keyup', function(e) {
     else
       hideKeyboardHighlights();
   } else if(keyboardMode && !keyboardModeJustEnabled && enableCounter == 0) {
-    if(widgetsByKey[e.key]) {
+    if($('#activeGameButton').dataset.overlay == 'buttonInputOverlay') {
+      if(e.key == 'ArrowLeft')
+        $('#buttonInputCancel').click();
+      if(e.key == 'ArrowRight')
+        $('#buttonInputGo').click();
+      setTimeout(_=>showKeyboardHighlights(allValidTargets()), 0);
+    } else if(widgetsByKey[e.key]) {
       if(widgetsByKey[e.key].length > 1) {
         showKeyboardHighlights(widgetsByKey[e.key]);
       } else if(widgetsByKey[e.key].length) {

--- a/client/js/keyboardmode.js
+++ b/client/js/keyboardmode.js
@@ -1,0 +1,158 @@
+let keyboardMode = false;
+let keyboardModeJustEnabled = true;
+
+let enableCounter = 0;
+
+let selectingDropTargetFor = null;
+
+const validKeys = [ 'ArrowLeft', 'ArrowUp', 'Enter', 'ArrowDown', 'ArrowRight' ];
+const widgetsByKey = {};
+
+function isClickable(widget) {
+  if(widget.get('clickRoutine') && widget.get('clickRoutine').length)
+    return true;
+  if(widget.get('type') == 'card' && widgets.get(widget.get('deck')).get('faceTemplates').length > 1)
+    return true;
+  if(widget.get('type') == 'card' && widgets.get(widget.get('deck')).get('faceTemplates').length > 1)
+    return true;
+  if(!widget.get('type') && widget.faces().length > 1)
+    return true;
+  if([ 'dice', 'seat', 'spinner' ].indexOf(widget.get('type')) != -1)
+    return true;
+}
+
+function isForeign(widget) {
+  return getComputedStyle(widget.domElement).getPropertyValue('--foreign') == 'true';
+}
+
+function allValidTargets() {
+  return widgetFilter(function(w) {
+    if(w.get('movable') || w.get('clickable')) {
+      const isInPile = w.get('parent') && widgets.get(w.get('parent')).get('type') == 'pile';
+      if(w.get('movable'))
+        return w.get('type') != 'deck' && !isInPile && !isForeign(w);
+      return isClickable(w) && !isForeign(w);
+    }
+    return false;
+  });
+}
+
+function emulateAnchor(widget) {
+  const rect = widget.domElement.getBoundingClientRect();
+  return widget.coordLocalFromCoordClient({x: rect.left, y: rect.top});
+}
+
+function emulateCoords(widget) {
+  const rect = widget.domElement.getBoundingClientRect();
+  return {x: (rect.left - roomRectangle.left) / scale, y: (rect.top - roomRectangle.top) / scale, clientX: rect.left, clientY: rect.top};
+}
+
+async function widgetSelected(widget) {
+  console.log('SELECTED', widget);
+
+  batchStart();
+  if(selectingDropTargetFor && selectingDropTargetFor == widget) {
+    await widget.click();
+    selectingDropTargetFor = null;
+  } else if(selectingDropTargetFor) {
+    await selectingDropTargetFor.moveStart();
+    batchEnd();
+    batchStart();
+    await selectingDropTargetFor.move(   emulateCoords(widget), emulateAnchor(selectingDropTargetFor));
+    batchEnd();
+    batchStart();
+    await selectingDropTargetFor.move(   emulateCoords(widget), emulateAnchor(selectingDropTargetFor));
+    batchEnd();
+    batchStart();
+    await selectingDropTargetFor.moveEnd(emulateCoords(widget), emulateAnchor(selectingDropTargetFor));
+    selectingDropTargetFor = null;
+  } else if(!widget.get('movable')) {
+    await widget.click();
+  } else {
+    selectingDropTargetFor = widget;
+  }
+  batchEnd();
+
+  if(selectingDropTargetFor) {
+    if(isClickable(widget))
+      showKeyboardHighlights(widget.validDropTargets(), widget);
+    else
+      showKeyboardHighlights(widget.validDropTargets());
+  } else {
+    showKeyboardHighlights(allValidTargets());
+  }
+}
+
+function hideKeyboardHighlights() {
+  for(const key of validKeys) {
+    if(widgetsByKey[key]) {
+      for(const widget of widgetsByKey[key]) {
+        widget.domElement.classList.remove('keyboardHighlight');
+        widget.domElement.classList.remove(key);
+      }
+    }
+    widgetsByKey[key] = [];
+  }
+}
+
+function sortByPosition(widgets) {
+  return widgets.sort((a,b)=>a.domElement.getBoundingClientRect().left-b.domElement.getBoundingClientRect().left || a.domElement.getBoundingClientRect().top-b.domElement.getBoundingClientRect().top);
+}
+
+function showKeyboardHighlights(widgets, widgetForEnter) {
+  const countPerKey = Math.ceil(widgets.length / (validKeys.length - (widgetForEnter ? 1 : 0)));
+
+  hideKeyboardHighlights();
+
+  let i = 0;
+  for(const widget of sortByPosition(widgets)) {
+    const key = validKeys[Math.floor(i/countPerKey)];
+    widget.domElement.classList.add('keyboardHighlight');
+    widget.domElement.classList.add(key);
+    widgetsByKey[key].push(widget);
+    ++i;
+    if(widgetForEnter && validKeys[Math.floor(i/countPerKey)] == 'Enter')
+      i += countPerKey;
+  }
+
+  if(widgetForEnter) {
+    widgetForEnter.domElement.classList.add('keyboardHighlight');
+    widgetForEnter.domElement.classList.add('Enter');
+    widgetsByKey['Enter'].push(widgetForEnter);
+  }
+
+  console.log(widgetsByKey, i, countPerKey);
+}
+
+window.addEventListener('keydown', function(e) {
+  if(validKeys.indexOf(e.key) != -1)
+    ++enableCounter;
+});
+
+window.addEventListener('keyup', function(e) {
+  if(validKeys.indexOf(e.key) != -1)
+    --enableCounter;
+
+  if(enableCounter == 2) {
+    keyboardMode = !keyboardMode;
+    selectingDropTargetFor = null;
+    if(keyboardMode)
+      keyboardModeJustEnabled = true;
+    $('body').classList.toggle('keyboardMode', keyboardMode);
+    if(keyboardMode)
+      showKeyboardHighlights(allValidTargets());
+    else
+      hideKeyboardHighlights();
+  } else if(keyboardMode && !keyboardModeJustEnabled && enableCounter == 0) {
+    if(widgetsByKey[e.key]) {
+      if(widgetsByKey[e.key].length > 1) {
+        showKeyboardHighlights(widgetsByKey[e.key]);
+      } else if(widgetsByKey[e.key].length) {
+        widgetSelected(widgetsByKey[e.key][0]);
+      }
+    }
+  }
+
+  if(enableCounter == 0)
+    keyboardModeJustEnabled = false;
+});

--- a/client/js/keyboardmode.js
+++ b/client/js/keyboardmode.js
@@ -87,6 +87,37 @@ async function widgetSelected(widget) {
   }
 }
 
+async function moveWidget(widget, key) {
+  const coords = emulateCoords(widget);
+
+  if(key == 'ArrowLeft')
+    coords.x -= 20;
+
+  if(key == 'ArrowRight')
+    coords.x += 20;
+
+  if(key == 'ArrowUp')
+    coords.y -= 20;
+
+  if(key == 'ArrowDown')
+    coords.y += 20;
+
+  batchStart();
+  await widget.moveStart();
+  batchEnd();
+  batchStart();
+  await widget.move(coords, emulateAnchor(widget));
+  batchEnd();
+  batchStart();
+  await widget.move(coords, emulateAnchor(widget));
+  batchEnd();
+  batchStart();
+  await widget.moveEnd(coords, emulateAnchor(widget));
+  batchEnd();
+
+  showKeyboardHighlights(allValidDropTargets(widget));
+}
+
 function hideKeyboardHighlights() {
   for(const key of validKeys) {
     if(widgetsByKey[key]) {
@@ -159,6 +190,13 @@ window.addEventListener('keyup', function(e) {
         showKeyboardHighlights(widgetsByKey[e.key]);
       } else if(widgetsByKey[e.key].length) {
         widgetSelected(widgetsByKey[e.key][0]);
+      } else if(selectingDropTargetFor) {
+        if(e.key == 'Enter') {
+          showKeyboardHighlights(allValidTargets());
+          selectingDropTargetFor = null;
+        } else {
+          moveWidget(selectingDropTargetFor, e.key);
+        }
       }
     }
   }

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -20,6 +20,7 @@ export default function minifyRoom() {
       input: [
         'client/css/layout.css',
 
+        'client/css/keyboardmode.css',
         'client/css/editmode.css',
         'client/css/jsonedit.css',
         'client/css/tracing.css',
@@ -64,6 +65,7 @@ export default function minifyRoom() {
           'client/js/jsonedit.js',
           'client/js/compute.js',
           'client/js/mousehandling.js',
+          'client/js/keyboardmode.js',
           'client/js/tracing.js',
           'client/js/statemanaged.js',
           'client/js/color.js',


### PR DESCRIPTION
This PR intends to make most games playable by using arrow keys and Enter.

Press three of those keys simultaneously to toggle this keyboard input mode.

All interactable widgets will get a colored outline. 

- Red is the left arrow.
- Yellow is the up arrow.
- Purple is Enter.
- Blue is the down arrow.
- Green is the right arrow.

Press the button in that color to filter the widgets and eventually select one widget.

- If the widget is not movable, it will be clicked immediately.
- If the widget is movable, you can now select a valid drop target holder using the same technique.
- If it is movable and clickable, the widget itself will be highlighted as a valid drop target which will then click the widget.

Current limitations:
- ~~You can not move widgets freely (only move to holders).~~ It only works if there are no valid drop targets.
- ~~You can not interact with the top card of a pile (only the whole pile).~~
- (You can not interact with input popups.) You can cancel or confirm them now, but not change any options.
- You can not interact with the rest of the UI (like changing the game).