### PR TITLE
fixed inconsistencies in scoreboard CSS

### DIFF
--- a/client/js/widgets/scoreboard.js
+++ b/client/js/widgets/scoreboard.js
@@ -16,6 +16,7 @@ class Scoreboard extends Widget {
       roundLabel: 'Round',
       totalsLabel: 'Totals',
       scoreProperty: 'score',
+      firstColWidth: 50,
       verticalHeader: false,
       seats: null,
       showAllRounds: false,
@@ -131,6 +132,21 @@ class Scoreboard extends Widget {
         console.log('The input overlay for the scoreboard failed to load.', e);
       }
     }
+  }
+
+  css() {
+    let css = super.css();
+
+    css += '; --firstColWidth:' + this.get('firstColWidth') + 'px';
+    css += '; --columns:' + this.numCols;
+
+    return css;
+  }
+
+  cssProperties() {
+    const p = super.cssProperties();
+    p.push('firstColWidth');
+    return p;
   }
 
   get(property) {
@@ -419,7 +435,7 @@ class Scoreboard extends Widget {
           this.tableDOM.rows[r].cells[numCols-1].classList.add('totalsLine');
       }
     }
-    this.domElement.style.setProperty('--firstColWidth', '50px');
-    this.domElement.style.setProperty('--columns', numCols);
+    this.numCols = numCols;
+    this.domElement.style.cssText = mapAssetURLs(this.css());
   }
 }

--- a/library/tutorials/Scoreboard/0.json
+++ b/library/tutorials/Scoreboard/0.json
@@ -18,11 +18,12 @@
       "similarAwards": "",
       "ruleText": "",
       "helpText": "",
-      "lastUpdate": 1679681162807,
+      "lastUpdate": 1715976506264,
       "variantImage": "",
       "variant": "Basic",
       "language": "en-US",
-      "players": "1"
+      "players": "1",
+      "similarDesigner": ""
     }
   },
   "seat1": {

--- a/library/tutorials/Scoreboard/1.json
+++ b/library/tutorials/Scoreboard/1.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "version": 8,
+    "version": 15,
     "info": {
       "name": "Scoreboard",
       "image": "/assets/-751946941_5803",
@@ -18,11 +18,12 @@
       "similarAwards": "",
       "ruleText": "",
       "helpText": "",
-      "lastUpdate": 1679681162809,
+      "lastUpdate": 1715976506265,
       "variantImage": "",
       "variant": "Appearance",
       "language": "en-US",
-      "players": "1"
+      "players": "1",
+      "similarDesigner": ""
     }
   },
   "seat1": {
@@ -238,9 +239,6 @@
     "z": 4,
     "movableInEdit": false,
     "css": {
-      ".scoreboard td:first-child": {
-        "--firstColWidth": "10px"
-      },
       ".scoreboard .currentRound": {
         "background-color": "pink"
       }
@@ -248,7 +246,8 @@
     "movable": false,
     "currentRound": 4,
     "roundLabel": "",
-    "showTotals": false
+    "showTotals": false,
+    "firstColWidth": 10
   },
   "comment3": {
     "id": "comment3",
@@ -257,7 +256,7 @@
     "width": 300,
     "z": 10076,
     "movable": false,
-    "text": "This shows how to change the width of the first column while letting every other column autosize. It also shows how to change the color of the 'currentRound' highlight.",
+    "text": "This shows how to change the width of the first column using the 'firstColWidth' property while letting every other column autosize. It also shows how to change the color of the 'currentRound' highlight using css.",
     "layer": -2
   },
   "scoreboard4": {

--- a/library/tutorials/Scoreboard/2.json
+++ b/library/tutorials/Scoreboard/2.json
@@ -18,11 +18,12 @@
       "similarAwards": "",
       "ruleText": "",
       "helpText": "",
-      "lastUpdate": 1679681162810,
+      "lastUpdate": 1715976506266,
       "variantImage": "",
       "variant": "Totals and Teams",
       "language": "en-US",
-      "players": "1"
+      "players": "1",
+      "similarDesigner": ""
     }
   },
   "seat1": {


### PR DESCRIPTION
The CSS variables `--firstColWidth` and `--columns` were not set reliably and disappeared whenever the CSS was updated without redrawing the entire scoreboard table.

This PR also introduces property `firstColWidth` so that the `50px` can be changed.