### PR TITLE
added widget buffer to copy widgets between games

### DIFF
--- a/client/js/editor/layout.js
+++ b/client/js/editor/layout.js
@@ -59,7 +59,8 @@ function initializeEditor() {
     new JsonModule(),
     new TreeModule(),
     new DebugModule(),
-    new AssetsModule()
+    new AssetsModule(),
+    new ToolboxModule()
   ]);
 
   openEditor();

--- a/client/js/editor/sidebar/toolbox.js
+++ b/client/js/editor/sidebar/toolbox.js
@@ -1,0 +1,58 @@
+class ToolboxModule extends SidebarModule {
+  constructor() {
+    super('home_repair_service', 'Toolbox', 'Miscellaneous tools that don\'t have a home yet.');
+  }
+
+  button_saveWidgetsToBuffer() {
+    function addRecursively(widget) {
+      widgetBuffer.push(widget.state);
+      for(const w of widgetFilter(w=>w.get('parent')==widget.id))
+        addRecursively(w);
+    }
+    const widgetBuffer = [];
+    for(const widget of selectedWidgets)
+      addRecursively(widget);
+    localStorage.setItem('widgetBuffer', JSON.stringify(widgetBuffer));
+    this.renderWidgetBuffer();
+  }
+
+  async button_loadWidgetsFromBuffer() {
+    const widgetBuffer = JSON.parse(localStorage.getItem('widgetBuffer') || '[]');
+    batchStart();
+    setDeltaCause(`${getPlayerDetails().playerName} loaded widgets from the widget buffer in editor`);
+    for(const state of widgetBuffer)
+      await addWidgetLocal(state);
+    batchEnd();
+  }
+
+  renderModule(target) {
+    this.addHeader('Toolbox');
+    this.widgetBuffer(target);
+  }
+
+  renderWidgetBuffer() {
+    const widgetBuffer = JSON.parse(localStorage.getItem('widgetBuffer') || '[]');
+    let list = '';
+    for(const state of widgetBuffer)
+      list += `<li>${html(state.id)}</li>`;
+    this.currentContents.innerHTML = `<ul>${list}</ul>`;
+  }
+
+  widgetBuffer(target) {
+    this.addSubHeader('Widget buffer');
+    div(target, 'buttonBar', `
+      <p>Here you can save the currently selected widgets (and their children) to a buffer so you can paste them later into a different game or room.</p>
+      <button icon=content_copy id=saveWidgetsToBuffer>Save widgets to buffer</button>
+      <button icon=content_paste id=loadWidgetsFromBuffer>Put widgets into the game</button>
+    `);
+    $('#saveWidgetsToBuffer').onclick = e=>this.button_saveWidgetsToBuffer();
+    $('#loadWidgetsFromBuffer').onclick = e=>this.button_loadWidgetsFromBuffer();
+
+    const widgetBuffer = JSON.parse(localStorage.getItem('widgetBuffer') || '[]');
+    let list = '';
+    for(const state of widgetBuffer)
+      list += `<li>${html(state.id)}</li>`;
+    this.currentContents = div(target);
+    this.renderWidgetBuffer();
+  }
+}

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -112,6 +112,7 @@ export default async function minifyHTML() {
     'client/js/editor/sidebar/undo.js',
     'client/js/editor/sidebar/json.js',
     'client/js/editor/sidebar/assets.js',
+    'client/js/editor/sidebar/toolbox.js',
 
     'node_modules/vue/dist/vue.global.js',
 


### PR DESCRIPTION
This is a new version of #694. Later this should be part of the widget library which should replace the Add Widget overlay. But for now this is a simple version that we can use in the meantime.