### PR TITLE
fixed a few crashes when properties have unexpected types

### DIFF
--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1225,7 +1225,7 @@ class PropertiesModule extends SidebarModule {
 
       const cardClone = new Card();
       const newState = {...card.state};
-      newState.activeFace = deck.get('faceTemplates').length>1?1:0;
+      newState.activeFace = card.getFaceCount()>1?1:0;
       newState.cardType = cardType;
       cardClone.renderReadonlyCopyRaw(newState, $('.renderedWidget', cardTypeDiv));
 
@@ -1357,6 +1357,8 @@ class PropertiesModule extends SidebarModule {
 
   renderForDice(widget) {
     this.addHeader(`Dice ${widget.id}`);
+    const widgetFaces = widget.get('faces');
+    const faceCount = Array.isArray(widgetFaces) ? widgetFaces.length : 0;
 
     this.addSubHeader('Dice types');
     const faces = [
@@ -1380,7 +1382,7 @@ class PropertiesModule extends SidebarModule {
       }, this.moduleDOM);
 
       this.addPropertyListener(widget, 'faces', widget => {
-        if (JSON.stringify(widget.get('faces')) === JSON.stringify(f)) {
+        if (JSON.stringify(widgetFaces) === JSON.stringify(f)) {
           dice.classList.add('selected');
         } else {
           dice.classList.remove('selected');
@@ -1399,8 +1401,8 @@ class PropertiesModule extends SidebarModule {
     for (const s of shape) {
       const diceShape = this.renderWidgetButton(new Dice(), {
         type: 'dice',
-        faces: widget.get('faces'),
-        activeFace: widget.get('faces').length - 1,
+        faces: widgetFaces,
+        activeFace: faceCount - 1,
         shape3d: s,
         pipSymbols: widget.get('pipSymbols')
       }, this.moduleDOM);
@@ -1426,8 +1428,8 @@ class PropertiesModule extends SidebarModule {
     for (const p of pipType) {
       const dicePip = this.renderWidgetButton(new Dice(), {
         type: 'dice',
-        faces: widget.get('faces'),
-        activeFace: widget.get('faces').length - 1,
+        faces: widgetFaces,
+        activeFace: faceCount - 1,
         shape3d: widget.get('shape3d'),
         pipSymbols: p
       }, this.moduleDOM);
@@ -1615,12 +1617,13 @@ class PropertiesModule extends SidebarModule {
 
     if(widget.get('type') == 'deck') {
       const parent = new BasicWidget().renderReadonlyCopyRaw({}, button).domElement;
+      const faceTemplates = widget.get('faceTemplates');
       widgets.set(widget.id, widget);
       for(const cardType of shuffleArray(Object.keys(widget.get('cardTypes'))).slice(0, 5)) {
         new Card().renderReadonlyCopyRaw(Object.assign({
           deck: widget.id,
           cardType,
-          activeFace: widget.get('faceTemplates').length > 1 ? 1 : 0
+          activeFace: Array.isArray(faceTemplates) && faceTemplates.length > 1 ? 1 : 0
         }, state), parent);
       }
       widgets.delete(widget.id, widget);

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1798,7 +1798,7 @@ function jeMultiSelectedWidgets() {
     const isProperty = search.match(/^([a-zA-Z0-9_-]+):(.*)$/);
     selected = selected.concat(widgetFilter(function(w) {
       try {
-        if(isRegex && w.get('id').match(new RegExp(isRegex[1], isRegex[2])))
+        if(isRegex && String(w.get('id')).match(new RegExp(isRegex[1], isRegex[2])))
           return true;
         if(isProperty) {
           const value = String(w.get(isProperty[1])).toLowerCase();
@@ -1858,7 +1858,7 @@ function jeUpdateMulti() {
 }
 
 function html(string) {
-  return string.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  return String(string).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
 function jeColorize() {
@@ -1968,7 +1968,7 @@ function jeDisplayTreeAddWidgets(allWidgets, parent, selectedIDs) {
   }
   let result = '';
 
-  for(const widget of (allWidgets.filter(w=>w.get('parent')==parent)).sort((w1,w2)=>w1.get('id').localeCompare(w2.get('id'), 'en', {numeric: true, ignorePunctuation: true}))) {
+  for(const widget of (allWidgets.filter(w=>w.get('parent')==parent)).sort((w1,w2)=>String(w1.get('id')).localeCompare(w2.get('id'), 'en', {numeric: true, ignorePunctuation: true}))) {
     const children = jeDisplayTreeAddWidgets(allWidgets, widget.get('id'), selectedIDs);
     const isSelected = selectedIDs.indexOf(widget.get('id')) != -1 ? 'jeHighlightRow' : '';
     const filter = html(widget.get('id')+(widget.get('type')||'basic')+(widget.get('cardType')||'')).toLowerCase();
@@ -1999,11 +1999,11 @@ function jeTreeGetWidgetHTML(widget) {
   const type = widget.get('type');
 
   let result = `${colored(widget.get('id'), 'key')} (${colored(type || 'basic','string')} - `;
-  if(widget.get('id').match(/^[0-9a-z]{4}$/) && $('#jsonEditor').classList.contains('wide')) {
-    if(type == 'card' && !widget.get('cardType').match(/^type-[0-9a-f-]{36}$/))
+  if(String(widget.get('id')).match(/^[0-9a-z]{4}$/) && $('#jsonEditor').classList.contains('wide')) {
+    if(type == 'card' && !String(widget.get('cardType')).match(/^type-[0-9a-f-]{36}$/))
       result += `${colored(widget.get('cardType'),'extern')} - `;
     if(type == 'button' && widget.get('text'))
-      result += `${colored(widget.get('text').replaceAll('\n', '\\n'),'extern')} - `;
+      result += `${colored(String(widget.get('text')).replaceAll('\n', '\\n'),'extern')} - `;
     if(type == null && widget.get('classes'))
       result += `${colored(widget.get('classes'),'extern')} - `;
   }

--- a/client/js/widgets/canvas.js
+++ b/client/js/widgets/canvas.js
@@ -35,7 +35,7 @@ class Canvas extends Widget {
         this.canvas.height = this.getResolution();
       }
 
-      const colors = this.get('colorMap');
+      const colors = this.getColorMap();
       const regionRes = Math.floor(this.getResolution()/10);
 
       for(let x=0; x<10; ++x) {
@@ -99,6 +99,13 @@ class Canvas extends Widget {
       n = Math.floor((n - c) / base);
     }
     return code;
+  }
+
+  getColorMap() {
+    if(Array.isArray(this.get('colorMap')))
+      return this.get('colorMap');
+    else
+      return Canvas.defaultColors;
   }
 
   getResolution() {

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -28,7 +28,8 @@ class Card extends Widget {
       if(delta.deck) {
         this.deck = widgets.get(delta.deck);
         this.deck.addCard(this);
-        this.createFaces(this.deck.get('faceTemplates'));
+        const faceTemplates = this.deck.get('faceTemplates');
+        this.createFaces(Array.isArray(faceTemplates) ? faceTemplates : []);
       } else {
         this.deck = null;
       }
@@ -227,6 +228,10 @@ class Card extends Widget {
   }
 
   getFaceCount() {
-    return this.deck.get('faceTemplates').length;
+    const faceTemplates = this.deck.get('faceTemplates');
+    if(Array.isArray(faceTemplates))
+      return faceTemplates.length;
+    else
+      return 0;
   }
 }

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -55,17 +55,18 @@ class Pile extends Widget {
     }
 
     const threshold = this.get('handleOffset')+5;
+    const handlePosition = String(this.get('handlePosition'));
     for(const e of [ [ 'x', 'right', 1600-this.get('width'), 'center' ], [ 'y', 'bottom', 1000-this.get('height'), 'middle' ] ]) {
       if(this.handle && (delta[e[0]] !== undefined || delta.parent !== undefined || delta.handlePosition !== undefined || delta.handleOffset !== undefined)) {
-        if(this.get('handlePosition') == 'static') {
+        if(handlePosition == 'static') {
           this.handle.classList.remove(e[1]);
           this.handle.classList.remove(e[3]);
-        } else if(this.get('handlePosition').match(e[3])) {
+        } else if(handlePosition.match(e[3])) {
           this.handle.classList.remove(e[1]);
           this.handle.classList.add(e[3]);
         } else {
           this.handle.classList.remove(e[3]);
-          const isRightOrBottom = this.get('handlePosition').match(e[1]);
+          const isRightOrBottom = handlePosition.match(e[1]);
           if(isRightOrBottom && this.absoluteCoord(e[0]) < e[2]-threshold || !isRightOrBottom && this.absoluteCoord(e[0]) < threshold)
             this.handle.classList.add(e[1]);
           else

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2688,15 +2688,15 @@ export class Widget extends StateManaged {
   }
 
   async snapToGrid() {
-    const grid = this.get('grid');
-    if(Array.isArray(grid) && grid.length) {
+    const gridArray = this.get('grid');
+    if(Array.isArray(gridArray) && gridArray.length) {
       const x = this.get('x');
       const y = this.get('y');
 
       let closest = null;
       let closestDistance = 999999;
 
-      for(const grid of grid) {
+      for(const grid of gridArray) {
         if(!grid)
           continue;
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -387,9 +387,10 @@ export class Widget extends StateManaged {
   classes(includeTemporary = true) {
     let className = this.get('typeClasses') + ' ' + this.get('classes');
 
-    if(Array.isArray(this.get('owner')) && this.get('owner').indexOf(playerName) == -1)
+    const owner = this.get('owner');
+    if(Array.isArray(owner) && owner.indexOf(playerName) == -1)
       className += ' foreign';
-    if(typeof this.get('owner') == 'string' && this.get('owner') != playerName)
+    if(typeof owner == 'string' && owner != playerName)
       className += ' foreign';
 
     let onlyVisibleForSeat = this.get('onlyVisibleForSeat');
@@ -1044,6 +1045,7 @@ export class Widget extends StateManaged {
         }
 
         const execute = async function(widget) {
+          const cm = widget.getColorMap();
           if(widget.get('type') == 'canvas') {
             if(a.mode == 'setPixel') {
               const res = widget.getResolution();
@@ -1053,19 +1055,18 @@ export class Widget extends StateManaged {
                 problems.push(`Pixel coordinate: (${a.x}, ${a.y}) out of range for resolution: ${res}.`);
               }
             } else if(a.mode == 'set')
-              await widget.set('activeColor', a.value % widget.get('colorMap').length);
+              await widget.set('activeColor', a.value % cm.length);
             else if(a.mode == 'reset')
               await widget.reset();
             else if(a.mode == 'dec')
-              await widget.set('activeColor', (widget.get('activeColor')+widget.get('colorMap').length - (a.value % widget.get('colorMap').length)) % widget.get('colorMap').length);
+              await widget.set('activeColor', (widget.get('activeColor')+cm.length - (a.value % cm.length)) % cm.length);
             else if(a.mode == 'change') {
-              var CM = widget.get('colorMap');
-              var index = ((a.value || 1) % CM.length) || 0;
-              CM[index] = a.color || '#1f5ca6' ;
-              await widget.set('colorMap', CM);
+              const index = ((a.value || 1) % cm.length) || 0;
+              cm[index] = a.color || '#1f5ca6' ;
+              await widget.set('colorMap', cm);
             }
             else
-              await widget.set('activeColor', (widget.get('activeColor')+ a.value) % widget.get('colorMap').length);
+              await widget.set('activeColor', (widget.get('activeColor')+ a.value) % cm.length);
           } else
             problems.push(`Widget ${widget.get('id')} is not a canvas.`);
         };
@@ -2503,7 +2504,7 @@ export class Widget extends StateManaged {
     if (this.get('text') !== undefined) {
       if(mode == 'inc' || mode == 'dec') {
         let newText = (parseFloat(this.get('text')) || 0) + (mode == 'dec' ? -1 : 1) * text;
-        const decimalPlacesOld = this.get('text').toString().match(/\..*$/);
+        const decimalPlacesOld = String(this.get('text')).match(/\..*$/);
         const decimalPlacesChange = (+text).toString().match(/\..*$/);
         const decimalPlaces = Math.max(decimalPlacesOld ? decimalPlacesOld[0].length-1 : 0, decimalPlacesChange ? decimalPlacesChange[0].length-1 : 0);
         const factor = 10**decimalPlaces;
@@ -2687,14 +2688,18 @@ export class Widget extends StateManaged {
   }
 
   async snapToGrid() {
-    if(this.get('grid').length) {
+    const grid = this.get('grid');
+    if(Array.isArray(grid) && grid.length) {
       const x = this.get('x');
       const y = this.get('y');
 
       let closest = null;
       let closestDistance = 999999;
 
-      for(const grid of this.get('grid')) {
+      for(const grid of grid) {
+        if(!grid)
+          continue;
+
         const alignX = (grid.alignX || 0) * this.get('width');
         const alignY = (grid.alignY || 0) * this.get('height');
 


### PR DESCRIPTION
While testing #1538, we noticed that using an actual number as an `id` leads to crashes.

I searched for occurences of `widget.get(property).function` in the code to see where we are having similar issues. Because `widget.get(property)` can basically always return something that does not know `function`.

This PR fixes a couple of obvious places but there are probably still plenty more. It is already hard enough to review and test the scope as it is.

There are still plenty of crashes for widgets with actual numbers as their `id`. But now I know that the only real solution is to enforce strings for `id`. I will do that in a separate PR though.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2312/pr-test (or any other room on that server)