### PR TITLE
revised editor layout

### DIFF
--- a/client/css/editor/sidebar.css
+++ b/client/css/editor/sidebar.css
@@ -3,22 +3,26 @@
 }
 
 #editorSidebar {
-  background: var(--VTTblue);
   position: absolute;
-  width: var(--editSidebarWidth);
+  width: calc(var(--modulesWidth));
   right: 0;
-  top: calc(var(--editToolbarHeight) - 1px);
+  top: 0;
   bottom: 0;
-  z-index: 2;
+  z-index: 3;
   display: flex;
   flex-direction: column;
 }
 
-#editorSidebar button span {
+.sidebarButtons {
+  background: var(--VTTblue);
+}
+
+.sidebarButtons button span {
   display: none;
   position: absolute;
-  right: calc(var(--editSidebarWidth) + 1px);
+  right: calc(var(--sidebarButtonsWidth) + 1px);
   background: var(--VTTblueDark);
+  top: 40px;
   margin: 0;
   padding: 9px;
   border-radius: 5px;
@@ -26,51 +30,71 @@
   width: 200px;
 }
 
-#editorSidebar button:hover span {
+.sidebarButtons button {
+  display: inline-flex;
+}
+
+.sidebarButtons button:hover span {
   display: block;
 }
 
-#editorSidebar button.active {
+.sidebarButtons button.active {
   position: relative;
-  left: -2px;
-  border-radius: 0 5px 5px 0;
+  bottom: -2px;
+  border-radius: 5px 5px 0 0;
   background: var(--backgroundColor);
   color: var(--VTTblue);
 }
-body.edit.darkMode #editorSidebar button.active {
+body.edit.darkMode .sidebarButtons button.active {
   color: var(--textColor);
 }
 
-#editorSidebar button.active::before {
+.sidebarButtons button.active::before {
   position: relative;
   left: 2px;
 }
 
-#editorSidebar button.active span {
+.sidebarButtons button.active span {
   color: white;
   right: calc(var(--editSidebarWidth) - 2px);
 }
 
-#editorModules {
-  display: none;
-  position: absolute;
-  right: var(--editSidebarWidth);
-  top: var(--editToolbarHeight);
-  bottom: 0;
-  min-width: 250px;
-  max-width: 90vw;
-  width: calc(var(--modulesWidth) - var(--editSidebarWidth));
+.editorModule {
+  position: relative;
+  right: 0;
   z-index: 1;
   box-sizing: border-box;
   padding: 10px;
   background: var(--backgroundColor);
-  grid-template-columns: 2fr 1fr;
-  grid-template-rows: 2fr 1fr;
-  grid-gap: 10px;
+  overflow: auto;
+  color: var(--textColor);
+  background-color: var(--backgroundColor);
 }
 
-#editorModules ::-webkit-scrollbar-track {
+.editorModule ::-webkit-scrollbar-track {
   background: var(--backgroundColor);
+}
+
+#editorEditSidebar {
+  top: 0;
+}
+
+#editorAuxiliarySidebar {
+  bottom: 0;
+}
+
+#editorEditModule {
+  flex-grow: 1;
+}
+
+#editorAuxiliaryModule {
+  height: 33%;
+  flex-shrink: 0;
+  border-top: 2px solid var(--VTTblue);
+}
+
+#editorAuxiliaryModule:not(.active) {
+  display: none;
 }
 
 #editorModulesResizer {
@@ -78,6 +102,7 @@ body.edit.darkMode #editorSidebar button.active {
   height: 100%;
   width: 5px;
   cursor: ew-resize;
