### PR TITLE
allow strings in `inheritFrom`

### DIFF
--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -80,7 +80,9 @@ export class StateManaged {
     if(properties == '*')
       return true;
 
-    if(Array.isArray(properties) && properties.length && properties[0].length && properties[0][0] == '!')
+    properties = asArray(properties);
+
+    if(properties.length && properties[0].length && properties[0][0] == '!')
       return properties.indexOf('!'+key) == -1;
     else
       return properties.indexOf(key) != -1;


### PR DESCRIPTION
`inheritFrom` can have these forms:

```JSON
{
  "inheritFrom": "seat"
}
```

```JSON
{
  "inheritFrom": {
    "seat": "*"
  }
}
```

```JSON
{
  "inheritFrom": {
    "seat": [ "width", "height" ]
  }
}
```

```JSON
{
  "inheritFrom": {
    "seat": [ "!width", "!height" ]
  }
}
```

This PR adds these forms because I stumbled over them multiple times wondering why they weren't working:

```JSON
{
  "inheritFrom": {
    "seat": "width"
  }
}
```

```JSON
{
  "inheritFrom": {
    "seat": "!width"
  }
}
```
