### PR TITLE
only `RECALL` cards not in the holder already

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1526,8 +1526,12 @@ export class Widget extends StateManaged {
                   cards = cards.filter(c=>!c.get('_ancestor'));
                 if(a.excludeCollection && excludeCollection)
                   cards = cards.filter(c=>!excludeCollection.includes(c));
-                for(const c of cards)
-                  await c.moveToHolder(widgets.get(holder));
+                for(const c of cards) {
+                  if(c.get('_ancestor') == holder && !c.get('owner'))
+                    await c.bringToFront();
+                  else
+                    await c.moveToHolder(widgets.get(holder));
+                }
               }
             } else {
               problems.push(`Holder ${holder} does not have a deck.`);


### PR DESCRIPTION
Another alternative to #1628. This one should result in the same card order as production. TestCafe still has differences but only `z` values because cards are not moved multiple times, resulting in lower `z` values. I checked Create Game and Bhukhar tests and they now deal the same cards to the holders.