### PR TITLE
only `RECALL` cards not in the holder already

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1526,6 +1526,7 @@ export class Widget extends StateManaged {
                   cards = cards.filter(c=>!c.get('_ancestor'));
                 if(a.excludeCollection && excludeCollection)
                   cards = cards.filter(c=>!excludeCollection.includes(c));
+                cards = cards.filter(c=>c.get('_ancestor')!=holder&&!c.get('owner'));
                 for(const c of cards)
                   await c.moveToHolder(widgets.get(holder));
               }

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -90,5 +90,5 @@ test('Create game using edit mode', async t => {
     .click('#buttonInputGo')
     .rightClick('#w_bldn')
     .click('#w_bldn');
-  await compareState(t, '8772bd7dcabdee257974142dbbc14992');
+  await compareState(t, 'baea5653ae08c29418425f4f870acfb9');
 });

--- a/tests/testcafe/publiclibrary.js
+++ b/tests/testcafe/publiclibrary.js
@@ -51,7 +51,7 @@ publicLibraryButtons('Blue',               0, '2d1b053f7f73edbbe67230c624c63a9a'
   'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_incrementButton', 'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_decrementButton',
   'reset_button', '#buttonInputGo', 'visibility_button'
 ]);
-publicLibraryButtons('Bhukhar',            0, 'f6ecd3329f62f059402b872b473b964c', [ 'btnMenuSettings', 'btn8Players', 'btn4Packs', 'btnCloseSettings', 'btnSelectPlayer', 'btnDeal', 'btnPile4', 'btnStartGame', 'btnTakeOne', 'btnNextPlayer', 'btnPickUp' ]);
+publicLibraryButtons('Bhukhar',            0, '4f5ff6341c2924db3594c61da7776302', [ 'btnMenuSettings', 'btn8Players', 'btn4Packs', 'btnCloseSettings', 'btnSelectPlayer', 'btnDeal', 'btnPile4', 'btnStartGame', 'btnTakeOne', 'btnNextPlayer', 'btnPickUp' ]);
 publicLibraryButtons('Dots',               0, '23894df38f786cb014fa1cd79f2345db', [ 'reset', '#buttonInputGo', 'col11', 'col21', 'col12', 'col22', 'row11', 'row31', 'row21', 'row32', 'row12', 'row42', 'row22', 'row23', 'col23' ]);
 publicLibraryButtons('Solitaire',          0, 'e83b2d21474496df86cd3dd2540efe58', [ 'reset', 'jemz', 'reset' ]);
 publicLibraryButtons('Mancala',            0, '92108a0e76fd295fee9881b6c7f8928b', ['btnRule1', 'btnRule2', 'getb5', 'getb5', 'getb5', 'getb5', 'getb1', 'getb1', 'getb1', 'getb1' ]);

--- a/tests/testcafe/publiclibrary.js
+++ b/tests/testcafe/publiclibrary.js
@@ -70,7 +70,7 @@ publicLibraryButtons('Reward',             0, '5290d9113f42a3c0e458a788b5a1ea99'
 ]);
 publicLibraryButtons('Rummy Tiles',        0, '2625ca4661785ca9a75cdf93d6379427', [ 'startMix', 'draw14' ]);
 publicLibraryButtons('Undercover',         1, '5c9b915862ef7443a04add178271b9f9', [ 'Reset', 'Spy Master Button' ]);
-publicLibraryButtons('Functions - CALL',   0, '15bc313f5adc00d310adb07ee2d6059a', [
+publicLibraryButtons('Functions - CALL',   0, '48ba3fc9c25e95aaefe87bdf20f37888', [
   'n4cw_8_C', '5a52', '5a52', '66kr', 'qeg1', 'n4cwB', '8r6p', 'qeg1', 'qeg1', 'n5eu'
 ]);
 publicLibraryButtons('Functions - CLICK',  0, 'd44e77e0782cadbc9594494e5a83dde0', [ '7u2q' ]);

--- a/tests/testcafe/publiclibrary.js
+++ b/tests/testcafe/publiclibrary.js
@@ -46,7 +46,7 @@ function publicLibraryButtons(game, variant, md5, tests) {
   });
 }
 
-publicLibraryButtons('Blue',               0, '406bd986ff21ab9fd5047a57b07a7117', ["player1Seat","player2Seat","player3Seat","player4Seat",
+publicLibraryButtons('Blue',               0, '2d1b053f7f73edbbe67230c624c63a9a', ["player1Seat","player2Seat","player3Seat","player4Seat",
   'Deal_button', 'e36b',
   'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_incrementButton', 'd3ab9f5f-daa4-4d81-8004-50a9c90af88e_decrementButton',
   'reset_button', '#buttonInputGo', 'visibility_button'
@@ -69,14 +69,14 @@ publicLibraryButtons('Reward',             0, '5290d9113f42a3c0e458a788b5a1ea99'
   'gmex', 'kprc', 'oksq', 'j1wz', 'vfhn', 'seat1', 'next'
 ]);
 publicLibraryButtons('Rummy Tiles',        0, '2625ca4661785ca9a75cdf93d6379427', [ 'startMix', 'draw14' ]);
-publicLibraryButtons('Undercover',         1, '8512b8cb117a694ee7e201869999e571', [ 'Reset', 'Spy Master Button' ]);
+publicLibraryButtons('Undercover',         1, '5c9b915862ef7443a04add178271b9f9', [ 'Reset', 'Spy Master Button' ]);
 publicLibraryButtons('Functions - CALL',   0, '15bc313f5adc00d310adb07ee2d6059a', [
   'n4cw_8_C', '5a52', '5a52', '66kr', 'qeg1', 'n4cwB', '8r6p', 'qeg1', 'qeg1', 'n5eu'
 ]);
 publicLibraryButtons('Functions - CLICK',  0, 'd44e77e0782cadbc9594494e5a83dde0', [ '7u2q' ]);
 publicLibraryButtons('Functions - ROTATE', 0, '93b985659f164300d871c37fc2635a0b', [ 'c44c', '9kdj', 'w53c', 'w53c' ]);
-publicLibraryButtons('Functions - SELECT', 2, '3e4652080a097cce27106579afa90e50', [ 'jkmt1']);
-publicLibraryButtons('Functions - SORT',   1, '9e83c7e238dcab8a28f59f8d1ccc5b97', [
+publicLibraryButtons('Functions - SELECT', 2, '82d63d5c39dd9157b2ebb9e178d24f0c', [ 'jkmt1']);
+publicLibraryButtons('Functions - SORT',   1, 'fdc756a0a1a2b359dcf51f5504a99fc9', [
   'ingw', 'k131', 'cnfu', 'i6yz', 'z394', '0v3h', '1h8o', 'v5ra', 'ingw-copy001', 'k131-copy001', 'cnfu-copy001',
   'i6yz-copy001', 'z394-copy001', '0v3h-copy001'
 ]);


### PR DESCRIPTION
This is my suggestion to replace #1628 which was in the news lately.

That PR tries to make a similar change in `moveToHolder` instead which would improve performance for more cases than just `RECALL`. To me that is pretty intimidating because it is called in many places and @robartsd does not seem to be sure about the side effects either.

In practice there are potential slowdowns in:

- `MOVE` (which already checks for same source and destination)
- `SET property:parent` which in theory should check that the property did not change but piles make it trigger anyway and it probably is slow when changing the `parent` of many widgets this way
- `RECALL` which this PR should fix and in practice this probably solves 99% of slowdowns.