### PR TITLE
always show all symbols for metadata icon picker

### DIFF
--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -466,6 +466,9 @@ export async function loadSymbolPicker() {
 }
 
 export async function pickSymbol(type='all', bigPreviews=true, closeOverlay=true) {
+  if($('#statesButton').dataset.overlay == 'symbolPickerOverlay')
+    $('#statesButton').dataset.overlay = detailsOverlay;
+
   await loadSymbolPicker();
   return new Promise((resolve, reject) => {
     showOverlay('symbolPickerOverlay');
@@ -561,6 +564,8 @@ export function addRichtextControls(dom) {
 
     showStatesOverlay('symbolPickerOverlay');
     $('#symbolPickerOverlay').scrollTop = 0;
+    for(const c of [ 'bigPreviews', 'hideFonts', 'hideImages' ])
+      $('#symbolPickerOverlay').classList.remove(c);
     $('#symbolPickerOverlay input').value = '';
     $('#symbolPickerOverlay input').focus();
     $('#symbolPickerOverlay input').onkeyup();


### PR DESCRIPTION
If you used the icon picker in the JSON editor, it gets filtered to either fonts or images. In production that filter is not reset when using it in the metadata again. This PR fixes that.

I also noticed that leaving the icon picker open in the metadata and then switching to edit mode leads to problems. So this also closes the icon picker in the Game Shelf whenever you use it somewhere else.