### PR TITLE
fixed editor crash for non-object `dragLimit` and `grid`

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1402,7 +1402,7 @@ function jeAddGridCommand(key, value) {
     id: 'grid_' + key,
     name: key,
     context: '^[^ ]* ↦ grid ↦ [0-9]+',
-    show: _=>!(key in jeStateNow.grid[+jeContext[2]]),
+    show: _=>typeof jeStateNow.grid[+jeContext[2]] == "object" && jeStateNow.grid[+jeContext[2]] !== null && !(key in jeStateNow.grid[+jeContext[2]]),
     call: async function() {
       jeStateNow.grid[+jeContext[2]][key] = '###SELECT ME###';
       jeSetAndSelect(value);
@@ -1410,26 +1410,13 @@ function jeAddGridCommand(key, value) {
   });
 }
 
-function jeAddHexGridCommand(key, value) {
-  jeCommands.push({
-    id: 'hexGrid_' + key,
-    name: key,
-    context: '^[^ ]* ↦ grid ↦ [0-9]+',
-    show: _=>!(key in jeStateNow.hexGrid[+jeContext[2]]),
-    call: async function() {
-      jeStateNow.hexGrid[+jeContext[2]][key] = '###SELECT ME###';
-      jeSetAndSelect(value);
-    }
-  });
-}
-    
 
 function jeAddLimitCommand(key, value) {
   jeCommands.push({
     id: 'limit_' + key,
     name: key,
     context: '^[^ ]* ↦ dragLimit',
-    show: _=>!(key in jeStateNow.dragLimit),
+    show: _=>typeof jeStateNow.dragLimit == "object" && jeStateNow.dragLimit !== null && !(key in jeStateNow.dragLimit),
     call: async function() {
       const w = widgets.get(jeStateNow.id);
       jeStateNow.dragLimit[key] = '###SELECT ME###';


### PR DESCRIPTION
The test for showing corresponding buttons assumed that the properties contain an object.