### PR TITLE
Added ability to specify tabindex and placeholder text for labels

### DIFF
--- a/client/js/widgets/label.js
+++ b/client/js/widgets/label.js
@@ -47,13 +47,17 @@ export class Label extends Widget {
     }
 
     if(delta.editable !== undefined) {
-      if(delta.editable)
+      if(delta.editable) {
         this.input.removeAttribute("readonly");
-      else
+        this.input.setAttribute('tabindex', this.get('tabindex'));
+      } else {
         this.input.setAttribute("readonly", true);
+        this.input.removeAttribute("tabindex");
+      }
     }
     if(delta.spellCheck !== undefined) {
-      this.input.setAttribute('spellcheck', this.get('spellCheck') === true)
+      this.input.setAttribute('spellcheck', this.get('spellCheck') === true);
     }
+    
   }
 }

--- a/client/js/widgets/label.js
+++ b/client/js/widgets/label.js
@@ -51,12 +51,12 @@ export class Label extends Widget {
     if(delta.placeholderText !== undefined) {
       this.input.setAttribute('placeholder', this.get('placeholderText'));
     }
+    if(delta.tabIndex !== undefined) {
+      this.input.setAttribute('tabindex', this.get('tabIndex'));
+    }
     if(delta.editable !== undefined) {
       if(delta.editable) {
         this.input.removeAttribute("readonly");
-        if(delta.tabIndex !== undefined) {
-          this.input.setAttribute('tabindex', this.get('tabIndex'));
-        }
       } else {
         this.input.setAttribute("readonly", true);
         this.input.removeAttribute("tabindex");

--- a/client/js/widgets/label.js
+++ b/client/js/widgets/label.js
@@ -12,6 +12,7 @@ export class Label extends Widget {
       typeClasses: 'widget label',
       clickable: false,
       spellCheck: false,
+      tabIndex: false,
 
       text: '',
       editable: false,
@@ -49,7 +50,9 @@ export class Label extends Widget {
     if(delta.editable !== undefined) {
       if(delta.editable) {
         this.input.removeAttribute("readonly");
-        this.input.setAttribute('tabindex', this.get('tabindex'));
+        if(delta.tabIndex !== undefined) {
+          this.input.setAttribute('tabindex', this.get('tabIndex'));
+        }
       } else {
         this.input.setAttribute("readonly", true);
         this.input.removeAttribute("tabindex");

--- a/client/js/widgets/label.js
+++ b/client/js/widgets/label.js
@@ -12,7 +12,7 @@ export class Label extends Widget {
       typeClasses: 'widget label',
       clickable: false,
       spellCheck: false,
-      tabIndex: false,
+      tabIndex: -1,
       placeholderText: '',
 
       text: '',
@@ -51,9 +51,9 @@ export class Label extends Widget {
     if(delta.placeholderText !== undefined) {
       this.input.setAttribute('placeholder', this.get('placeholderText'));
     }
-    if(delta.tabIndex !== undefined) {
-      this.input.setAttribute('tabindex', this.get('tabIndex'));
-    }
+
+    this.input.setAttribute('tabindex', this.get('tabIndex'));
+    
     if(delta.editable !== undefined) {
       if(delta.editable) {
         this.input.removeAttribute("readonly");

--- a/client/js/widgets/label.js
+++ b/client/js/widgets/label.js
@@ -13,6 +13,7 @@ export class Label extends Widget {
       clickable: false,
       spellCheck: false,
       tabIndex: false,
+      placeholderText: false,
 
       text: '',
       editable: false,
@@ -47,6 +48,9 @@ export class Label extends Widget {
       this.input.style.overflowY = contentHeight-this.get('height') < 5 ? 'hidden' : 'scroll';
     }
 
+    if(delta.placeholderText !== undefined) {
+      this.input.setAttribute('placeholder', this.get('placeholderText'));
+    }
     if(delta.editable !== undefined) {
       if(delta.editable) {
         this.input.removeAttribute("readonly");

--- a/client/js/widgets/label.js
+++ b/client/js/widgets/label.js
@@ -13,7 +13,7 @@ export class Label extends Widget {
       clickable: false,
       spellCheck: false,
       tabIndex: false,
-      placeholderText: false,
+      placeholderText: '',
 
       text: '',
       editable: false,

--- a/client/js/widgets/label.js
+++ b/client/js/widgets/label.js
@@ -12,7 +12,7 @@ export class Label extends Widget {
       typeClasses: 'widget label',
       clickable: false,
       spellCheck: false,
-      tabIndex: -1,
+      tabIndex: null,
       placeholderText: '',
 
       text: '',
@@ -48,23 +48,24 @@ export class Label extends Widget {
       this.input.style.overflowY = contentHeight-this.get('height') < 5 ? 'hidden' : 'scroll';
     }
 
-    if(delta.placeholderText !== undefined) {
+    if(delta.placeholderText !== undefined)
       this.input.setAttribute('placeholder', this.get('placeholderText'));
-    }
 
-    this.input.setAttribute('tabindex', this.get('tabIndex'));
-    
-    if(delta.editable !== undefined) {
-      if(delta.editable) {
-        this.input.removeAttribute("readonly");
+    if(delta.editable !== undefined || delta.tabIndex !== undefined) {
+      if(this.get('editable')) {
+        this.input.removeAttribute('readonly');
+        if(this.get('tabIndex') !== null)
+          this.input.setAttribute('tabindex', this.get('tabIndex'));
+        else
+          this.input.removeAttribute('tabindex');
       } else {
-        this.input.setAttribute("readonly", true);
-        this.input.removeAttribute("tabindex");
+        this.input.setAttribute('readonly', true);
+        this.input.setAttribute('tabindex', -1);
       }
     }
-    if(delta.spellCheck !== undefined) {
+
+    if(delta.spellCheck !== undefined)
       this.input.setAttribute('spellcheck', this.get('spellCheck') === true);
-    }
-    
+
   }
 }


### PR DESCRIPTION
Added ability to specify `tabindex` on labels to control navigation between labels when they are editable. Set this with:
`"tabIndex": 𝑥`.

Similarly:
`"placeholderText": "𝑦"`

Thanks to LawDawg for explaining how things get added to the JSON editor.