### PR TITLE
added `fillTo` to `MOVE`

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -902,7 +902,7 @@ function jeAddCommands() {
   jeAddRoutineOperationCommands('IF', { condition: null, operand1: null, relation: '==', operand2: null, thenRoutine: [], elseRoutine: [] });
   jeAddRoutineOperationCommands('INPUT', { cancelButtonIcon: null, cancelButtonText: "Cancel", confirmButtonIcon: null, confirmButtonText: "Go", fields: [], header: "" } );
   jeAddRoutineOperationCommands('LABEL', { value: 0, mode: 'set', label: null, collection: 'DEFAULT' });
-  jeAddRoutineOperationCommands('MOVE', { count: 1, face: null, from: null, to: null });
+  jeAddRoutineOperationCommands('MOVE', { count: 1, face: null, from: null, to: null, fillTo: null });
   jeAddRoutineOperationCommands('MOVEXY', { count: 1, face: null, from: null, x: 0, y: 0, snapToGrid: true, resetOwner: true });
   jeAddRoutineOperationCommands('RECALL', { owned: true, inHolder: true, holder: null });
   jeAddRoutineOperationCommands('ROTATE', { count: 1, angle: 90, mode: 'add', holder: null, collection: 'DEFAULT' });


### PR DESCRIPTION
A new parameter for `MOVE` that makes it possible to fill cards to target holders/hands up to a defined value.

I am not sure how this should work with `count` and `fillTo`. The way I did it now, `fillTo` defaults to `null` and if it is set, it basically overrides `count`. A different way to do it would be to make `fillTo` boolean and use `count` for the count but then you would have to set two parameters every time you want to use `fillTo`.