+  z-index: 5;
 }
 body.editorModulesResizing {
   cursor: ew-resize !important;
@@ -86,116 +111,6 @@ body.editorModulesResizing {
 
 #editorModules.active {
   display: grid;
-}
-
-#editor.hasTopLeft #editorModules.active {
-  grid-template-areas:
-    "topleft topleft"
-    "topleft topleft";
-}
-
-#editor.hasTopRight #editorModules.active {
-  grid-template-areas:
-    "topright topright"
-    "topright topright";
-}
-
-#editor.hasBottomLeft #editorModules.active {
-  grid-template-areas:
-    "bottomleft bottomleft"
-    "bottomleft bottomleft";
-}
-
-#editor.hasBottomRight #editorModules.active {
-  grid-template-areas:
-    "bottomright bottomright"
-    "bottomright bottomright";
-}
-
-#editor.hasTopLeft.hasBottomLeft #editorModules.active {
-  grid-template-areas:
-    "topleft topleft"
-    "bottomleft bottomleft";
-}
-
-#editor.hasTopRight.hasBottomRight #editorModules.active {
-  grid-template-areas:
-    "topright topright"
-    "bottomright bottomright";
-}
-
-#editor.hasTopRight.hasTopLeft #editorModules.active {
-  grid-template-areas:
-    "topleft topright"
-    "topleft topright";
-}
-
-#editor.hasBottomRight.hasBottomLeft #editorModules.active {
-  grid-template-areas:
-    "bottomleft bottomright"
-    "bottomleft bottomright";
-}
-
-#editor.hasTopRight.hasBottomLeft #editorModules.active {
-  grid-template-areas:
-    "topright topright"
-    "bottomleft bottomleft";
-}
-
-#editor.hasTopLeft.hasBottomRight #editorModules.active {
-  grid-template-areas:
-    "topleft topleft"
-    "bottomright bottomright";
-}
-
-#editor.hasTopRight.hasBottomLeft.hasBottomRight #editorModules.active {
-  grid-template-areas:
-    "topright topright"
-    "bottomleft bottomright";
-}
-
-#editor.hasTopLeft.hasBottomLeft.hasBottomRight #editorModules.active {
-  grid-template-areas:
-    "topleft topleft"
-    "bottomleft bottomright";
-}
-
-#editor.hasTopLeft.hasTopRight.hasBottomRight #editorModules.active {
-  grid-template-areas:
-    "topleft topright"
-    "bottomright bottomright";
-}
-
-#editor.hasTopLeft.hasTopRight.hasBottomLeft #editorModules.active {
-  grid-template-areas:
-    "topleft topright"
-    "bottomleft bottomleft";
-}
-
-#editor.hasTopLeft.hasTopRight.hasBottomLeft.hasBottomRight #editorModules.active {
-  grid-template-areas:
-    "topleft topright"
-    "bottomleft bottomright";
-}
-
-.editorModule {
-  display: none;
-  position: relative;
-  overflow: auto;
-  color: var(--textColor);
-  background-color: var(--backgroundColor);
-}
-
-#editorModuleOverlay {
-  background-color: var(--backgroundColor);
-}
-
-#editorModuleInOverlay {
-  position: absolute;
-  left: 10px;
-  right: 10px;
-  top: 10px;
-  bottom: 10px;
 }
 
 .editorModule .widget {
@@ -220,20 +135,6 @@ body.draggingEditorSidebarModule .editorModule {
 
 body.draggingEditorSidebarModule .editorModule.dragHighlight {
   border: 2px red solid;
-}
-
-
-#editorModuleTopLeft {
-  grid-area: topleft;
-}
-#editorModuleTopRight {
-  grid-area: topright;
-}
-#editorModuleBottomLeft {
-  grid-area: bottomleft;
-}
-#editorModuleBottomRight {
-  grid-area: bottomright;
 }
 
 .active.editorModule {

--- a/client/css/editor/toolbar.css
+++ b/client/css/editor/toolbar.css
@@ -5,7 +5,7 @@
 #editorToolbar, #editorDragToolbar {
   position: absolute;
   background: var(--VTTblue);
-  z-index: 3;
+  z-index: 2;
 }
 
 #editorToolbar {

--- a/client/editor.html
+++ b/client/editor.html
@@ -136,22 +136,18 @@
       <button class="ui-button" id="addBasicWidget">Add Basic Widget</button>
     </div>
   </div>
