### PR TITLE
Public Library: Small fixes for Egyptian Epochs

### DIFF
--- a/library/games/Egyptian Epochs/0.json
+++ b/library/games/Egyptian Epochs/0.json
@@ -69,29 +69,12 @@
         "variable": "result"
       }
     ],
-    "moveToCashHolderRoutine": [
-      {
-        "func": "SET",
-        "collection": [
-          "${token}"
-        ],
-        "property": "parent",
-        "value": "setup-holder-cash"
-      }
-    ],
     "distributeToPlayerRoutine": [
       {
-        "func": "FOREACH",
-        "in": "${tokens}",
-        "loopRoutine": [
-          {
-            "func": "CALL",
-            "routine": "moveToCashHolderRoutine",
-            "arguments": {
-              "token": "${value}"
-            }
-          }
-        ]
+        "func": "SET",
+        "collection": "${tokens}",
+        "property": "parent",
+        "value": "setup-holder-cash"
       },
       {
         "func": "CALL",

--- a/library/games/Egyptian Epochs/0.json
+++ b/library/games/Egyptian Epochs/0.json
@@ -533,7 +533,10 @@
     "y": 260,
     "width": 340,
     "height": 40,
-    "css": "font-family:sans-serif;font-size:10px;text-align:center",
+    "css": {
+      "font-size": "12px",
+      "text-align": "center"
+    },
     "text": "None: -5VP\n3/4/5 different types: 5/10/15VP"
   },
   "description-god": {
@@ -601,7 +604,9 @@
     "width": 60,
     "height": 60,
     "movable": false,
-    "css": "opacity:0.2",
+    "css": {
+      "opacity": 0.2
+    },
     "image": "/assets/-625665537_891"
   },
   "example-civ-2": {
@@ -838,7 +843,10 @@
     "parent": "tiles-discard",
     "x": 0,
     "y": -10,
-    "css": "font-family:sans-serif;font-size:8px;text-align:center",
+    "css": {
+      "font-size": "9px",
+      "text-align": "center"
+    },
     "text": "DISCARD",
     "width": 70,
     "height": 10,
@@ -1053,7 +1061,10 @@
     "x": 55,
     "y": 280,
     "height": 14,
-    "css": "font-family:sans-serif;font-size:12px;text-align:center",
+    "css": {
+      "font-size": "14px",
+      "text-align": "center",
+    },
     "editable": true,
     "text": 10,
     "width": 70,

--- a/library/games/Egyptian Epochs/0.json
+++ b/library/games/Egyptian Epochs/0.json
@@ -37,7 +37,6 @@
     ],
     "x": 1010,
     "y": 95,
-    "z": 1,
     "id": "button-end-turn",
     "width": 70,
     "height": 70
@@ -47,7 +46,6 @@
     "text": "SETUP",
     "x": 1520,
     "y": 10,
-    "z": 1,
     "id": "button-setup",
     "width": 70,
     "height": 70,
@@ -2294,7 +2292,6 @@
       "deck": "suns-deck"
     },
     "linkedToSeat": "p3-seat",
-    "z": 6,
     "stackOffsetX": 30
   },
   "p4-civ1-holder": {
@@ -2471,7 +2468,6 @@
       "deck": "tiles-deck",
       "cardType": "monument-3"
     },
-    "z": 4,
     "linkedToSeat": "p4-seat"
   },
   "p4-monument4-holder": {
@@ -2504,7 +2500,6 @@
       "deck": "tiles-deck",
       "cardType": "monument-5"
     },
-    "z": 5,
     "linkedToSeat": "p4-seat"
   },
   "p4-monument6-holder": {
@@ -3127,8 +3122,7 @@
     "x": 1700,
     "y": 130,
     "width": 40,
-    "height": 40,
-    "z": 8
+    "height": 40
   },
   "sun-1": {
     "type": "card",
@@ -3137,15 +3131,13 @@
     "deck": "suns-deck",
     "cardType": "sun-1",
     "x": 4,
-    "y": 4,
-    "z": 767
+    "y": 4
   },
   "sun-10": {
     "type": "card",
     "id": "sun-10",
     "cardType": "sun-10",
     "deck": "suns-deck",
-    "z": 910,
     "parent": "suns-pile"
   },
   "sun-11": {
@@ -3153,7 +3145,6 @@
     "id": "sun-11",
     "cardType": "sun-11",
     "deck": "suns-deck",
-    "z": 912,
     "parent": "suns-pile"
   },
   "sun-12": {
@@ -3161,7 +3152,6 @@
     "id": "sun-12",
     "cardType": "sun-12",
     "deck": "suns-deck",
-    "z": 914,
     "parent": "suns-pile"
   },
   "sun-13": {
@@ -3169,7 +3159,6 @@
     "id": "sun-13",
     "cardType": "sun-13",
     "deck": "suns-deck",
-    "z": 916,
     "parent": "suns-pile"
   },
   "sun-14": {
@@ -3177,7 +3166,6 @@
     "id": "sun-14",
     "deck": "suns-deck",
     "cardType": "sun-14",
-    "z": 918,
     "parent": "suns-pile"
   },
   "sun-15": {
@@ -3185,7 +3173,6 @@
     "id": "sun-15",
     "deck": "suns-deck",
     "cardType": "sun-15",
-    "z": 920,
     "parent": "suns-pile"
   },
   "sun-16": {
@@ -3193,7 +3180,6 @@
     "id": "sun-16",
     "deck": "suns-deck",
     "cardType": "sun-16",
-    "z": 922,
     "parent": "suns-pile"
   },
   "sun-2": {
@@ -3201,7 +3187,6 @@
     "id": "sun-2",
     "cardType": "sun-2",
     "deck": "suns-deck",
-    "z": 894,
     "parent": "suns-pile"
   },
   "sun-3": {
@@ -3209,7 +3194,6 @@
     "id": "sun-3",
     "cardType": "sun-3",
     "deck": "suns-deck",
-    "z": 896,
     "parent": "suns-pile"
   },
   "sun-4": {
@@ -3217,14 +3201,12 @@
     "id": "sun-4",
     "deck": "suns-deck",
     "cardType": "sun-4",
-    "z": 898,
     "parent": "suns-pile"
   },
   "sun-5": {
     "type": "card",
     "id": "sun-5",
     "cardType": "sun-5",
-    "z": 900,
     "deck": "suns-deck",
     "parent": "suns-pile"
   },
@@ -3232,7 +3214,6 @@
     "type": "card",
     "id": "sun-6",
     "cardType": "sun-6",
-    "z": 902,
     "deck": "suns-deck",
     "parent": "suns-pile"
   },
@@ -3241,7 +3222,6 @@
     "id": "sun-7",
     "cardType": "sun-7",
     "deck": "suns-deck",
-    "z": 904,
     "parent": "suns-pile"
   },
   "sun-8": {
@@ -3249,14 +3229,12 @@
     "id": "sun-8",
     "cardType": "sun-8",
     "deck": "suns-deck",
-    "z": 906,
     "parent": "suns-pile"
   },
   "sun-9": {
     "type": "card",
     "id": "sun-9",
     "cardType": "sun-9",
-    "z": 908,
     "deck": "suns-deck",
     "parent": "suns-pile"
   },
