### PR TITLE
added property `hidePlayerCursors`

### DIFF
--- a/client/css/overlays/players.css
+++ b/client/css/overlays/players.css
@@ -181,3 +181,6 @@ label.ui-line::before{
   border: none;
   background-color: var(--playerColor);
 }
+.cursor.hidden {
+  display: none;
+}

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -1795,6 +1795,7 @@ export function initializeEditMode() {
       stackOffsetX: 40,
       childrenPerOwner: true,
       dropShadow: true,
+      hidePlayerCursors: true,
       x: 50,
       y: 820,
       width: 1500,

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -43,6 +43,7 @@ async function inputHandler(name, e) {
       return;
     target = target.parentNode;
   }
+  const targetForHiddenCursorCheck = target && target.id && target.id.slice(0,2) == 'w_' && widgets.has(unescapeID(target.id.slice(2))) ? target : null;
 
   e.preventDefault();
 
@@ -128,13 +129,17 @@ async function inputHandler(name, e) {
   clientPointer.style.top = `${coords.clientY}px`;
   clientPointer.style.left = `${coords.clientX}px`;
 
-  toServer('mouse',
-    {
-      x: Math.round(coords.x),
-      y: Math.round(coords.y),
-      pressed: (e.buttons & 1 == 1) || name == 'touchstart' || name == 'touchmove',
-      target: mouseTarget? unescapeID(mouseTarget.id.slice(2)) : null
-    });
+  if(targetForHiddenCursorCheck && widgets.get(unescapeID(targetForHiddenCursorCheck.id.slice(2))).requiresHiddenCursor()) {
+    toServer('mouse', { hidden: true });
+  } else {
+    toServer('mouse',
+      {
+        x: Math.round(coords.x),
+        y: Math.round(coords.y),
+        pressed: (e.buttons & 1 == 1) || name == 'touchstart' || name == 'touchmove',
+        target: mouseTarget? unescapeID(mouseTarget.id.slice(2)) : null
+      });
+  }
 }
 
 onLoad(function() {

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -129,7 +129,7 @@ async function inputHandler(name, e) {
   clientPointer.style.top = `${coords.clientY}px`;
   clientPointer.style.left = `${coords.clientX}px`;
 
-  if(targetForHiddenCursorCheck && widgets.get(unescapeID(targetForHiddenCursorCheck.id.slice(2))).requiresHiddenCursor()) {
+  if(targetForHiddenCursorCheck && widgets.has(unescapeID(targetForHiddenCursorCheck.id.slice(2))) && widgets.get(unescapeID(targetForHiddenCursorCheck.id.slice(2))).requiresHiddenCursor()) {
     toServer('mouse', { hidden: true });
   } else {
     toServer('mouse',

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -76,6 +76,7 @@ onLoad(function() {
   onMessage('mouse', function(args) {
     if(args.player != playerName) {
       clearTimeout(playerCursorsTimeout[args.player]);
+      playerCursors[args.player].classList.toggle('hidden', !!args.mouseState.hidden);
       if(args.mouseState.inactive) {
         playerCursors[args.player].classList.remove('pressed','active','foreign');
       } else {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -70,6 +70,7 @@ export class Widget extends StateManaged {
       dropShadowWidget: null,
       inheritChildZ: false,
       hoverTarget: null,
+      hidePlayerCursors: false,
 
       linkedToSeat: null,
       onlyVisibleForSeat: null,
@@ -2174,6 +2175,14 @@ export class Widget extends StateManaged {
 
   readOnlyProperties() {
     return readOnlyProperties;
+  }
+
+  requiresHiddenCursor() {
+    if(this.get('hidePlayerCursors'))
+      return true;
+    if(this.get('parent') && widgets.has(this.get('parent')))
+      return widgets.get(this.get('parent')).requiresHiddenCursor();
+    return false;
   }
 
   async rotate(degrees, mode) {

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -1,4 +1,4 @@
-export const VERSION = 13;
+export const VERSION = 14;
 
 export default function FileUpdater(state) {
   const v = state._meta.version;
@@ -96,6 +96,7 @@ function updateProperties(properties, v, globalProperties) {
   v<10 && v10GridOffset(properties);
   v<12 && globalProperties.v12DropShadowAllowed && v12HandDropShadow(properties);
   v<13 && v13EnlargeTinyLabels(properties);
+  v<13 && v14HidePlayerCursors(properties);
 }
 
 function updateRoutine(routine, v, globalProperties) {
@@ -443,4 +444,9 @@ function v13EnlargeTinyLabels(properties) {
     if((properties.height || 20) < fontSize + 2)
       properties.height = fontSize + 2;
   }
+}
+
+function v14HidePlayerCursors(properties) {
+  if(properties.type == 'holder' && properties.childrenPerOwner)
+    properties.hidePlayerCursors = true;
 }

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -96,7 +96,7 @@ function updateProperties(properties, v, globalProperties) {
   v<10 && v10GridOffset(properties);
   v<12 && globalProperties.v12DropShadowAllowed && v12HandDropShadow(properties);
   v<13 && v13EnlargeTinyLabels(properties);
-  v<13 && v14HidePlayerCursors(properties);
+  v<14 && v14HidePlayerCursors(properties);
 }
 
 function updateRoutine(routine, v, globalProperties) {

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -89,5 +89,5 @@ test('Create game using edit mode', async t => {
     .click('#buttonInputGo')
     .rightClick('#w_bldn')
     .click('#w_bldn');
-  await compareState(t, 'cb023736a75beddb2f5134dc683ab368');
+  await compareState(t, '8772bd7dcabdee257974142dbbc14992');
 });

--- a/tests/testcafe/publiclibrary.js
+++ b/tests/testcafe/publiclibrary.js
@@ -51,7 +51,7 @@ publicLibraryButtons('Blue',               0, '406bd986ff21ab9fd5047a57b07a7117'
   'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_incrementButton', 'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_decrementButton',
   'reset_button', '#buttonInputGo', 'visibility_button'
 ]);
-publicLibraryButtons('Bhukhar',            0, 'c32671a16623cc91202fbba4d62f3371', [ 'btnMenuSettings', 'btn8Players', 'btn4Packs', 'btnCloseSettings', 'btnSelectPlayer', 'btnDeal', 'btnPile4', 'btnStartGame', 'btnTakeOne', 'btnNextPlayer', 'btnPickUp' ]);
+publicLibraryButtons('Bhukhar',            0, 'f6ecd3329f62f059402b872b473b964c', [ 'btnMenuSettings', 'btn8Players', 'btn4Packs', 'btnCloseSettings', 'btnSelectPlayer', 'btnDeal', 'btnPile4', 'btnStartGame', 'btnTakeOne', 'btnNextPlayer', 'btnPickUp' ]);
 publicLibraryButtons('Dots',               0, '23894df38f786cb014fa1cd79f2345db', [ 'reset', '#buttonInputGo', 'col11', 'col21', 'col12', 'col22', 'row11', 'row31', 'row21', 'row32', 'row12', 'row42', 'row22', 'row23', 'col23' ]);
 publicLibraryButtons('Solitaire',          0, 'e83b2d21474496df86cd3dd2540efe58', [ 'reset', 'jemz', 'reset' ]);
 publicLibraryButtons('Mancala',            0, '92108a0e76fd295fee9881b6c7f8928b', ['btnRule1', 'btnRule2', 'getb5', 'getb5', 'getb5', 'getb5', 'getb1', 'getb1', 'getb1', 'getb1' ]);
@@ -65,16 +65,16 @@ publicLibraryButtons('Reversi',            0, '35e0017570f9ecd206a2317c1528be36'
          [ ()=>Selector("#w_zpiece19"), ()=>Selector("#w_sq35") ],
          [ ()=>Selector("#w_zpiece08"), ()=>Selector("#w_sq53") ]
        ]);
-publicLibraryButtons('Reward',             0, '2269ff3e3c72fec2eacb81be5fab3236', [
+publicLibraryButtons('Reward',             0, '5290d9113f42a3c0e458a788b5a1ea99', [
   'gmex', 'kprc', 'oksq', 'j1wz', 'vfhn', 'seat1', 'next'
 ]);
-publicLibraryButtons('Rummy Tiles',        0, 'ab2a2638cdb61809a644c5ca73770f77', [ 'startMix', 'draw14' ]);
+publicLibraryButtons('Rummy Tiles',        0, '2625ca4661785ca9a75cdf93d6379427', [ 'startMix', 'draw14' ]);
 publicLibraryButtons('Undercover',         1, '8512b8cb117a694ee7e201869999e571', [ 'Reset', 'Spy Master Button' ]);
 publicLibraryButtons('Functions - CALL',   0, '15bc313f5adc00d310adb07ee2d6059a', [
   'n4cw_8_C', '5a52', '5a52', '66kr', 'qeg1', 'n4cwB', '8r6p', 'qeg1', 'qeg1', 'n5eu'
 ]);
 publicLibraryButtons('Functions - CLICK',  0, 'd44e77e0782cadbc9594494e5a83dde0', [ '7u2q' ]);
-publicLibraryButtons('Functions - ROTATE', 0, '241d87e4b6b825f8835893a2dd5dbdcc', [ 'c44c', '9kdj', 'w53c', 'w53c' ]);
+publicLibraryButtons('Functions - ROTATE', 0, '93b985659f164300d871c37fc2635a0b', [ 'c44c', '9kdj', 'w53c', 'w53c' ]);
 publicLibraryButtons('Functions - SELECT', 2, '3e4652080a097cce27106579afa90e50', [ 'jkmt1']);
 publicLibraryButtons('Functions - SORT',   1, '9e83c7e238dcab8a28f59f8d1ccc5b97', [
   'ingw', 'k131', 'cnfu', 'i6yz', 'z394', '0v3h', '1h8o', 'v5ra', 'ingw-copy001', 'k131-copy001', 'cnfu-copy001',


### PR DESCRIPTION
This is keeping it simple. It might be a good idea to highlight the widget instead of showing a cursor but this PR really just hides the cursor.

It is added to new hands by default and also to any holder with `childrenPerOwner: true` by using a file updater.