### PR TITLE
PL Update Carnival to Fix Sort Problem

### DIFF
--- a/library/games/Carnival/0.json
+++ b/library/games/Carnival/0.json
@@ -18,7 +18,7 @@
       "similarAwards": "2015 As d'Or - Jeu de l'Année Nominee\n2014 Fairplay À la carte Runner-up",
       "ruleText": "<h4><span style=\"color: var(--overlayFontColor);\">Rounds and actions</span><br></h4><div><span style=\"color: var(--overlayFontColor);\">Players need to play a card at the end of the card line (right side of the line).</span><br></div><div>The value in the card played blocks equals the number of safe cards in front of the played card.</div><div><br></div><div>The player needs to take all unsafe cards that are equal or lower value than the played card and all unsafe cards that are of the same color as the played card.</div><div><br></div><div>Example:</div><div>\nIf the player plays a Yellow-4 card they count 4 cards from the end (right side) of the line. Those cards are safe and the player does not need to take them.&nbsp;<span style=\"color: var(--overlayFontColor);\">In the image below the 4 cards from Green-2 to Purple-1 are safe cards. No matter the value or color they will not be taken.&nbsp;</span><span style=\"color: var(--overlayFontColor);\">All other cards (to the left of Purple-1) are not safe.</span></div><div>\nFrom the unsafe cards the player needs to take all cards that have values equal to the value of the played card and all cards that are the same color no matter the value.&nbsp;<span style=\"color: var(--overlayFontColor);\">The player must take all yellow cards and all cards with a value 4 or lower. In the image below, those cards are the Red-1, Red-4, and Yellow-3.</span></div><div><br></div><div><a href=\"/assets/-658727007_225205\"><img src=\"/assets/-658727007_225205\" class=\"richtextAsset\"></a></div><div><br></div><div><h4>End of the game&nbsp;</h4></div><div>The last round begins either when a player gets the last card from the draw pile or one player has collected at least one of each type of card. The player that completed the set of cards plays that turn normally and will go last in the final round. If the draw pile is exhausted, all players play one last card ending in the player the drew the last card from the draw pile.</div><div><span style=\"color: var(--overlayFontColor);\"><br></span></div><div><span style=\"color: var(--overlayFontColor);\">All players then choose 2 cards to add to their pile and 2 cards to discard.</span></div><div>&nbsp;</div><h4>Counting points</h4><div>The player that has the majority of each color counts 1 point for each card of that color. If two players have the majority of the same color both count 1 point per card.\n<br></div><div>All other cards points are added using their printed value.\n\nThe player with the LEAST amount of points wins.</div>",
       "helpText": "<h4>Setup</h4><div><ul><li><span style=\"font-weight: normal;\">All players should select a seat.</span></li></ul><a href=\"/assets/1655350907_20528\"><img src=\"/assets/1655350907_20528\" class=\"richtextAsset\"></a><ul><li><span style=\"font-weight: normal;\">Click on the play button&nbsp;to deal cards.<a href=\"/assets/-660941794_1759\"><img src=\"/assets/-660941794_1759\" class=\"richtextAsset\"></a></span></li></ul><h4>Round</h4><ul><li><span style=\"font-weight: 400;\">The player puts a card in the holder next to their hand. The number to the left of the line displays the count of the number of cards in the line.</span></li></ul><a href=\"/assets/1706549567_302976\"><img src=\"/assets/1706549567_302976\" class=\"richtextAsset\"></a><a href=\"/assets/-1527996678_145413\"><br></a><ul><li><span style=\"font-weight: normal;\">All cards that should be taken into the player's pile will be highlighted.</span><a href=\"/assets/385578086_109456\"><br></a><a href=\"/assets/-658727007_225205\"><img src=\"/assets/-658727007_225205\" class=\"richtextAsset\"></a></li></ul><ul><li><span style=\"font-weight: 400;\">The player can click the arrow to move the played card into the line and take the card into their pile.</span></li></ul><a href=\"/assets/-1835983689_722\"><img src=\"/assets/-1835983689_722\" class=\"richtextAsset\"></a><ul><li><span style=\"font-weight: 400;\">The player will be given a new card to keep the hand at 5. If this is the final round, no new card will be dealt.</span><a href=\"/assets/-424757628_56321\"><br></a></li></ul><h4>Ending the game</h4><div><ul><li><span style=\"font-weight: 400;\">The scoreboard button appears in the lower left of the room to indicate the last round is beginning.</span></li><li><span style=\"font-weight: 400;\">After the last round is played, players need to discard 2 cards into the draw pile.</span></li><li><span style=\"font-weight: 400;\">When all players have chosen the remainder 2 cards in their hands, the cards can be played into their piles.</span></li><li><span style=\"font-weight: 400;\">Press the scoreboard button to automatically calculate scores for all players.</span></li></ul><a href=\"/assets/-1919788969_3587\"><img src=\"/assets/-1919788969_3587\" class=\"richtextAsset\"></a></div></div>",
-      "lastUpdate": 1702388241257,
+      "lastUpdate": 1702472260196,
       "similarDesigner": "Naoki Homma",
       "variantImage": "",
       "variant": "",
@@ -449,528 +449,528 @@
     "type": "card",
     "cardType": "01-Spades-00",
     "id": "86ig",
