### PR TITLE
Add event listeners to implement `selectedBy` property

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -30,6 +30,7 @@ export class Widget extends StateManaged {
     this.targetTransform = '';
     this.childArray = [];
     this.propertiesUsedInProperty = {};
+    this.addOverlay = document.getElementById('addOverlay');
 
     if(StateManaged.inheritFromMapping[id] === undefined)
       StateManaged.inheritFromMapping[id] = [];
@@ -101,8 +102,7 @@ export class Widget extends StateManaged {
       if (!this.timer) {
         this.timer = setTimeout(this.onlongtouch.bind(this), 500, false);
       }
-      const addOverlay = document.getElementById('addOverlay');
-      if (!addOverlay || window.getComputedStyle(addOverlay).display === 'none')
+      if (!this.addOverlay || window.getComputedStyle(addOverlay).display === 'none')
         this.set('selectedBy', playerName);
     }
 
@@ -110,8 +110,7 @@ export class Widget extends StateManaged {
       clearTimeout(this.timer);
       this.timer = null;
       this.hideEnlarged();
-      const addOverlay = document.getElementById('addOverlay');
-      if (!addOverlay || window.getComputedStyle(addOverlay).display === 'none')
+      if (!this.addOverlay || window.getComputedStyle(addOverlay).display === 'none')
         this.set('selectedBy', null);
     }
 
@@ -2312,14 +2311,12 @@ export class Widget extends StateManaged {
   }
 
   async selected() {
-    const addOverlay = document.getElementById('addOverlay');
-    if (!addOverlay || window.getComputedStyle(addOverlay).display === 'none')
+    if (!this.addOverlay || window.getComputedStyle(addOverlay).display === 'none')
       await this.set('selectedBy', playerName);
   }
 
   async selectedEnd() {
-    const addOverlay = document.getElementById('addOverlay');
-    if (!addOverlay || window.getComputedStyle(addOverlay).display === 'none')
+    if (!this.addOverlay || window.getComputedStyle(addOverlay).display === 'none')
       await this.set('selectedBy', null);
   }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -101,7 +101,8 @@ export class Widget extends StateManaged {
       if (!this.timer) {
         this.timer = setTimeout(this.onlongtouch.bind(this), 500, false);
       }
-      if (!document.body.classList.contains('edit'))
+      const addOverlay = document.getElementById('addOverlay');
+      if (!addOverlay || window.getComputedStyle(addOverlay).display === 'none')
         this.set('selectedBy', playerName);
     }
 
@@ -109,7 +110,8 @@ export class Widget extends StateManaged {
       clearTimeout(this.timer);
       this.timer = null;
       this.hideEnlarged();
-      if (!document.body.classList.contains('edit'))
+      const addOverlay = document.getElementById('addOverlay');
+      if (!addOverlay || window.getComputedStyle(addOverlay).display === 'none')
         this.set('selectedBy', null);
     }
 
@@ -2310,12 +2312,14 @@ export class Widget extends StateManaged {
   }
 
   async selected() {
-    if (!document.body.classList.contains('edit'))
+    const addOverlay = document.getElementById('addOverlay');
+    if (!addOverlay || window.getComputedStyle(addOverlay).display === 'none')
       await this.set('selectedBy', playerName);
   }
 
   async selectedEnd() {
-    if (!document.body.classList.contains('edit'))
+    const addOverlay = document.getElementById('addOverlay');
+    if (!addOverlay || window.getComputedStyle(addOverlay).display === 'none')
       await this.set('selectedBy', null);
   }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2525,14 +2525,6 @@ export class Widget extends StateManaged {
     return true;
   }
 
-  async touchstart() {
-    await selected();
-  }
-
-  async touchend() {
-    await selectedEnd();
-  }
-
   updateOwner() {
     this.domElement.className = this.classes();
   }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -72,6 +72,7 @@ export class Widget extends StateManaged {
       hoverTarget: null,
       hoverParent: null,
       hidePlayerCursors: false,
+      selectedBy: null,
 
       linkedToSeat: null,
       onlyVisibleForSeat: null,
@@ -93,6 +94,8 @@ export class Widget extends StateManaged {
     this.domElement.addEventListener('mouseleave',  e => this.hideEnlarged(e), false);
     this.domElement.addEventListener("touchstart", e => this.touchstart(), false);
     this.domElement.addEventListener("touchend", e => this.touchend(), false);
+    this.domElement.addEventListener('mousedown', e => this.selected(), false);
+    this.domElement.addEventListener('mouseup', e => this.notSelected(), false);
 
     this.touchstart = function() {
       if (!this.timer) {
@@ -115,6 +118,14 @@ export class Widget extends StateManaged {
 
     this.animateTimeouts = {};
     this.animateClasses = new Set;
+  }
+
+  selected() {
+    this.set('selectedBy', playerName);
+  }
+
+  notSelected() {
+    this.set('selectedBy', null);
   }
 
   absoluteCoord(coord) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -101,14 +101,12 @@ export class Widget extends StateManaged {
       if (!this.timer) {
         this.timer = setTimeout(this.onlongtouch.bind(this), 500, false);
       }
-      selected();
     }
 
     this.touchend = function() {
       clearTimeout(this.timer);
       this.timer = null;
       this.hideEnlarged();
-      selectedEnd();
     }
 
     this.onlongtouch = function() {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -104,6 +104,7 @@ export class Widget extends StateManaged {
       }
       if (!this.addOverlay || window.getComputedStyle(addOverlay).display === 'none')
         this.set('selectedBy', playerName);
+        this.domElement.classList.add('selected');
     }
 
     this.touchend = function() {
@@ -112,6 +113,7 @@ export class Widget extends StateManaged {
       this.hideEnlarged();
       if (!this.addOverlay || window.getComputedStyle(addOverlay).display === 'none')
         this.set('selectedBy', null);
+        this.domElement.classList.remove('selected');
     }
 
     this.onlongtouch = function() {
@@ -2312,12 +2314,14 @@ export class Widget extends StateManaged {
 
   async selected() {
     if (!this.addOverlay || window.getComputedStyle(addOverlay).display === 'none')
-      await this.set('selectedBy', playerName);
+      this.set('selectedBy', playerName);
+      this.domElement.classList.add('selected');
   }
 
   async selectedEnd() {
     if (!this.addOverlay || window.getComputedStyle(addOverlay).display === 'none')
-      await this.set('selectedBy', null);
+      this.set('selectedBy', null);
+      this.domElement.classList.remove('selected');
   }
 
   setHighlighted(isHighlighted) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -101,12 +101,16 @@ export class Widget extends StateManaged {
       if (!this.timer) {
         this.timer = setTimeout(this.onlongtouch.bind(this), 500, false);
       }
+      if (!document.body.classList.contains('edit'))
+        this.set('selectedBy', playerName);
     }
 
     this.touchend = function() {
       clearTimeout(this.timer);
       this.timer = null;
       this.hideEnlarged();
+      if (!document.body.classList.contains('edit'))
+        this.set('selectedBy', null);
     }
 
     this.onlongtouch = function() {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -95,7 +95,7 @@ export class Widget extends StateManaged {
     this.domElement.addEventListener("touchstart", e => this.touchstart(), false);
     this.domElement.addEventListener("touchend", e => this.touchend(), false);
     this.domElement.addEventListener('mousedown', e => this.selected(), false);
-    this.domElement.addEventListener('mouseup', e => this.notSelected(), false);
+    this.domElement.addEventListener('mouseup', e => this.selectedEnd(), false);
 
     this.touchstart = function() {
       if (!this.timer) {
@@ -118,14 +118,6 @@ export class Widget extends StateManaged {
 
     this.animateTimeouts = {};
     this.animateClasses = new Set;
-  }
-
-  selected() {
-    this.set('selectedBy', playerName);
-  }
-
-  notSelected() {
-    this.set('selectedBy', null);
   }
 
   absoluteCoord(coord) {
@@ -2311,6 +2303,16 @@ export class Widget extends StateManaged {
       await this.set('rotation', (this.get('rotation') + degrees) % 360);
     else
       await this.set('rotation', degrees);
+  }
+
+  async selected() {
+    if (!document.body.classList.contains('edit'))
+      await this.set('selectedBy', playerName);
+  }
+
+  async selectedEnd() {
+    if (!document.body.classList.contains('edit'))
+      await this.set('selectedBy', null);
   }
 
   setHighlighted(isHighlighted) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2525,6 +2525,14 @@ export class Widget extends StateManaged {
     return true;
   }
 
+  async touchstart() {
+    await selected();
+  }
+
+  async touchend() {
+    await selectedEnd();
+  }
+
   updateOwner() {
     this.domElement.className = this.classes();
   }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -101,12 +101,14 @@ export class Widget extends StateManaged {
       if (!this.timer) {
         this.timer = setTimeout(this.onlongtouch.bind(this), 500, false);
       }
+      selected();
     }
 
     this.touchend = function() {
       clearTimeout(this.timer);
       this.timer = null;
       this.hideEnlarged();
+      selectedEnd();
     }
 
     this.onlongtouch = function() {


### PR DESCRIPTION
Implements #1023.  Would essentially resolve #929 and #930 as well (not directly, but through implementation of a changeRoutine -- will post example in test room).

We have lots of temporary custom properties that get added to widgets:  Ex: dragging, hoverTarget, hoverParent, etc. But until this PR, there has not been a way to detect if a widget was selected by something like a mousedown event.  I'm not talking about clicking, just selecting.  Because clicking (like a clickRoutine) doesn't actually happen until the mouse is released.  And dragging does not show up until the widget moves (if that is even possible, which it usually is not for regular buttons).

This PR adds an event listener for mousedown and mouseup and adds the "selectedBy" property with the name of the player.  If we do, this should we also add a `.selected` class?  Apparently it was there at one time (https://github.com/ArnoldSmith86/virtualtabletop/pull/716/files).  Not sure what happened to that.

I don't yet know how this will work with touch devices.  Something I will test.