### PR TITLE
Show anonymous widget details in the tree view

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -550,8 +550,6 @@ body.jsonEdit #toolbar {
 }
 #je_openParent{
 }
-#je_toggleWide{
-}
 #je_toggleHighlight{
 }
 #je_toggleDebug{

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -207,19 +207,6 @@ const jeCommands = [
     }
   },
   {
-    id: 'je_toggleWide',
-    name: 'Toggle wide editor',
-    icon: '[width]',
-    forceKey: 'ArrowRight',
-    classes: _=> $('#jsonEditor').classList.contains('wide') ? 'onState' : '',
-    call: async function() {
-      $('#jsonEditor').classList.toggle('wide');
-      setScale();
-      $('#jeTextHighlight').scrollTop = $('#jeText').scrollTop;
-      jeDisplayTree();
-    }
-  },
-  {
     id: 'je_toggleHighlight',
     name: 'Toggle widget highlighting',
     icon: 'flashlight_on',
@@ -2006,7 +1993,7 @@ function jeTreeGetWidgetHTML(widget) {
   const type = widget.get('type');
 
   let result = `${colored(widget.get('id'), 'key')} (${colored(type || 'basic','string')} - `;
-  if(String(widget.get('id')).match(/^[0-9a-z]{4}$/) && $('#jsonEditor').classList.contains('wide')) {
+  if(String(widget.get('id')).match(/^[0-9a-z]{4}$/)) {
     if(type == 'card' && !String(widget.get('cardType')).match(/^type-[0-9a-f-]{36}$/))
       result += `${colored(widget.get('cardType'),'extern')} - `;
     if(type == 'button' && widget.get('text'))


### PR DESCRIPTION
Fixes #2314.  Removes the toggle-wide button which is not needed with the new UI. Also permanently displays the additional (red) details in the tree for cards, buttons, and classes.  I played around with settings for various widths, but I think it makes the most sense just to always display this.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2414/pr-test (or any other room on that server)