-    "z": 35524,
-    "parent": "al6y"
+    "z": 36503,
+    "parent": "dapq"
   },
   "jjkk": {
     "deck": "DECK",
     "type": "card",
     "cardType": "01-Spades-01",
     "id": "jjkk",
-    "z": 35462,
-    "parent": "al6y"
+    "z": 36450,
+    "parent": "dapq"
   },
   "6ads": {
     "deck": "DECK",
     "type": "card",
     "cardType": "01-Spades-02",
     "id": "6ads",
-    "z": 35482,
-    "parent": "al6y"
+    "z": 36475,
+    "parent": "dapq"
   },
   "99r0": {
     "deck": "DECK",
     "type": "card",
     "cardType": "01-Spades-03",
     "id": "99r0",
-    "z": 35470,
-    "parent": "al6y"
+    "z": 36487,
+    "parent": "dapq"
   },
   "cd3x": {
     "deck": "DECK",
     "type": "card",
     "cardType": "01-Spades-04",
     "id": "cd3x",
-    "z": 35478,
-    "parent": "al6y"
+    "z": 36468,
+    "parent": "dapq"
   },
   "pd8t": {
     "deck": "DECK",
     "type": "card",
     "cardType": "01-Spades-05",
     "id": "pd8t",
-    "z": 35488,
-    "parent": "al6y"
+    "z": 36427,
+    "parent": "dapq"
   },
   "8zjq": {
     "deck": "DECK",
     "type": "card",
     "cardType": "01-Spades-06",
     "id": "8zjq",
-    "z": 35521,
-    "parent": "al6y"
+    "z": 36378,
+    "parent": "dapq"
   },
   "a8m3": {
     "deck": "DECK",
     "type": "card",
     "cardType": "01-Spades-07",
     "id": "a8m3",
-    "z": 35494,
-    "parent": "al6y"
+    "z": 36530,
+    "parent": "dapq"
   },
   "xpd2": {
     "deck": "DECK",
     "type": "card",
     "cardType": "01-Spades-08",
     "id": "xpd2",
-    "z": 35481,
-    "parent": "al6y"
+    "z": 36385,
+    "parent": "dapq"
   },
   "ir8h": {
     "deck": "DECK",
     "type": "card",
     "cardType": "01-Spades-09",
     "id": "ir8h",
-    "z": 35465,
-    "parent": "al6y"
+    "z": 36528,
+    "parent": "dapq"
   },
   "yvmr": {
     "deck": "DECK",
     "type": "card",
     "cardType": "01-Spades-10",
     "id": "yvmr",
-    "z": 35499,
-    "parent": "al6y"
+    "z": 36479,
+    "parent": "dapq"
   },
   "0jgt": {
     "deck": "DECK",
     "type": "card",
     "cardType": "02-Hearts-00",
     "id": "0jgt",
-    "z": 35474,
-    "parent": "al6y"
+    "z": 36488,
+    "parent": "dapq"
   },
   "6c0v": {
     "deck": "DECK",
     "type": "card",
     "cardType": "02-Hearts-01",
     "id": "6c0v",
-    "z": 35442,
-    "parent": "al6y"
+    "z": 36415,
+    "parent": "dapq"
   },
   "84qt": {
     "deck": "DECK",
     "type": "card",
     "cardType": "02-Hearts-02",
     "id": "84qt",
-    "z": 35497,
-    "parent": "al6y"
+    "z": 36414,
+    "parent": "dapq"
   },
   "xfq2": {
     "deck": "DECK",
     "type": "card",
     "cardType": "02-Hearts-03",
     "id": "xfq2",
-    "z": 35527,
-    "parent": "al6y"
+    "z": 36509,
+    "parent": "dapq"
   },
   "5tzs": {
     "deck": "DECK",
     "type": "card",
     "cardType": "02-Hearts-04",
     "id": "5tzs",
-    "z": 35468,
-    "parent": "al6y"
+    "z": 36522,
+    "parent": "dapq"
   },
   "sqkp": {
     "deck": "DECK",
     "type": "card",
     "cardType": "02-Hearts-05",
     "id": "sqkp",
-    "z": 35455,
-    "parent": "al6y"
+    "z": 36421,
+    "parent": "dapq"
   },
   "vqug": {
     "deck": "DECK",
     "type": "card",
     "cardType": "02-Hearts-06",
     "id": "vqug",
-    "z": 35458,
-    "parent": "al6y"
+    "z": 36515,
+    "parent": "dapq"
   },
   "gagc": {
     "deck": "DECK",
     "type": "card",
     "cardType": "02-Hearts-07",
     "id": "gagc",
-    "z": 35459,
-    "parent": "al6y"
+    "z": 36529,
+    "parent": "dapq"
   },
   "iccr": {
     "deck": "DECK",
     "type": "card",
     "cardType": "02-Hearts-08",
     "id": "iccr",
-    "z": 35490,
-    "parent": "al6y"
+    "z": 36420,
+    "parent": "dapq"
   },
   "0mi6": {
     "deck": "DECK",
     "type": "card",
     "cardType": "02-Hearts-09",
     "id": "0mi6",
-    "z": 35495,
-    "parent": "al6y"
+    "z": 36508,
+    "parent": "dapq"
   },
   "o6c0": {
     "deck": "DECK",
     "type": "card",
     "cardType": "02-Hearts-10",
     "id": "o6c0",
-    "z": 35486,
-    "parent": "al6y"
+    "z": 36409,
+    "parent": "dapq"
   },
   "uu1e": {
     "deck": "DECK",
     "type": "card",
     "cardType": "03-Clubs-00",
     "id": "uu1e",
-    "z": 35475,
-    "parent": "al6y"
+    "z": 36525,
+    "parent": "dapq"
   },
   "41o3": {
     "deck": "DECK",
     "type": "card",
     "cardType": "03-Clubs-01",
     "id": "41o3",
-    "z": 35515,
-    "parent": "al6y"
+    "z": 36518,
+    "parent": "dapq"
   },
   "orr7": {
     "deck": "DECK",
     "type": "card",
     "cardType": "03-Clubs-02",
     "id": "orr7",
-    "z": 35467,
-    "parent": "al6y"
+    "z": 36496,
+    "parent": "dapq"
   },
   "62uz": {
     "deck": "DECK",
     "type": "card",
     "cardType": "03-Clubs-03",
     "id": "62uz",
-    "z": 35452,
-    "parent": "al6y"
+    "z": 36482,
+    "parent": "dapq"
   },
   "gtf3": {
     "deck": "DECK",
     "type": "card",
     "cardType": "03-Clubs-04",
     "id": "gtf3",
-    "z": 35444,
-    "parent": "al6y"
+    "z": 36469,
+    "parent": "dapq"
   },
   "czsp": {
     "deck": "DECK",
     "type": "card",
     "cardType": "03-Clubs-05",
     "id": "czsp",
-    "z": 35480,
-    "parent": "al6y"
+    "z": 36510,
+    "parent": "dapq"
   },
   "bfxl": {
     "deck": "DECK",
     "type": "card",
     "cardType": "03-Clubs-06",
     "id": "bfxl",
-    "z": 35471,
-    "parent": "al6y"
+    "z": 36500,
+    "parent": "dapq"
   },
   "a838": {
     "deck": "DECK",
     "type": "card",
     "cardType": "03-Clubs-07",
     "id": "a838",
-    "z": 35496,
-    "parent": "al6y"
+    "z": 36424,
+    "parent": "dapq"
   },
   "n86s": {
     "deck": "DECK",
     "type": "card",
     "cardType": "03-Clubs-08",
     "id": "n86s",
-    "z": 35443,
-    "parent": "al6y"
+    "z": 36498,
+    "parent": "dapq"
   },
   "7v23": {
     "deck": "DECK",
     "type": "card",
     "cardType": "03-Clubs-09",
     "id": "7v23",
-    "z": 35453,
-    "parent": "al6y"
+    "z": 36531,
+    "parent": "dapq"
   },
   "ql4q": {
     "deck": "DECK",
     "type": "card",
     "cardType": "03-Clubs-10",
     "id": "ql4q",
-    "z": 35454,
-    "parent": "al6y"
+    "z": 36494,
+    "parent": "dapq"
   },
   "x5kd": {
     "deck": "DECK",
     "type": "card",
     "cardType": "04-Diamonds-00",
     "id": "x5kd",
-    "z": 35464,
-    "parent": "al6y"
+    "z": 36504,
+    "parent": "dapq"
   },
   "bjy5": {
     "deck": "DECK",
     "type": "card",
     "cardType": "04-Diamonds-01",
     "id": "bjy5",
-    "z": 35518,
-    "parent": "al6y"
+    "z": 36523,
+    "parent": "dapq"
   },
   "m1cn": {
     "deck": "DECK",
     "type": "card",
     "cardType": "04-Diamonds-02",
     "id": "m1cn",
-    "z": 35449,
-    "parent": "al6y"
+    "z": 36513,
+    "parent": "dapq"
   },
   "s5no": {
     "deck": "DECK",
     "type": "card",
     "cardType": "04-Diamonds-03",
     "id": "s5no",
-    "z": 35477,
-    "parent": "al6y"
+    "z": 36491,
+    "parent": "dapq"
   },
   "kqr5": {
     "deck": "DECK",
     "type": "card",
     "cardType": "04-Diamonds-04",
     "id": "kqr5",
-    "z": 35447,
-    "parent": "al6y"
+    "z": 36399,
+    "parent": "dapq"
   },
   "17os": {
     "deck": "DECK",
     "type": "card",
     "cardType": "04-Diamonds-05",
     "id": "17os",
-    "z": 35487,
-    "parent": "al6y"
+    "z": 36382,
+    "parent": "dapq"
   },
   "po6m": {
     "deck": "DECK",
     "type": "card",
     "cardType": "04-Diamonds-06",
     "id": "po6m",
-    "z": 35489,
-    "parent": "al6y"
+    "z": 36404,
+    "parent": "dapq"
   },
   "budl": {
     "deck": "DECK",
     "type": "card",
     "cardType": "04-Diamonds-07",
     "id": "budl",
-    "z": 35456,
-    "parent": "al6y"
+    "z": 36476,
+    "parent": "dapq"
   },
   "fxba": {
     "deck": "DECK",
     "type": "card",
     "cardType": "04-Diamonds-08",
     "id": "fxba",
-    "z": 35530,
-    "parent": "al6y"
+    "z": 36470,
+    "parent": "dapq"
   },
   "187l": {
     "deck": "DECK",
     "type": "card",
     "cardType": "04-Diamonds-09",
     "id": "187l",
-    "z": 35469,
-    "parent": "al6y"
+    "z": 36526,
+    "parent": "dapq"
   },
   "o9lb": {
     "deck": "DECK",
     "type": "card",
     "cardType": "04-Diamonds-10",
     "id": "o9lb",
-    "z": 35461,
-    "parent": "al6y"
+    "z": 36524,
+    "parent": "dapq"
   },
   "lfbw": {
     "deck": "DECK",
     "type": "card",
     "cardType": "05-Starts-00",
     "id": "lfbw",
-    "z": 35492,
-    "parent": "al6y"
+    "z": 36521,
+    "parent": "dapq"
   },
   "j2nr": {
     "deck": "DECK",
     "type": "card",
     "cardType": "05-Starts-01",
     "id": "j2nr",
-    "z": 35457,
-    "parent": "al6y"
+    "z": 36405,
+    "parent": "dapq"
   },
   "6iba": {
     "deck": "DECK",
     "type": "card",
     "cardType": "05-Starts-02",
     "id": "6iba",
-    "z": 35484,
-    "parent": "al6y"
+    "z": 36395,
+    "parent": "dapq"
   },
   "ydp6": {
     "deck": "DECK",
     "type": "card",
     "cardType": "05-Starts-03",
     "id": "ydp6",
-    "z": 35441,
-    "parent": "al6y"
+    "z": 36502,
+    "parent": "dapq"
   },
   "b1mn": {
     "deck": "DECK",
     "type": "card",
     "cardType": "05-Starts-04",
     "id": "b1mn",
-    "z": 35479,
-    "parent": "al6y"
+    "z": 36393,
+    "parent": "dapq"
   },
   "a594": {
     "deck": "DECK",
     "type": "card",
     "cardType": "05-Starts-05",
     "id": "a594",
-    "z": 35472,
-    "parent": "al6y"
+    "z": 36490,
+    "parent": "dapq"
   },
   "527c": {
     "deck": "DECK",
     "type": "card",
     "cardType": "05-Starts-06",
     "id": "527c",
-    "z": 35466,
-    "parent": "al6y"
+    "z": 36400,
+    "parent": "dapq"
   },
   "vtke": {
     "deck": "DECK",
     "type": "card",
     "cardType": "05-Starts-07",
     "id": "vtke",
-    "z": 35493,
-    "parent": "al6y"
+    "z": 36429,
+    "parent": "dapq"
   },
   "p1x2": {
     "deck": "DECK",
     "type": "card",
     "cardType": "05-Starts-08",
     "id": "p1x2",
-    "z": 35498,
-    "parent": "al6y"
+    "z": 36514,
+    "parent": "dapq"
   },
   "luqt": {
     "deck": "DECK",
     "type": "card",
     "cardType": "05-Starts-09",
     "id": "luqt",
-    "z": 35448,
-    "parent": "al6y"
+    "z": 36506,
+    "parent": "dapq"
   },
   "eonc": {
     "deck": "DECK",
     "type": "card",
     "cardType": "05-Starts-10",
     "id": "eonc",
-    "z": 35446,
-    "parent": "al6y"
+    "z": 36495,
+    "parent": "dapq"
   },
   "qq5r": {
     "deck": "DECK",
     "type": "card",
     "cardType": "06-Moons-00",
     "id": "qq5r",
-    "z": 35463,
-    "parent": "al6y"
+    "z": 36527,
+    "parent": "dapq"
   },
   "zxm8": {
     "deck": "DECK",
     "type": "card",
     "cardType": "06-Moons-01",
     "id": "zxm8",
-    "z": 35473,
-    "parent": "al6y"
+    "z": 36501,
+    "parent": "dapq"
   },
   "04fw": {
     "deck": "DECK",
     "type": "card",
     "cardType": "06-Moons-02",
     "id": "04fw",
-    "z": 35460,
-    "parent": "al6y"
+    "z": 36497,
+    "parent": "dapq"
   },
   "d4af": {
     "deck": "DECK",
     "type": "card",
     "cardType": "06-Moons-03",
     "id": "d4af",
-    "z": 35500,
-    "parent": "al6y"
+    "z": 36410,
+    "parent": "dapq"
   },
   "jws8": {
     "deck": "DECK",
     "type": "card",
     "cardType": "06-Moons-04",
     "id": "jws8",
-    "z": 35450,
-    "parent": "al6y"
+    "z": 36519,
+    "parent": "dapq"
   },
   "bakg": {
     "deck": "DECK",
     "type": "card",
     "cardType": "06-Moons-05",
     "id": "bakg",
-    "z": 35483,
-    "parent": "al6y"
+    "z": 36520,
+    "parent": "dapq"
   },
   "d31h": {
     "deck": "DECK",
     "type": "card",
     "cardType": "06-Moons-06",
     "id": "d31h",
-    "z": 35485,
-    "parent": "al6y"
+    "z": 36492,
+    "parent": "dapq"
   },
   "dml1": {
     "deck": "DECK",
     "type": "card",
     "cardType": "06-Moons-07",
     "id": "dml1",
-    "z": 35476,
-    "parent": "al6y"
+    "z": 36392,
+    "parent": "dapq"
   },
   "8dco": {
     "deck": "DECK",
     "type": "card",
     "cardType": "06-Moons-08",
     "id": "8dco",
-    "z": 35445,
-    "parent": "al6y"
+    "z": 36394,
+    "parent": "dapq"
   },
   "viq2": {
     "deck": "DECK",
     "type": "card",
     "cardType": "06-Moons-09",
     "id": "viq2",
-    "z": 35491,
-    "parent": "al6y"
+    "z": 36381,
+    "parent": "dapq"
   },
   "ibxx": {
     "deck": "DECK",
     "type": "card",
     "cardType": "06-Moons-10",
     "id": "ibxx",
-    "z": 35451,
-    "parent": "al6y"
+    "z": 36432,
+    "parent": "dapq"
   },
   "DEAL": {
     "type": "holder",
@@ -983,7 +983,28 @@
     },
     "x": 1395,
     "y": 810,
