### PR TITLE
fixed updating scoreboard for verticalHeader

### DIFF
--- a/client/js/widgets/scoreboard.js
+++ b/client/js/widgets/scoreboard.js
@@ -46,7 +46,8 @@ class Scoreboard extends Widget {
       'showAllSeats',
       'sortAscending',
       'rounds',
-      'showAllRounds'
+      'showAllRounds',
+      'verticalHeader'
     ]
     if(Object.keys(delta).some(k=>updateTableProps.includes(k)))
       this.updateTable();


### PR DESCRIPTION
When changing the property `verticalHeader`, the scoreboard gets not updated immediately. This fixes that.