### PR TITLE
fixed typo in PCIO importer

### DIFF
--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -259,7 +259,7 @@ export default async function convertPCIO(content) {
       if(widget.layoutType == 'spread') {
         if(widget.spreadDirection == 'down') {
           w.stackOffsetY = 168;
-        } else if(widget.spreadDirection == 'down') {
+        } else if(widget.spreadDirection == 'up') {
           w.dropOffsetY = (w.height || 168) - 168;
           w.stackOffsetY = -168;
         } else if(widget.spreadDirection == 'left') {


### PR DESCRIPTION
This fixes importing holders with an upward spread direction but it still only works for default card dimensions. I will probably continue working on this soonish but we might as well merge this obvious typo.