### PR TITLE
fixed client crash in `TURN`

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1911,7 +1911,8 @@ export class Widget extends StateManaged {
         let c = (a.source=='all' ? allSeats : collections[getCollection(a.source)].filter(w=>w.get('type')=='seat')).filter(w=>w.get('player'));
 
         if (c.length == 0) {
-          jeLoggingRoutineOperationSummary(`no active seats found in collection ${a.source}`);
+          if(jeRoutineLogging)
+            jeLoggingRoutineOperationSummary(`no active seats found in collection ${a.source}`);
         } else {
           if (c.length > 1) {
             if (a.turnCycle == 'forward' || a.turnCycle == 'position') {


### PR DESCRIPTION
A call to `jeLoggingRoutineOperationSummary` did not check for `jeRoutineLogging` first, making it crash when not in edit mode.

See https://discord.com/channels/871236474589286461/979427827587903580/1256688714130653214 in Online Card Players Discord.