-  <div id="editorModuleOverlay" class="overlay" style="display: none">
-    <div id="editorModuleInOverlay" class="editorModule"></div>
-  </div>
 </div>
 
 <div id="editor">
   <div id="editorSelection"></div>
   <div id="editorToolbar"></div>
   <div id="editorDragToolbar"><div id="editorDragToolbarFeedback"></div></div>
-  <div id="editorSidebar"></div>
-  <div id="editorModules">
+  <div id="editorSidebar">
+    <div id="editorEditSidebar" class="sidebarButtons"></div>
+    <div id="editorEditModule" class="editorModule"></div>
+    <div id="editorAuxiliaryModule" class="editorModule"></div>
+    <div id="editorAuxiliarySidebar" class="sidebarButtons"></div>
     <div id="editorModulesResizer"></div>
-    <div id="editorModuleTopLeft" class="editorModule"></div>
-    <div id="editorModuleTopRight" class="editorModule"></div>
-    <div id="editorModuleBottomLeft" class="editorModule"></div>
-    <div id="editorModuleBottomRight" class="editorModule"></div>
   </div>
 </div>
 

--- a/client/js/editor/layout.js
+++ b/client/js/editor/layout.js
@@ -1,5 +1,7 @@
 let toolbarButtons = null;
 let dragToolbarButtons = null;
+let editSidebarModules = null;
+let auxiliarySidebarModules = null;
 let sidebarModules = null;
 
 let fullToolbarWidth = 0;
@@ -63,15 +65,20 @@ function initializeEditor(currentMetaData) {
     new MoveDragButton()
   ]);
 
-  renderSidebar(sidebarModules = [
+  renderSidebar(editSidebarModules = [
     new PropertiesModule(),
-    new UndoModule(),
     new JsonModule(),
+    new AssetsModule()
+  ], 'Edit');
+
+  renderSidebar(auxiliarySidebarModules = [
+    new UndoModule(),
     new TreeModule(),
     new DebugModule(),
-    new AssetsModule(),
     new ToolboxModule()
-  ]);
+  ], 'Auxiliary');
+
+  sidebarModules = [ ...editSidebarModules, ...auxiliarySidebarModules ];
 
   onMessage('meta', metaReceived);
   metaReceived(currentMetaData);
