### PR TITLE
only allow dropping files in Game Shelf

### DIFF
--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -1091,7 +1091,7 @@ onLoad(function() {
     updateFilterOverflow();
   });
   document.addEventListener('dragover', function(e) {
-    if(e.dataTransfer.types.includes('Files')) {
+    if($('#statesOverlay').style.display == 'flex' && e.dataTransfer.types.includes('Files')) {
       e.preventDefault();
       e.dataTransfer.dropEffect = 'copy';
       $('#statesButton').click();


### PR DESCRIPTION
This resolves #1938 by only allowing files to be dropped if the Game Shelf is visible.