### PR TITLE
card text layers default to black color

### DIFF
--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -165,7 +165,7 @@ class Card extends Widget {
             objectDiv.srcdoc = html;
           } else {
             objectDiv.textContent = object.value;
-            objectDiv.style.color = object.color;
+            objectDiv.style.color = object.color || 'black';
           }
           return usedProperties;
         }


### PR DESCRIPTION
Previously the default was to not set a color at all which made it inherit the color of its parent. Which leads to transparent text in holders or something.