### PR TITLE
also update `dropTarget` when a widget `id` changes

### DIFF
--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -169,6 +169,20 @@ async function updateWidgetId(widget, oldID) {
     await inheritor.set('inheritFrom', newInherits)
   };
 
+  // Change dropTargets that specifially target the old ID
+  for(const [ _, t ] of dropTargets) {
+    const originalDropTarget = JSON.stringify(t.get('dropTarget'));
+    const dropTarget = JSON.parse(originalDropTarget);
+    if(dropTarget.id == oldID)
+      dropTarget.id = id;
+    if(Array.isArray(dropTarget))
+      for(const d of dropTarget)
+        if(d.id == oldID)
+          d.id = id;
+    if(originalDropTarget != JSON.stringify(dropTarget))
+      await t.set('dropTarget', dropTarget);
+  }
+
   // Update references in routines
   const updateParam = function(a, func, param) {
     if(a.func == func && Array.isArray(a[param])) {

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -173,11 +173,11 @@ async function updateWidgetId(widget, oldID) {
   for(const [ _, t ] of dropTargets) {
     const originalDropTarget = JSON.stringify(t.get('dropTarget'));
     const dropTarget = JSON.parse(originalDropTarget);
-    if(dropTarget.id == oldID)
+    if(dropTarget && dropTarget.id == oldID)
       dropTarget.id = id;
     if(Array.isArray(dropTarget))
       for(const d of dropTarget)
-        if(d.id == oldID)
+        if(d && d.id == oldID)
           d.id = id;
     if(originalDropTarget != JSON.stringify(dropTarget))
       await t.set('dropTarget', dropTarget);


### PR DESCRIPTION
Fixes #2315. Was missing from #1538.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2316/pr-test (or any other room on that server)