### PR TITLE
prevent crashes in asset downloader

### DIFF
--- a/client/js/editor/sidebar/assets.js
+++ b/client/js/editor/sidebar/assets.js
@@ -103,8 +103,9 @@ class AssetsModule extends SidebarModule {
       div.classList.remove('queued');
       div.classList.add('processing');
       const asset = await this.externalLinkToAsset(url);
-      for(const id of this.urlMap[url])
-        await this.replaceLinkInWidget(id, url, asset);
+      if(asset.match(/^\/asset/))
+        for(const id of this.urlMap[url])
+          await this.replaceLinkInWidget(id, url, asset);
       $('span', div).innerText = asset;
       div.classList.remove('processing');
       div.classList.add('done');
@@ -122,7 +123,7 @@ class AssetsModule extends SidebarModule {
     this.urlMap = {};
     this.urlDIVs = {};
     for(const widget of widgets.values()) {
-      for(const url of JSON.stringify(widget.state).match(/http[^'") ]+/g) || []) {
+      for(const url of JSON.stringify(widget.state).match(/https?:\/\/[^'") ]+/g) || []) {
         if(!this.urlMap[url])
           this.urlMap[url] = [];
         this.urlMap[url].push(widget.get('id'));

--- a/server.mjs
+++ b/server.mjs
@@ -350,11 +350,15 @@ MinifyHTML().then(function(result) {
   });
 
   router.put('/asset/:link', async function(req, res) {
-    const content = Buffer.from(await (await fetch(req.params.link)).arrayBuffer());
-    const filename = `/${CRC32.buf(content)}_${content.length}`;
-    if(!Config.resolveAsset(filename.substr(1)))
-      fs.writeFileSync(assetsdir + filename, content);
-    res.send(`/assets${filename}`);
+    try {
+      const content = Buffer.from(await (await fetch(req.params.link)).arrayBuffer());
+      const filename = `/${CRC32.buf(content)}_${content.length}`;
+      if(!Config.resolveAsset(filename.substr(1)))
+        fs.writeFileSync(assetsdir + filename, content);
+      res.send(`/assets${filename}`);
+    } catch(e) {
+      res.status(404).send('Downloading external asset failed.');
+    }
   });
 
   router.put('/asset', bodyParser.raw({ limit: '10mb' }), function(req, res) {


### PR DESCRIPTION
If downloading an asset URL failed on the server, the entire server would crash. This improves the URL detection a bit and catches errors if the download failed.