### PR TITLE
added property `hotkey`

### DIFF
--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -148,7 +148,7 @@ async function keyHandler(e) {
     return;
 
   batchStart();
-  for(const widget of widgetFilter(w=>w.get('hotkey')===e.key))
+  for(const widget of widgetFilter(w=>w.get('hotkey')===e.key).sort((a,b)=>String(a.get('id')).localeCompare(b.get('id'))))
     await widget.click();
   batchEnd();
 }

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -148,7 +148,7 @@ async function keyHandler(e) {
     return;
 
   batchStart();
-  for(const widget of widgetFilter(w=>w.get('hotkey')===e.key).sort((a,b)=>String(a.get('id')).localeCompare(b.get('id'))))
+  for(const widget of widgetFilter(w=>w.get('hotkey')===e.key&&w.isVisible()).sort((a,b)=>String(a.get('id')).localeCompare(b.get('id'))))
     await widget.click();
   batchEnd();
 }

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -143,8 +143,19 @@ async function inputHandler(name, e) {
   }
 }
 
+async function keyHandler(e) {
+  if(isLoading || overlayActive || $('body').classList.contains('edit') || e.target.tagName == 'INPUT' || e.target.tagName == 'TEXTAREA')
+    return;
+
+  batchStart();
+  for(const widget of widgetFilter(w=>w.get('hotkey')===e.key))
+    await widget.click();
+  batchEnd();
+}
+
 onLoad(function() {
   [ 'touchstart', 'touchend', 'touchmove', 'touchcancel', 'mousedown', 'mousemove', 'mouseup', 'contextmenu' ].forEach(function(event) {
     window.addEventListener(event, e => inputHandler(event, e));
   });
+  window.addEventListener('keydown', e => keyHandler(e));
 });

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2140,6 +2140,34 @@ export class Widget extends StateManaged {
     return false;
   }
 
+  isVisible() {
+    // Ensure the element exists
+    if (!this.domElement) return false;
+
+    // Traverse the element and all parent elements to check visibility (display, visibility, opacity)
+    let parent = this.domElement;
+    while (parent) {
+      const style = window.getComputedStyle(parent);
+      if (style.display === 'none' || style.visibility === 'hidden' || parseFloat(style.opacity) <= 0)
+        return false;
+      parent = parent.parentElement;
+    }
+
+    // Get the bounding rect of the element relative to the viewport
+    const rect = this.domElement.getBoundingClientRect();
+
+    // Get the bounding rect of the #room element
+    const roomRect = $('#roomArea').getBoundingClientRect();
+
+    // Check if the element is within the viewport of the room
+    return (
+      rect.top < roomRect.bottom &&
+      rect.left < roomRect.right &&
+      rect.bottom > roomRect.top &&
+      rect.right > roomRect.left
+    );
+  }
+
   async moveToHolder(holder) {
     if(this.inRemovalQueue)
       return;

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -84,6 +84,7 @@ export class Widget extends StateManaged {
       leaveRoutine: null,
       globalUpdateRoutine: null,
       gameStartRoutine: null,
+      hotkey: null,
 
       animatePropertyChange: []
     });


### PR DESCRIPTION
Any widget can now define `hotkey` and it will be clicked whenever the given key is pressed.

Policy for public library games should be that it's never _required_ to use the key so that all games still work on touchscreens IMO.