### PR TITLE
increased production test wait time

### DIFF
--- a/.github/workflows/production-environment.yml
+++ b/.github/workflows/production-environment.yml
@@ -25,5 +25,5 @@ jobs:
         cp config.template.json config.json
         sed -i 's/minifyJavascript": false/minifyJavascript": true/' config.json
         npm start &
-        sleep 10
+        sleep 15
         curl -I http://localhost:8272


### PR DESCRIPTION
The GitHub test Production Environment fails more and more often because the started server is not ready yet. This PR makes the test wait 5 more seconds before attempting to reach the server.