### PR TITLE
fixed `IF` complaining about missing `condition`

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1334,15 +1334,15 @@ export class Widget extends StateManaged {
           problems.push(`Relation ${a.relation} is unsupported. Using '==' relation.`);
           a.relation = '==';
         }
-        if(a.condition !== undefined || a.operand1 !== undefined) {
+        if(original.condition !== undefined || original.operand1 !== undefined) {
           let condition = a.condition;
-          if (condition === undefined)
+          if (original.condition === undefined)
             condition = await compute(a.relation, null, a.operand1, a.operand2);
           const branch = condition ? 'thenRoutine' : 'elseRoutine';
           if(Array.isArray(a[branch]))
             await this.evaluateRoutine(a[branch], variables, collections, (depth || 0) + 1, true);
           if(jeRoutineLogging) {
-            if (a.condition === undefined)
+            if (original.condition === undefined)
               jeLoggingRoutineOperationSummary(`'${original.operand1}' ${a.relation} '${original.operand2}'`, `${JSON.stringify(condition)}`)
             else
               jeLoggingRoutineOperationSummary(`'${original.condition}'`, `${JSON.stringify(condition)}`)


### PR DESCRIPTION
I use `condition` to check for a variable all the time. But if the variable resolves to `undefined`, `IF` complains about missing a `condition` in the first place.

This PR changes the checks for `IF` to look at the code instead of the resolved values. This fixes the incorrect problem messages but it also changes behavior:

Previously the `elseRoutine` would not be executed if `condition` and `operand1` would evaluate to `undefined`. Now they should be executed.

This probably breaks games. I will think a second about a fileupdater but it might make existing code too ugly to justify it.