-    "css": "background:#fff6"
+    "css": "background:#fff6",
+    "leaveRoutine": [
+      {
+        "func": "COUNT",
+        "holder": "${PROPERTY id}"
+      },
+      {
+        "func": "IF",
+        "operand1": "${COUNT}",
+        "operand2": 0,
+        "thenRoutine": [
+          {
+            "func": "SET",
+            "collection": [
+              "scoreButton"
+            ],
+            "property": "scale",
+            "value": 1
+          }
+        ]
+      }
+    ]
   },
   "8jekD": {
     "id": "8jekD",
@@ -2063,15 +2084,6 @@
     "text": 0,
     "x": 120
   },
-  "al6y": {
-    "type": "pile",
-    "parent": "DEAL",
-    "x": 4,
-    "y": 4,
-    "width": 103,
-    "height": 160,
-    "id": "al6y"
-  },
   "scoreButton": {
     "type": "button",
     "id": "scoreButton",
@@ -2473,5 +2485,14 @@
     "y": -80,
     "parent": "SEAT6",
     "linkedToSeat": "SEAT6"
+  },
+  "dapq": {
+    "type": "pile",
+    "parent": "DEAL",
+    "x": 4,
+    "y": 4,
+    "width": 103,
+    "height": 160,
+    "id": "dapq"
   }
 }

--- a/library/games/Carnival/0.json
+++ b/library/games/Carnival/0.json
@@ -18,7 +18,7 @@
       "similarAwards": "2015 As d'Or - Jeu de l'Année Nominee\n2014 Fairplay À la carte Runner-up",
       "ruleText": "<h4><span style=\"color: var(--overlayFontColor);\">Rounds and actions</span><br></h4><div><span style=\"color: var(--overlayFontColor);\">Players need to play a card at the end of the card line (right side of the line).</span><br></div><div>The value in the card played blocks equals the number of safe cards in front of the played card.</div><div><br></div><div>The player needs to take all unsafe cards that are equal or lower value than the played card and all unsafe cards that are of the same color as the played card.</div><div><br></div><div>Example:</div><div>\nIf the player plays a Yellow-4 card they count 4 cards from the end (right side) of the line. Those cards are safe and the player does not need to take them.&nbsp;<span style=\"color: var(--overlayFontColor);\">In the image below the 4 cards from Green-2 to Purple-1 are safe cards. No matter the value or color they will not be taken.&nbsp;</span><span style=\"color: var(--overlayFontColor);\">All other cards (to the left of Purple-1) are not safe.</span></div><div>\nFrom the unsafe cards the player needs to take all cards that have values equal to the value of the played card and all cards that are the same color no matter the value.&nbsp;<span style=\"color: var(--overlayFontColor);\">The player must take all yellow cards and all cards with a value 4 or lower. In the image below, those cards are the Red-1, Red-4, and Yellow-3.</span></div><div><br></div><div><a href=\"/assets/-658727007_225205\"><img src=\"/assets/-658727007_225205\" class=\"richtextAsset\"></a></div><div><br></div><div><h4>End of the game&nbsp;</h4></div><div>The last round begins either when a player gets the last card from the draw pile or one player has collected at least one of each type of card. The player that completed the set of cards plays that turn normally and will go last in the final round. If the draw pile is exhausted, all players play one last card ending in the player the drew the last card from the draw pile.</div><div><span style=\"color: var(--overlayFontColor);\"><br></span></div><div><span style=\"color: var(--overlayFontColor);\">All players then choose 2 cards to add to their pile and 2 cards to discard.</span></div><div>&nbsp;</div><h4>Counting points</h4><div>The player that has the majority of each color counts 1 point for each card of that color. If two players have the majority of the same color both count 1 point per card.\n<br></div><div>All other cards points are added using their printed value.\n\nThe player with the LEAST amount of points wins.</div>",
       "helpText": "<h4>Setup</h4><div><ul><li><span style=\"font-weight: normal;\">All players should select a seat.</span></li></ul><a href=\"/assets/1655350907_20528\"><img src=\"/assets/1655350907_20528\" class=\"richtextAsset\"></a><ul><li><span style=\"font-weight: normal;\">Click on the play button&nbsp;to deal cards.<a href=\"/assets/-660941794_1759\"><img src=\"/assets/-660941794_1759\" class=\"richtextAsset\"></a></span></li></ul><h4>Round</h4><ul><li><span style=\"font-weight: 400;\">The player puts a card in the holder next to their hand. The number to the left of the line displays the count of the number of cards in the line.</span></li></ul><a href=\"/assets/1706549567_302976\"><img src=\"/assets/1706549567_302976\" class=\"richtextAsset\"></a><a href=\"/assets/-1527996678_145413\"><br></a><ul><li><span style=\"font-weight: normal;\">All cards that should be taken into the player's pile will be highlighted.</span><a href=\"/assets/385578086_109456\"><br></a><a href=\"/assets/-658727007_225205\"><img src=\"/assets/-658727007_225205\" class=\"richtextAsset\"></a></li></ul><ul><li><span style=\"font-weight: 400;\">The player can click the arrow to move the played card into the line and take the card into their pile.</span></li></ul><a href=\"/assets/-1835983689_722\"><img src=\"/assets/-1835983689_722\" class=\"richtextAsset\"></a><ul><li><span style=\"font-weight: 400;\">The player will be given a new card to keep the hand at 5. If this is the final round, no new card will be dealt.</span><a href=\"/assets/-424757628_56321\"><br></a></li></ul><h4>Ending the game</h4><div><ul><li><span style=\"font-weight: 400;\">The scoreboard button appears in the lower left of the room to indicate the last round is beginning.</span></li><li><span style=\"font-weight: 400;\">After the last round is played, players need to discard 2 cards into the draw pile.</span></li><li><span style=\"font-weight: 400;\">When all players have chosen the remainder 2 cards in their hands, the cards can be played into their piles.</span></li><li><span style=\"font-weight: 400;\">Press the scoreboard button to automatically calculate scores for all players.</span></li></ul><a href=\"/assets/-1919788969_3587\"><img src=\"/assets/-1919788969_3587\" class=\"richtextAsset\"></a></div></div>",
