### PR TITLE
Add player count to toolbar

### DIFF
--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -391,6 +391,11 @@ body.aspectTooGood.hiddenToolbar {
       background: var(--toolbarColor);
       box-shadow: 0 0 5px #0005;
       pointer-events: none;
+      transition: color 0.3s ease;   
+    }
+
+    .tooltip.playerChange {
+      color: yellow;
     }
 
     body:not(.loading) .toolbarButton:hover .tooltip, body.wideToolbar .toolbarButton .tooltip {
@@ -854,6 +859,11 @@ button {
   border-radius: 5px;
   background-repeat: no-repeat;
   margin: 1px;
+  transition: color 0.3s ease
+}
+
+button.playerChange {
+  color: yellow
 }
 
 button:hover {

--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -394,10 +394,6 @@ body.aspectTooGood.hiddenToolbar {
       transition: color 0.3s ease;   
     }
 
-    .tooltip.playerChange {
-      color: yellow;
-    }
-
     body:not(.loading) .toolbarButton:hover .tooltip, body.wideToolbar .toolbarButton .tooltip {
       display: block;
     }
@@ -862,7 +858,7 @@ button {
   transition: color 0.3s ease
 }
 
-button.playerChange {
+button.playerChange .tooltip.playerChange {
   color: yellow
 }
 

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -79,14 +79,10 @@ function updatePlayerCountDisplay() {
   const tooltip = $('.tooltip', playersButton);
   if (tooltip) tooltip.textContent = `Players: ${playerCount}`;
 
-  [playersButton, tooltip].forEach(element => {
-      if (element) element.classList.add('playerChange');
-  });
-
+  [playersButton, tooltip].forEach(element => element.classList.add('playerChange'));
+  
   setTimeout(() => {
-      [playersButton, tooltip].forEach(element => {
-          if (element) element.classList.remove('playerChange');
-      });
+    [playersButton, tooltip].forEach(element => element.classList.remove('playerChange'));
   }, 1000);
 }
 

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -76,7 +76,7 @@ function updatePlayerCountDisplay() {
   const playersButton = $('#playersButton');
   const playerCount = activePlayers.length;
 
-  const tooltip = playersButton.querySelector('.tooltip');
+  const tooltip = $('.tooltip', playersButton);
   if (tooltip) tooltip.textContent = `Players: ${playerCount}`;
 
   [playersButton, tooltip].forEach(element => {

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -69,6 +69,25 @@ function fillPlayerList(players, active) {
   if(activePlayers.length < 2){
     document.getElementById("template-playerlist-entry").insertAdjacentHTML("afterend", "<div class='nothingtoshow'>There are no other players at this table.</div>");
   }
+  updatePlayerCountDisplay();
+}
+
+function updatePlayerCountDisplay() {
+  const playersButton = document.getElementById('playersButton');
+  const playerCount = activePlayers.length;
+
+  const tooltip = playersButton.querySelector('.tooltip');
+  if (tooltip) tooltip.textContent = `Players: ${playerCount}`;
+
+  [playersButton, tooltip].forEach(element => {
+      if (element) element.classList.add('playerChange');
+  });
+
+  setTimeout(() => {
+      [playersButton, tooltip].forEach(element => {
+          if (element) element.classList.remove('playerChange');
+      });
+  }, 1000);
 }
 
 onLoad(function() {

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -73,7 +73,7 @@ function fillPlayerList(players, active) {
 }
 
 function updatePlayerCountDisplay() {
-  const playersButton = document.getElementById('playersButton');
+  const playersButton = $('#playersButton');
   const playerCount = activePlayers.length;
 
   const tooltip = playersButton.querySelector('.tooltip');


### PR DESCRIPTION
Fixes #2373.

The toolbar Players tooltip now displays the active player count.  If the player count changes or if a player changes their name, then the icon and the tooltip turn yellow for a second and then back to white.  If the window size does not show the tooltip, then the player count is not shown but the yellow flash still happens on the icon.

The effect is subtle.  We could add a small sound to accompany the change.  Lots of apps do that.  But we don't have any other sounds and I don't want this to be annoying.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2376/pr-test (or any other room on that server)