### PR TITLE
fixed crash when editing an in-progress game save

### DIFF
--- a/client/js/editor/toolbar/save.js
+++ b/client/js/editor/toolbar/save.js
@@ -37,11 +37,12 @@ class SaveButton extends ToolbarButtonWithContent {
 
   onMetaReceived(data) {
     this.activeState = data.meta.activeState;
-    this.currentMetadata = this.activeState ? Object.assign({}, data.meta.states[this.activeState.stateID], data.meta.states[this.activeState.stateID].variants[this.activeState.variantID]) : { name: 'Unnamed' };
+    const isValidState = this.activeState && data.meta.states[this.activeState.stateID] && data.meta.states[this.activeState.stateID].variants[this.activeState.variantID];
+    this.currentMetadata = isValidState ? Object.assign({}, data.meta.states[this.activeState.stateID], data.meta.states[this.activeState.stateID].variants[this.activeState.variantID]) : { name: 'Unnamed' };
     this.currentVersion = data.meta.version;
-    $('[data-mode=addVariant]', this.domContentElement).innerText = this.activeState ? `Save as new variant of ${this.currentMetadata.name}` : 'Save as new variant';
+    $('[data-mode=addVariant]', this.domContentElement).innerText = isValidState ? `Save as new variant of ${this.currentMetadata.name}` : 'Save as new variant';
     for(const button of $a('.onlyIfActive', this.domContentElement))
-      button.disabled = !data.meta.activeState || data.meta.activeState.stateID.match(/^PL:/) && !config.allowPublicLibraryEdits;
+      button.disabled = !isValidState || data.meta.activeState.stateID.match(/^PL:/) && !config.allowPublicLibraryEdits;
   }
 
   renderContent(target) {


### PR DESCRIPTION
Especially if you create an in-progress save game, remove the origin game and then enter edit mode, it would crash because the Save button would try to read from the deleted game.