-      "lastUpdate": 1702302143578,
+      "lastUpdate": 1702387862400,
       "similarDesigner": "Naoki Homma",
       "variantImage": "",
       "variant": "",
@@ -449,7 +449,7 @@
     "type": "card",
     "cardType": "01-Spades-00",
     "id": "86ig",
-    "z": 30891,
+    "z": 34487,
     "parent": "al6y"
   },
   "jjkk": {
@@ -457,7 +457,7 @@
     "type": "card",
     "cardType": "01-Spades-01",
     "id": "jjkk",
-    "z": 30877,
+    "z": 34507,
     "parent": "al6y"
   },
   "6ads": {
@@ -465,7 +465,7 @@
     "type": "card",
     "cardType": "01-Spades-02",
     "id": "6ads",
-    "z": 30907,
+    "z": 34469,
     "parent": "al6y"
   },
   "99r0": {
@@ -473,7 +473,7 @@
     "type": "card",
     "cardType": "01-Spades-03",
     "id": "99r0",
-    "z": 30917,
+    "z": 34444,
     "parent": "al6y"
   },
   "cd3x": {
@@ -481,7 +481,7 @@
     "type": "card",
     "cardType": "01-Spades-04",
     "id": "cd3x",
-    "z": 30884,
+    "z": 34466,
     "parent": "al6y"
   },
   "pd8t": {
@@ -489,7 +489,7 @@
     "type": "card",
     "cardType": "01-Spades-05",
     "id": "pd8t",
-    "z": 30897,
+    "z": 34437,
     "parent": "al6y"
   },
   "8zjq": {
@@ -497,7 +497,7 @@
     "type": "card",
     "cardType": "01-Spades-06",
     "id": "8zjq",
-    "z": 30931,
+    "z": 34433,
     "parent": "al6y"
   },
   "a8m3": {
@@ -505,7 +505,7 @@
     "type": "card",
     "cardType": "01-Spades-07",
     "id": "a8m3",
-    "z": 30881,
+    "z": 34446,
     "parent": "al6y"
   },
   "xpd2": {
@@ -513,7 +513,7 @@
     "type": "card",
     "cardType": "01-Spades-08",
     "id": "xpd2",
-    "z": 30878,
+    "z": 34452,
     "parent": "al6y"
   },
   "ir8h": {
@@ -521,7 +521,7 @@
     "type": "card",
     "cardType": "01-Spades-09",
     "id": "ir8h",
-    "z": 30882,
+    "z": 34482,
     "parent": "al6y"
   },
   "yvmr": {
@@ -529,7 +529,7 @@
     "type": "card",
     "cardType": "01-Spades-10",
     "id": "yvmr",
-    "z": 30895,
+    "z": 34483,
     "parent": "al6y"
   },
   "0jgt": {
@@ -537,7 +537,7 @@
     "type": "card",
     "cardType": "02-Hearts-00",
     "id": "0jgt",
-    "z": 30961,
+    "z": 34436,
     "parent": "al6y"
   },
   "6c0v": {
@@ -545,7 +545,7 @@
     "type": "card",
     "cardType": "02-Hearts-01",
     "id": "6c0v",
-    "z": 30919,
+    "z": 34476,
     "parent": "al6y"
   },
   "84qt": {
@@ -553,7 +553,7 @@
     "type": "card",
     "cardType": "02-Hearts-02",
     "id": "84qt",
-    "z": 30901,
+    "z": 34440,
     "parent": "al6y"
   },
   "xfq2": {
@@ -561,7 +561,7 @@
     "type": "card",
     "cardType": "02-Hearts-03",
     "id": "xfq2",
-    "z": 30924,
+    "z": 34460,
     "parent": "al6y"
   },
   "5tzs": {
@@ -569,7 +569,7 @@
     "type": "card",
     "cardType": "02-Hearts-04",
     "id": "5tzs",
-    "z": 30875,
+    "z": 34463,
     "parent": "al6y"
   },
   "sqkp": {
@@ -577,7 +577,7 @@
     "type": "card",
     "cardType": "02-Hearts-05",
     "id": "sqkp",
-    "z": 30898,
+    "z": 34451,
     "parent": "al6y"
   },
   "vqug": {
@@ -585,7 +585,7 @@
     "type": "card",
     "cardType": "02-Hearts-06",
     "id": "vqug",
-    "z": 30912,
+    "z": 34522,
     "parent": "al6y"
   },
   "gagc": {
@@ -593,7 +593,7 @@
     "type": "card",
     "cardType": "02-Hearts-07",
     "id": "gagc",
-    "z": 30885,
+    "z": 34470,
     "parent": "al6y"
   },
   "iccr": {
@@ -601,7 +601,7 @@
     "type": "card",
     "cardType": "02-Hearts-08",
     "id": "iccr",
-    "z": 30923,
+    "z": 34462,
     "parent": "al6y"
   },
   "0mi6": {
@@ -609,7 +609,7 @@
     "type": "card",
     "cardType": "02-Hearts-09",
     "id": "0mi6",
-    "z": 30920,
+    "z": 34477,
     "parent": "al6y"
   },
   "o6c0": {
@@ -617,7 +617,7 @@
     "type": "card",
     "cardType": "02-Hearts-10",
     "id": "o6c0",
-    "z": 30899,
+    "z": 34480,
     "parent": "al6y"
   },
   "uu1e": {
@@ -625,7 +625,7 @@
     "type": "card",
     "cardType": "03-Clubs-00",
     "id": "uu1e",
-    "z": 30916,
+    "z": 34484,
     "parent": "al6y"
   },
   "41o3": {
@@ -633,7 +633,7 @@
     "type": "card",
     "cardType": "03-Clubs-01",
     "id": "41o3",
-    "z": 30896,
+    "z": 34513,
     "parent": "al6y"
   },
   "orr7": {
@@ -641,7 +641,7 @@
     "type": "card",
     "cardType": "03-Clubs-02",
     "id": "orr7",
-    "z": 30883,
+    "z": 34455,
     "parent": "al6y"
   },
   "62uz": {
@@ -649,7 +649,7 @@
     "type": "card",
     "cardType": "03-Clubs-03",
     "id": "62uz",
-    "z": 30955,
+    "z": 34465,
     "parent": "al6y"
   },
   "gtf3": {
@@ -657,7 +657,7 @@
     "type": "card",
     "cardType": "03-Clubs-04",
     "id": "gtf3",
-    "z": 30873,
+    "z": 34453,
     "parent": "al6y"
   },
   "czsp": {
@@ -665,7 +665,7 @@
     "type": "card",
     "cardType": "03-Clubs-05",
     "id": "czsp",
-    "z": 30902,
+    "z": 34492,
     "parent": "al6y"
   },
   "bfxl": {
@@ -673,7 +673,7 @@
     "type": "card",
     "cardType": "03-Clubs-06",
     "id": "bfxl",
-    "z": 30903,
+    "z": 34434,
     "parent": "al6y"
   },
   "a838": {
@@ -681,7 +681,7 @@
     "type": "card",
     "cardType": "03-Clubs-07",
     "id": "a838",
-    "z": 30904,
+    "z": 34519,
     "parent": "al6y"
   },
   "n86s": {
@@ -689,7 +689,7 @@
     "type": "card",
     "cardType": "03-Clubs-08",
     "id": "n86s",
-    "z": 30894,
+    "z": 34485,
     "parent": "al6y"
   },
   "7v23": {
@@ -697,7 +697,7 @@
     "type": "card",
     "cardType": "03-Clubs-09",
     "id": "7v23",
-    "z": 30880,
+    "z": 34443,
     "parent": "al6y"
   },
   "ql4q": {
@@ -705,7 +705,7 @@
     "type": "card",
     "cardType": "03-Clubs-10",
     "id": "ql4q",
-    "z": 30874,
+    "z": 34489,
     "parent": "al6y"
   },
   "x5kd": {
@@ -713,7 +713,7 @@
     "type": "card",
     "cardType": "04-Diamonds-00",
     "id": "x5kd",
-    "z": 30929,
+    "z": 34475,
     "parent": "al6y"
   },
   "bjy5": {
@@ -721,7 +721,7 @@
     "type": "card",
     "cardType": "04-Diamonds-01",
     "id": "bjy5",
-    "z": 30914,
+    "z": 34439,
     "parent": "al6y"
   },
   "m1cn": {
@@ -729,7 +729,7 @@
     "type": "card",
     "cardType": "04-Diamonds-02",
     "id": "m1cn",
-    "z": 30908,
+    "z": 34510,
     "parent": "al6y"
   },
   "s5no": {
@@ -737,7 +737,7 @@
     "type": "card",
     "cardType": "04-Diamonds-03",
     "id": "s5no",
-    "z": 30952,
+    "z": 34481,
     "parent": "al6y"
   },
   "kqr5": {
@@ -745,7 +745,7 @@
     "type": "card",
     "cardType": "04-Diamonds-04",
     "id": "kqr5",
-    "z": 30889,
+    "z": 34449,
     "parent": "al6y"
   },
   "17os": {
@@ -753,7 +753,7 @@
     "type": "card",
     "cardType": "04-Diamonds-05",
     "id": "17os",
-    "z": 30890,
+    "z": 34461,
     "parent": "al6y"
   },
   "po6m": {
@@ -761,7 +761,7 @@
     "type": "card",
     "cardType": "04-Diamonds-06",
     "id": "po6m",
-    "z": 30918,
+    "z": 34445,
     "parent": "al6y"
   },
   "budl": {
@@ -769,7 +769,7 @@
     "type": "card",
     "cardType": "04-Diamonds-07",
     "id": "budl",
-    "z": 30911,
+    "z": 34478,
     "parent": "al6y"
   },
   "fxba": {
@@ -777,7 +777,7 @@
     "type": "card",
     "cardType": "04-Diamonds-08",
     "id": "fxba",
-    "z": 30928,
+    "z": 34472,
     "parent": "al6y"
   },
   "187l": {
@@ -785,7 +785,7 @@
     "type": "card",
     "cardType": "04-Diamonds-09",
     "id": "187l",
-    "z": 30872,
+    "z": 34516,
     "parent": "al6y"
   },
   "o9lb": {
@@ -793,7 +793,7 @@
     "type": "card",
     "cardType": "04-Diamonds-10",
     "id": "o9lb",
-    "z": 30879,
+    "z": 34435,
     "parent": "al6y"
   },
   "lfbw": {
@@ -801,7 +801,7 @@
     "type": "card",
     "cardType": "05-Starts-00",
     "id": "lfbw",
-    "z": 30906,
+    "z": 34438,
     "parent": "al6y"
   },
   "j2nr": {
@@ -809,7 +809,7 @@
     "type": "card",
     "cardType": "05-Starts-01",
     "id": "j2nr",
-    "z": 30930,
+    "z": 34442,
     "parent": "al6y"
   },
   "6iba": {
@@ -817,7 +817,7 @@
     "type": "card",
     "cardType": "05-Starts-02",
     "id": "6iba",
-    "z": 30909,
+    "z": 34441,
     "parent": "al6y"
   },
   "ydp6": {
@@ -825,7 +825,7 @@
     "type": "card",
     "cardType": "05-Starts-03",
     "id": "ydp6",
-    "z": 30958,
+    "z": 34474,
     "parent": "al6y"
   },
   "b1mn": {
@@ -833,7 +833,7 @@
     "type": "card",
     "cardType": "05-Starts-04",
     "id": "b1mn",
-    "z": 30946,
+    "z": 34490,
     "parent": "al6y"
   },
   "a594": {
@@ -841,7 +841,7 @@
     "type": "card",
     "cardType": "05-Starts-05",
     "id": "a594",
-    "z": 30949,
+    "z": 34448,
     "parent": "al6y"
   },
   "527c": {
@@ -849,7 +849,7 @@
     "type": "card",
     "cardType": "05-Starts-06",
     "id": "527c",
-    "z": 30887,
+    "z": 34456,
     "parent": "al6y"
   },
   "vtke": {
@@ -857,7 +857,7 @@
     "type": "card",
     "cardType": "05-Starts-07",
     "id": "vtke",
-    "z": 30892,
+    "z": 34450,
     "parent": "al6y"
   },
   "p1x2": {
@@ -865,7 +865,7 @@
     "type": "card",
     "cardType": "05-Starts-08",
     "id": "p1x2",
-    "z": 30927,
+    "z": 34486,
     "parent": "al6y"
   },
   "luqt": {
@@ -873,7 +873,7 @@
     "type": "card",
     "cardType": "05-Starts-09",
     "id": "luqt",
-    "z": 30913,
+    "z": 34447,
     "parent": "al6y"
   },
   "eonc": {
@@ -881,7 +881,7 @@
     "type": "card",
     "cardType": "05-Starts-10",
     "id": "eonc",
-    "z": 30910,
+    "z": 34479,
     "parent": "al6y"
   },
   "qq5r": {
@@ -889,7 +889,7 @@
     "type": "card",
     "cardType": "06-Moons-00",
     "id": "qq5r",
-    "z": 30926,
+    "z": 34458,
     "parent": "al6y"
   },
   "zxm8": {
@@ -897,7 +897,7 @@
     "type": "card",
     "cardType": "06-Moons-01",
     "id": "zxm8",
-    "z": 30905,
+    "z": 34457,
     "parent": "al6y"
   },
   "04fw": {
@@ -905,7 +905,7 @@
     "type": "card",
     "cardType": "06-Moons-02",
     "id": "04fw",
-    "z": 30915,
+    "z": 34464,
     "parent": "al6y"
   },
   "d4af": {
@@ -913,7 +913,7 @@
     "type": "card",
     "cardType": "06-Moons-03",
     "id": "d4af",
-    "z": 30876,
+    "z": 34491,
     "parent": "al6y"
   },
   "jws8": {
@@ -921,7 +921,7 @@
     "type": "card",
     "cardType": "06-Moons-04",
     "id": "jws8",
-    "z": 30893,
+    "z": 34467,
     "parent": "al6y"
   },
   "bakg": {
@@ -929,7 +929,7 @@
     "type": "card",
     "cardType": "06-Moons-05",
     "id": "bakg",
-    "z": 30900,
+    "z": 34468,
     "parent": "al6y"
   },
   "d31h": {
@@ -937,7 +937,7 @@
     "type": "card",
     "cardType": "06-Moons-06",
     "id": "d31h",
-    "z": 30886,
+    "z": 34471,
     "parent": "al6y"
   },
   "dml1": {
@@ -945,7 +945,7 @@
     "type": "card",
     "cardType": "06-Moons-07",
     "id": "dml1",
-    "z": 30925,
+    "z": 34459,
     "parent": "al6y"
   },
   "8dco": {
@@ -953,7 +953,7 @@
     "type": "card",
     "cardType": "06-Moons-08",
     "id": "8dco",
-    "z": 30921,
+    "z": 34488,
     "parent": "al6y"
   },
   "viq2": {
@@ -961,7 +961,7 @@
     "type": "card",
     "cardType": "06-Moons-09",
     "id": "viq2",
-    "z": 30888,
+    "z": 34454,
     "parent": "al6y"
   },
   "ibxx": {
@@ -969,7 +969,7 @@
     "type": "card",
     "cardType": "06-Moons-10",
     "id": "ibxx",
-    "z": 30922,
+    "z": 34473,
     "parent": "al6y"
   },
   "DEAL": {
@@ -1044,8 +1044,7 @@
     "#b9130f": 0,
     "#56b4e9": 0,
     "#01020c": 0,
-    "#eed227": 0,
-    "turn": true
+    "#eed227": 0
   },
   "TopHolder-SEAT1": {
     "type": "holder",
@@ -1150,27 +1149,8 @@
     "classes": "transparent",
     "x": 160,
     "y": -80,
-    "enterRoutine": [
-      {
-        "func": "IF",
-        "condition": "${PROPERTY endCheck OF Move}",
-        "thenRoutine": [
-          "var bottomHolder = 'BottomHolder-' + ${PROPERTY linkedToSeat}",
-          {
-            "func": "SORT",
-            "key": "cardType",
-            "holder": "${bottomHolder}",
-            "reverse": true
-          },
-          {
-            "func": "SORT",
-            "key": "cardType",
-            "holder": "${PROPERTY id}",
-            "reverse": true
-          }
-        ]
-      }
-    ]
+    "enterRoutine": [],
+    "dropLimit": 0
   },
   "Counter-SEAT1": {
     "type": "label",
@@ -1370,7 +1350,8 @@
     "#b9130f": 0,
     "#56b4e9": 0,
     "#01020c": 0,
-    "#eed227": 0
+    "#eed227": 0,
+    "turn": true
   },
   "TopHolder-SEAT4": {
     "type": "holder",
@@ -1937,7 +1918,8 @@
     "onLeave": {
       "activeFace": 0
     },
-    "stackOffsetX": 40
+    "stackOffsetX": 40,
+    "dropLimit": 0
   },
   "BottomHolder-SEAT2": {
     "type": "holder",
@@ -2408,5 +2390,77 @@
       }
     ],
     "scale": 0
