### PR TITLE
Clicking scoreboard shows better defaults in options

### DIFF
--- a/client/js/widgets/scoreboard.js
+++ b/client/js/widgets/scoreboard.js
@@ -71,6 +71,8 @@ class Scoreboard extends Widget {
       if(!players.length || !rounds.length)
         return;
 
+      const currentPlayer = players.find(player => player.text == playerName);
+
       try {
         const result = await this.showInputOverlay({
           header: this.get('editPaneTitle'),
@@ -80,7 +82,7 @@ class Scoreboard extends Widget {
               label: 'Player',
               options: players,
               variable: 'player',
-              value: players.find(player => player.text == playerName).value
+              value: currentPlayer? currentPlayer.value : undefined
             },
             {
               type: 'select',

--- a/client/js/widgets/scoreboard.js
+++ b/client/js/widgets/scoreboard.js
@@ -78,7 +78,8 @@ class Scoreboard extends Widget {
               type: 'select',
               label: 'Player',
               options: players,
-              variable: 'player'
+              variable: 'player',
+              value: players.find(player => player.text == playerName).value
             },
             {
               type: 'select',

--- a/client/js/widgets/scoreboard.js
+++ b/client/js/widgets/scoreboard.js
@@ -56,10 +56,10 @@ class Scoreboard extends Widget {
       const seats = this.getIncludedSeats();
       let players = [];
       if(Array.isArray(seats))
-        players = seats.map(function(s) { return { value: s.get('id'), text: s.get('player') || '-' }; });
+        players = seats.map(function(s) { return { value: s.get('id'), text: s.get('player') || '-', selected: s.get('player') == playerName }; });
       else { // Teams
         for (const team in seats)
-          players = players.concat(seats[team].map(function(s) { return { value: s.get('id'), text: `${s.get('player') || '-'} (${team})` } }))
+          players = players.concat(seats[team].map(function(s) { return { value: s.get('id'), text: `${s.get('player') || '-'} (${team})`, selected: s.get('player') == playerName } }))
       }
 
       let rounds = this.getRounds(seats, scoreProperty, 1).map(function(r, i) { return { text: r, value: i+1 }; });
@@ -71,8 +71,6 @@ class Scoreboard extends Widget {
       if(!players.length || !rounds.length)
         return;
 
-      const currentPlayer = players.find(player => player.text == playerName);
-
       try {
         const result = await this.showInputOverlay({
           header: this.get('editPaneTitle'),
@@ -82,7 +80,6 @@ class Scoreboard extends Widget {
               label: 'Player',
               options: players,
               variable: 'player',
-              value: currentPlayer? currentPlayer.value : undefined
             },
             {
               type: 'select',

--- a/client/js/widgets/scoreboard.js
+++ b/client/js/widgets/scoreboard.js
@@ -103,7 +103,9 @@ class Scoreboard extends Widget {
         } else
           scores = +result.score;
         await seat.set(scoreProperty, scores);
-      } catch(e) {}
+      } catch(e) {
+        console.log('The input overlay for the scoreboard failed to load.', e);
+      }
     }
   }
 

--- a/client/js/widgets/scoreboard.js
+++ b/client/js/widgets/scoreboard.js
@@ -58,15 +58,16 @@ class Scoreboard extends Widget {
       if(Array.isArray(seats))
         players = seats.map(function(s) { return { value: s.get('id'), text: s.get('player') || '-' }; });
       else { // Teams
-        for (const team in seats) 
+        for (const team in seats)
           players = players.concat(seats[team].map(function(s) { return { value: s.get('id'), text: `${s.get('player') || '-'} (${team})` } }))
       }
 
       let rounds = this.getRounds(seats, scoreProperty, 1).map(function(r, i) { return { text: r, value: i+1 }; });
+      const everyPlayerFilledLatestRound = !seats.map(s=>(s.get(scoreProperty) || []).length != rounds.length - 1).reduce((a,b)=>a||b);
 
       if(this.totalsOnly)
         rounds = [{text: this.get('totalsLabel'), value: 0}];
-      
+
       if(!players.length || !rounds.length)
         return;
 
@@ -85,7 +86,8 @@ class Scoreboard extends Widget {
               type: 'select',
               label: this.get('roundLabel'),
               options: rounds,
-              variable: 'round'
+              variable: 'round',
+              value: everyPlayerFilledLatestRound ? rounds.length : rounds.length - 1
             },
             {
               type: 'number',

--- a/client/js/widgets/scoreboard.js
+++ b/client/js/widgets/scoreboard.js
@@ -54,16 +54,19 @@ class Scoreboard extends Widget {
     if(!await super.click(mode)) {
       const scoreProperty = this.get('scoreProperty');
       const seats = this.getIncludedSeats();
+      const seatsArray = Array.isArray(seats)? seats : [];
       let players = [];
       if(Array.isArray(seats))
         players = seats.map(function(s) { return { value: s.get('id'), text: s.get('player') || '-', selected: s.get('player') == playerName }; });
       else { // Teams
-        for (const team in seats)
-          players = players.concat(seats[team].map(function(s) { return { value: s.get('id'), text: `${s.get('player') || '-'} (${team})`, selected: s.get('player') == playerName } }))
+        for (const team in seats) {
+          players = players.concat(seats[team].map(function(s) { return { value: s.get('id'), text: `${s.get('player') || '-'} (${team})`, selected: s.get('player') == playerName } }));
+          seatsArray.push(...seats[team]);
+        }
       }
 
       let rounds = this.getRounds(seats, scoreProperty, 1).map(function(r, i) { return { text: r, value: i+1 }; });
-      const everyPlayerFilledLatestRound = !seats.map(s=>(s.get(scoreProperty) || []).length != rounds.length - 1).reduce((a,b)=>a||b);
+      const everyPlayerFilledLatestRound = !seatsArray.map(s=>(s.get(scoreProperty) || []).length != rounds.length - 1).reduce((a,b)=>a||b, false);
 
       if(this.totalsOnly)
         rounds = [{text: this.get('totalsLabel'), value: 0}];


### PR DESCRIPTION
When you click a scoreboard currently, the overlay values default to the player in the first seat and the first round.  This PR changes that so that the default value is the playerName.

I want to change the default round to be the next round.  But I wanted to go ahead and get this started because I had so much trouble doing it.  Hopefully the round will be easier.