### PR TITLE
fixed cursor check client crash on touch devices

### DIFF
--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -134,7 +134,7 @@ async function inputHandler(name, e) {
   clientPointer.style.top = `${coords.clientY}px`;
   clientPointer.style.left = `${coords.clientX}px`;
 
-  let hoveredWidgetsWithHiddenCursor = document.elementsFromPoint(e.clientX, e.clientY).map(el => widgets.get(unescapeID(el.id.slice(2)))).filter(w => w != null && w.requiresHiddenCursor());
+  let hoveredWidgetsWithHiddenCursor = document.elementsFromPoint(coords.clientX, coords.clientY).map(el => widgets.get(unescapeID(el.id.slice(2)))).filter(w => w != null && w.requiresHiddenCursor());
 
   if(hoveredWidgetsWithHiddenCursor.length) {
     toServer('mouse', { hidden: true });


### PR DESCRIPTION
#2113 used a wrong variable that is not defined for touch events. Apparently this problem does not surface by breaking anything else. #2329 made it visible. This should fix it.

Hopefully the production server can get back to the latest version in `main` with this.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2337/pr-test (or any other room on that server)