### PR TITLE
Update select dropdowns to show a visible arrow for better usability

### DIFF
--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -1373,7 +1373,7 @@ button:disabled:hover {
 .inputselect label,
 .inputpalette label,
 .inputchoose label{
-  padding: 4px 5px 0 5px;
+  padding: 4px 5px 2px 5px;
     width: 100%;
     vertical-align: top;
     flex-shrink: 0;

--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -1397,7 +1397,6 @@ button:disabled:hover {
 .inputstring input,
 .inputselect select
 {
-  appearance: none;
   padding: 20.6px 5px 0px 5px;
   margin: -20.6px 0 0 0;
   font-size: 16px;
@@ -1406,6 +1405,11 @@ button:disabled:hover {
   border: 0px none transparent;
   line-height: 36px;
   border-radius: 4px;
+}
+.inputnumber input,
+.inputstring input
+{
+  appearance: none;
 }
 .inputnumber label:empty ~ input,
 .inputstring label:empty ~ input,


### PR DESCRIPTION
Current appearance is confusing with no visible indicator that this is a select field:
![Screenshot from 2023-11-04 12-23-15](https://github.com/ArnoldSmith86/virtualtabletop/assets/8403378/462f87ff-51a6-4a88-8e16-bae09f345219)

Revised appearance is more clear for the user:
![Screenshot from 2023-11-04 12-24-21](https://github.com/ArnoldSmith86/virtualtabletop/assets/8403378/1293e894-e489-4372-aefd-ac6357e95651)
