### PR TITLE
fixed crash with PROPERTY x OF array

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -777,7 +777,7 @@ export class Widget extends StateManaged {
         let widget = this;
         if(match[8]) {
           const id = evaluateIdentifier(match[7], match[8]);
-          if(!this.isValidID(id, problems))
+          if(Array.isArray(id) || !this.isValidID(id, problems))
             return null;
           widget = widgets.get(id);
         }


### PR DESCRIPTION
Fixes #2189. By absolute chance I did `${PROPERTY x OF $var}` and `$var` evaluated to `[]`. And `isValidID` returns `true` for an empty array because it works with arrays for other reasons.