### PR TITLE
Interact with widgets without clicking

### DIFF
--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -44,6 +44,9 @@ async function inputHandler(name, e) {
       return;
     target = target.parentNode;
   }
+  if (target && target.classList.contains('underCursor')) {
+    underCursorID = unescapeID(target.id.slice(2));
+  }
 
   if(!usedTouch && name == 'touchstart') {
     usedTouch = true;

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -7,6 +7,7 @@ let playerColor = 'red';
 let activePlayers = [];
 let activeColors = [];
 let mouseCoords = [];
+let underCursorID = '';
 localStorage.setItem('playerName', playerName);
 
 export {
@@ -14,7 +15,8 @@ export {
   playerColor,
   activePlayers,
   activeColors,
-  mouseCoords
+  mouseCoords,
+  underCursorID,
 }
 
 function getPlayerDetails() {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1,6 +1,6 @@
 import { $, removeFromDOM, asArray, escapeID, mapAssetURLs } from '../domhelpers.js';
 import { StateManaged } from '../statemanaged.js';
-import { playerName, playerColor, activePlayers, activeColors, mouseCoords } from '../overlays/players.js';
+import { playerName, playerColor, activePlayers, activeColors, mouseCoords, underCursorID } from '../overlays/players.js';
 import { batchStart, batchEnd, widgetFilter, widgets } from '../serverstate.js';
 import { showOverlay, shuffleWidgets, sortWidgets } from '../main.js';
 import { tracingEnabled } from '../tracing.js';
@@ -89,6 +89,8 @@ export class Widget extends StateManaged {
       globalUpdateRoutine: null,
       gameStartRoutine: null,
       hotkey: null,
+      underCursor: null,
+      underCursorMode: null,
 
       animatePropertyChange: []
     });
@@ -121,6 +123,8 @@ export class Widget extends StateManaged {
 
     this.animateTimeouts = {};
     this.animateClasses = new Set;
+
+    this.updateUnderCursor();
   }
 
   absoluteCoord(coord) {
@@ -877,6 +881,7 @@ export class Widget extends StateManaged {
         playerName,
         playerColor,
         activePlayers,
+        underCursorID,
         thisID : this.get('id')
       });
       collections = Object.assign({
@@ -2801,6 +2806,20 @@ export class Widget extends StateManaged {
     }
   }
 
+  updateUnderCursor() {
+    this.domElement.addEventListener('mousemove', () => {
+      if (underCursorID) {
+        const mode = this.get('underCursorMode');
+        if (mode === 'select') {
+          this.set('underCursor', true);
+        } else if (mode === 'deselect') {
+          this.set('underCursor', false);
+        }
+        underCursorID = '';
+      }
+    });
+  }  
+  
   validDropTargets() {
     return getValidDropTargets(this);
   }


### PR DESCRIPTION
This is a proof of concept / demo.  I'm sure there are problems with it and things that can be improved.  See the test room.  Click on the blue button to rotate through 3 settings: select, deselect, or off.  You can also use the spacebar as a hotkey to cycle through the settings.  Move over the area of squares to turn them black or white.  Move over the cards in the hand to raise them up a few pixels.

Lots of uses for this, but maybe it is computationally expensive.  I don't know.  If implemented, it would be a good idea to have a permanent button where we have sound and lights to change the cursor status and maybe a permanent hot key since some uses require the deselect mode to be active while the cursor is in position.

Also, would be nice to expand this to an area select (click and drag a rectangle).

Have not tested on mobile.  Pretty sure it will not work in its current configuration, but I think it could be made to work.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2426/pr-test (or any other room on that server)