### PR TITLE
fixed dropTarget setting in editor

### DIFF
--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1054,7 +1054,8 @@ class PropertiesModule extends SidebarModule {
     for(const deck of widgetFilter(w=>w.get('type') == 'deck')) {
       if(!Object.keys(deck.get('cardTypes')).length)
         continue;
-      const deckButton = this.renderWidgetButton(deck, {}, this.moduleDOM);
+      const deckCloneState = Object.assign(deck.state, { id: generateUniqueWidgetID() });
+      const deckButton = this.renderWidgetButton(new Deck(deckCloneState.id), deckCloneState, this.moduleDOM);
       this.addPropertyListener(widget, 'dropTarget', widget=>{
         if(asArray(widget.get('dropTarget')).filter(t=>t.deck == deck.id).length)
           deckButton.classList.add('selected');

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1054,7 +1054,7 @@ class PropertiesModule extends SidebarModule {
     for(const deck of widgetFilter(w=>w.get('type') == 'deck')) {
       if(!Object.keys(deck.get('cardTypes')).length)
         continue;
-      const deckCloneState = Object.assign(deck.state, { id: generateUniqueWidgetID() });
+      const deckCloneState = Object.assign({}, deck.state, { id: generateUniqueWidgetID() });
       const deckButton = this.renderWidgetButton(new Deck(deckCloneState.id), deckCloneState, this.moduleDOM);
       this.addPropertyListener(widget, 'dropTarget', widget=>{
         if(asArray(widget.get('dropTarget')).filter(t=>t.deck == deck.id).length)


### PR DESCRIPTION
In production it only works the first time and also breaks stuff because it removes the visualized deck from `widgets`. This should fix that.