### PR TITLE
fixed crash when renaming

### DIFF
--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -89,7 +89,7 @@ function updatePlayerCountDisplay() {
 onLoad(function() {
   onMessage('meta', args=>fillPlayerList(args.meta.players, args.activePlayers));
   onMessage('mouse', function(args) {
-    if(args.player != playerName) {
+    if(args.player != playerName && playerCursors[args.player]) {
       clearTimeout(playerCursorsTimeout[args.player]);
       playerCursors[args.player].classList.toggle('hidden', !!args.mouseState.hidden);
       if(args.mouseState.inactive) {


### PR DESCRIPTION
Fixes #2351. Looks like it is possible for a client to receive a new players mouse state before knowing about its existance. This PR makes sure that each client only tries to render cursors for known players.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2382/pr-test (or any other room on that server)