### PR TITLE
fixed crash when pressing ESC on an INPUT overlay

### DIFF
--- a/client/js/main.js
+++ b/client/js/main.js
@@ -433,7 +433,7 @@ onLoad(function() {
     if(e.currentTarget.classList.contains('active')) {
       if($('#stateDetailsOverlay.notEditing') && $('#stateDetailsOverlay.notEditing').style.display != 'none')
         showStatesOverlay('statesOverlay');
-      if(e.currentTarget == $('#activeGameButton') && $('#addOverlay').style.display != 'none')
+      if(e.currentTarget == $('#activeGameButton'))
         showOverlay();
       e.stopImmediatePropagation();
       return;


### PR DESCRIPTION
It was checking for the Add Widget overlay which is no longer accessible without edit mode.