### PR TITLE
fixed default `count` for `MOVE`

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1450,7 +1450,7 @@ export class Widget extends StateManaged {
       }
 
       if(a.func == 'MOVE') {
-        setDefaults(a, { count: a.from ? 1 : 0, face: null, fillTo: null, collection: 'DEFAULT' });
+        setDefaults(a, { count: a.from ? 1 : 'all', face: null, fillTo: null, collection: 'DEFAULT' });
         let count = a.fillTo || a.count;
         if(count === 'all')
           count = 999999;


### PR DESCRIPTION
I have no idea how this happened with #1466 but the default for `MOVE` is currently to not move anything if it uses a `collection`.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2321/pr-test (or any other room on that server)