### PR TITLE
fixed crash when receiving a delta while having invalid JSON

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1601,6 +1601,23 @@ function jeApplyDelta(delta) {
         }
       }
     }
+
+    // if the JSON in the editor is invalid, and the delta contains the widget, try to update the invalid JSON as much as possible
+    if(!jeStateNow && jeJSONerror && delta.s[jeWidget.id]) {
+      let text = $('#jeText').textContent;
+      for(const [ key, value ] of Object.entries(delta.s[jeWidget.id])) {
+        if(value === null) {
+          if(!text.match(new RegExp(`^  "${key}": ${JSON.stringify(jeWidget.getDefaultValue(key))},?$`, 'm')))
+            text = text.replace(new RegExp(`,\n?\n  "${key}": ("[^"]*"|true|false|\\d+(\.\\d+)?)(?=,?$)`, 'gm'), '');
+        } else if(!text.match(new RegExp(`^  "${key}"`, 'm')))
+          text = text.replace(new RegExp(`\n\}`, 'gm'), `,\n  "${key}": ${JSON.stringify(value)}\n}`);
+        else if(text.match(new RegExp(`^  "${key}": ("[^"]*"|true|false|\\d+(\.\\d+)?),?$`, 'm')))
+          text = text.replace(new RegExp(`^  "${key}":[^,\n]*`, 'gm'), `  "${key}": ${JSON.stringify(value)}`);
+        else
+          text = text + `\n\n--- GOT DELTA WHILE JSON WAS INVALID ---\n${delta.c}\n\nApply this to your JSON:\n\n  "${key}": ${JSON.stringify(value, null, '  ').replace(/\n/g, '\n  ')}`;
+      }
+      jeSet(text);
+    }
   }
 
   if(jeMode == 'multi' && !jeDeltaIsOurs) {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1608,10 +1608,10 @@ function jeApplyDelta(delta) {
       for(const [ key, value ] of Object.entries(delta.s[jeWidget.id])) {
         if(value === null) {
           if(!text.match(new RegExp(`^  "${key}": ${JSON.stringify(jeWidget.getDefaultValue(key))},?$`, 'm')))
-            text = text.replace(new RegExp(`,\n?\n  "${key}": ("[^"]*"|true|false|\\d+(\.\\d+)?)(?=,?$)`, 'gm'), '');
+            text = text.replace(new RegExp(`,\n?\n  "${key}": ("[^"]*"|true|false|\\d+(\\.\\d+)?)(?=,?$)`, 'gm'), '');
         } else if(!text.match(new RegExp(`^  "${key}"`, 'm')))
-          text = text.replace(new RegExp(`\n\}`, 'gm'), `,\n  "${key}": ${JSON.stringify(value)}\n}`);
-        else if(text.match(new RegExp(`^  "${key}": ("[^"]*"|true|false|\\d+(\.\\d+)?),?$`, 'm')))
+          text = text.replace(new RegExp(`\n\\}`, 'gm'), `,\n  "${key}": ${JSON.stringify(value)}\n}`);
+        else if(text.match(new RegExp(`^  "${key}": ("[^"]*"|true|false|\\d+(\\.\\d+)?),?$`, 'm')))
           text = text.replace(new RegExp(`^  "${key}":[^,\n]*`, 'gm'), `  "${key}": ${JSON.stringify(value)}`);
         else
           text = text + `\n\n--- GOT DELTA WHILE JSON WAS INVALID ---\n${delta.c}\n\nApply this to your JSON:\n\n  "${key}": ${JSON.stringify(value, null, '  ').replace(/\n/g, '\n  ')}`;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1581,8 +1581,8 @@ async function jeApplyChangesMulti() {
 
 function jeApplyDelta(delta) {
   if(jeMode == 'widget') {
-    if(delta.s[jeStateNow.id] && delta.s[jeStateNow.id].type !== undefined) {
-      const w = widgets.get(jeStateNow.id);
+    if(delta.s[jeWidget.id] && delta.s[jeWidget.id].type !== undefined) {
+      const w = widgets.get(jeWidget.id);
       jePlainWidget = new w.constructor();
       jeColorize();
     }


### PR DESCRIPTION
Fixes #2341. Caused by #2041. This seems to be the most frequent client crash.

Receiving a delta while you're editing a widget and you currently have invalid JSON in your editor.

Behavior in production:

[cinnamon-2024-12-03T124855+0100.webm](https://github.com/user-attachments/assets/405bed08-cf26-4c71-ae34-439571985d1d)

Behavior before #2041:

[cinnamon-2024-12-03T124807+0100.webm](https://github.com/user-attachments/assets/711b9ba1-c27b-4182-addc-72320640d51c)

Behavior with this PR:

[cinnamon-2024-12-03T124555+0100.webm](https://github.com/user-attachments/assets/3d64074e-0e26-40cb-b726-a06dfb56655a)

---

So now the JSON editor tries to apply the changes from the delta to the invalid JSON. If it can't, it appends them to the editor for the user to merge.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2385/pr-test (or any other room on that server)