### PR TITLE
fixed prev and next images in game library

### DIFF
--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -464,7 +464,7 @@ function fillStatesList(states, starred, activeState, returnServer, activePlayer
     if(state.image) {
       const mappedURL = mapAssetURLs(state.image);
       if(loadedLibraryImages[mappedURL]) {
-        $('img:not(.emoji)', entry).src = mappedURL;
+        $('img:not(.emoji)', entry).dataset.src = $('img:not(.emoji)', entry).src = mappedURL;
       } else {
         $('img:not(.emoji)', entry).dataset.src = mappedURL;
         lazyImageObserver.observe($('img:not(.emoji)', entry));


### PR DESCRIPTION
Fixes #2200. Something I broke when disabling lazy-loading for images that were already loaded.