### PR TITLE
prevent undoing initial state load

### DIFF
--- a/client/js/editor/toolbar/undo.js
+++ b/client/js/editor/toolbar/undo.js
@@ -6,7 +6,7 @@ class UndoButton extends ToolbarButton {
   click() {
     const protocol = [...getUndoProtocol()];
 
-    if(protocol.length) {
+    if(protocol.length > 1) {
       sendRawDelta({s:protocol[protocol.length-1].undoDelta});
       setUndoProtocol(protocol.slice(0, protocol.length-1));
       setSelection([...selectedWidgets].filter(w=>widgets.has(w.id)));


### PR DESCRIPTION
When pressing the Undo button in the editor toolbar, you can undo the intial room state loading which completely removes everything from the room.

I want to improve more things about Undo and auto saving but I feel like we should fix this pretty quickly because it is very destructive.