### PR TITLE
removed type when adding basic widget

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1336,7 +1336,7 @@ function jeAddWidgetPropertyCommands(object, widgetBase) {
     context: 'No widget selected.',
     onEmpty: true,
     call: async function() {
-      setSelection([ widgets.get(await addWidgetLocal({type})) ]);
+      setSelection([ widgets.get(await addWidgetLocal(type == 'basic' ? {} : {type})) ]);
     }
   });
   return type == 'basic' ? null : type;


### PR DESCRIPTION
The command `Add basic widget` in the JSON editor currently adds `type: basic` to the added widget implying that that is required. In fact any value for `type`, that is _not_ one of the other widget types, results in a basic widget.