### PR TITLE
fixed disabled game shelf

### DIFF
--- a/client/js/editor/toolbarButton.js
+++ b/client/js/editor/toolbarButton.js
@@ -45,7 +45,7 @@ class ToolbarButton {
 
   setMinimumSelection(count) {
     this.minimumSelection = count;
-    if($('button', this.domElement))
+    if(this.domElement && $('button', this.domElement))
       $('button', this.domElement).disabled = selectedWidgets.length < count;
   }
 }


### PR DESCRIPTION
Oops, an oversight in #2219 caused the Game Shelf button to be disabled whenever the editor was opened.