### PR TITLE
fixed cut off enlarged view

### DIFF
--- a/client/css/widgets/card.css
+++ b/client/css/widgets/card.css
@@ -4,15 +4,15 @@
 
 .card > .cardFace {
   display: none;
+}
+
+.card > .active.cardFace {
+  display: block;
   overflow: hidden;
   width: 100%;
   height: 100%;
   position: absolute;
   box-sizing: border-box;
-}
-
-.card > .active.cardFace {
-  display: block;
 }
 
 .card > .cardFace > .cardFaceObject {


### PR DESCRIPTION
This reverts a small part of #1654 that was not really necessary but broke an example in the Enlarge: Cards tutorial.