### PR TITLE
fixed `INPUT.choose` visualization inheriting undesired properties

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2226,14 +2226,14 @@ export class Widget extends StateManaged {
 
   renderReadonlyCopyRaw(state, target) {
     delete state.id;
-    delete state.x;
-    delete state.y;
-    delete state.rotation;
-    delete state.scale;
-    delete state.parent;
-    delete state.owner;
-    delete state.linkedToSeat;
-    delete state.onlyVisibleForSeat;
+    state.x = 0;
+    state.y = 0;
+    state.rotation = 0;
+    state.scale = 1;
+    state.parent = null;
+    state.owner = null;
+    state.linkedToSeat = null;
+    state.onlyVisibleForSeat = null;
 
     this.applyInitialDelta(state);
     target.appendChild(this.domElement);


### PR DESCRIPTION
When rendering a copy of a widget, I deleted properties like `x` and `y` to make sure it is displayed where I want it to.

Unfortunately I did not think about `inheritFrom` so in some cases deleting `x` simply leads to inheriting it from somewhere else.

This PR explicitly sets these values to their defaults so they do not get inherited.