### PR TITLE
Fix problem from setting card text layers to black by default

### DIFF
--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -165,7 +165,9 @@ class Card extends Widget {
             objectDiv.srcdoc = html;
           } else {
             objectDiv.textContent = object.value;
-            objectDiv.style.color = (object.css && object.css.includes('color')) ? object.css.split('color:')[1].trim() : (object.color || 'black');
+            objectDiv.style.color = object.color;
+            if(!objectDiv.style.color)
+              objectDiv.style.color = 'black';
           }
           return usedProperties;
         }

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -165,7 +165,7 @@ class Card extends Widget {
             objectDiv.srcdoc = html;
           } else {
             objectDiv.textContent = object.value;
-            objectDiv.style.color = object.color || 'black';
+            objectDiv.style.color = (object.css.includes('color')) ? object.css.split('color:')[1].trim() : (object.color || 'black');
           }
           return usedProperties;
         }

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -165,7 +165,7 @@ class Card extends Widget {
             objectDiv.srcdoc = html;
           } else {
             objectDiv.textContent = object.value;
-            objectDiv.style.color = (object.css.includes('color')) ? object.css.split('color:')[1].trim() : (object.color || 'black');
+            objectDiv.style.color = (object.css && object.css.includes('color')) ? object.css.split('color:')[1].trim() : (object.color || 'black');
           }
           return usedProperties;
         }


### PR DESCRIPTION
Fixes a problem created by #1874.

If a text layer use something like ` "css": "color:darkgray",` but did not just directly specify `'color": "darkgray"` as was the case in Shattered Dominions, the card text was being set to black and the css was being ignored.  This PR adds a check to see if a css color has already been set and then will not apply the default black.

