### PR TITLE
added option `visibleChildWidgets` to `INPUT.choose`

### DIFF
--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -1755,7 +1755,7 @@ input:invalid+span::after, .inputError::before {
   z-index: 2;
 }
 
-.inputchoose .widget {
+.inputchoose .inputchooseWidgetWrapper > .widget {
   position: relative !important;
   transform-origin: top left !important;
   z-index: 1 !important;

--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -309,7 +309,7 @@ export function formField(field, dom, id) {
           propertyOverride.activeFace = face;
 
         const widgetContainer = div(input, 'inputchooseWidgetWrapper');
-        const widgetClone = widget.renderReadonlyCopy(propertyOverride, $('body'));
+        const widgetClone = widget.renderReadonlyCopy(propertyOverride, $('body'), field.visibleChildWidgets);
         const widgetDOM = widgetClone.domElement;
         widgetClone.state.scale = scale * (field.scale || 1);
         widgetClone.domElement.style.cssText = mapAssetURLs(widgetClone.css());

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1081,6 +1081,7 @@ function jeAddCommands() {
   jeAddFieldCommand('faces', 'choose', null);
   jeAddFieldCommand('scale', 'choose', 1);
   jeAddFieldCommand('propertyOverride', 'choose', {});
+  jeAddFieldCommand('visibleChildWidgets', 'choose', false);
 
   jeAddEnumCommands('^[a-z]+ ↦ type', widgetTypes.slice(1));
   jeAddEnumCommands('^.*\\([A-Z]+\\) ↦ value', [ '${}' ]);

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2394,13 +2394,14 @@ export class Widget extends StateManaged {
     return this;
   }
 
-  renderReadonlyCopy(propertyOverride, target, isChild=false) {
+  renderReadonlyCopy(propertyOverride, target, includeChildren=false, isChild=false) {
     const newID = generateUniqueWidgetID();
     const newWidget = new this.constructor(newID);
     newWidget.renderReadonlyCopyRaw(Object.assign({}, this.state, propertyOverride), target, isChild);
-    for(const child of widgetFilter(w=>w.get('parent') == this.id))
-      if(this.get('type') != 'holder' || !compareDropTarget(child, this))
-        child.renderReadonlyCopy({}, newWidget.domElement, true);
+    if(includeChildren)
+      for(const child of widgetFilter(w=>w.get('parent') == this.id))
+        if(this.get('type') != 'holder' || !compareDropTarget(child, this) || includeChildren == 'all')
+          child.renderReadonlyCopy({}, newWidget.domElement, includeChildren, true);
     return newWidget;
   }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2374,12 +2374,14 @@ export class Widget extends StateManaged {
     return readOnlyProperties;
   }
 
-  renderReadonlyCopyRaw(state, target) {
+  renderReadonlyCopyRaw(state, target, isChild=false) {
     delete state.id;
-    state.x = 0;
-    state.y = 0;
-    state.rotation = 0;
-    state.scale = 1;
+    if(!isChild) {
+      state.x = 0;
+      state.y = 0;
+      state.rotation = 0;
+      state.scale = 1;
+    }
     state.parent = null;
     state.owner = null;
     state.linkedToSeat = null;
@@ -2392,8 +2394,14 @@ export class Widget extends StateManaged {
     return this;
   }
 
-  renderReadonlyCopy(propertyOverride, target) {
-    return new this.constructor(generateUniqueWidgetID()).renderReadonlyCopyRaw(Object.assign({}, this.state, propertyOverride), target);
+  renderReadonlyCopy(propertyOverride, target, isChild=false) {
+    const newID = generateUniqueWidgetID();
+    const newWidget = new this.constructor(newID);
+    newWidget.renderReadonlyCopyRaw(Object.assign({}, this.state, propertyOverride), target, isChild);
+    for(const child of widgetFilter(w=>w.get('parent') == this.id))
+      if(this.get('type') != 'holder' || !compareDropTarget(child, this))
+        child.renderReadonlyCopy({}, newWidget.domElement, true);
+    return newWidget;
   }
 
   requiresHiddenCursor() {


### PR DESCRIPTION
Fixes #2188. I hope this is a good solution. Children will now be visible on UI representations of a widget (like in `INPUT.choose` or the `dropTarget` buttons in the properties panel) _unless_ they are in a holder and match its `dropTarget`. So a card dropped into a holder is not rendered because it is considered a different widget in that context.