### PR TITLE
fixed selection behavior for multi-select and changing id or type

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -570,24 +570,3 @@ body.jsonEdit #toolbar {
 #jeCommands #jeCommandOptions input[type="number"]{
   width: 6ch;
 }
-
-
-
-
-/* FIXME: put this where it makes sense */
-
-.jeLineNumber {
-  display: inline-block;
-  width: 40px;
-  text-align: right;
-  padding-right: 10px;
-  color: #444;
-}
-
-.jeLineContent {
-  display: inline-block;
-}
-
-#jeText {
-  padding-left: 50px;
-}

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -570,3 +570,24 @@ body.jsonEdit #toolbar {
 #jeCommands #jeCommandOptions input[type="number"]{
   width: 6ch;
 }
+
+
+
+
+/* FIXME: put this where it makes sense */
+
+.jeLineNumber {
+  display: inline-block;
+  width: 40px;
+  text-align: right;
+  padding-right: 10px;
+  color: #444;
+}
+
+.jeLineContent {
+  display: inline-block;
+}
+
+#jeText {
+  padding-left: 50px;
+}

--- a/client/js/editor/sidebar/json.js
+++ b/client/js/editor/sidebar/json.js
@@ -28,6 +28,9 @@ class JsonModule extends SidebarModule {
   }
 
   onSelectionChangedWhileActive(newSelection) {
+    if(jeDeltaIsOurs)
+      return;
+
     if(newSelection.length == 1) {
       jeSelectWidget(newSelection[0]);
     } else if(newSelection.length) {
@@ -35,8 +38,7 @@ class JsonModule extends SidebarModule {
     } else {
       jeEmpty();
     }
-    if(!jeDeltaIsOurs)
-      $('#jeText').blur();
+    $('#jeText').blur();
   }
 
   renderModule(target) {
@@ -63,6 +65,11 @@ class TreeModule extends SidebarModule {
   }
 
   onSelectionChangedWhileActive(newSelection) {
+    if(jeDeltaIsOurs) {
+      jeCenterSelection();
+      return;
+    }
+
     if(newSelection.length == 1) {
       jeSelectWidget(newSelection[0]);
     } else if(newSelection.length) {
@@ -71,8 +78,7 @@ class TreeModule extends SidebarModule {
       jeEmpty();
       jeCenterSelection();
     }
-    if(!jeDeltaIsOurs)
-      $('#jeText').blur();
+    $('#jeText').blur();
   }
 
   onStateReceivedWhileActive() {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1807,13 +1807,18 @@ function jeColorize() {
     [ /^( +")(.*)(",?)$/, null, 'string', null ]
   ];
   let out = [];
+  let nr = 0;
+  function push(line) {
+    out.push(`<div class=jeTextLine><span class=jeLineNumber>${nr}</span><span class=jeLineContent>${line}</span></div>`);
+  }
   for(let line of jeGetEditorContent().split('\n')) {
+    ++nr;
     let foundMatch = false;
     for(const l of langObj) {
       const match = line.match(l[0]);
       if(match) {
         if(jeMode == 'widget' && match[1] == '  "' && l[2] == 'key' && (l[4] == "null" && match[4] == "null" || String(jeWidget.defaults[match[2]]) == match[4])) {
-          out.push(`<i class=default>${html(line)}</i>`);
+          push(`<i class=default>${html(line)}</i>`);
           foundMatch = true;
           break;
         }
@@ -1831,18 +1836,16 @@ function jeColorize() {
             match[i] = html(match[i]);
         }
 
-        let newLine = match.slice(1).join('');
-
-        out.push(newLine);
+        push(match.slice(1).join(''));
         foundMatch = true;
 
         break;
       }
     }
     if(!foundMatch)
-      out.push(html(line));
+      push(html(line));
   }
-  $('#jeTextHighlight').innerHTML = out.join('\n');
+  $('#jeTextHighlight').innerHTML = out.join('');
 }
 
 /* Displaying and controlling tree subpane of edit area */

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1807,18 +1807,13 @@ function jeColorize() {
     [ /^( +")(.*)(",?)$/, null, 'string', null ]
   ];
   let out = [];
-  let nr = 0;
-  function push(line) {
-    out.push(`<div class=jeTextLine><span class=jeLineNumber>${nr}</span><span class=jeLineContent>${line}</span></div>`);
-  }
   for(let line of jeGetEditorContent().split('\n')) {
-    ++nr;
     let foundMatch = false;
     for(const l of langObj) {
       const match = line.match(l[0]);
       if(match) {
         if(jeMode == 'widget' && match[1] == '  "' && l[2] == 'key' && (l[4] == "null" && match[4] == "null" || String(jeWidget.defaults[match[2]]) == match[4])) {
-          push(`<i class=default>${html(line)}</i>`);
+          out.push(`<i class=default>${html(line)}</i>`);
           foundMatch = true;
           break;
         }
@@ -1836,16 +1831,18 @@ function jeColorize() {
             match[i] = html(match[i]);
         }
 
-        push(match.slice(1).join(''));
+        let newLine = match.slice(1).join('');
+
+        out.push(newLine);
         foundMatch = true;
 
         break;
       }
     }
     if(!foundMatch)
-      push(html(line));
+      out.push(html(line));
   }
-  $('#jeTextHighlight').innerHTML = out.join('');
+  $('#jeTextHighlight').innerHTML = out.join('\n');
 }
 
 /* Displaying and controlling tree subpane of edit area */


### PR DESCRIPTION
Fixes #2222 and #2187. Changing `type` or `id` should now always keep the selection and tree updated. The same should be true for changing multi-selection using the `widget` section in the JSON editor (including using regular expressions).

It is really nice that manipulating multi-selection is so much faster after #2211. Should make it a lot more useful.