### PR TITLE
improved performance when selecting multiple widgets

### DIFF
--- a/client/js/editor/sidebar/json.js
+++ b/client/js/editor/sidebar/json.js
@@ -28,10 +28,10 @@ class JsonModule extends SidebarModule {
   }
 
   onSelectionChangedWhileActive(newSelection) {
-    if(newSelection.length) {
+    if(newSelection.length == 1) {
       jeSelectWidget(newSelection[0]);
-      for(let i=1; i<newSelection.length; ++i)
-        jeSelectWidget(newSelection[i], true);
+    } else if(newSelection.length) {
+      jeSelectSetMulti(newSelection);
     } else {
       jeEmpty();
     }
@@ -62,10 +62,10 @@ class TreeModule extends SidebarModule {
   }
 
   onSelectionChangedWhileActive(newSelection) {
-    if(newSelection.length) {
+    if(newSelection.length == 1) {
       jeSelectWidget(newSelection[0]);
-      for(let i=1; i<newSelection.length; ++i)
-        jeSelectWidget(newSelection[i], true);
+    } else if(newSelection.length) {
+      jeSelectSetMulti(newSelection);
     } else {
       jeEmpty();
       jeCenterSelection();

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1716,6 +1716,16 @@ function jeSelectWidgetMulti(widget) {
   jeUpdateMulti();
 }
 
+function jeSelectSetMulti(widgets) {
+  const wIDs = widgets.map(w=>w.get('id'));
+
+  jeStateNow = { widgets: wIDs };
+
+  jeWidget = null;
+  jeMode = 'multi';
+  jeUpdateMulti();
+}
+
 function jeMultiSelectedWidgets() {
   let selected = [];
   for(const search of jeStateNow.widgets) {
@@ -1760,6 +1770,7 @@ function jeHighlightWidgets() {
 }
 
 function jeUpdateMulti() {
+  const selectedWidgets = jeMultiSelectedWidgets();
   jeCenterSelection();
   const keys = [ 'x', 'y', 'width', 'height', 'parent', 'z', 'layer' ];
   for(const usedKey in jeStateNow || [])
@@ -1767,7 +1778,7 @@ function jeUpdateMulti() {
       keys.push(usedKey);
   for(const key of keys) {
     jeStateNow[key] = {};
-    for(const selectedWidget of jeMultiSelectedWidgets())
+    for(const selectedWidget of selectedWidgets)
       jeStateNow[key][selectedWidget.get('id')] = selectedWidget.get(key);
     if(Object.values(jeStateNow[key]).every( (val, i, arr) => val === arr[0] ))
       jeStateNow[key] = Object.values(jeStateNow[key])[0];


### PR DESCRIPTION
Fixes #2207. It was regenerating the output for every selected widget instead of doing it once when all of them are selected.

It still does way too much work when selecting widgets but for now this should be fast enough.