### PR TITLE
feedback when pressing `INPUT` button

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -678,11 +678,14 @@ export class Widget extends StateManaged {
     }
 
     if(!go || this.evaluateInputOverlayErrors(o, variables)) {
-      showOverlay(null);
-      if(go)
-        resolve({ variables, collections });
-      else
-        reject({ variables, collections });
+      this.showInputOverlayWorkingState(true);
+      sleep(1).then(function() {
+        showOverlay(null);
+        if(go)
+          resolve({ variables, collections });
+        else
+          reject({ variables, collections });
+      })
       return true;
     }
   }
@@ -2414,6 +2417,8 @@ export class Widget extends StateManaged {
   }
 
   async showInputOverlay(o, widgets, variables, collections, getCollection, problems) {
+    this.showInputOverlayWorkingState(false);
+
     $('#activeGameButton').dataset.overlay = 'buttonInputOverlay';
     $('#buttonInputCancel').style.visibility = "visible";
     return new Promise((resolve, reject) => {
@@ -2482,6 +2487,16 @@ export class Widget extends StateManaged {
       on('#buttonInputCancel', 'click', cancelHandler);
       showOverlay('buttonInputOverlay');
     });
+  }
+
+  showInputOverlayWorkingState(isWorking) {
+    for(const b of $a('#buttonInputOverlay button'))
+      b.style.disabled = isWorking;
+
+    if(isWorking) {
+      $('#buttonInputGo label').textContent = 'Working...';
+      $('#buttonInputCancel').style.visibility = 'hidden';
+    }
   }
 
   async snapToGrid() {


### PR DESCRIPTION
Pressing a button in an `INPUT` overlay quite often triggers routines that take a while. This PR hides the Cancel button and changes the OK button to Working so the player knows that they hit the button. It also disables the buttons - not sure if that is necessary.

I will probably add something similar to clicks in the room but that needs more thought and can be its own PR.