### PR TITLE
fixed crash when opening deck properties

### DIFF
--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1196,6 +1196,7 @@ class PropertiesModule extends SidebarModule {
   renderCardTypes(deck, onlyCardType=null) {
     const card = new Card();
     card.state.deck = deck.id;
+    card.deck = deck;
     const cardTypes = this.cardTypes = JSON.parse(JSON.stringify(deck.get('cardTypes')));
 
     this.cardTypeCards = [];


### PR DESCRIPTION
The widgets in the visualizations in the Properties sidebar are not quite complete widgets. Apparently they need one hack more now. :)

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2325/pr-test (or any other room on that server)