@@ -80,7 +87,7 @@ function initializeEditor(currentMetaData) {
 }
 
 function metaReceived(data) {
-  for(const module of sidebarModules)
+  for(const module of editSidebarModules)
     module.onMetaReceived(data);
   for(const button of toolbarButtons)
     button.onMetaReceived(data);
@@ -88,7 +95,7 @@ function metaReceived(data) {
 
 export function openEditor() {
   setJEroutineLogging(jeRoutineLogging = true);
-  for(const module of sidebarModules)
+  for(const module of editSidebarModules)
     module.onEditorOpen();
   for(const button of toolbarButtons)
     button.onEditorOpen();
@@ -97,7 +104,7 @@ export function openEditor() {
 function closeEditor() {
   setJEroutineLogging(jeRoutineLogging = false);
 
-  for(const module of sidebarModules)
+  for(const module of editSidebarModules)
     module.onEditorClose();
   for(const button of toolbarButtons)
     button.onEditorClose();
@@ -116,12 +123,12 @@ function renderDragToolbar(buttons) {
     button.render($('#editorDragToolbar'));
 }
 
-function renderSidebar(modules) {
+function renderSidebar(modules, className) {
   const state = JSON.parse(localStorage.getItem('editorState') || '{"modules":{}}').modules;
   for(const module of modules) {
-    module.renderButton($('#editorSidebar'));
-    if(state[module.title] && state[module.title] != 'editorModuleInOverlay' && $(`#${state[module.title]}`))
-      module.openInTarget($(`#${state[module.title]}`));
+    module.renderButton($(`#editor${className}Sidebar`));
+    if(state[module.title] && state[module.title] != 'editorModuleInOverlay' && $(`#editor${className}Module`))
+      module.openInTarget($(`#editor${className}Module`));
   }
 
   editorModulesResizer();
@@ -133,11 +140,11 @@ function editorModulesResizer() {
   let mouseReference;
   let resizerReference;
   let percentage = editorState.modulesWidth || 50;
-  $('#editorModules').style.setProperty('--modulesWidth', percentage + '%');
+  $('#editorSidebar').style.setProperty('--modulesWidth', percentage + '%');
 
   function resize(e) {
     percentage = (1 - e.x / window.innerWidth) * 100;
-    $('#editorModules').style.setProperty('--modulesWidth', percentage + '%');
+    $('#editorSidebar').style.setProperty('--modulesWidth', percentage + '%');
     setScale();
   }
 
@@ -169,7 +176,7 @@ function hint(html) {
 export function getAvailableRoomRectangle() {
   return {
     top: window.innerWidth/window.innerHeight > 1 || window.innerWidth < 700 ? $('#editorToolbar').getBoundingClientRect().bottom : window.innerHeight/2,
-    right: (window.innerWidth/window.innerHeight > 1 && ($('#editor.moduleActive') || $('body.draggingEditorSidebarModule')) ? $('#editorModules') : $('#editorSidebar')).offsetLeft,
+    right: (window.innerWidth/window.innerHeight > 1 && ($('#editor.moduleActive') || $('body.draggingEditorSidebarModule')) ? $('#editorSidebar') : $('#editorSidebar')).offsetLeft,
     left: 0,
     bottom: window.innerHeight
   };

--- a/client/js/editor/sidebarModule.js
+++ b/client/js/editor/sidebarModule.js
@@ -18,14 +18,7 @@ class SidebarModule {
   }
 
   click(e) {
-    let target = e.ctrlKey ? $('#editorModuleBottomLeft') : $('#editorModuleTopLeft');
-    if(e.button == 2)
-      target = e.ctrlKey ? $('#editorModuleBottomRight') : $('#editorModuleTopRight');
-
-    if(e.shiftKey)
-      target = $('#editorModuleInOverlay');
-
-    this.openInTarget(target);
+    this.openInTarget(this.buttonDOM.parentElement.id == 'editorEditSidebar' ? $('#editorEditModule') : $('#editorAuxiliaryModule'));
     e.preventDefault();
   }
 
@@ -126,7 +119,7 @@ class SidebarModule {
       this.saveToLocalStorage(null);
     } else {
       if(target.dataset.currentlyLoaded && target.dataset.currentlyLoaded != this.icon)
-        $(`#editorSidebar button.active[icon="${target.dataset.currentlyLoaded}"]`).click();
+        $(`.sidebarButtons button.active[icon="${target.dataset.currentlyLoaded}"]`).click();
 
       this.moduleDOM = target;
       this.moduleDOM.dataset.currentlyLoaded = this.icon;

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -410,8 +410,8 @@ window.addEventListener('keydown', async function(e) {
     } else {
       await loadEditMode();
       $('#editButton').click();
-      if(!$('#editorSidebar button[icon=data_object].active'))
-        $('#editorSidebar button[icon=data_object]').click();
+      if(!$('#editorEditSidebar button[icon=data_object].active'))
+        $('#editorEditSidebar button[icon=data_object]').click();
     }
   }
 });
@@ -598,8 +598,8 @@ window.onresize = function(event) {
 
 window.onkeyup = function(event) {
   if(event.key == 'Escape') {
-    if($('body.edit #editorSidebar button.active'))
-      $('#editorSidebar button.active').click();
+    if($('body.edit #editorEditSidebar button.active'))
+      $('#editorEditSidebar button.active').click();
     else if(edit)
       $('#editorToolbar button[icon=close]').click();
     else if(overlayActive && $('#buttonInputOverlay').style.display == 'none')


### PR DESCRIPTION
I have been meaning to try this for a while. This is based on a quick feeback drawing @mousewax did in February 2023 (see below). The idea is to make it easier to find buttons. As of writing this, I only moved the sidebar buttons to the top and bottom of the sidebar and they control a top region and a bottom region.

The idea is to move History into the Undo button in the toolbar and to incorporate the tree into a new Jump To Widget thingy at the top including ways to open the parent, the deck and a few previously opened widgets to quickly jump between them (and remember the cursor position in each one).