### PR TITLE
fixed widget buffer with invalid parent

### DIFF
--- a/client/js/editor/sidebar/toolbox.js
+++ b/client/js/editor/sidebar/toolbox.js
@@ -20,8 +20,14 @@ class ToolboxModule extends SidebarModule {
     const widgetBuffer = JSON.parse(localStorage.getItem('widgetBuffer') || '[]');
     batchStart();
     setDeltaCause(`${getPlayerDetails().playerName} loaded widgets from the widget buffer in editor`);
-    for(const state of widgetBuffer)
-      await addWidgetLocal(state);
+    for(const state of widgetBuffer) {
+      if(!widgetBuffer.filter(w=>w.id==state.parent).length && !widgets.has(state.parent))
+        delete state.parent;
+      if(!widgetBuffer.filter(w=>w.id==state.deck).length && !widgets.has(state.deck))
+        alert(`Widget ${state.id} references a deck that is not in the buffer and is not already in the room. It will not be loaded.`);
+      else
+        await addWidgetLocal(state);
+    }
     batchEnd();
   }
 

--- a/client/js/editor/sidebar/toolbox.js
+++ b/client/js/editor/sidebar/toolbox.js
@@ -23,7 +23,7 @@ class ToolboxModule extends SidebarModule {
     for(const state of widgetBuffer) {
       if(!widgetBuffer.filter(w=>w.id==state.parent).length && !widgets.has(state.parent))
         delete state.parent;
-      if(!widgetBuffer.filter(w=>w.id==state.deck).length && !widgets.has(state.deck))
+      if(state.type == 'card' && !widgetBuffer.filter(w=>w.id==state.deck).length && !widgets.has(state.deck))
         alert(`Widget ${state.id} references a deck that is not in the buffer and is not already in the room. It will not be loaded.`);
       else
         await addWidgetLocal(state);

--- a/client/js/editor/sidebar/toolbox.js
+++ b/client/js/editor/sidebar/toolbox.js
@@ -21,8 +21,11 @@ class ToolboxModule extends SidebarModule {
     batchStart();
     setDeltaCause(`${getPlayerDetails().playerName} loaded widgets from the widget buffer in editor`);
     for(const state of widgetBuffer) {
-      if(!widgetBuffer.filter(w=>w.id==state.parent).length && !widgets.has(state.parent))
+      if(!widgetBuffer.filter(w=>w.id==state.parent).length && !widgets.has(state.parent)) {
         delete state.parent;
+        delete state.x;
+        delete state.y;
+      }
       if(state.type == 'card' && !widgetBuffer.filter(w=>w.id==state.deck).length && !widgets.has(state.deck))
         alert(`Widget ${state.id} references a deck that is not in the buffer and is not already in the room. It will not be loaded.`);
       else


### PR DESCRIPTION
Putting widgets from the widget buffer into the game now checks if their parents exist in the buffer or in the game. If a parent does not exist, it will be set to `null` instead.

Additionally this gives an error message if a referenced deck does not exist.