+  },
+  "DropHolder-SEAT1": {
+    "type": "holder",
+    "id": "DropHolder-SEAT1",
+    "parent": "SEAT1",
+    "x": 160,
+    "y": -80,
+    "width": 631,
+    "height": 225,
+    "layer": -4,
+    "z": 12,
+    "movableInEdit": false,
+    "classes": "transparent",
+    "linkedToSeat": "SEAT1",
+    "enterRoutine": [
+      "var topHolder = 'TopHolder-' + ${PROPERTY linkedToSeat}",
+      {
+        "func": "MOVE",
+        "collection": "child",
+        "to": "${topHolder}"
+      },
+      {
+        "func": "CALL",
+        "routine": "sortRoutine",
+        "widget": "${topHolder}"
+      }
+    ]
+  },
+  "DropHolder-SEAT2": {
+    "inheritFrom": "DropHolder-SEAT1",
+    "type": "holder",
+    "id": "DropHolder-SEAT2",
+    "x": 160,
+    "y": -80,
+    "parent": "SEAT2",
+    "linkedToSeat": "SEAT2"
+  },
+  "DropHolder-SEAT3": {
+    "inheritFrom": "DropHolder-SEAT1",
+    "type": "holder",
+    "id": "DropHolder-SEAT3",
+    "x": 160,
+    "y": -80,
+    "parent": "SEAT3",
+    "linkedToSeat": "SEAT3"
+  },
+  "DropHolder-SEAT4": {
+    "inheritFrom": "DropHolder-SEAT1",
+    "type": "holder",
+    "id": "DropHolder-SEAT4",
+    "x": 160,
+    "y": -80,
+    "parent": "SEAT4",
+    "linkedToSeat": "SEAT4"
+  },
+  "DropHolder-SEAT5": {
+    "inheritFrom": "DropHolder-SEAT1",
+    "type": "holder",
+    "id": "DropHolder-SEAT5",
+    "x": 160,
+    "y": -80,
+    "parent": "SEAT5",
+    "linkedToSeat": "SEAT5"
+  },
+  "DropHolder-SEAT6": {
+    "inheritFrom": "DropHolder-SEAT1",
+    "type": "holder",
+    "id": "DropHolder-SEAT6",
+    "x": 160,
+    "y": -80,
+    "parent": "SEAT6",
+    "linkedToSeat": "SEAT6"
   }
 }

