### PR TITLE
fixed crash while CLONEing when the given id already exists

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -463,7 +463,7 @@ export class Widget extends StateManaged {
     if(widgets.has(clone.id)) {
       delete clone.id;
       if(problems && overrideProperties.id !== undefined)
-        problems.push(`There is already a widget with id:${a.properties.id}, generating new ID.`);
+        problems.push(`There is already a widget with id:${overrideProperties.id}, generating new ID.`);
     }
     delete clone.parent;
     const newID = await addWidgetLocal(clone);


### PR DESCRIPTION
The case was already handled in the code but the error message referenced the wrong variable.