### PR TITLE
fixed minification

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -258,7 +258,7 @@ const jeCommands = [
   {
     id: 'je_uploadAsset',
     name: 'upload a different asset',
-    context: '.*"(/assets/[0-9_-]+)"|^.* ↦ image$|^deck ↦ faceTemplates ↦ [0-9]+ ↦ objects ↦ [0-9]+ ↦ value' + String.fromCharCode(36), // the minifier doesn't like "$" or "\x24" here
+    context: '.*"(/assets/[0-9_-]+)"|^.* ↦ image$|^deck ↦ faceTemplates ↦ [0-9]+ ↦ objects ↦ [0-9]+ ↦ value$',
     call: async function() {
       uploadAsset().then(a=> {
         if(a) {
@@ -999,7 +999,7 @@ function jeAddAlignmentCommands() {
   jeCommands.push({
     id: 'jeCenterInParent',
     name: 'center in parent',
-    context: '^.* ↦ (x|y)( ↦ "[0-9]+")?' + String.fromCharCode(36), // the minifier doesn't like "$" or "\x24" here
+    context: '^.* ↦ (x|y)( ↦ "[0-9]+")?$',
     show: _=>!jeContext.includes('grid'),
     call: async function() {
       const key = jeGetLastKey();

--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -314,7 +314,7 @@ function loadGameFromURLproperties(states) {
   if(widgets.size || !urlProperties.load)
     return;
 
-  const match = String(urlProperties.load).match(`^${regexEscape(config.externalURL)}/library/(.*?)(#VTT/([0-9]+)(\\.json)?)?`+String.fromCharCode(36));
+  const match = String(urlProperties.load).match(`^${regexEscape(config.externalURL)}/library/(.*?)(#VTT/([0-9]+)(\\.json)?)?$`);
   if(match) {
     let targetStateID = 'PL:games:' + match[1].substr(0, match[1].length-4);
     if(match[1].match(/^Tutorial%20-%20/))
@@ -330,7 +330,7 @@ function loadGameFromURLproperties(states) {
     addState(null, 'link', urlProperties.load);
     loadedFromURLproperties = true;
   } else if(urlProperties.load) {
-    const urlMatch = String(urlProperties.load).match(`^(.*?)(#VTT/([0-9]+)(\\.json)?)?`+String.fromCharCode(36))
+    const urlMatch = String(urlProperties.load).match(`^(.*?)(#VTT/([0-9]+)(\\.json)?)?$`)
     const foundStates = (Object.values(states).filter(s=>s.link && s.link.match(`^${regexEscape(urlMatch[1])}`)));
     if(foundStates.length) {
       toServer('loadState', { stateID: foundStates[0].id, variantID: urlMatch[3] || 0 });

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -123,14 +123,17 @@ export default async function minifyHTML() {
     'client/components/deckEditor.js',
     'client/components/loadComponents.js'
   ]);
-  editorJS = editorJS.replace(/["']\ \/\/\*\*\*\ CSS\ \*\*\*\/\/\ ["']/, '`' + editorCSS.replace(/\\/g, '\\\\') + '`');
-  editorJS = editorJS.replace(/["']\ \/\/\*\*\*\ HTML\ \*\*\*\/\/\ ["']/, '`' + await minify({
+
+  const editorHTML = await minify({
     compressor: htmlMinifier,
     content: fs.readFileSync(path.resolve() + '/client/editor.html', {encoding:'utf8'}),
     options: {
       conservativeCollapse: true
     }
-  }) + '`');
+  });
+
+  editorJS = editorJS.replace(/["']\ \/\/\*\*\*\ CSS\ \*\*\*\/\/\ ["']/, _=>'`' + editorCSS.replace(/\\/g, '\\\\') + '`');
+  editorJS = editorJS.replace(/["']\ \/\/\*\*\*\ HTML\ \*\*\*\/\/\ ["']/, _=>'`' + editorHTML + '`');
 
   return {
     min: room.min,
@@ -160,10 +163,10 @@ async function compress(htmlFile, cssFiles, jsFiles) {
   let htmlString = fs.readFileSync(path.resolve() + '/' + htmlFile, {encoding:'utf8'});
 
   const css = await compressCSS(cssFiles);
-  htmlString = htmlString.replace(/\ \/\*\*\*\ CSS\ \*\*\*\/\ /, css).replace(/\ \/\/\*\*\*\ CONFIG\ \*\*\*\/\/\ /, `const config = ${JSON.stringify(Config.config)};`);
+  htmlString = htmlString.replace(/\ \/\*\*\*\ CSS\ \*\*\*\/\ /, _=>css).replace(/\ \/\/\*\*\*\ CONFIG\ \*\*\*\/\/\ /, _=>`const config = ${JSON.stringify(Config.config)};`);
 
   const js = await compressJS(jsFiles);
-  htmlString = htmlString.replace(/\ \/\/\*\*\*\ JS\ \*\*\*\/\/\ /, js.replace(/\bimport[^(][^;]*\.\/[^;]*;/g, ""));
+  htmlString = htmlString.replace(/\ \/\/\*\*\*\ JS\ \*\*\*\/\/\ /, _=>js.replace(/\bimport[^(][^;]*\.\/[^;]*;/g, ""));
 
   const html = await minify({
     compressor: htmlMinifier,


### PR DESCRIPTION
After merging #1482, the production server did not start. The cause is that the minified Javascript contains `$&` and that it is put into the HTML by replacing `//*** JS ***//` by the minified contents. The `String.replace` function treats `$` as a special character to access a few parts of the matched results so the `$&` was replaced by `//*** JS ***//` again which made the resulting Javascript invalid.

Turns out this is the same problem that made me insert a bunch of `String.fromCharCode(36) // the minifier does not like $ or \x24 here` into the code.\n\nThe fix is to use an anonymous function as the replacement in `replace`. Its output is used as is.