--- a/library/games/Carnival/0.json
+++ b/library/games/Carnival/0.json
@@ -18,7 +18,7 @@
       "similarAwards": "2015 As d'Or - Jeu de l'Année Nominee\n2014 Fairplay À la carte Runner-up",
       "ruleText": "<h4><span style=\"color: var(--overlayFontColor);\">Rounds and actions</span><br></h4><div><span style=\"color: var(--overlayFontColor);\">Players need to play a card at the end of the card line (right side of the line).</span><br></div><div>The value in the card played blocks equals the number of safe cards in front of the played card.</div><div><br></div><div>The player needs to take all unsafe cards that are equal or lower value than the played card and all unsafe cards that are of the same color as the played card.</div><div><br></div><div>Example:</div><div>\nIf the player plays a Yellow-4 card they count 4 cards from the end (right side) of the line. Those cards are safe and the player does not need to take them.&nbsp;<span style=\"color: var(--overlayFontColor);\">In the image below the 4 cards from Green-2 to Purple-1 are safe cards. No matter the value or color they will not be taken.&nbsp;</span><span style=\"color: var(--overlayFontColor);\">All other cards (to the left of Purple-1) are not safe.</span></div><div>\nFrom the unsafe cards the player needs to take all cards that have values equal to the value of the played card and all cards that are the same color no matter the value.&nbsp;<span style=\"color: var(--overlayFontColor);\">The player must take all yellow cards and all cards with a value 4 or lower. In the image below, those cards are the Red-1, Red-4, and Yellow-3.</span></div><div><br></div><div><a href=\"/assets/-658727007_225205\"><img src=\"/assets/-658727007_225205\" class=\"richtextAsset\"></a></div><div><br></div><div><h4>End of the game&nbsp;</h4></div><div>The last round begins either when a player gets the last card from the draw pile or one player has collected at least one of each type of card. The player that completed the set of cards plays that turn normally and will go last in the final round. If the draw pile is exhausted, all players play one last card ending in the player the drew the last card from the draw pile.</div><div><span style=\"color: var(--overlayFontColor);\"><br></span></div><div><span style=\"color: var(--overlayFontColor);\">All players then choose 2 cards to add to their pile and 2 cards to discard.</span></div><div>&nbsp;</div><h4>Counting points</h4><div>The player that has the majority of each color counts 1 point for each card of that color. If two players have the majority of the same color both count 1 point per card.\n<br></div><div>All other cards points are added using their printed value.\n\nThe player with the LEAST amount of points wins.</div>",
       "helpText": "<h4>Setup</h4><div><ul><li><span style=\"font-weight: normal;\">All players should select a seat.</span></li></ul><a href=\"/assets/1655350907_20528\"><img src=\"/assets/1655350907_20528\" class=\"richtextAsset\"></a><ul><li><span style=\"font-weight: normal;\">Click on the play button&nbsp;to deal cards.<a href=\"/assets/-660941794_1759\"><img src=\"/assets/-660941794_1759\" class=\"richtextAsset\"></a></span></li></ul><h4>Round</h4><ul><li><span style=\"font-weight: 400;\">The player puts a card in the holder next to their hand. The number to the left of the line displays the count of the number of cards in the line.</span></li></ul><a href=\"/assets/1706549567_302976\"><img src=\"/assets/1706549567_302976\" class=\"richtextAsset\"></a><a href=\"/assets/-1527996678_145413\"><br></a><ul><li><span style=\"font-weight: normal;\">All cards that should be taken into the player's pile will be highlighted.</span><a href=\"/assets/385578086_109456\"><br></a><a href=\"/assets/-658727007_225205\"><img src=\"/assets/-658727007_225205\" class=\"richtextAsset\"></a></li></ul><ul><li><span style=\"font-weight: 400;\">The player can click the arrow to move the played card into the line and take the card into their pile.</span></li></ul><a href=\"/assets/-1835983689_722\"><img src=\"/assets/-1835983689_722\" class=\"richtextAsset\"></a><ul><li><span style=\"font-weight: 400;\">The player will be given a new card to keep the hand at 5. If this is the final round, no new card will be dealt.</span><a href=\"/assets/-424757628_56321\"><br></a></li></ul><h4>Ending the game</h4><div><ul><li><span style=\"font-weight: 400;\">The scoreboard button appears in the lower left of the room to indicate the last round is beginning.</span></li><li><span style=\"font-weight: 400;\">After the last round is played, players need to discard 2 cards into the draw pile.</span></li><li><span style=\"font-weight: 400;\">When all players have chosen the remainder 2 cards in their hands, the cards can be played into their piles.</span></li><li><span style=\"font-weight: 400;\">Press the scoreboard button to automatically calculate scores for all players.</span></li></ul><a href=\"/assets/-1919788969_3587\"><img src=\"/assets/-1919788969_3587\" class=\"richtextAsset\"></a></div></div>",
