### PR TITLE
PL Egyptian Epochs: Fix bug with skipTurn introduction

### DIFF
--- a/library/games/Egyptian Epochs/0.json
+++ b/library/games/Egyptian Epochs/0.json
@@ -431,7 +431,7 @@
     "type": "holder",
     "id": "holder-suns-bid-p1",
     "y": 75,
-    "inheritFrom": "holder-suns-active-p1",
+    "inheritFrom": "holder-suns-future-p1",
     "x": 140,
     "width": 40,
     "dropOffsetX": 5,

--- a/library/games/Egyptian Epochs/1.json
+++ b/library/games/Egyptian Epochs/1.json
@@ -431,7 +431,7 @@
     "type": "holder",
     "id": "holder-suns-bid-p1",
     "y": 75,
-    "inheritFrom": "holder-suns-active-p1",
+    "inheritFrom": "holder-suns-future-p1",
     "x": 140,
     "width": 40,
     "dropOffsetX": 5,


### PR DESCRIPTION
In simplifying Egyptian Epochs routines to use `skipTurn` to skip players without any suns, an error was introduced meaning that `skipTurn` was also set on players that won an auction. This corrects this by ensuring that current-bid holders inherit from the future sun holder instead of the active sun holder.