### PR TITLE
Fixed typo in name of faceCycle property in FLIP

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1120,7 +1120,7 @@ export class Widget extends StateManaged {
       }
 
       if(a.func == 'FLIP') {
-        setDefaults(a, { count: 0, face: null, faceCyle: null, collection: 'DEFAULT' });
+        setDefaults(a, { count: 0, face: null, faceCycle: null, collection: 'DEFAULT' });
         let collection;
         if(a.holder !== undefined) {
           if(this.isValidID(a.holder,problems)) {


### PR DESCRIPTION
This fixes #1690.

This looks like a safe fix. As things currently stand, `a.faceCycle` will be `undefined` unless it was specified in the `FLIP` call. After this fix, `a.faceCycle` will be `null` if not specified in `FLIP`, and the flip routines in basicwidget and card treat `undefined` and `null` identically.