-      "lastUpdate": 1702387862400,
+      "lastUpdate": 1702388241257,
       "similarDesigner": "Naoki Homma",
       "variantImage": "",
       "variant": "",
@@ -449,7 +449,7 @@
     "type": "card",
     "cardType": "01-Spades-00",
     "id": "86ig",
-    "z": 34487,
+    "z": 35524,
     "parent": "al6y"
   },
   "jjkk": {
@@ -457,7 +457,7 @@
     "type": "card",
     "cardType": "01-Spades-01",
     "id": "jjkk",
-    "z": 34507,
+    "z": 35462,
     "parent": "al6y"
   },
   "6ads": {
@@ -465,7 +465,7 @@
     "type": "card",
     "cardType": "01-Spades-02",
     "id": "6ads",
-    "z": 34469,
+    "z": 35482,
     "parent": "al6y"
   },
   "99r0": {
@@ -473,7 +473,7 @@
     "type": "card",
     "cardType": "01-Spades-03",
     "id": "99r0",
-    "z": 34444,
+    "z": 35470,
     "parent": "al6y"
   },
   "cd3x": {
@@ -481,7 +481,7 @@
     "type": "card",
     "cardType": "01-Spades-04",
     "id": "cd3x",
-    "z": 34466,
+    "z": 35478,
     "parent": "al6y"
   },
   "pd8t": {
@@ -489,7 +489,7 @@
     "type": "card",
     "cardType": "01-Spades-05",
     "id": "pd8t",
-    "z": 34437,
+    "z": 35488,
     "parent": "al6y"
   },
   "8zjq": {
@@ -497,7 +497,7 @@
     "type": "card",
     "cardType": "01-Spades-06",
     "id": "8zjq",
-    "z": 34433,
+    "z": 35521,
     "parent": "al6y"
   },
   "a8m3": {
@@ -505,7 +505,7 @@
     "type": "card",
     "cardType": "01-Spades-07",
     "id": "a8m3",
-    "z": 34446,
+    "z": 35494,
     "parent": "al6y"
   },
   "xpd2": {
@@ -513,7 +513,7 @@
     "type": "card",
     "cardType": "01-Spades-08",
     "id": "xpd2",
-    "z": 34452,
+    "z": 35481,
     "parent": "al6y"
   },
   "ir8h": {
@@ -521,7 +521,7 @@
     "type": "card",
     "cardType": "01-Spades-09",
     "id": "ir8h",
-    "z": 34482,
+    "z": 35465,
     "parent": "al6y"
   },
   "yvmr": {
@@ -529,7 +529,7 @@
     "type": "card",
     "cardType": "01-Spades-10",
     "id": "yvmr",
-    "z": 34483,
+    "z": 35499,
     "parent": "al6y"
   },
   "0jgt": {
@@ -537,7 +537,7 @@
     "type": "card",
     "cardType": "02-Hearts-00",
     "id": "0jgt",
-    "z": 34436,
+    "z": 35474,
     "parent": "al6y"
   },
   "6c0v": {
@@ -545,7 +545,7 @@
     "type": "card",
     "cardType": "02-Hearts-01",
     "id": "6c0v",
-    "z": 34476,
+    "z": 35442,
     "parent": "al6y"
   },
   "84qt": {
@@ -553,7 +553,7 @@
     "type": "card",
     "cardType": "02-Hearts-02",
     "id": "84qt",
-    "z": 34440,
+    "z": 35497,
     "parent": "al6y"
   },
   "xfq2": {
@@ -561,7 +561,7 @@
     "type": "card",
     "cardType": "02-Hearts-03",
     "id": "xfq2",
-    "z": 34460,
+    "z": 35527,
     "parent": "al6y"
   },
   "5tzs": {
@@ -569,7 +569,7 @@
     "type": "card",
     "cardType": "02-Hearts-04",
     "id": "5tzs",
-    "z": 34463,
+    "z": 35468,
     "parent": "al6y"
   },
   "sqkp": {
@@ -577,7 +577,7 @@
     "type": "card",
     "cardType": "02-Hearts-05",
     "id": "sqkp",
-    "z": 34451,
+    "z": 35455,
     "parent": "al6y"
   },
   "vqug": {
@@ -585,7 +585,7 @@
     "type": "card",
     "cardType": "02-Hearts-06",
     "id": "vqug",
-    "z": 34522,
+    "z": 35458,
     "parent": "al6y"
   },
   "gagc": {
@@ -593,7 +593,7 @@
     "type": "card",
     "cardType": "02-Hearts-07",
     "id": "gagc",
-    "z": 34470,
+    "z": 35459,
     "parent": "al6y"
   },
   "iccr": {
@@ -601,7 +601,7 @@
     "type": "card",
     "cardType": "02-Hearts-08",
     "id": "iccr",
-    "z": 34462,
+    "z": 35490,
     "parent": "al6y"
   },
   "0mi6": {
@@ -609,7 +609,7 @@
     "type": "card",
     "cardType": "02-Hearts-09",
     "id": "0mi6",
-    "z": 34477,
+    "z": 35495,
     "parent": "al6y"
   },
   "o6c0": {
@@ -617,7 +617,7 @@
     "type": "card",
     "cardType": "02-Hearts-10",
     "id": "o6c0",
-    "z": 34480,
+    "z": 35486,
     "parent": "al6y"
   },
   "uu1e": {
@@ -625,7 +625,7 @@
     "type": "card",
     "cardType": "03-Clubs-00",
     "id": "uu1e",
-    "z": 34484,
+    "z": 35475,
     "parent": "al6y"
   },
   "41o3": {
@@ -633,7 +633,7 @@
     "type": "card",
     "cardType": "03-Clubs-01",
     "id": "41o3",
-    "z": 34513,
+    "z": 35515,
     "parent": "al6y"
   },
   "orr7": {
@@ -641,7 +641,7 @@
     "type": "card",
     "cardType": "03-Clubs-02",
     "id": "orr7",
-    "z": 34455,
+    "z": 35467,
     "parent": "al6y"
   },
   "62uz": {
@@ -649,7 +649,7 @@
     "type": "card",
     "cardType": "03-Clubs-03",
     "id": "62uz",
-    "z": 34465,
+    "z": 35452,
     "parent": "al6y"
   },
   "gtf3": {
@@ -657,7 +657,7 @@
     "type": "card",
     "cardType": "03-Clubs-04",
     "id": "gtf3",
-    "z": 34453,
+    "z": 35444,
     "parent": "al6y"
   },
   "czsp": {
@@ -665,7 +665,7 @@
     "type": "card",
     "cardType": "03-Clubs-05",
     "id": "czsp",
-    "z": 34492,
+    "z": 35480,
     "parent": "al6y"
   },
   "bfxl": {
@@ -673,7 +673,7 @@
     "type": "card",
     "cardType": "03-Clubs-06",
     "id": "bfxl",
-    "z": 34434,
+    "z": 35471,
     "parent": "al6y"
   },
   "a838": {
@@ -681,7 +681,7 @@
     "type": "card",
     "cardType": "03-Clubs-07",
     "id": "a838",
-    "z": 34519,
+    "z": 35496,
     "parent": "al6y"
   },
   "n86s": {
@@ -689,7 +689,7 @@
     "type": "card",
     "cardType": "03-Clubs-08",
     "id": "n86s",
-    "z": 34485,
+    "z": 35443,
     "parent": "al6y"
   },
   "7v23": {
@@ -697,7 +697,7 @@
     "type": "card",
     "cardType": "03-Clubs-09",
     "id": "7v23",
-    "z": 34443,
+    "z": 35453,
     "parent": "al6y"
   },
   "ql4q": {
@@ -705,7 +705,7 @@
     "type": "card",
     "cardType": "03-Clubs-10",
     "id": "ql4q",
-    "z": 34489,
+    "z": 35454,
     "parent": "al6y"
   },
   "x5kd": {
@@ -713,7 +713,7 @@
     "type": "card",
     "cardType": "04-Diamonds-00",
     "id": "x5kd",
-    "z": 34475,
+    "z": 35464,
     "parent": "al6y"
   },
   "bjy5": {
@@ -721,7 +721,7 @@
     "type": "card",
     "cardType": "04-Diamonds-01",
     "id": "bjy5",
-    "z": 34439,
+    "z": 35518,
     "parent": "al6y"
   },
   "m1cn": {
@@ -729,7 +729,7 @@
     "type": "card",
     "cardType": "04-Diamonds-02",
     "id": "m1cn",
-    "z": 34510,
+    "z": 35449,
     "parent": "al6y"
   },
   "s5no": {
@@ -737,7 +737,7 @@
     "type": "card",
     "cardType": "04-Diamonds-03",
     "id": "s5no",
-    "z": 34481,
+    "z": 35477,
     "parent": "al6y"
   },
   "kqr5": {
@@ -745,7 +745,7 @@
     "type": "card",
     "cardType": "04-Diamonds-04",
     "id": "kqr5",
-    "z": 34449,
+    "z": 35447,
     "parent": "al6y"
   },
   "17os": {
@@ -753,7 +753,7 @@
     "type": "card",
     "cardType": "04-Diamonds-05",
     "id": "17os",
-    "z": 34461,
+    "z": 35487,
     "parent": "al6y"
   },
   "po6m": {
@@ -761,7 +761,7 @@
     "type": "card",
     "cardType": "04-Diamonds-06",
     "id": "po6m",
-    "z": 34445,
+    "z": 35489,
     "parent": "al6y"
   },
   "budl": {
@@ -769,7 +769,7 @@
     "type": "card",
     "cardType": "04-Diamonds-07",
     "id": "budl",
-    "z": 34478,
+    "z": 35456,
     "parent": "al6y"
   },
   "fxba": {
@@ -777,7 +777,7 @@
     "type": "card",
     "cardType": "04-Diamonds-08",
     "id": "fxba",
-    "z": 34472,
+    "z": 35530,
     "parent": "al6y"
   },
   "187l": {
@@ -785,7 +785,7 @@
     "type": "card",
     "cardType": "04-Diamonds-09",
     "id": "187l",
-    "z": 34516,
+    "z": 35469,
     "parent": "al6y"
   },
   "o9lb": {
@@ -793,7 +793,7 @@
     "type": "card",
     "cardType": "04-Diamonds-10",
     "id": "o9lb",
-    "z": 34435,
+    "z": 35461,
     "parent": "al6y"
   },
   "lfbw": {
@@ -801,7 +801,7 @@
     "type": "card",
     "cardType": "05-Starts-00",
     "id": "lfbw",
-    "z": 34438,
+    "z": 35492,
     "parent": "al6y"
   },
   "j2nr": {
@@ -809,7 +809,7 @@
     "type": "card",
     "cardType": "05-Starts-01",
     "id": "j2nr",
-    "z": 34442,
+    "z": 35457,
     "parent": "al6y"
   },
   "6iba": {
@@ -817,7 +817,7 @@
     "type": "card",
     "cardType": "05-Starts-02",
     "id": "6iba",
-    "z": 34441,
+    "z": 35484,
     "parent": "al6y"
   },
   "ydp6": {
@@ -825,7 +825,7 @@
     "type": "card",
     "cardType": "05-Starts-03",
     "id": "ydp6",
-    "z": 34474,
+    "z": 35441,
     "parent": "al6y"
   },
   "b1mn": {
@@ -833,7 +833,7 @@
     "type": "card",
     "cardType": "05-Starts-04",
     "id": "b1mn",
-    "z": 34490,
+    "z": 35479,
     "parent": "al6y"
   },
   "a594": {
@@ -841,7 +841,7 @@
     "type": "card",
     "cardType": "05-Starts-05",
     "id": "a594",
-    "z": 34448,
+    "z": 35472,
     "parent": "al6y"
   },
   "527c": {
@@ -849,7 +849,7 @@
     "type": "card",
     "cardType": "05-Starts-06",
     "id": "527c",
-    "z": 34456,
+    "z": 35466,
     "parent": "al6y"
   },
   "vtke": {
@@ -857,7 +857,7 @@
     "type": "card",
     "cardType": "05-Starts-07",
     "id": "vtke",
-    "z": 34450,
+    "z": 35493,
     "parent": "al6y"
   },
   "p1x2": {
@@ -865,7 +865,7 @@
     "type": "card",
     "cardType": "05-Starts-08",
     "id": "p1x2",
-    "z": 34486,
+    "z": 35498,
     "parent": "al6y"
   },
   "luqt": {
@@ -873,7 +873,7 @@
     "type": "card",
     "cardType": "05-Starts-09",
     "id": "luqt",
-    "z": 34447,
+    "z": 35448,
     "parent": "al6y"
   },
   "eonc": {
@@ -881,7 +881,7 @@
     "type": "card",
     "cardType": "05-Starts-10",
     "id": "eonc",
-    "z": 34479,
+    "z": 35446,
     "parent": "al6y"
   },
   "qq5r": {
@@ -889,7 +889,7 @@
     "type": "card",
     "cardType": "06-Moons-00",
     "id": "qq5r",
-    "z": 34458,
+    "z": 35463,
     "parent": "al6y"
   },
   "zxm8": {
@@ -897,7 +897,7 @@
     "type": "card",
     "cardType": "06-Moons-01",
     "id": "zxm8",
-    "z": 34457,
+    "z": 35473,
     "parent": "al6y"
   },
   "04fw": {
@@ -905,7 +905,7 @@
     "type": "card",
     "cardType": "06-Moons-02",
     "id": "04fw",
-    "z": 34464,
+    "z": 35460,
     "parent": "al6y"
   },
   "d4af": {
@@ -913,7 +913,7 @@
     "type": "card",
     "cardType": "06-Moons-03",
     "id": "d4af",
-    "z": 34491,
+    "z": 35500,
     "parent": "al6y"
   },
   "jws8": {
@@ -921,7 +921,7 @@
     "type": "card",
     "cardType": "06-Moons-04",
     "id": "jws8",
-    "z": 34467,
+    "z": 35450,
     "parent": "al6y"
   },
   "bakg": {
@@ -929,7 +929,7 @@
     "type": "card",
     "cardType": "06-Moons-05",
     "id": "bakg",
-    "z": 34468,
+    "z": 35483,
     "parent": "al6y"
   },
   "d31h": {
@@ -937,7 +937,7 @@
     "type": "card",
     "cardType": "06-Moons-06",
     "id": "d31h",
-    "z": 34471,
+    "z": 35485,
     "parent": "al6y"
   },
   "dml1": {
@@ -945,7 +945,7 @@
     "type": "card",
     "cardType": "06-Moons-07",
     "id": "dml1",
-    "z": 34459,
+    "z": 35476,
     "parent": "al6y"
   },
   "8dco": {
@@ -953,7 +953,7 @@
     "type": "card",
     "cardType": "06-Moons-08",
     "id": "8dco",
-    "z": 34488,
+    "z": 35445,
     "parent": "al6y"
   },
   "viq2": {
@@ -961,7 +961,7 @@
     "type": "card",
     "cardType": "06-Moons-09",
     "id": "viq2",
-    "z": 34454,
+    "z": 35491,
     "parent": "al6y"
   },
   "ibxx": {
@@ -969,7 +969,7 @@
     "type": "card",
     "cardType": "06-Moons-10",
     "id": "ibxx",
-    "z": 34473,
+    "z": 35451,
     "parent": "al6y"
   },
   "DEAL": {
@@ -1350,8 +1350,7 @@
     "#b9130f": 0,
     "#56b4e9": 0,
     "#01020c": 0,
-    "#eed227": 0,
-    "turn": true
+    "#eed227": 0
   },
   "TopHolder-SEAT4": {
     "type": "holder",
@@ -1436,7 +1435,8 @@
     "#b9130f": 0,
     "#56b4e9": 0,
     "#01020c": 0,
-    "#eed227": 0
+    "#eed227": 0,
+    "turn": true
   },
   "TopHolder-SEAT5": {
     "type": "holder",
@@ -1738,6 +1738,17 @@
           "Move"
         ],
         "value": "#000"
+      },
+      {
+        "func": "SELECT",
+        "type": "card",
+        "property": "parent",
+        "value": "carnivalLine"
+      },
+      {
+        "func": "SET",
+        "property": "y",
+        "value": 4
       }
     ]
   },


### PR DESCRIPTION
There was a problem in the last round with sorting.  This fixes that.

It also fixes the problem that if the player changed their mind after staging a card to play, the previously selected cards would also move to the player's hand.