### PR TITLE
fixed that basic widgets would lose their children when editing their `html`

### DIFF
--- a/client/js/widgets/basicwidget.js
+++ b/client/js/widgets/basicwidget.js
@@ -42,11 +42,17 @@ class BasicWidget extends Widget {
       }
     }
     if(delta.html !== undefined || delta.text !== undefined || this.getWithPropertyReplacements_checkDelta('html', delta)) {
-      if(this.get('html') === null)
+      const childNodes = [...this.domElement.childNodes];
+      this.domElement.innerHTML = '';
+      if(this.get('html') === null) {
         setText(this.domElement, this.get('text'));
-      else
+      } else {
         this.domElement.innerHTML = DOMPurify.sanitize(mapAssetURLs(this.getWithPropertyReplacements('html')), { USE_PROFILES: { html: true } });
-    }
+      }
+      for(const child of childNodes)
+        if(String(child.className).match(/widget/))
+          this.domElement.appendChild(child);
+  }
 
     for(const property of Object.values(this.get('svgReplaces') || {}))
       if(delta[property] !== undefined)


### PR DESCRIPTION
Now the children should stay in place and adding/removing `html` or `text` properties should update the widget as expected.