### PR TITLE
lazy-load game library images so the active game loads first

### DIFF
--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -454,8 +454,10 @@ function fillStatesList(states, starred, activeState, returnServer, activePlayer
         updateSaveButton.style.display = 'inline-flex';
     }
 
-    if(state.image)
-      $('img', entry).src = mapAssetURLs(state.image);
+    if(state.image) {
+      $('img', entry).dataset.src = mapAssetURLs(state.image);
+      lazyImageObserver.observe($('img', entry));
+    }
 
     fillStateTileTitles(entry, state.name, state.similarName, state.savePlayers, state.saveDate);
 
@@ -1096,4 +1098,13 @@ onLoad(function() {
         resolveStateCollections(file, addStateFile);
     }
   });
+});
+
+const lazyImageObserver = new IntersectionObserver(entries => {
+  for(const entry of entries) {
+    if(entry.isIntersecting) {
+      entry.target.src = entry.target.dataset.src;
+      lazyImageObserver.unobserve(entry.target);
+    }
+  }
 });


### PR DESCRIPTION
If the game library images are not in the cache and you connect through a slow connection, it would load _all_ the library images first before loading any assets of the active game.

This PR adds lazy-loading so that game images are only loaded when actually visible on the screen.

Note that browser dev tools can emulate slower connections and disable cache (top right corner for Firefox):
![image](https://user-images.githubusercontent.com/73538315/226325118-73465b48-e420-434c-b62e-1e65ecd30a0d.png)