### PR TITLE
PL Cirque de la Cascade: Correct mistyped property on alternative board

### DIFF
--- a/library/games/Cirque de la Cascade/0.json
+++ b/library/games/Cirque de la Cascade/0.json
@@ -6880,9 +6880,9 @@
     "type": "holder",
     "id": "holder-hex-f-o18",
     "parent": "board-map-farmer",
-    "inheritFrom": "holder-farm-a6",
     "x": 672,
-    "y": 498.87
+    "y": 498.87,
+    "inheritFrom": "holder-hex-a4"
   },
   "holder-hex-f-o20": {
     "type": "holder",


### PR DESCRIPTION
Corrects a mistyped property in public library game Cirque de la Cascade, when playing on the advanced/alternate board side. This allows player pieces to snap to hex O18, consistent with other hexes on both sides of the board.