### PR TITLE
fixed crash when dragging widget off screen

### DIFF
--- a/client/js/editor/selection.js
+++ b/client/js/editor/selection.js
@@ -20,7 +20,7 @@ export function editInputHandler(name, e) {
       }, 0);
     }
   }
-  if((selectionModeActive == isRightMouseButton || isOverlayActive()) && e.target.parentNode.id != 'editorDragToolbar' && !draggingDragButton)
+  if((selectionModeActive == isRightMouseButton || isOverlayActive()) && (!e.target.parentNode || e.target.parentNode.id != 'editorDragToolbar') && !draggingDragButton)
     return;
 
   const coords = eventCoords(name, e);


### PR DESCRIPTION
When in edit mode in Firefox, the client crashes when you try to drag a widget to outside of the browser window. This PR should fix that.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2340/pr-test (or any other room on that server)