### PR TITLE
World Whirl: fixed correct rotation detection

### DIFF
--- a/library/games/Word Whirl/0.json
+++ b/library/games/Word Whirl/0.json
@@ -5560,6 +5560,15 @@
           "var offsetCardRotation = ${CurrentCardRotation} % 360",
           {
             "func": "IF",
+            "operand1": "${offsetCardRotation}",
+            "relation": "<",
+            "operand2": 0,
+            "thenRoutine": [
+              "var offsetCardRotation = ${offsetCardRotation} + 360"
+            ]
+          },
+          {
+            "func": "IF",
             "operand1": "${correctCardID}",
             "operand2": "${CurrentCardID}",
             "thenRoutine": [
@@ -8515,7 +8524,7 @@
     "inheritFrom": "Player1ReadyButtonLabel"
   },
   "_meta": {
-    "version": 13,
+    "version": 15,
     "info": {
       "name": "Word Whirl",
       "image": "/assets/1180657484_49827",
@@ -8534,11 +8543,11 @@
       "similarAwards": "2022 Spiel des Jahres Recommended\n2021 Japan Boardgame Prize Voters' Selection Nominee\n2021 Golden Geek Light Game of the Year Nominee\n2021 Golden Geek Best Party Game Winner\n2021 Golden Geek Best Cooperative Game Nominee\n2021 Cardboard Republic Socializer Laurel Winner",
       "ruleText": "<h4><strong>Setup</strong> 📐</h4><ol><li>Every player joins by clicking on a seat on the left.</li><li>Click <i class=\"richtextSymbol material-icons\">restart_alt</i> to start the game.<br></li></ol><h4><strong>Write Clues</strong> ✍️</h4><div>In the first part of the game, all players write down clues for their cards simultaneously.<br></div><ol><li>Without moving or rotating the word cards, write a clue on each side that relates the two words on that side of your word square. These clues should help the other players guess the arrangement of your cards. For example, if the words are \"Snow\" and \"Sun,\" the clue might be \"Weather.\"<br></li><li>After writing the clues, press <i class=\"richtextSymbol material-icons\">done</i>.</li><li>Wait for everybody to finish their clues.</li></ol><div><h4>Guess Arrangement 🗣️</h4><div>In the second part of the game, you go through everybody's clues as a team and try to find the correct word arrangement.<br></div></div><ol><li>Click on any player's Guess Clues button on the left.</li><li>As a team, try to match the clues with the word cards by rotating (clicking) and dragging them to one of the corners. The player that came up with the clues has to remain completely silent and can not intervene.<br></li><li>After all the word cards have been placed, press <i class=\"richtextSymbol material-icons\">thumb_up</i>. Correct answers will be highlighted in green, incorrect cards will be returned to the holder on the right. For each correct guess, the team gets a point. ⭐</li><li>Continue until you guessed each player's card arrangement.<br></li></ol><h4><strong>Winning the Game</strong> 🏆\n</h4><p>In Word Whirl, you're not playing against each other, but as a team against the game itself. The game ends when all players have had a chance to be the clue-giver. The total score (number of correct guesses) is compared to previous games. The real goal is to have fun though.<br></p>",
       "helpText": "",
-      "variantImage": "",
-      "variant": "",
-      "language": "de-DE, en-US, es-ES, fr-FR, pt-BR",
+      "similarDesigner": "François Romain",
       "players": "2-6",
-      "similarDesigner": "François Romain"
+      "language": "de-DE, en-US, es-ES, fr-FR, pt-BR",
+      "variant": "",
+      "variantImage": ""
     }
   }
 }


### PR DESCRIPTION
When the player board is rotated to the left a bunch, it has a negative angle big enough to result in a negative angle when comparing to the correct angle. And modulo is not enough to map to 0...360. This now adds a simple check that fixes negative angles.