### PR TITLE
removed broken language from game link

### DIFF
--- a/client/room.html
+++ b/client/room.html
@@ -401,12 +401,9 @@
         <div class="details">
           <h1 data-field="name"></h1>
           <h2 data-showfor="similarName">Similar to: <span data-field="similarName"></span><span data-showfor="year"> (<span data-field="year"></span>)</span></h2>
-          <!--<div data-showfor="bgg" class="hideForEdit"><i class="material-icons">info</i> <a data-field="bgg" data-target="href">Game details on <nobr><i class="material-icons intext">launch</i> <span id="similarDetailsDomain"></span></nobr></a></div>-->
           <div data-showfor="time"><i class="material-icons">schedule</i> Time: <span data-field="time"></span> minutes</div>
           <div data-showfor="mode"><i class="material-icons">groups</i> Mode: <span data-field="mode"></span></div>
           <div data-showfor="skill"><i class="material-icons">psychology</i> Skill: <span data-field="skill"></span></div>
-          <div class="language-info" data-showfor="language"><i class="material-icons">language</i><span data-field="language"></span></div>
-          <div class="player-number-info" data-showfor="players"><i class="material-icons">person</i><span data-field="players"></span></div>
           <p data-field="description" data-placeholder="&lt;empty game description&gt;"></p>
         </div>
       </div>


### PR DESCRIPTION
Fixes #2034 by removing the HTML that should not be used in the first place.

It was triggered because the variant metadata ended up in the game metadata which is not always the case (and should probably be fixed).