### PR TITLE
fixed crash after renaming a widget

### DIFF
--- a/client/js/editor/sidebar/json.js
+++ b/client/js/editor/sidebar/json.js
@@ -35,7 +35,8 @@ class JsonModule extends SidebarModule {
     } else {
       jeEmpty();
     }
-    $('#jeText').blur();
+    if(!jeDeltaIsOurs)
+      $('#jeText').blur();
   }
 
   renderModule(target) {
@@ -70,7 +71,8 @@ class TreeModule extends SidebarModule {
       jeEmpty();
       jeCenterSelection();
     }
-    $('#jeText').blur();
+    if(!jeDeltaIsOurs)
+      $('#jeText').blur();
   }
 
   onStateReceivedWhileActive() {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1482,12 +1482,15 @@ async function jeApplyChanges() {
 
   const currentState = JSON.stringify(jePostProcessObject(completeState));
   if(currentStateRaw != jeStateBeforeRaw || jeKeyIsDownDeltas.length) {
+    const idChanged = JSON.parse(currentState).id != JSON.parse(jeStateBefore).id;
     jeDeltaIsOurs = true;
     await jeApplyExternalChanges(completeState);
     jeStateBeforeRaw = currentStateRaw;
     const oldState = jeStateBefore;
     jeStateBefore = currentState;
     await updateWidget(currentState, oldState); // in editmode.js
+    if(idChanged)
+      setSelection([ widgets.get(JSON.parse(currentState).id) ]);
     jeDeltaIsOurs = false;
   }
 }

--- a/tests/testcafe/functions.js
+++ b/tests/testcafe/functions.js
@@ -153,7 +153,6 @@ test('Dynamic expressions', async t => {
     .click(Selector('button').withAttribute('icon', 'data_object'))
     .typeText('#jeText', button, { replace: true, paste: true })
     .rightClick('#w_jyo6')
-    .rightClick('#w_jyo6')
     .click(Selector('button').withAttribute('icon', 'pest_control'))
   const log = await Selector('#jeLog').textContent
   for (let i=0; i<ops.length; i++) {

--- a/tests/testcafe/functions.js
+++ b/tests/testcafe/functions.js
@@ -150,7 +150,6 @@ test('Dynamic expressions', async t => {
     .click('#editButton')
     .click('#editorToolbar > div > [icon=add]')
     .click('#addBasicWidget')
-    .click('#room',{offsetX: 1, offsetY: 1, modifiers:{ctrl:true}})
     .click(Selector('button').withAttribute('icon', 'data_object'))
     .typeText('#jeText', button, { replace: true, paste: true })
     .rightClick('#w_jyo6')


### PR DESCRIPTION
Fixes #1974. When changing the `id` of a widget using the JSON editor, the editor selection will now be updated to the new id.