### PR TITLE
minor fixes in Animal Race

### DIFF
--- a/library/games/Animal Race/0.json
+++ b/library/games/Animal Race/0.json
@@ -24,7 +24,7 @@
       "hare": {
         "image": "/assets/1451258073_2960"
       },
-      "hegdehog": {
+      "hedgehog": {
         "image": "/assets/425961551_3877"
       }
     },
@@ -95,7 +95,7 @@
   "fyb5": {
     "deck": "f9ym",
     "type": "card",
-    "cardType": "hegdehog",
+    "cardType": "hedgehog",
     "id": "fyb5",
     "z": 142,
     "y": 860,
@@ -370,7 +370,6 @@
     "z": 201,
     "x": 860,
     "y": 180,
-    "movable": true,
     "parent": "Board"
   },
   "4uhc": {
@@ -426,7 +425,7 @@
   "luxe": {
     "deck": "f9ym",
     "type": "card",
-    "cardType": "hegdehog",
+    "cardType": "hedgehog",
     "id": "luxe",
     "z": 145,
     "x": 220,
@@ -436,7 +435,7 @@
   "uj6a": {
     "deck": "f9ym",
     "type": "card",
-    "cardType": "hegdehog",
+    "cardType": "hedgehog",
     "id": "uj6a",
     "z": 191,
     "x": 1020,
@@ -446,7 +445,7 @@
   "dt9c": {
     "deck": "f9ym",
     "type": "card",
-    "cardType": "hegdehog",
+    "cardType": "hedgehog",
     "id": "dt9c",
     "z": 185,
     "x": 1300,
@@ -456,7 +455,7 @@
   "o4f4": {
     "deck": "f9ym",
     "type": "card",
-    "cardType": "hegdehog",
+    "cardType": "hedgehog",
     "id": "o4f4",
     "z": 178,
     "x": 1300,
@@ -466,7 +465,7 @@
   "kc1p": {
     "deck": "f9ym",
     "type": "card",
-    "cardType": "hegdehog",
+    "cardType": "hedgehog",
     "id": "kc1p",
     "z": 172,
     "x": 1060,
@@ -476,7 +475,7 @@
   "vq4x": {
     "deck": "f9ym",
     "type": "card",
-    "cardType": "hegdehog",
+    "cardType": "hedgehog",
     "id": "vq4x",
     "z": 165,
     "y": 100,
@@ -486,7 +485,7 @@
   "n72d": {
     "deck": "f9ym",
     "type": "card",
-    "cardType": "hegdehog",
+    "cardType": "hedgehog",
     "id": "n72d",
     "z": 158,
     "y": 60,
@@ -496,7 +495,7 @@
   "erpj": {
     "deck": "f9ym",
     "type": "card",
-    "cardType": "hegdehog",
+    "cardType": "hedgehog",
     "id": "erpj",
     "z": 153,
     "x": 260,
@@ -506,7 +505,7 @@
   "4nl8": {
     "deck": "f9ym",
     "type": "card",
-    "cardType": "hegdehog",
+    "cardType": "hedgehog",
     "id": "4nl8",
     "z": 149,
     "x": 260,
@@ -3590,7 +3589,7 @@
       "similarName": "Hare & Tortoise",
       "description": "Move around board by collecting and spending carrots and lettuce.  First around the board having depleted all lettuce and all but 10 carrots wins.",
       "showName": true,
-      "lastUpdate": 1634502388000
+      "lastUpdate": 1679045125000
     }
   }
 }


### PR DESCRIPTION
Fixed typo `hegdehog` in card types. Fixed that _one_ tile of the board was movable.