@@ -3360,15 +3338,13 @@
     "dropTarget": {
       "type": "card",
       "deck": "suns-deck"
-    },
-    "z": 1
+    }
   },
   "suns-pile": {
     "type": "pile",
     "id": "suns-pile",
     "width": 30,
     "height": 30,
-    "z": 924,
     "parent": "suns-holder"
   },
   "tile-civ-1-1": {
@@ -3376,47 +3352,41 @@
     "id": "tile-civ-1-1",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-1",
-    "z": 793
+    "cardType": "civ-1"
   },
   "tile-civ-1-2": {
     "type": "card",
     "id": "tile-civ-1-2",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-1",
-    "z": 791
+    "cardType": "civ-1"
   },
   "tile-civ-1-3": {
     "type": "card",
     "id": "tile-civ-1-3",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-1",
-    "z": 789
+    "cardType": "civ-1"
   },
   "tile-civ-1-4": {
     "type": "card",
     "id": "tile-civ-1-4",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-1",
-    "z": 795
+    "cardType": "civ-1"
   },
   "tile-civ-1-5": {
     "type": "card",
     "id": "tile-civ-1-5",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-1",
-    "z": 471
+    "cardType": "civ-1"
   },
   "tile-civ-2-1": {
     "type": "card",
     "id": "tile-civ-2-1",
     "deck": "tiles-deck",
     "cardType": "civ-2",
-    "z": 797,
     "parent": "tiles-pile"
   },
   "tile-civ-2-2": {
@@ -3424,23 +3394,20 @@
     "id": "tile-civ-2-2",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-2",
-    "z": 801
+    "cardType": "civ-2"
   },
   "tile-civ-2-3": {
     "type": "card",
     "id": "tile-civ-2-3",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-2",
-    "z": 803
+    "cardType": "civ-2"
   },
   "tile-civ-2-4": {
     "type": "card",
     "id": "tile-civ-2-4",
     "deck": "tiles-deck",
     "cardType": "civ-2",
-    "z": 799,
     "parent": "tiles-pile"
   },
   "tile-civ-2-5": {
@@ -3448,103 +3415,90 @@
     "id": "tile-civ-2-5",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-2",
-    "z": 486
+    "cardType": "civ-2"
   },
   "tile-civ-3-1": {
     "type": "card",
     "id": "tile-civ-3-1",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-3",
-    "z": 809
+    "cardType": "civ-3"
   },
   "tile-civ-3-2": {
     "type": "card",
     "id": "tile-civ-3-2",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-3",
-    "z": 811
+    "cardType": "civ-3"
   },
   "tile-civ-3-3": {
     "type": "card",
     "id": "tile-civ-3-3",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-3",
-    "z": 807
+    "cardType": "civ-3"
   },
   "tile-civ-3-4": {
     "type": "card",
     "id": "tile-civ-3-4",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-3",
-    "z": 805
+    "cardType": "civ-3"
   },
   "tile-civ-3-5": {
     "type": "card",
     "id": "tile-civ-3-5",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-3",
-    "z": 503
+    "cardType": "civ-3"
   },
   "tile-civ-4-1": {
     "type": "card",
     "id": "tile-civ-4-1",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-4",
-    "z": 815
+    "cardType": "civ-4"
   },
   "tile-civ-4-2": {
     "type": "card",
     "id": "tile-civ-4-2",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-4",
-    "z": 813
+    "cardType": "civ-4"
   },
   "tile-civ-4-3": {
     "type": "card",
     "id": "tile-civ-4-3",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-4",
-    "z": 819
+    "cardType": "civ-4"
   },
   "tile-civ-4-4": {
     "type": "card",
     "id": "tile-civ-4-4",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-4",
-    "z": 817
+    "cardType": "civ-4"
   },
   "tile-civ-4-5": {
     "type": "card",
     "id": "tile-civ-4-5",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-4",
-    "z": 519
+    "cardType": "civ-4"
   },
   "tile-civ-5-1": {
     "type": "card",
     "id": "tile-civ-5-1",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-5",
-    "z": 821
+    "cardType": "civ-5"
   },
   "tile-civ-5-2": {
     "type": "card",
     "id": "tile-civ-5-2",
     "deck": "tiles-deck",
     "cardType": "civ-5",
-    "z": 825,
     "parent": "tiles-pile"
   },
   "tile-civ-5-3": {
@@ -3552,7 +3506,6 @@
     "id": "tile-civ-5-3",
     "deck": "tiles-deck",
     "cardType": "civ-5",
-    "z": 827,
     "parent": "tiles-pile"
   },
   "tile-civ-5-4": {
@@ -3560,23 +3513,20 @@
     "id": "tile-civ-5-4",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-5",
-    "z": 823
+    "cardType": "civ-5"
   },
   "tile-civ-5-5": {
     "type": "card",
     "id": "tile-civ-5-5",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "civ-5",
-    "z": 523
+    "cardType": "civ-5"
   },
   "tile-drought-01": {
     "type": "card",
     "id": "tile-drought-01",
     "deck": "tiles-deck",
     "cardType": "drought",
-    "z": 465,
     "parent": "tiles-pile"
   },
   "tile-drought-02": {
@@ -3584,15 +3534,13 @@
     "id": "tile-drought-02",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "drought",
-    "z": 457
+    "cardType": "drought"
   },
   "tile-earthquake-1": {
     "type": "card",
     "id": "tile-earthquake-1",
     "deck": "tiles-deck",
     "cardType": "earthquake",
-    "z": 818,
     "parent": "tiles-pile"
   },
   "tile-earthquake-2": {
@@ -3600,7 +3548,6 @@
     "id": "tile-earthquake-2",
     "deck": "tiles-deck",
     "cardType": "earthquake",
-    "z": 818,
     "parent": "tiles-pile"
   },
   "tile-flood-01": {
@@ -3608,79 +3555,69 @@
     "id": "tile-flood-01",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "flood",
-    "z": 787
+    "cardType": "flood"
   },
   "tile-flood-02": {
     "type": "card",
     "id": "tile-flood-02",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "flood",
-    "z": 773
+    "cardType": "flood"
   },
   "tile-flood-03": {
     "type": "card",
     "id": "tile-flood-03",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "flood",
-    "z": 775
+    "cardType": "flood"
   },
   "tile-flood-04": {
     "type": "card",
     "id": "tile-flood-04",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "flood",
-    "z": 779
+    "cardType": "flood"
   },
   "tile-flood-05": {
     "type": "card",
     "id": "tile-flood-05",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "flood",
-    "z": 777
+    "cardType": "flood"
   },
   "tile-flood-06": {
     "type": "card",
     "id": "tile-flood-06",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "flood",
-    "z": 771
+    "cardType": "flood"
   },
   "tile-flood-07": {
     "type": "card",
     "id": "tile-flood-07",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "flood",
-    "z": 781
+    "cardType": "flood"
   },
   "tile-flood-08": {
     "type": "card",
     "id": "tile-flood-08",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "flood",
-    "z": 769
+    "cardType": "flood"
   },
   "tile-flood-09": {
     "type": "card",
     "id": "tile-flood-09",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "flood",
-    "z": 783
+    "cardType": "flood"
   },
   "tile-flood-10": {
     "type": "card",
     "id": "tile-flood-10",
     "deck": "tiles-deck",
     "cardType": "flood",
-    "z": 785,
     "parent": "tiles-pile"
   },
   "tile-flood-11": {
@@ -3688,23 +3625,20 @@
     "id": "tile-flood-11",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "flood",
-    "z": 437
+    "cardType": "flood"
   },
   "tile-flood-12": {
     "type": "card",
     "id": "tile-flood-12",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "flood",
-    "z": 429
+    "cardType": "flood"
   },
   "tile-funeral-01": {
     "type": "card",
     "id": "tile-funeral-01",
     "deck": "tiles-deck",
     "cardType": "funeral",
-    "z": 351,
     "parent": "tiles-pile"
   },
   "tile-funeral-02": {
@@ -3712,7 +3646,6 @@
     "id": "tile-funeral-02",
     "deck": "tiles-deck",
     "cardType": "funeral",
-    "z": 347,
     "parent": "tiles-pile"
   },
   "tile-god-01": {
@@ -3720,7 +3653,6 @@
     "id": "tile-god-01",
     "deck": "tiles-deck",
     "cardType": "god",
-    "z": 247,
     "parent": "tiles-pile"
   },
   "tile-god-02": {
@@ -3728,39 +3660,34 @@
     "id": "tile-god-02",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "god",
-    "z": 249
+    "cardType": "god"
   },
   "tile-god-03": {
     "type": "card",
     "id": "tile-god-03",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "god",
-    "z": 253
+    "cardType": "god"
   },
   "tile-god-04": {
     "type": "card",
     "id": "tile-god-04",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "god",
-    "z": 257
+    "cardType": "god"
   },
   "tile-god-05": {
     "type": "card",
     "id": "tile-god-05",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "god",
-    "z": 259
+    "cardType": "god"
   },
   "tile-god-06": {
     "type": "card",
     "id": "tile-god-06",
     "deck": "tiles-deck",
     "cardType": "god",
-    "z": 266,
     "parent": "tiles-pile"
   },
   "tile-god-07": {
@@ -3768,23 +3695,20 @@
     "id": "tile-god-07",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "god",
-    "z": 255
+    "cardType": "god"
   },
   "tile-god-08": {
     "type": "card",
     "id": "tile-god-08",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "god",
-    "z": 251
+    "cardType": "god"
   },
   "tile-gold-1": {
     "type": "card",
     "id": "tile-gold-1",
     "deck": "tiles-deck",
     "cardType": "gold",
-    "z": 599,
     "parent": "tiles-pile"
   },
   "tile-gold-2": {
@@ -3792,7 +3716,6 @@
     "id": "tile-gold-2",
     "deck": "tiles-deck",
     "cardType": "gold",
-    "z": 602,
     "parent": "tiles-pile"
   },
   "tile-gold-3": {
@@ -3800,7 +3723,6 @@
     "id": "tile-gold-3",
     "deck": "tiles-deck",
     "cardType": "gold",
-    "z": 588,
     "parent": "tiles-pile"
   },
   "tile-gold-4": {
@@ -3808,7 +3730,6 @@
     "id": "tile-gold-4",
     "deck": "tiles-deck",
     "cardType": "gold",
-    "z": 592,
     "parent": "tiles-pile"
   },
   "tile-gold-5": {
@@ -3816,7 +3737,6 @@
     "id": "tile-gold-5",
     "deck": "tiles-deck",
     "cardType": "gold",
-    "z": 595,
     "parent": "tiles-pile"
   },
   "tile-monument-1-1": {
@@ -3824,447 +3744,391 @@
     "id": "tile-monument-1-1",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-1",
-    "z": 839
+    "cardType": "monument-1"
   },
   "tile-monument-1-2": {
     "type": "card",
     "id": "tile-monument-1-2",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-1",
-    "z": 841
+    "cardType": "monument-1"
   },
   "tile-monument-1-3": {
     "type": "card",
     "id": "tile-monument-1-3",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-1",
-    "z": 845
+    "cardType": "monument-1"
   },
   "tile-monument-1-4": {
     "type": "card",
     "id": "tile-monument-1-4",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-1",
-    "z": 843
+    "cardType": "monument-1"
   },
   "tile-monument-1-5": {
     "type": "card",
     "id": "tile-monument-1-5",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-1",
-    "z": 610
+    "cardType": "monument-1"
   },
   "tile-monument-2-1": {
     "type": "card",
     "id": "tile-monument-2-1",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-2",
-    "z": 849
+    "cardType": "monument-2"
   },
   "tile-monument-2-2": {
     "type": "card",
     "id": "tile-monument-2-2",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-2",
-    "z": 847
+    "cardType": "monument-2"
   },
   "tile-monument-2-3": {
     "type": "card",
     "id": "tile-monument-2-3",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-2",
-    "z": 851
+    "cardType": "monument-2"
   },
   "tile-monument-2-4": {
     "type": "card",
     "id": "tile-monument-2-4",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-2",
-    "z": 853
+    "cardType": "monument-2"
   },
   "tile-monument-2-5": {
     "type": "card",
     "id": "tile-monument-2-5",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-2",
-    "z": 622
+    "cardType": "monument-2"
   },
   "tile-monument-3-1": {
     "type": "card",
     "id": "tile-monument-3-1",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-3",
-    "z": 859
+    "cardType": "monument-3"
   },
   "tile-monument-3-2": {
     "type": "card",
     "id": "tile-monument-3-2",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-3",
-    "z": 861
+    "cardType": "monument-3"
   },
   "tile-monument-3-3": {
     "type": "card",
     "id": "tile-monument-3-3",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-3",
-    "z": 855
+    "cardType": "monument-3"
   },
   "tile-monument-3-4": {
     "type": "card",
     "id": "tile-monument-3-4",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-3",
-    "z": 857
+    "cardType": "monument-3"
   },
   "tile-monument-3-5": {
     "type": "card",
     "id": "tile-monument-3-5",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-3",
-    "z": 634
+    "cardType": "monument-3"
   },
   "tile-monument-4-1": {
     "type": "card",
     "id": "tile-monument-4-1",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-4",
-    "z": 865
+    "cardType": "monument-4"
   },
   "tile-monument-4-2": {
     "type": "card",
     "id": "tile-monument-4-2",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-4",
-    "z": 869
+    "cardType": "monument-4"
   },
   "tile-monument-4-3": {
     "type": "card",
     "id": "tile-monument-4-3",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-4",
-    "z": 863
+    "cardType": "monument-4"
   },
   "tile-monument-4-4": {
     "type": "card",
     "id": "tile-monument-4-4",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-4",
-    "z": 867
+    "cardType": "monument-4"
   },
   "tile-monument-4-5": {
     "type": "card",
     "id": "tile-monument-4-5",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-4",
-    "z": 644
+    "cardType": "monument-4"
   },
   "tile-monument-5-1": {
     "type": "card",
     "id": "tile-monument-5-1",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-5",
-    "z": 877
+    "cardType": "monument-5"
   },
   "tile-monument-5-2": {
     "type": "card",
     "id": "tile-monument-5-2",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-5",
-    "z": 873
+    "cardType": "monument-5"
   },
   "tile-monument-5-3": {
     "type": "card",
     "id": "tile-monument-5-3",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-5",
-    "z": 871
+    "cardType": "monument-5"
   },
   "tile-monument-5-4": {
     "type": "card",
     "id": "tile-monument-5-4",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-5",
-    "z": 875
+    "cardType": "monument-5"
   },
   "tile-monument-5-5": {
     "type": "card",
     "id": "tile-monument-5-5",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-5",
-    "z": 656
+    "cardType": "monument-5"
   },
   "tile-monument-6-1": {
     "type": "card",
     "id": "tile-monument-6-1",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-6",
-    "z": 883
+    "cardType": "monument-6"
   },
   "tile-monument-6-2": {
     "type": "card",
     "id": "tile-monument-6-2",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-6",
-    "z": 885
+    "cardType": "monument-6"
   },
   "tile-monument-6-3": {
     "type": "card",
     "id": "tile-monument-6-3",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-6",
-    "z": 881
+    "cardType": "monument-6"
   },
   "tile-monument-6-4": {
     "type": "card",
     "id": "tile-monument-6-4",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-6",
-    "z": 879
+    "cardType": "monument-6"
   },
   "tile-monument-6-5": {
     "type": "card",
     "id": "tile-monument-6-5",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-6",
-    "z": 879
+    "cardType": "monument-6"
   },
   "tile-monument-7-1": {
     "type": "card",
     "id": "tile-monument-7-1",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-7",
-    "z": 891
+    "cardType": "monument-7"
   },
   "tile-monument-7-2": {
     "type": "card",
     "id": "tile-monument-7-2",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-7",
-    "z": 889
+    "cardType": "monument-7"
   },
   "tile-monument-7-3": {
     "type": "card",
     "id": "tile-monument-7-3",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-7",
-    "z": 887
+    "cardType": "monument-7"
   },
   "tile-monument-7-4": {
     "type": "card",
     "id": "tile-monument-7-4",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-7",
-    "z": 893
+    "cardType": "monument-7"
   },
   "tile-monument-7-5": {
     "type": "card",
     "id": "tile-monument-7-5",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-7",
-    "z": 893
+    "cardType": "monument-7"
   },
   "tile-monument-8-1": {
     "type": "card",
     "id": "tile-monument-8-1",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-8",
-    "z": 678
+    "cardType": "monument-8"
   },
   "tile-monument-8-2": {
     "type": "card",
     "id": "tile-monument-8-2",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-8",
-    "z": 680
+    "cardType": "monument-8"
   },
   "tile-monument-8-3": {
     "type": "card",
     "id": "tile-monument-8-3",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-8",
-    "z": 680
+    "cardType": "monument-8"
   },
   "tile-monument-8-4": {
     "type": "card",
     "id": "tile-monument-8-4",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-8",
-    "z": 680
+    "cardType": "monument-8"
   },
   "tile-monument-8-5": {
     "type": "card",
     "id": "tile-monument-8-5",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "monument-8",
-    "z": 680
+    "cardType": "monument-8"
   },
   "tile-nile-01": {
     "type": "card",
     "id": "tile-nile-01",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 395
+    "cardType": "nile"
   },
   "tile-nile-02": {
     "type": "card",
     "id": "tile-nile-02",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 381
+    "cardType": "nile"
   },
   "tile-nile-03": {
     "type": "card",
     "id": "tile-nile-03",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 373
+    "cardType": "nile"
   },
   "tile-nile-04": {
     "type": "card",
     "id": "tile-nile-04",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 391
+    "cardType": "nile"
   },
   "tile-nile-05": {
     "type": "card",
     "id": "tile-nile-05",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 397
+    "cardType": "nile"
   },
   "tile-nile-06": {
     "type": "card",
     "id": "tile-nile-06",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 379
+    "cardType": "nile"
   },
   "tile-nile-07": {
     "type": "card",
     "id": "tile-nile-07",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 383
+    "cardType": "nile"
   },
   "tile-nile-08": {
     "type": "card",
     "id": "tile-nile-08",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 359
+    "cardType": "nile"
   },
   "tile-nile-09": {
     "type": "card",
     "id": "tile-nile-09",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 387
+    "cardType": "nile"
   },
   "tile-nile-10": {
     "type": "card",
     "id": "tile-nile-10",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 365
+    "cardType": "nile"
   },
   "tile-nile-11": {
     "type": "card",
     "id": "tile-nile-11",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 399
+    "cardType": "nile"
   },
   "tile-nile-12": {
     "type": "card",
     "id": "tile-nile-12",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 363
+    "cardType": "nile"
   },
   "tile-nile-13": {
     "type": "card",
     "id": "tile-nile-13",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 377
+    "cardType": "nile"
   },
   "tile-nile-14": {
     "type": "card",
     "id": "tile-nile-14",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 355
+    "cardType": "nile"
   },
   "tile-nile-15": {
     "type": "card",
     "id": "tile-nile-15",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 369
+    "cardType": "nile"
   },
   "tile-nile-16": {
     "type": "card",
     "id": "tile-nile-16",
     "deck": "tiles-deck",
     "cardType": "nile",
-    "z": 415,
     "parent": "tiles-pile"
   },
   "tile-nile-17": {
@@ -4272,215 +4136,188 @@
     "id": "tile-nile-17",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 375
+    "cardType": "nile"
   },
   "tile-nile-18": {
     "type": "card",
     "id": "tile-nile-18",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 353
+    "cardType": "nile"
   },
   "tile-nile-19": {
     "type": "card",
     "id": "tile-nile-19",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 357
+    "cardType": "nile"
   },
   "tile-nile-20": {
     "type": "card",
     "id": "tile-nile-20",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 367
+    "cardType": "nile"
   },
   "tile-nile-21": {
     "type": "card",
     "id": "tile-nile-21",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 371
+    "cardType": "nile"
   },
   "tile-nile-22": {
     "type": "card",
     "id": "tile-nile-22",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 361
+    "cardType": "nile"
   },
   "tile-nile-23": {
     "type": "card",
     "id": "tile-nile-23",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 393
+    "cardType": "nile"
   },
   "tile-nile-24": {
     "type": "card",
     "id": "tile-nile-24",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 389
+    "cardType": "nile"
   },
   "tile-nile-25": {
     "type": "card",
     "id": "tile-nile-25",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "nile",
-    "z": 385
+    "cardType": "nile"
   },
   "tile-pharaoh-01": {
     "type": "card",
     "id": "tile-pharaoh-01",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 274
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-02": {
     "type": "card",
     "id": "tile-pharaoh-02",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 831
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-03": {
     "type": "card",
     "id": "tile-pharaoh-03",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 837
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-04": {
     "type": "card",
     "id": "tile-pharaoh-04",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 835
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-05": {
     "type": "card",
     "id": "tile-pharaoh-05",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 833
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-06": {
     "type": "card",
     "id": "tile-pharaoh-06",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 829
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-07": {
     "type": "card",
     "id": "tile-pharaoh-07",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 304
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-08": {
     "type": "card",
     "id": "tile-pharaoh-08",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 312
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-09": {
     "type": "card",
     "id": "tile-pharaoh-09",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 286
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-10": {
     "type": "card",
     "id": "tile-pharaoh-10",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 280
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-11": {
     "type": "card",
     "id": "tile-pharaoh-11",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 278
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-12": {
     "type": "card",
     "id": "tile-pharaoh-12",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 310
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-13": {
     "type": "card",
     "id": "tile-pharaoh-13",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 284
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-14": {
     "type": "card",
     "id": "tile-pharaoh-14",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 314
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-15": {
     "type": "card",
     "id": "tile-pharaoh-15",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 294
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-16": {
     "type": "card",
     "id": "tile-pharaoh-16",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 290
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-17": {
     "type": "card",
     "id": "tile-pharaoh-17",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 268
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-18": {
     "type": "card",
     "id": "tile-pharaoh-18",
     "deck": "tiles-deck",
     "cardType": "pharaoh",
-    "z": 344,
     "parent": "tiles-pile"
   },
   "tile-pharaoh-19": {
@@ -4488,63 +4325,55 @@
     "id": "tile-pharaoh-19",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 296
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-20": {
     "type": "card",
     "id": "tile-pharaoh-20",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 300
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-21": {
     "type": "card",
     "id": "tile-pharaoh-21",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 306
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-22": {
     "type": "card",
     "id": "tile-pharaoh-22",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 302
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-23": {
     "type": "card",
     "id": "tile-pharaoh-23",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 276
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-24": {
     "type": "card",
     "id": "tile-pharaoh-24",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 292
+    "cardType": "pharaoh"
   },
   "tile-pharaoh-25": {
     "type": "card",
     "id": "tile-pharaoh-25",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "pharaoh",
-    "z": 282
+    "cardType": "pharaoh"
   },
   "tile-ra-01": {
     "type": "card",
     "id": "tile-ra-01",
     "deck": "tiles-deck",
     "cardType": "ra",
-    "z": 174,
     "parent": "tiles-pile"
   },
   "tile-ra-02": {
@@ -4552,7 +4381,6 @@
     "id": "tile-ra-02",
     "deck": "tiles-deck",
     "cardType": "ra",
-    "z": 175,
     "parent": "tiles-pile"
   },
   "tile-ra-03": {
@@ -4560,23 +4388,20 @@
     "id": "tile-ra-03",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 225
+    "cardType": "ra"
   },
   "tile-ra-04": {
     "type": "card",
     "id": "tile-ra-04",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 181
+    "cardType": "ra"
   },
   "tile-ra-05": {
     "type": "card",
     "id": "tile-ra-05",
     "deck": "tiles-deck",
     "cardType": "ra",
-    "z": 236,
     "parent": "tiles-pile"
   },
   "tile-ra-06": {
@@ -4584,183 +4409,160 @@
     "id": "tile-ra-06",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 191
+    "cardType": "ra"
   },
   "tile-ra-07": {
     "type": "card",
     "id": "tile-ra-07",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 189
+    "cardType": "ra"
   },
   "tile-ra-08": {
     "type": "card",
     "id": "tile-ra-08",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 211
+    "cardType": "ra"
   },
   "tile-ra-09": {
     "type": "card",
     "id": "tile-ra-09",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 199
+    "cardType": "ra"
   },
   "tile-ra-10": {
     "type": "card",
     "id": "tile-ra-10",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 207
+    "cardType": "ra"
   },
   "tile-ra-11": {
     "type": "card",
     "id": "tile-ra-11",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 187
+    "cardType": "ra"
   },
   "tile-ra-12": {
     "type": "card",
     "id": "tile-ra-12",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 227
+    "cardType": "ra"
   },
   "tile-ra-13": {
     "type": "card",
     "id": "tile-ra-13",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 183
+    "cardType": "ra"
   },
   "tile-ra-14": {
     "type": "card",
     "id": "tile-ra-14",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 213
+    "cardType": "ra"
   },
   "tile-ra-15": {
     "type": "card",
     "id": "tile-ra-15",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 193
+    "cardType": "ra"
   },
   "tile-ra-16": {
     "type": "card",
     "id": "tile-ra-16",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 221
+    "cardType": "ra"
   },
   "tile-ra-17": {
     "type": "card",
     "id": "tile-ra-17",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 217
+    "cardType": "ra"
   },
   "tile-ra-18": {
     "type": "card",
     "id": "tile-ra-18",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 223
+    "cardType": "ra"
   },
   "tile-ra-19": {
     "type": "card",
     "id": "tile-ra-19",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 219
+    "cardType": "ra"
   },
   "tile-ra-20": {
     "type": "card",
     "id": "tile-ra-20",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 215
+    "cardType": "ra"
   },
   "tile-ra-21": {
     "type": "card",
     "id": "tile-ra-21",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 203
+    "cardType": "ra"
   },
   "tile-ra-22": {
     "type": "card",
     "id": "tile-ra-22",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 201
+    "cardType": "ra"
   },
   "tile-ra-23": {
     "type": "card",
     "id": "tile-ra-23",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 197
+    "cardType": "ra"
   },
   "tile-ra-24": {
     "type": "card",
     "id": "tile-ra-24",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 205
+    "cardType": "ra"
   },
   "tile-ra-25": {
     "type": "card",
     "id": "tile-ra-25",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 185
+    "cardType": "ra"
   },
   "tile-ra-26": {
     "type": "card",
     "id": "tile-ra-26",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 177
+    "cardType": "ra"
   },
   "tile-ra-27": {
     "type": "card",
     "id": "tile-ra-27",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 209
+    "cardType": "ra"
   },
   "tile-ra-28": {
     "type": "card",
     "id": "tile-ra-28",
     "deck": "tiles-deck",
     "cardType": "ra",
-    "z": 239,
     "parent": "tiles-pile"
   },
   "tile-ra-29": {
@@ -4768,23 +4570,20 @@
     "id": "tile-ra-29",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 195
+    "cardType": "ra"
   },
   "tile-ra-30": {
     "type": "card",
     "id": "tile-ra-30",
     "parent": "tiles-pile",
     "deck": "tiles-deck",
-    "cardType": "ra",
-    "z": 179
+    "cardType": "ra"
   },
   "tile-unrest-1": {
     "type": "card",
     "id": "tile-unrest-1",
     "deck": "tiles-deck",
     "cardType": "unrest",
-    "z": 584,
     "parent": "tiles-pile"
   },
   "tile-unrest-2": {
@@ -4792,7 +4591,6 @@
     "id": "tile-unrest-2",
     "deck": "tiles-deck",
     "cardType": "unrest",
-    "z": 581,
     "parent": "tiles-pile"
   },
   "tile-unrest-3": {
@@ -4800,7 +4598,6 @@
     "id": "tile-unrest-3",
     "deck": "tiles-deck",
     "cardType": "unrest",
-    "z": 577,
     "parent": "tiles-pile"
   },
   "tile-unrest-4": {
@@ -4808,7 +4605,6 @@
     "id": "tile-unrest-4",
     "deck": "tiles-deck",
     "cardType": "unrest",
-    "z": 572,
     "parent": "tiles-pile"
   },
   "tiles-deck": {

--- a/library/games/Egyptian Epochs/0.json
+++ b/library/games/Egyptian Epochs/0.json
@@ -532,72 +532,67 @@
     "x": 575,
     "y": 260,
     "width": 340,
+    "height": 40,
     "css": "font-family:sans-serif;font-size:10px;text-align:center",
     "text": "None: -5VP\n3/4/5 different types: 5/10/15VP"
   },
   "description-god": {
     "type": "label",
     "id": "description-god",
+    "inheritFrom": "description-civ",
     "x": 260,
-    "y": 260,
-    "css": "font-family:sans-serif;font-size:10px;text-align:center",
-    "text": "2VP each",
-    "width": 70
+    "width": 70,
+    "text": "2VP each"
   },
   "description-gold": {
     "type": "label",
     "id": "description-gold",
+    "inheritFrom": "description-civ",
     "x": 180,
-    "y": 260,
-    "css": "font-family:sans-serif;font-size:10px;text-align:center",
-    "text": "3VP each",
-    "width": 70
+    "width": 70,
+    "text": "3VP each"
   },
   "description-monuments": {
     "type": "label",
     "id": "description-monuments",
+    "inheritFrom": "description-civ",
     "x": 1075,
-    "y": 260,
     "width": 380,
-    "css": "font-family:sans-serif;font-size:10px;text-align:center",
     "text": "1/2/3/4/5/6/7/8 different types: 1/2/3/4/5/6/10/15VP\nEach 3/4/5 of a kind: 5/10/15VP"
   },
   "description-monuments-nb": {
     "type": "label",
     "id": "description-monuments-nb",
+    "inheritFrom": "description-civ",
     "x": 935,
-    "y": 260,
     "width": 140,
-    "css": "font-family:sans-serif;font-size:10px;text-align:center",
     "text": "- LAST ROUND ONLY -"
   },
   "description-niles-and-floods": {
     "type": "label",
     "id": "description-niles-and-floods",
+    "inheritFrom": "description-civ",
     "x": 420,
-    "y": 260,
     "width": 140,
-    "css": "font-family:sans-serif;font-size:10px;text-align:center",
     "text": "1VP each as long as at\nleast one is a Flood"
   },
   "description-pharaohs": {
     "type": "label",
     "id": "description-pharaohs",
+    "inheritFrom": "description-civ",
     "x": 340,
-    "y": 260,
     "width": 70,
-    "css": "font-family:sans-serif;font-size:10px;text-align:center",
     "text": "Most: 5VP\nFewest: -2VP"
   },
   "description-suns": {
     "type": "label",
     "id": "description-suns",
+    "inheritFrom": "description-civ",
     "x": 10,
     "y": 195,
     "width": 160,
-    "css": "font-family:sans-serif;font-size:10px;text-align:center",
-    "text": "End of Game:\nHighest suns total +5VP\nLowest suns total -5VP",
-    "height": 50
+    "height": 60,
+    "text": "End of Game:\nHighest suns total +5VP\nLowest suns total -5VP"
   },
   "example-civ-1": {
     "id": "example-civ-1",
@@ -611,172 +606,104 @@
   },
   "example-civ-2": {
     "id": "example-civ-2",
+    "inheritFrom": "example-civ-1",
     "x": 645,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "movable": false,
-    "css": "opacity:0.2",
     "image": "/assets/-1702131538_2699"
   },
   "example-civ-3": {
     "id": "example-civ-3",
+    "inheritFrom": "example-civ-1",
     "x": 715,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "movable": false,
-    "css": "opacity:0.2",
     "image": "/assets/-2114748596_2177"
   },
   "example-civ-4": {
     "id": "example-civ-4",
+    "inheritFrom": "example-civ-1",
     "x": 785,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "movable": false,
-    "css": "opacity:0.2",
     "image": "/assets/193559844_2070"
   },
   "example-civ-5": {
     "id": "example-civ-5",
+    "inheritFrom": "example-civ-1",
     "x": 855,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "movable": false,
-    "css": "opacity:0.2",
     "image": "/assets/619132480_690"
   },
   "example-flood": {
     "id": "example-flood",
+    "inheritFrom": "example-civ-1",
     "x": 495,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "movable": false,
-    "css": "opacity:0.2",
     "image": "/assets/2087897998_1650"
   },
   "example-god": {
     "id": "example-god",
+    "inheritFrom": "example-civ-1",
     "x": 265,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "movable": false,
-    "css": "opacity:0.2",
     "image": "/assets/-1035570913_1930"
   },
   "example-gold": {
     "id": "example-gold",
+    "inheritFrom": "example-civ-1",
     "x": 185,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "css": "opacity:0.2",
-    "image": "/assets/878665639_708",
-    "movable": false
+    "image": "/assets/878665639_708"
   },
   "example-monument-1": {
     "id": "example-monument-1",
+    "inheritFrom": "example-civ-1",
     "x": 935,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "movable": false,
-    "css": "opacity:0.2",
     "image": "/assets/919082358_2358"
   },
   "example-monument-2": {
     "id": "example-monument-2",
+    "inheritFrom": "example-civ-1",
     "x": 1005,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "movable": false,
-    "css": "opacity:0.2",
     "image": "/assets/115156902_3894"
   },
   "example-monument-3": {
     "id": "example-monument-3",
+    "inheritFrom": "example-civ-1",
     "x": 1075,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "movable": false,
-    "css": "opacity:0.2",
     "image": "/assets/90033529_2750"
   },
   "example-monument-4": {
     "id": "example-monument-4",
+    "inheritFrom": "example-civ-1",
     "x": 1145,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "movable": false,
-    "css": "opacity:0.2",
     "image": "/assets/-683215186_2565"
   },
   "example-monument-5": {
     "id": "example-monument-5",
+    "inheritFrom": "example-civ-1",
     "x": 1215,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "movable": false,
-    "css": "opacity:0.2",
     "image": "/assets/-1481745525_2916"
   },
   "example-monument-6": {
     "id": "example-monument-6",
+    "inheritFrom": "example-civ-1",
     "x": 1285,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "movable": false,
-    "css": "opacity:0.2",
     "image": "/assets/1697467342_2236"
   },
   "example-monument-7": {
     "id": "example-monument-7",
+    "inheritFrom": "example-civ-1",
     "x": 1355,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "movable": false,
-    "css": "opacity:0.2",
     "image": "/assets/870000677_4386"
   },
   "example-monument-8": {
     "id": "example-monument-8",
+    "inheritFrom": "example-civ-1",
     "x": 1425,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "movable": false,
-    "css": "opacity:0.2",
     "image": "/assets/1319532171_3354"
   },
   "example-nile": {
     "id": "example-nile",
+    "inheritFrom": "example-civ-1",
     "x": 425,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "movable": false,
-    "css": "opacity:0.2",
     "image": "/assets/-1320926012_2684"
   },
   "example-pharaoh": {
     "id": "example-pharaoh",
+    "inheritFrom": "example-civ-1",
     "x": 345,
-    "y": 195,
-    "width": 60,
-    "height": 60,
-    "movable": false,
-    "css": "opacity:0.2",
     "image": "/assets/-1906399272_3567"
   },
   "holder-current-1": {
@@ -797,107 +724,44 @@
   "holder-current-2": {
     "type": "holder",
     "id": "holder-current-2",
-    "x": 310,
-    "y": 100,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck"
-    },
-    "dropLimit": 1
+    "inheritFrom": "holder-current-1",
+    "x": 310
   },
   "holder-current-3": {
     "type": "holder",
     "id": "holder-current-3",
-    "x": 410,
-    "y": 100,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck"
-    },
-    "dropLimit": 1
+    "inheritFrom": "holder-current-1",
+    "x": 410
   },
   "holder-current-4": {
     "type": "holder",
     "id": "holder-current-4",
-    "x": 510,
-    "y": 100,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck"
-    },
-    "dropLimit": 1
+    "inheritFrom": "holder-current-1",
+    "x": 510
   },
   "holder-current-5": {
     "type": "holder",
     "id": "holder-current-5",
-    "x": 610,
-    "y": 100,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck"
-    },
-    "dropLimit": 1
+    "inheritFrom": "holder-current-1",
+    "x": 610
   },
   "holder-current-6": {
     "type": "holder",
     "id": "holder-current-6",
-    "x": 710,
-    "y": 100,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck"
-    },
-    "dropLimit": 1
+    "inheritFrom": "holder-current-1",
+    "x": 710
   },
   "holder-current-7": {
     "type": "holder",
     "id": "holder-current-7",
-    "x": 810,
-    "y": 100,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck"
-    },
-    "dropLimit": 1
+    "inheritFrom": "holder-current-1",
+    "x": 810
   },
   "holder-current-8": {
     "type": "holder",
     "id": "holder-current-8",
-    "x": 910,
-    "y": 100,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck"
-    },
-    "dropLimit": 1
+    "inheritFrom": "holder-current-1",
+    "x": 910
   },
   "holder-ra-1": {
     "type": "holder",
@@ -917,137 +781,56 @@
   "holder-ra-2": {
     "type": "holder",
     "id": "holder-ra-2",
-    "x": 310,
-    "y": 10,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "cardType": "ra"
-    },
-    "dropLimit": 1
+    "inheritFrom": "holder-ra-1",
+    "x": 310
   },
   "holder-ra-3": {
     "type": "holder",
     "id": "holder-ra-3",
-    "x": 410,
-    "y": 10,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "cardType": "ra"
-    },
-    "dropLimit": 1
+    "inheritFrom": "holder-ra-1",
+    "x": 410
   },
   "holder-ra-4": {
     "type": "holder",
     "id": "holder-ra-4",
-    "x": 510,
-    "y": 10,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "cardType": "ra"
-    },
-    "dropLimit": 1
+    "inheritFrom": "holder-ra-1",
+    "x": 510
   },
   "holder-ra-5": {
     "type": "holder",
     "id": "holder-ra-5",
-    "x": 610,
-    "y": 10,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "cardType": "ra"
-    },
-    "dropLimit": 1
+    "inheritFrom": "holder-ra-1",
+    "x": 610
   },
   "holder-ra-6": {
     "type": "holder",
     "id": "holder-ra-6",
-    "x": 710,
-    "y": 10,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "cardType": "ra"
-    },
-    "dropLimit": 1
+    "inheritFrom": "holder-ra-1",
+    "x": 710
   },
   "holder-ra-7": {
     "type": "holder",
     "id": "holder-ra-7",
-    "x": 810,
-    "y": 10,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "cardType": "ra"
-    },
-    "dropLimit": 1
+    "inheritFrom": "holder-ra-1",
+    "x": 810
   },
   "holder-ra-8": {
     "type": "holder",
     "id": "holder-ra-8",
-    "x": 910,
-    "y": 10,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "cardType": "ra"
-    },
-    "dropLimit": 1
+    "inheritFrom": "holder-ra-1",
+    "x": 910
   },
   "holder-ra-9": {
     "type": "holder",
     "id": "holder-ra-9",
-    "x": 1010,
-    "y": 10,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "cardType": "ra"
-    },
-    "dropLimit": 1
+    "inheritFrom": "holder-ra-1",
+    "x": 1010
   },
   "holder-ra-10": {
     "type": "holder",
     "id": "holder-ra-10",
-    "x": 1110,
-    "y": 10,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "cardType": "ra"
-    },
-    "dropLimit": 1
+    "inheritFrom": "holder-ra-1",
+    "x": 1110
   },
   "label-discard": {
     "type": "label",
@@ -1080,274 +863,189 @@
   "p1-civ2-holder": {
     "type": "holder",
     "id": "p1-civ2-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 640,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "civ-2"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-civ3-holder": {
     "type": "holder",
     "id": "p1-civ3-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 710,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "civ-3"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-civ4-holder": {
     "type": "holder",
     "id": "p1-civ4-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 780,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "civ-4"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-civ5-holder": {
     "type": "holder",
     "id": "p1-civ5-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 850,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "civ-5"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-flood-holder": {
     "type": "holder",
     "id": "p1-flood-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 490,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "flood"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-god-holder": {
     "type": "holder",
     "id": "p1-god-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 260,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "god"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-gold-holder": {
     "type": "holder",
     "id": "p1-gold-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 180,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "gold"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-monument1-holder": {
     "type": "holder",
     "id": "p1-monument1-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 930,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "monument-1"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-monument2-holder": {
     "type": "holder",
     "id": "p1-monument2-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 1000,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "monument-2"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-monument3-holder": {
     "type": "holder",
     "id": "p1-monument3-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 1070,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "monument-3"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-monument4-holder": {
     "type": "holder",
     "id": "p1-monument4-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 1140,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "monument-4"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-monument5-holder": {
     "type": "holder",
     "id": "p1-monument5-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 1210,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "monument-5"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-monument6-holder": {
     "type": "holder",
     "id": "p1-monument6-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 1280,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "monument-6"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-monument7-holder": {
     "type": "holder",
     "id": "p1-monument7-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 1350,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "monument-7"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-monument8-holder": {
     "type": "holder",
     "id": "p1-monument8-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 1420,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "monument-8"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-nile-holder": {
     "type": "holder",
     "id": "p1-nile-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 420,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "nile"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-pharaoh-holder": {
     "type": "holder",
     "id": "p1-pharaoh-holder",
+    "inheritFrom": "p1-civ1-holder",
     "x": 340,
-    "y": 310,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
     "dropTarget": {
       "type": "card",
       "deck": "tiles-deck",
       "cardType": "pharaoh"
-    },
-    "linkedToSeat": "p1-seat"
+    }
   },
   "p1-score": {
     "type": "label",
@@ -1441,7 +1139,6 @@
         "mode": "ignoreClickRoutine"
       }
     ],
-    "turn": true,
     "hand": "p1-suns-holder-1"
   },
   "p1-suns-holder-1": {
@@ -1461,1660 +1158,988 @@
   "p1-suns-holder-2": {
     "type": "holder",
     "id": "p1-suns-holder-2",
-    "x": 30,
-    "y": 345,
-    "width": 120,
-    "height": 40,
-    "dropTarget": {
-      "type": "card",
-      "deck": "suns-deck"
-    },
-    "linkedToSeat": "p1-seat",
-    "stackOffsetX": 30
+    "inheritFrom": "p1-suns-holder-1",
+    "y": 345
   },
   "p2-civ1-holder": {
     "type": "holder",
     "id": "p2-civ1-holder",
-    "x": 570,
+    "inheritFrom": "p1-civ1-holder",
     "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-1"
-    },
     "linkedToSeat": "p2-seat"
   },
   "p2-civ2-holder": {
     "type": "holder",
     "id": "p2-civ2-holder",
-    "x": 640,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-2"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-civ2-holder": "*"
+    }
   },
   "p2-civ3-holder": {
     "type": "holder",
     "id": "p2-civ3-holder",
-    "x": 710,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-3"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-civ3-holder": "*"
+    }
   },
   "p2-civ4-holder": {
     "type": "holder",
     "id": "p2-civ4-holder",
-    "x": 780,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-4"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-civ4-holder": "*"
+    }
   },
   "p2-civ5-holder": {
     "type": "holder",
     "id": "p2-civ5-holder",
-    "x": 850,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-5"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-civ5-holder": "*"
+    }
   },
   "p2-flood-holder": {
     "type": "holder",
     "id": "p2-flood-holder",
-    "x": 490,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "flood"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-flood-holder": "*"
+    }
   },
   "p2-god-holder": {
     "type": "holder",
     "id": "p2-god-holder",
-    "x": 260,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "god"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-god-holder": "*"
+    }
   },
   "p2-gold-holder": {
     "type": "holder",
     "id": "p2-gold-holder",
-    "x": 180,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "gold"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-gold-holder": "*"
+    }
   },
   "p2-monument1-holder": {
     "type": "holder",
     "id": "p2-monument1-holder",
-    "x": 930,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-1"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument1-holder": "*"
+    }
   },
   "p2-monument2-holder": {
     "type": "holder",
     "id": "p2-monument2-holder",
-    "x": 1000,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-2"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument2-holder": "*"
+    }
   },
   "p2-monument3-holder": {
     "type": "holder",
     "id": "p2-monument3-holder",
-    "x": 1070,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-3"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument3-holder": "*"
+    }
   },
   "p2-monument4-holder": {
     "type": "holder",
     "id": "p2-monument4-holder",
-    "x": 1140,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-4"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument4-holder": "*"
+    }
   },
   "p2-monument5-holder": {
     "type": "holder",
     "id": "p2-monument5-holder",
-    "x": 1210,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-5"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument5-holder": "*"
+    }
   },
   "p2-monument6-holder": {
     "type": "holder",
     "id": "p2-monument6-holder",
-    "x": 1280,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-6"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument6-holder": "*"
+    }
   },
   "p2-monument7-holder": {
     "type": "holder",
     "id": "p2-monument7-holder",
-    "x": 1350,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-7"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument7-holder": "*"
+    }
   },
   "p2-monument8-holder": {
     "type": "holder",
     "id": "p2-monument8-holder",
-    "x": 1420,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-8"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument8-holder": "*"
+    }
   },
   "p2-nile-holder": {
     "type": "holder",
     "id": "p2-nile-holder",
-    "x": 420,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "nile"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-nile-holder": "*"
+    }
   },
   "p2-pharaoh-holder": {
     "type": "holder",
     "id": "p2-pharaoh-holder",
-    "x": 340,
-    "y": 450,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "pharaoh"
-    },
-    "linkedToSeat": "p2-seat"
+    "inheritFrom": {
+      "p2-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-pharaoh-holder": "*"
+    }
   },
   "p2-score": {
     "type": "label",
     "id": "p2-score",
-    "x": 55,
+    "inheritFrom": "p1-score",
     "y": 420,
-    "height": 14,
-    "css": "font-family:sans-serif;font-size:12px;text-align:center",
-    "editable": true,
     "text": 10,
-    "width": 70,
     "linkedToSeat": "p2-seat"
   },
   "p2-score-dec": {
     "type": "button",
     "id": "p2-score-dec",
     "parent": "p2-score",
-    "x": -8,
-    "width": 20,
-    "height": 20,
-    "movableInEdit": false,
-    "clickRoutine": [
-      {
-        "func": "LABEL",
-        "label": "${PROPERTY parent}",
-        "mode": "dec",
-        "value": 1
-      }
-    ],
-    "text": "-",
-    "y": -1
+    "inheritFrom": "p1-score-dec"
   },
   "p2-score-inc": {
     "type": "button",
     "id": "p2-score-inc",
     "parent": "p2-score",
-    "x": 58,
-    "y": -1,
-    "width": 20,
-    "height": 20,
-    "movableInEdit": false,
-    "clickRoutine": [
-      {
-        "func": "LABEL",
-        "label": "${PROPERTY parent}",
-        "mode": "inc",
-        "value": 1
-      }
-    ],
-    "text": "+"
+    "inheritFrom": "p1-score-inc"
   },
   "p2-seat": {
     "type": "seat",
     "id": "p2-seat",
-    "x": 10,
+    "inheritFrom": {
+      "p1-seat": [
+        "x",
+        "height",
+        "width",
+        "scale",
+        "hideWhenUnused",
+        "clickRoutine"
+      ]
+    },
     "y": 382,
-    "height": 25,
-    "scale": 0.8,
-    "width": 148,
     "index": 2,
-    "hideWhenUnused": true,
-    "clickRoutine": [
-      "var playerPrefix = substr ${playerName} 0 5",
-      {
-        "func": "IF",
-        "operand1": "${playerPrefix}",
-        "operand2": "Guest",
-        "thenRoutine": [
-          {
-            "func": "INPUT",
-            "header": "Enter your name and choice of player color.",
-            "fields": [
-              {
-                "type": "string",
-                "label": "Name",
-                "variable": "playerName",
-                "value": "${playerName}"
-              },
-              {
-                "type": "color",
-                "label": "Color",
-                "variable": "playerColor",
-                "value": "${playerColor}"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "func": "CLICK",
-        "collection": "thisButton",
-        "mode": "ignoreClickRoutine"
-      }
-    ],
     "hand": "p2-suns-holder-1"
   },
   "p2-suns-holder-1": {
     "type": "holder",
     "id": "p2-suns-holder-1",
-    "x": 30,
+    "inheritFrom": "p1-suns-holder-1",
     "y": 445,
-    "width": 120,
-    "height": 40,
-    "dropTarget": {
-      "type": "card",
-      "deck": "suns-deck"
-    },
-    "linkedToSeat": "p2-seat",
-    "stackOffsetX": 30
+    "linkedToSeat": "p2-seat"
   },
   "p2-suns-holder-2": {
     "type": "holder",
     "id": "p2-suns-holder-2",
-    "x": 30,
+    "inheritFrom": "p1-suns-holder-2",
     "y": 485,
-    "width": 120,
-    "height": 40,
-    "dropTarget": {
-      "type": "card",
-      "deck": "suns-deck"
-    },
-    "linkedToSeat": "p2-seat",
-    "stackOffsetX": 30
+    "linkedToSeat": "p2-seat"
   },
   "p3-civ1-holder": {
     "type": "holder",
     "id": "p3-civ1-holder",
-    "x": 570,
+    "inheritFrom": "p1-civ1-holder",
     "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-1"
-    },
     "linkedToSeat": "p3-seat"
   },
   "p3-civ2-holder": {
     "type": "holder",
     "id": "p3-civ2-holder",
-    "x": 640,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-2"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-civ2-holder": "*"
+    }
   },
   "p3-civ3-holder": {
     "type": "holder",
     "id": "p3-civ3-holder",
-    "x": 710,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-3"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-civ3-holder": "*"
+    }
   },
   "p3-civ4-holder": {
     "type": "holder",
     "id": "p3-civ4-holder",
-    "x": 780,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-4"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-civ4-holder": "*"
+    }
   },
   "p3-civ5-holder": {
     "type": "holder",
     "id": "p3-civ5-holder",
-    "x": 850,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-5"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-civ5-holder": "*"
+    }
   },
   "p3-flood-holder": {
     "type": "holder",
     "id": "p3-flood-holder",
-    "x": 490,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "flood"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-flood-holder": "*"
+    }
   },
   "p3-god-holder": {
     "type": "holder",
     "id": "p3-god-holder",
-    "x": 260,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "god"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-god-holder": "*"
+    }
   },
   "p3-gold-holder": {
     "type": "holder",
     "id": "p3-gold-holder",
-    "x": 180,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "gold"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-gold-holder": "*"
+    }
   },
   "p3-monument1-holder": {
     "type": "holder",
     "id": "p3-monument1-holder",
-    "x": 930,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-1"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument1-holder": "*"
+    }
   },
   "p3-monument2-holder": {
     "type": "holder",
     "id": "p3-monument2-holder",
-    "x": 1000,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-2"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument2-holder": "*"
+    }
   },
   "p3-monument3-holder": {
     "type": "holder",
     "id": "p3-monument3-holder",
-    "x": 1070,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-3"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument3-holder": "*"
+    }
   },
   "p3-monument4-holder": {
     "type": "holder",
     "id": "p3-monument4-holder",
-    "x": 1140,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-4"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument4-holder": "*"
+    }
   },
   "p3-monument5-holder": {
     "type": "holder",
     "id": "p3-monument5-holder",
-    "x": 1210,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-5"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument5-holder": "*"
+    }
   },
   "p3-monument6-holder": {
     "type": "holder",
     "id": "p3-monument6-holder",
-    "x": 1280,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-6"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument6-holder": "*"
+    }
   },
   "p3-monument7-holder": {
     "type": "holder",
     "id": "p3-monument7-holder",
-    "x": 1350,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-7"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument7-holder": "*"
+    }
   },
   "p3-monument8-holder": {
     "type": "holder",
     "id": "p3-monument8-holder",
-    "x": 1420,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-8"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument8-holder": "*"
+    }
   },
   "p3-nile-holder": {
     "type": "holder",
     "id": "p3-nile-holder",
-    "x": 420,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "nile"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-nile-holder": "*"
+    }
   },
   "p3-pharaoh-holder": {
     "type": "holder",
     "id": "p3-pharaoh-holder",
-    "x": 340,
-    "y": 590,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "pharaoh"
-    },
-    "linkedToSeat": "p3-seat"
+    "inheritFrom": {
+      "p3-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-pharaoh-holder": "*"
+    }
   },
   "p3-score": {
     "type": "label",
     "id": "p3-score",
-    "x": 55,
+    "inheritFrom": "p1-score",
     "y": 560,
-    "height": 14,
-    "css": "font-family:sans-serif;font-size:12px;text-align:center",
-    "editable": true,
     "text": 10,
-    "width": 70,
     "linkedToSeat": "p3-seat"
   },
   "p3-score-dec": {
     "type": "button",
     "id": "p3-score-dec",
-    "parent": "p3-score",
-    "x": -8,
-    "width": 20,
-    "height": 20,
-    "movableInEdit": false,
-    "clickRoutine": [
-      {
-        "func": "LABEL",
-        "label": "${PROPERTY parent}",
-        "mode": "dec",
-        "value": 1
-      }
-    ],
-    "text": "-",
-    "y": -1
+    "inheritFrom": "p1-score-dec",
+    "parent": "p3-score"
   },
   "p3-score-inc": {
     "type": "button",
     "id": "p3-score-inc",
-    "parent": "p3-score",
-    "x": 58,
-    "y": -1,
-    "width": 20,
-    "height": 20,
-    "movableInEdit": false,
-    "clickRoutine": [
-      {
-        "func": "LABEL",
-        "label": "${PROPERTY parent}",
-        "mode": "inc",
-        "value": 1
-      }
-    ],
-    "text": "+"
+    "inheritFrom": "p1-score-inc",
+    "parent": "p3-score"
   },
   "p3-seat": {
     "type": "seat",
     "id": "p3-seat",
-    "x": 10,
+    "inheritFrom": {
+      "p1-seat": [
+        "x",
+        "height",
+        "width",
+        "scale",
+        "hideWhenUnused",
+        "clickRoutine"
+      ]
+    },
     "y": 522,
-    "height": 25,
-    "scale": 0.8,
-    "width": 148,
     "index": 3,
-    "hideWhenUnused": true,
-    "clickRoutine": [
-      "var playerPrefix = substr ${playerName} 0 5",
-      {
-        "func": "IF",
-        "operand1": "${playerPrefix}",
-        "operand2": "Guest",
-        "thenRoutine": [
-          {
-            "func": "INPUT",
-            "header": "Enter your name and choice of player color.",
-            "fields": [
-              {
-                "type": "string",
-                "label": "Name",
-                "variable": "playerName",
-                "value": "${playerName}"
-              },
-              {
-                "type": "color",
-                "label": "Color",
-                "variable": "playerColor",
-                "value": "${playerColor}"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "func": "CLICK",
-        "collection": "thisButton",
-        "mode": "ignoreClickRoutine"
-      }
-    ],
     "hand": "p3-suns-holder-1"
   },
   "p3-suns-holder-1": {
     "type": "holder",
     "id": "p3-suns-holder-1",
-    "x": 30,
+    "inheritFrom": "p1-suns-holder-1",
     "y": 585,
-    "width": 120,
-    "height": 40,
-    "dropTarget": {
-      "type": "card",
-      "deck": "suns-deck"
-    },
-    "linkedToSeat": "p3-seat",
-    "stackOffsetX": 30
+    "linkedToSeat": "p3-seat"
   },
   "p3-suns-holder-2": {
     "type": "holder",
     "id": "p3-suns-holder-2",
-    "x": 30,
+    "inheritFrom": "p1-suns-holder-2",
     "y": 624,
-    "width": 120,
-    "height": 40,
-    "dropTarget": {
-      "type": "card",
-      "deck": "suns-deck"
-    },
-    "linkedToSeat": "p3-seat",
-    "stackOffsetX": 30
+    "linkedToSeat": "p3-seat"
   },
   "p4-civ1-holder": {
     "type": "holder",
     "id": "p4-civ1-holder",
-    "x": 570,
+    "inheritFrom": "p1-civ1-holder",
     "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-1"
-    },
     "linkedToSeat": "p4-seat"
   },
   "p4-civ2-holder": {
     "type": "holder",
     "id": "p4-civ2-holder",
-    "x": 640,
-    "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-2"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-civ2-holder": "*"
+    }
   },
   "p4-civ3-holder": {
     "type": "holder",
     "id": "p4-civ3-holder",
-    "x": 710,
-    "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-3"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-civ3-holder": "*"
+    }
   },
   "p4-civ4-holder": {
     "type": "holder",
     "id": "p4-civ4-holder",
-    "x": 780,
-    "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-4"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-civ4-holder": "*"
+    }
   },
   "p4-civ5-holder": {
     "type": "holder",
     "id": "p4-civ5-holder",
-    "x": 850,
-    "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-5"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-civ5-holder": "*"
+    }
   },
   "p4-flood-holder": {
     "type": "holder",
     "id": "p4-flood-holder",
-    "x": 490,
-    "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "flood"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-flood-holder": "*"
+    }
   },
   "p4-god-holder": {
     "type": "holder",
     "id": "p4-god-holder",
-    "x": 260,
-    "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "god"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-god-holder": "*"
+    }
   },
   "p4-gold-holder": {
     "type": "holder",
     "id": "p4-gold-holder",
-    "x": 180,
-    "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "gold"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-gold-holder": "*"
+    }
   },
   "p4-monument1-holder": {
     "type": "holder",
     "id": "p4-monument1-holder",
-    "x": 930,
-    "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-1"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument1-holder": "*"
+    }
   },
   "p4-monument2-holder": {
     "type": "holder",
     "id": "p4-monument2-holder",
-    "x": 1000,
-    "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-2"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument2-holder": "*"
+    }
   },
   "p4-monument3-holder": {
     "type": "holder",
     "id": "p4-monument3-holder",
-    "x": 1070,
-    "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-3"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument3-holder": "*"
+    }
   },
   "p4-monument4-holder": {
     "type": "holder",
     "id": "p4-monument4-holder",
-    "x": 1140,
-    "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-4"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument4-holder": "*"
+    }
   },
   "p4-monument5-holder": {
     "type": "holder",
     "id": "p4-monument5-holder",
-    "x": 1209,
-    "y": 729,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-5"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument5-holder": "*"
+    }
   },
   "p4-monument6-holder": {
     "type": "holder",
     "id": "p4-monument6-holder",
-    "x": 1280,
-    "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-6"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument6-holder": "*"
+    }
   },
   "p4-monument7-holder": {
     "type": "holder",
     "id": "p4-monument7-holder",
-    "x": 1350,
-    "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-7"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument7-holder": "*"
+    }
   },
   "p4-monument8-holder": {
     "type": "holder",
     "id": "p4-monument8-holder",
-    "x": 1420,
-    "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-8"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument8-holder": "*"
+    }
   },
   "p4-nile-holder": {
     "type": "holder",
     "id": "p4-nile-holder",
-    "x": 420,
-    "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "nile"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-nile-holder": "*"
+    }
   },
   "p4-pharaoh-holder": {
     "type": "holder",
     "id": "p4-pharaoh-holder",
-    "x": 340,
-    "y": 730,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "pharaoh"
-    },
-    "linkedToSeat": "p4-seat"
+    "inheritFrom": {
+      "p4-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-pharaoh-holder": "*"
+    }
   },
   "p4-score": {
     "type": "label",
     "id": "p4-score",
-    "x": 55,
+    "inheritFrom": "p1-score",
     "y": 700,
-    "height": 14,
-    "css": "font-family:sans-serif;font-size:12px;text-align:center",
-    "editable": true,
     "text": 10,
-    "width": 70,
     "linkedToSeat": "p4-seat"
   },
   "p4-score-dec": {
     "type": "button",
     "id": "p4-score-dec",
-    "parent": "p4-score",
-    "x": -8,
-    "width": 20,
-    "height": 20,
-    "movableInEdit": false,
-    "clickRoutine": [
-      {
-        "func": "LABEL",
-        "label": "${PROPERTY parent}",
-        "mode": "dec",
-        "value": 1
-      }
-    ],
-    "text": "-",
-    "y": -1
+    "inheritFrom": "p1-score-dec",
+    "parent": "p4-score"
   },
   "p4-score-inc": {
     "type": "button",
     "id": "p4-score-inc",
-    "parent": "p4-score",
-    "x": 58,
-    "y": -1,
-    "width": 20,
-    "height": 20,
-    "movableInEdit": false,
-    "clickRoutine": [
-      {
-        "func": "LABEL",
-        "label": "${PROPERTY parent}",
-        "mode": "inc",
-        "value": 1
-      }
-    ],
-    "text": "+"
+    "inheritFrom": "p1-score-inc",
+    "parent": "p4-score"
   },
   "p4-seat": {
     "type": "seat",
     "id": "p4-seat",
-    "x": 10,
+    "inheritFrom": {
+      "p1-seat": [
+        "x",
+        "height",
+        "width",
+        "scale",
+        "hideWhenUnused",
+        "clickRoutine"
+      ]
+    },
     "y": 662,
-    "height": 25,
-    "scale": 0.8,
-    "width": 148,
     "index": 4,
-    "hideWhenUnused": true,
-    "clickRoutine": [
-      "var playerPrefix = substr ${playerName} 0 5",
-      {
-        "func": "IF",
-        "operand1": "${playerPrefix}",
-        "operand2": "Guest",
-        "thenRoutine": [
-          {
-            "func": "INPUT",
-            "header": "Enter your name and choice of player color.",
-            "fields": [
-              {
-                "type": "string",
-                "label": "Name",
-                "variable": "playerName",
-                "value": "${playerName}"
-              },
-              {
-                "type": "color",
-                "label": "Color",
-                "variable": "playerColor",
-                "value": "${playerColor}"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "func": "CLICK",
-        "collection": "thisButton",
-        "mode": "ignoreClickRoutine"
-      }
-    ],
     "hand": "p4-suns-holder-1"
   },
   "p4-suns-holder-1": {
     "type": "holder",
     "id": "p4-suns-holder-1",
-    "x": 30,
+    "inheritFrom": "p1-suns-holder-1",
     "y": 725,
-    "width": 120,
-    "height": 40,
-    "dropTarget": {
-      "type": "card",
-      "deck": "suns-deck"
-    },
-    "linkedToSeat": "p4-seat",
-    "stackOffsetX": 30
+    "linkedToSeat": "p4-seat"
   },
   "p4-suns-holder-2": {
     "type": "holder",
     "id": "p4-suns-holder-2",
-    "x": 30,
+    "inheritFrom": "p1-suns-holder-2",
     "y": 765,
-    "width": 120,
-    "height": 40,
-    "dropTarget": {
-      "type": "card",
-      "deck": "suns-deck"
-    },
-    "linkedToSeat": "p4-seat",
-    "stackOffsetX": 30
+    "linkedToSeat": "p4-seat"
   },
   "p5-civ1-holder": {
     "type": "holder",
     "id": "p5-civ1-holder",
-    "x": 570,
+    "inheritFrom": "p1-civ1-holder",
     "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-1"
-    },
     "linkedToSeat": "p5-seat"
   },
   "p5-civ2-holder": {
     "type": "holder",
     "id": "p5-civ2-holder",
-    "x": 640,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-2"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-civ2-holder": "*"
+    }
   },
   "p5-civ3-holder": {
     "type": "holder",
     "id": "p5-civ3-holder",
-    "x": 710,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-3"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-civ3-holder": "*"
+    }
   },
   "p5-civ4-holder": {
     "type": "holder",
     "id": "p5-civ4-holder",
-    "x": 780,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-4"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-civ4-holder": "*"
+    }
   },
   "p5-civ5-holder": {
     "type": "holder",
     "id": "p5-civ5-holder",
-    "x": 850,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "civ-5"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-civ5-holder": "*"
+    }
   },
   "p5-flood-holder": {
     "type": "holder",
     "id": "p5-flood-holder",
-    "x": 490,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "flood"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-flood-holder": "*"
+    }
   },
   "p5-god-holder": {
     "type": "holder",
     "id": "p5-god-holder",
-    "x": 260,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "god"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-god-holder": "*"
+    }
   },
   "p5-gold-holder": {
     "type": "holder",
     "id": "p5-gold-holder",
-    "x": 180,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "gold"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-gold-holder": "*"
+    }
   },
   "p5-monument1-holder": {
     "type": "holder",
     "id": "p5-monument1-holder",
-    "x": 930,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-1"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument1-holder": "*"
+    }
   },
   "p5-monument2-holder": {
     "type": "holder",
     "id": "p5-monument2-holder",
-    "x": 1000,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-2"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument2-holder": "*"
+    }
   },
   "p5-monument3-holder": {
     "type": "holder",
     "id": "p5-monument3-holder",
-    "x": 1070,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-3"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument3-holder": "*"
+    }
   },
   "p5-monument4-holder": {
     "type": "holder",
     "id": "p5-monument4-holder",
-    "x": 1140,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-4"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument4-holder": "*"
+    }
   },
   "p5-monument5-holder": {
     "type": "holder",
     "id": "p5-monument5-holder",
-    "x": 1210,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-5"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument5-holder": "*"
+    }
   },
   "p5-monument6-holder": {
     "type": "holder",
     "id": "p5-monument6-holder",
-    "x": 1280,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-6"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument6-holder": "*"
+    }
   },
   "p5-monument7-holder": {
     "type": "holder",
     "id": "p5-monument7-holder",
-    "x": 1350,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-7"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument7-holder": "*"
+    }
   },
   "p5-monument8-holder": {
     "type": "holder",
     "id": "p5-monument8-holder",
-    "x": 1420,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "monument-8"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-monument8-holder": "*"
+    }
   },
   "p5-nile-holder": {
     "type": "holder",
     "id": "p5-nile-holder",
-    "x": 420,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "nile"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-nile-holder": "*"
+    }
   },
   "p5-pharaoh-holder": {
     "type": "holder",
     "id": "p5-pharaoh-holder",
-    "x": 340,
-    "y": 870,
-    "width": 70,
-    "height": 70,
-    "dropOffsetX": 5,
-    "dropOffsetY": 5,
-    "dropTarget": {
-      "type": "card",
-      "deck": "tiles-deck",
-      "cardType": "pharaoh"
-    },
-    "linkedToSeat": "p5-seat"
+    "inheritFrom": {
+      "p5-civ1-holder": [
+        "y",
+        "linkedToSeat"
+      ],
+      "p1-pharaoh-holder": "*"
+    }
   },
   "p5-score": {
     "type": "label",
     "id": "p5-score",
-    "x": 55,
+    "inheritFrom": "p1-score",
     "y": 840,
-    "height": 14,
-    "css": "font-family:sans-serif;font-size:12px;text-align:center",
-    "editable": true,
     "text": 10,
-    "width": 70,
     "linkedToSeat": "p5-seat"
   },
   "p5-score-dec": {
     "type": "button",
     "id": "p5-score-dec",
-    "parent": "p5-score",
-    "x": -8,
-    "width": 20,
-    "height": 20,
-    "movableInEdit": false,
-    "clickRoutine": [
-      {
-        "func": "LABEL",
-        "label": "${PROPERTY parent}",
-        "mode": "dec",
-        "value": 1
-      }
-    ],
-    "text": "-",
-    "y": -1
+    "inheritFrom": "p1-score-dec",
+    "parent": "p5-score"
   },
   "p5-score-inc": {
     "type": "button",
     "id": "p5-score-inc",
-    "parent": "p5-score",
-    "x": 58,
-    "y": -1,
-    "width": 20,
-    "height": 20,
-    "movableInEdit": false,
-    "clickRoutine": [
-      {
-        "func": "LABEL",
-        "label": "${PROPERTY parent}",
-        "mode": "inc",
-        "value": 1
-      }
-    ],
-    "text": "+"
+    "inheritFrom": "p1-score-inc",
+    "parent": "p5-score"
   },
   "p5-seat": {
     "type": "seat",
     "id": "p5-seat",
-    "x": 10,
+    "inheritFrom": {
+      "p1-seat": [
+        "x",
+        "height",
+        "width",
+        "scale",
+        "hideWhenUnused",
+        "clickRoutine"
+      ]
+    },
     "y": 802,
-    "height": 25,
-    "scale": 0.8,
-    "width": 148,
     "index": 5,
-    "hideWhenUnused": true,
-    "clickRoutine": [
-      "var playerPrefix = substr ${playerName} 0 5",
-      {
-        "func": "IF",
-        "operand1": "${playerPrefix}",
-        "operand2": "Guest",
-        "thenRoutine": [
-          {
-            "func": "INPUT",
-            "header": "Enter your name and choice of player color.",
-            "fields": [
-              {
-                "type": "string",
-                "label": "Name",
-                "variable": "playerName",
-                "value": "${playerName}"
-              },
-              {
-                "type": "color",
-                "label": "Color",
-                "variable": "playerColor",
-                "value": "${playerColor}"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "func": "CLICK",
-        "collection": "thisButton",
-        "mode": "ignoreClickRoutine"
-      }
-    ],
     "hand": "p5-suns-holder-1"
   },
   "p5-suns-holder-1": {
     "type": "holder",
     "id": "p5-suns-holder-1",
-    "x": 30,
+    "inheritFrom": "p1-suns-holder-1",
     "y": 865,
-    "width": 120,
-    "height": 40,
-    "dropTarget": {
-      "type": "card",
-      "deck": "suns-deck"
-    },
-    "linkedToSeat": "p5-seat",
-    "stackOffsetX": 30
+    "linkedToSeat": "p5-seat"
   },
   "p5-suns-holder-2": {
     "type": "holder",
     "id": "p5-suns-holder-2",
-    "x": 30,
+    "inheritFrom": "p1-suns-holder-2",
     "y": 905,
-    "width": 120,
-    "height": 40,
-    "dropTarget": {
-      "type": "card",
-      "deck": "suns-deck"
-    },
-    "linkedToSeat": "p5-seat",
-    "stackOffsetX": 30
+    "linkedToSeat": "p5-seat"
   },
   "setup-holder-cash": {
     "type": "holder",

--- a/library/games/Egyptian Epochs/0.json
+++ b/library/games/Egyptian Epochs/0.json
@@ -176,6 +176,19 @@
     ],
     "clickRoutine": [
       {
+        "note": "Check that the user really wants to start a new game",
+        "func": "INPUT",
+        "header": "Set up a new game?",
+        "confirmButtonText": "Yes",
+        "cancelButtonText": "No",
+        "fields": [
+          {
+            "type": "subtitle",
+            "text": "Are you sure that you want to erase any progress and start a new game?"
+          }
+        ]
+      },
+      {
         "note": "Return all suns ready for game setup",
         "func": "RECALL",
         "holder": "suns-holder"

--- a/library/games/Egyptian Epochs/0.json
+++ b/library/games/Egyptian Epochs/0.json
@@ -203,9 +203,26 @@
         "value": "current-holder-sun"
       },
       {
+        "note": "Return all tiles to the draw stack",
+        "func": "RECALL",
+        "holder": "tiles-holder"
+      },
+      {
         "note": "Shuffle the tiles",
         "func": "SHUFFLE",
         "holder": "tiles-holder"
+      },
+      {
+        "note": "Set all player scores to 10",
+        "func": "LABEL",
+        "label": [
+          "p1-score",
+          "p2-score",
+          "p3-score",
+          "p4-score",
+          "p5-score"
+        ],
+        "value": 10
       },
       {
         "note": "Select all player seats",

--- a/library/games/Egyptian Epochs/0.json
+++ b/library/games/Egyptian Epochs/0.json
@@ -71,12 +71,10 @@
     ],
     "moveToCashHolderRoutine": [
       {
-        "func": "SELECT",
-        "property": "id",
-        "value": "${token}"
-      },
-      {
         "func": "SET",
+        "collection": [
+          "${token}"
+        ],
         "property": "parent",
         "value": "setup-holder-cash"
       }
@@ -108,102 +106,87 @@
     ],
     "setUpRaTrackRoutine": [
       {
-        "func": "SELECT",
-        "property": "id",
-        "value": "holder-ra-10"
-      },
-      {
         "func": "IF",
         "operand1": "${COUNT}",
-        "relation": "==",
         "operand2": 5,
         "thenRoutine": [
           {
             "func": "SET",
+            "collection": [
+              "holder-ra-7",
+              "holder-ra-8",
+              "holder-ra-9",
+              "holder-ra-10"
+            ],
             "property": "y",
             "value": 10
           }
         ],
         "elseRoutine": [
           {
-            "func": "SET",
-            "property": "y",
-            "value": -300
-          }
-        ]
-      },
-      {
-        "func": "SELECT",
-        "property": "id",
-        "value": "holder-ra-9"
-      },
-      {
-        "func": "IF",
-        "operand1": "${COUNT}",
-        "relation": ">=",
-        "operand2": 4,
-        "thenRoutine": [
-          {
-            "func": "SET",
-            "property": "y",
-            "value": 10
-          }
-        ],
-        "elseRoutine": [
-          {
-            "func": "SET",
-            "property": "y",
-            "value": -300
-          }
-        ]
-      },
-      {
-        "func": "SELECT",
-        "property": "id",
-        "value": "holder-ra-8"
-      },
-      {
-        "func": "IF",
-        "operand1": "${COUNT}",
-        "relation": ">=",
-        "operand2": 3,
-        "thenRoutine": [
-          {
-            "func": "SET",
-            "property": "y",
-            "value": 10
-          }
-        ],
-        "elseRoutine": [
-          {
-            "func": "SET",
-            "property": "y",
-            "value": -300
-          }
-        ]
-      },
-      {
-        "func": "SELECT",
-        "property": "id",
-        "value": "holder-ra-7"
-      },
-      {
-        "func": "IF",
-        "operand1": "${COUNT}",
-        "relation": ">=",
-        "operand2": 3,
-        "thenRoutine": [
-          {
-            "func": "SET",
-            "property": "y",
-            "value": 10
-          }
-        ],
-        "elseRoutine": [
-          {
-            "func": "SET",
-            "property": "y",
-            "value": -300
+            "func": "IF",
+            "operand1": "${COUNT}",
+            "operand2": 4,
+            "thenRoutine": [
+              {
+                "func": "SET",
+                "collection": [
+                  "holder-ra-7",
+                  "holder-ra-8",
+                  "holder-ra-9"
+                ],
+                "property": "y",
+                "value": 10
+              },
+              {
+                "func": "SET",
+                "collection": [
+                  "holder-ra-10"
+                ],
+                "property": "y",
+                "value": -300
+              }
+            ],
+            "elseRoutine": [
+              {
+                "func": "IF",
+                "operand1": "${COUNT}",
+                "operand2": 3,
+                "thenRoutine": [
+                  {
+                    "func": "SET",
+                    "collection": [
+                      "holder-ra-7",
+                      "holder-ra-8"
+                    ],
+                    "property": "y",
+                    "value": 10
+                  },
+                  {
+                    "func": "SET",
+                    "collection": [
+                      "holder-ra-9",
+                      "holder-ra-10"
+                    ],
+                    "property": "y",
+                    "value": -300
+                  }
+                ],
+                "elseRoutine": [
+                  {
+                    "func": "SET",
+                    "collection": [
+                      "holder-ra-7",
+                      "holder-ra-8",
+                      "holder-ra-9",
+                      "holder-ra-10"
+                    ],
+                    "property": "y",
+                    "value": -300
+                  }
+                ]
+              }
+            ]
           }
         ]
       }
@@ -215,14 +198,11 @@
         "holder": "suns-holder"
       },
       {
-        "note": "Select the 1 Sun token.",
-        "func": "SELECT",
-        "property": "id",
-        "value": "sun-1"
-      },
-      {
         "note": "Place the 1 Sun as part of the opening auction lot.",
         "func": "SET",
+        "collection": [
+          "sun-1"
+        ],
         "property": "parent",
         "value": "current-holder-sun"
       },
@@ -1063,7 +1043,7 @@
     "height": 14,
     "css": {
       "font-size": "14px",
-      "text-align": "center",
+      "text-align": "center"
     },
     "editable": true,
     "text": 10,

--- a/library/games/Egyptian Epochs/0.json
+++ b/library/games/Egyptian Epochs/0.json
@@ -585,10 +585,10 @@
     "id": "description-suns",
     "inheritFrom": "description-civ",
     "x": 10,
-    "y": 195,
+    "y": 175,
     "width": 160,
     "height": 60,
-    "text": "End of Game:\nHighest suns total +5VP\nLowest suns total -5VP"
+    "text": "END OF GAME:\nHighest suns total +5VP\nLowest suns total -5VP"
   },
   "example-civ-1": {
     "id": "example-civ-1",


### PR DESCRIPTION
Small tweaks to improve Egyptian Epochs (similar to Ra) in the public library:
- Resized text labels to avoid text being cut off;
- Removed unneeded z values from many widgets;
- Used inheritance where possible to reduce the size of the json file and make future edits easier;
- Added an "are you sure?" prompt to the Setup button and also added some missing items to completely resetting the game (recalling all decks and ensuring player scores are reset)