### PR TITLE
PL Egyptian Epochs: Reset pass markers when End Turn pressed

### DIFF
--- a/library/games/Egyptian Epochs/0.json
+++ b/library/games/Egyptian Epochs/0.json
@@ -4055,6 +4055,17 @@
     "clickRoutine": [
       {
         "func": "TURN"
+      },
+      {
+        "func": "FLIP",
+        "collection": [
+          "pass-marker-p1",
+          "pass-marker-p2",
+          "pass-marker-p3",
+          "pass-marker-p4",
+          "pass-marker-p5"
+        ],
+        "face": 0
       }
     ]
   },

--- a/library/games/Egyptian Epochs/1.json
+++ b/library/games/Egyptian Epochs/1.json
@@ -3918,6 +3918,17 @@
     "clickRoutine": [
       {
         "func": "TURN"
+      },
+      {
+        "func": "FLIP",
+        "collection": [
+          "pass-marker-p1",
+          "pass-marker-p2",
+          "pass-marker-p3",
+          "pass-marker-p4",
+          "pass-marker-p5"
+        ],
+        "face": 0
       }
     ]
   },

--- a/library/games/Egyptian Epochs/2.json
+++ b/library/games/Egyptian Epochs/2.json
@@ -3395,6 +3395,17 @@
     "clickRoutine": [
       {
         "func": "TURN"
+      },
+      {
+        "func": "FLIP",
+        "collection": [
+          "pass-marker-p1",
+          "pass-marker-p2",
+          "pass-marker-p3",
+          "pass-marker-p4",
+          "pass-marker-p5"
+        ],
+        "face": 0
       }
     ]
   },


### PR DESCRIPTION
Reset the new pass markers added in #2231 so that they reset to the blank side when the End Turn button is clicked, as well as when the Win buttons are used.