### PR TITLE
fixed scoreboard totals row position on Safari

### DIFF
--- a/client/css/widgets/scoreboard.css
+++ b/client/css/widgets/scoreboard.css
@@ -77,3 +77,9 @@
   bottom: 0;
 }
 
+@supports (-webkit-hyphens:none) {
+  .scoreboard > div.scoreboardIntermediate > table .totalsLine {
+    position: static;
+    bottom: unset;
+  }
+}


### PR DESCRIPTION
I could not figure out how to make it sticky at the bottom while scrolling so on Safari, you will have to scroll down to the totals row for now.