### PR TITLE
support transparent canvas

### DIFF
--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -45,7 +45,10 @@ class Canvas extends Widget {
             for(let px=0; px<regionRes; ++px) {
               for(let py=0; py<regionRes; ++py) {
                 this.context.fillStyle = colors[region.charCodeAt(py*regionRes+px)-48] || 'white';
-                this.context.fillRect(x*regionRes+px, y*regionRes+py, 1, 1);
+                if(colors[region.charCodeAt(py*regionRes+px)-48] != 'transparent')
+                  this.context.fillRect(x*regionRes+px, y*regionRes+py, 1, 1);
+                else
+                  this.context.clearRect(x*regionRes+px, y*regionRes+py, 1, 1);
               }
             }
           }


### PR DESCRIPTION
With this PR, you can use `transparent` in the canvas `colorMap` property to let the widget underneath the canvas shine through.