### PR TITLE
enforce `id` to be a string

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -2080,6 +2080,8 @@ function jeGetContext() {
 
     if(!jeStateNow.id)
       jeJSONerror = 'No ID given.';
+    else if(typeof jeStateNow.id != 'string')
+      jeJSONerror = 'ID has to be a string.';
     else if(JSON.parse(jeStateBefore).id != jeStateNow.id && widgets.has(jeStateNow.id))
       jeJSONerror = `ID ${jeStateNow.id} is already in use.`;
     else if(jeStateNow.parent !== undefined && jeStateNow.parent !== null && !widgets.has(jeStateNow.parent))

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -108,6 +108,8 @@ export function addWidget(widget, instance) {
 async function addWidgetLocal(widget) {
   if (!widget.id)
     widget.id = generateUniqueWidgetID();
+  else
+    widget.id = String(widget.id);
 
   if(widget.parent && !widgets.has(widget.parent)) {
     console.error(`Refusing to add widget ${widget.id} with invalid parent ${widget.parent}.`);

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1737,12 +1737,14 @@ export class Widget extends StateManaged {
               let newState = JSON.parse(JSON.stringify(oldWidget.state));
               newState.id = await compute(a.relation, null, oldWidget.get(a.property), a.value);
 
-              if(!widgets.has(newState.id)) {
+              if(widgets.has(newState.id)) {
+                problems.push(`id ${newState.id} already in use, ignored.`);
+              } else if(typeof newState.id != 'string' || newState.id.length == 0) {
+                problems.push(`id ${newState.id} is not a string or empty, ignored.`);
+              } else {
                 await updateWidgetId(newState, oldID);
                 for(const c in collections)
                   collections[c] = collections[c].map(w=>w.id==oldID ? widgets.get(newState.id) : w);
-              } else {
-                problems.push(`id ${newState.id} already in use, ignored.`);
               }
             }
           } else {


### PR DESCRIPTION
It currently just crashes if it is anything else and it really is not worth it to allow it.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2313/pr-test (or any other room on that server)