### PR TITLE
adds v0.5 of Line widget, also includes inheritFrom change

### DIFF
--- a/client/css/widgets/line.css
+++ b/client/css/widgets/line.css
@@ -1,0 +1,14 @@
+.controlPoint {
+  border: solid #666;
+  background-color: #666;
+  display: none;
+}
+
+.controlPoint:hover {
+  border: solid #666;
+  background-color: #666;
+}
+
+body.jsonEdit .controlPoint, body.edit .controlPoint {
+  display: flex;
+}

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -277,6 +277,7 @@ function generateLineWidgets(id, x, y) {
       width: 100, //hack for now
       height: 100, //hack for now
       movable:false, //hack for now
+      movableInEdit: false, //hack for now
       layer: -5, //hack for now, the large size of the widget blocks much of the overlay unless it is behind the other widgets
       inheritFrom: {
         [id + "_S"]: [
@@ -299,8 +300,9 @@ function generateLineWidgets(id, x, y) {
     },
     Object.assign({ ...ctrlPoints }, { id: id + "_S", x: x + 50, y: y + 50, text: "S" }),
     Object.assign({ ...ctrlPoints }, { id: id + "_E", x: x + 100, y: y + 100, text: "E" }),
-    Object.assign({ ...ctrlPoints }, { id: id + "_C1", x: x + 50, y: y + 100, width: 20, height: 20, text: "1" }),
-    Object.assign({ ...ctrlPoints }, { id: id + "_C2", x: x + 100, y: y + 50, width: 20, height: 20, text: "2" }),    
+    Object.assign({ ...ctrlPoints }, { id: id + "_C1", x: x + 50, y: y + 100, width: 20, height: 20, text: "1", classes: "controlPoint" }),
+    Object.assign({ ...ctrlPoints }, { id: id + "_C2", x: x + 100, y: y + 50, width: 20, height: 20, text: "2", classes: "controlPoint" }),
+    // added controlPoint class on the widget, but could be done behind the scenes (like active for timer), I just couldn't figure out how
   ];
 }
 

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -261,6 +261,86 @@ function generateCounterWidgets(id, x, y) {
   ];
 }
 
+function generateLineWidgets(id, x, y) {
+  return [
+    { type: "line",
+      id: id,
+      x: 0, //this is a hack to make the line appear in the right place for now; should be x
+      y: 0, //hack for now
+      movable:false, //hack for now
+      layer: -3, //hack for now
+      inheritFrom: {
+        [id + "_start"]: [
+          "x->startx",
+          "y->starty"
+        ],
+        [id + "_control1"]: [
+          "x->cp1x",
+          "y->cp1y"
+        ],
+        [id + "_control2"]: [
+          "x->cp2x",
+          "y->cp2y"
+        ],
+        [id + "_end"]: [
+          "x->endx",
+          "y->endy"
+        ]
+      }
+    },
+    {
+      type: "button",
+      id: id+"_start",
+      x: x + 50,
+      y: y + 50,
+      width: 30,
+      height: 30,
+      movable: true,
+      movableInEdit: true,
+      borderRadius: '50%',
+      text: "Start"
+      
+    },
+    {
+      type: "button",
+      id: id+"_end",
+      x: x + 100,
+      y: y + 100,
+      width: 30,
+      height: 30,
+      movable: true,
+      movableInEdit: true,
+      borderRadius: '50%',
+      text: "End"
+     
+    },
+    {
+      type: "button",
+      id: id+"_control1",
+      x: x + 50,
+      y: y + 100,
+      width: 20,
+      height: 20,
+      movable: true,
+      movableInEdit: true,
+      borderRadius: '50%',
+      text: "Control1",     
+    },
+    {
+      type: "button",
+      id: id+"_control2",
+      x: x + 100,
+      y: y + 50,
+      width: 20,
+      height: 20,
+      movable: true,
+      movableInEdit: true,
+      borderRadius: '50%',
+      text: "Control2",
+    }
+  ];
+}
+
 function generateTimerWidgets(id, x, y) {
   return [
     { type:'timer', id: id, x: x, y: y },
@@ -317,6 +397,7 @@ function addCompositeWidgetToAddWidgetOverlay(widgetsToAdd, onClick) {
     if(wi.type == 'deck')   w = new Deck(wi.id);
     if(wi.type == 'holder') w = new Holder(wi.id);
     if(wi.type == 'label')  w = new Label(wi.id);
+    if(wi.type == 'line')   w = new Line(wi.id);
     if(wi.type == 'pile')   w = new Pile(wi.id);
     if(wi.type == 'timer')  w = new Timer(wi.id);
     widgets.set(wi.id, w);
@@ -1264,6 +1345,14 @@ function populateAddWidgetOverlay() {
     borderRadius: "3px",
 
     css: { "border": "3px solid #666" }
+  });
+
+   // Add the composite line widget
+   addCompositeWidgetToAddWidgetOverlay(generateLineWidgets('add-line', 1300, 430), async function() {
+    const id = generateUniqueWidgetID();
+    for(const w of generateLineWidgets(id, 1300, 430))
+      await addWidgetLocal(w);
+    return id
   });
 }
 // end of JSON generators

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -262,82 +262,45 @@ function generateCounterWidgets(id, x, y) {
 }
 
 function generateLineWidgets(id, x, y) {
+  const ctrlPoints = {
+    type: "button", // Should be basic widget, but that type does not work??
+    width: 30,
+    height: 30,
+    movable: true,
+    movableInEdit: true,
+  };
   return [
-    { type: "line",
+    { type: 'line',
       id: id,
-      x: 0, //this is a hack to make the line appear in the right place for now; should be x
+      x: 0, //this is a hack to make the line appear in the right place for now; should be x?
       y: 0, //hack for now
+      width: 100, //hack for now
+      height: 100, //hack for now
       movable:false, //hack for now
-      layer: -3, //hack for now
+      layer: -5, //hack for now, the large size of the widget blocks much of the overlay unless it is behind the other widgets
       inheritFrom: {
-        [id + "_start"]: [
+        [id + "_S"]: [
           "x->startx",
           "y->starty"
         ],
-        [id + "_control1"]: [
+        [id + "_C1"]: [
           "x->cp1x",
           "y->cp1y"
         ],
-        [id + "_control2"]: [
+        [id + "_C2"]: [
           "x->cp2x",
           "y->cp2y"
         ],
-        [id + "_end"]: [
+        [id + "_E"]: [
           "x->endx",
           "y->endy"
         ]
       }
     },
-    {
-      type: "button",
-      id: id+"_start",
-      x: x + 50,
-      y: y + 50,
-      width: 30,
-      height: 30,
-      movable: true,
-      movableInEdit: true,
-      borderRadius: '50%',
-      text: "Start"
-      
-    },
-    {
-      type: "button",
-      id: id+"_end",
-      x: x + 100,
-      y: y + 100,
-      width: 30,
-      height: 30,
-      movable: true,
-      movableInEdit: true,
-      borderRadius: '50%',
-      text: "End"
-     
-    },
-    {
-      type: "button",
-      id: id+"_control1",
-      x: x + 50,
-      y: y + 100,
-      width: 20,
-      height: 20,
-      movable: true,
-      movableInEdit: true,
-      borderRadius: '50%',
-      text: "Control1",     
-    },
-    {
-      type: "button",
-      id: id+"_control2",
-      x: x + 100,
-      y: y + 50,
-      width: 20,
-      height: 20,
-      movable: true,
-      movableInEdit: true,
-      borderRadius: '50%',
-      text: "Control2",
-    }
+    Object.assign({ ...ctrlPoints }, { id: id + "_S", x: x + 50, y: y + 50, text: "S" }),
+    Object.assign({ ...ctrlPoints }, { id: id + "_E", x: x + 100, y: y + 100, text: "E" }),
+    Object.assign({ ...ctrlPoints }, { id: id + "_C1", x: x + 50, y: y + 100, width: 20, height: 20, text: "1" }),
+    Object.assign({ ...ctrlPoints }, { id: id + "_C2", x: x + 100, y: y + 50, width: 20, height: 20, text: "2" }),    
   ];
 }
 

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1046,6 +1046,7 @@ function jeAddCommands() {
   widgetTypes.push(jeAddWidgetPropertyCommands(new Dice(), widgetBase));
   widgetTypes.push(jeAddWidgetPropertyCommands(new Holder(), widgetBase));
   widgetTypes.push(jeAddWidgetPropertyCommands(new Label(), widgetBase));
+  widgetTypes.push(jeAddWidgetPropertyCommands(new Line(), widgetBase));
   widgetTypes.push(jeAddWidgetPropertyCommands(new Pile(), widgetBase));
   widgetTypes.push(jeAddWidgetPropertyCommands(new Scoreboard(), widgetBase));
   widgetTypes.push(jeAddWidgetPropertyCommands(new Seat(), widgetBase));

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -385,7 +385,7 @@ async function loadEditMode() {
       uploadAsset, _uploadAsset, mapAssetURLs, pickSymbol, selectFile, triggerDownload,
       config, getPlayerDetails, roomID, getDeltaID, widgets, widgetFilter, isOverlayActive,
       html, formField,
-      Widget, BasicWidget, Button, Canvas, Card, Deck, Dice, Holder, Label, Pile, Scoreboard, Seat, Spinner, Timer,
+      Widget, BasicWidget, Button, Canvas, Card, Deck, Dice, Holder, Label, Line, Pile, Scoreboard, Seat, Spinner, Timer,
       toHex, contrastAnyColor,
       asArray, compute_ops,
       eventCoords

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -72,6 +72,8 @@ export function addWidget(widget, instance) {
     w = new Holder(id);
   } else if(widget.type == 'label') {
     w = new Label(id);
+  } else if(widget.type == 'line') {
+    w = new Line(id);
   } else if(widget.type == 'pile') {
     w = new Pile(id);
   } else if(widget.type == 'scoreboard') {

--- a/client/js/widgets/line.js
+++ b/client/js/widgets/line.js
@@ -15,6 +15,7 @@ class Line extends Widget {
       // ^ this works to skip no id or the overlay on add widget page
       // if (this.unalteredState['inheritFrom'] == undefined) {
         // but this doesn't work and resets my line is resetting on reload.  Why?
+        //LawDawg test; just to see if I have Git configured correctly
 
         this.state['inheritFrom'] = {}
         this.state['inheritFrom'][`${id}_start`] = ["x->startx","y->starty"]

--- a/client/js/widgets/line.js
+++ b/client/js/widgets/line.js
@@ -1,0 +1,266 @@
+class Line extends Widget {
+
+  constructor(id) {
+    super(id);
+    let riders = this.get('riders') || 3
+    this.addDefaults({
+      typeClasses: 'widget line',
+      riders: riders,
+      stroke: 'blue',
+      fill: 'none',
+      strokeWidth: 2,
+      z: -1000000,
+    });
+    if (id !== undefined && id !== "curvy_overlay") {
+      // ^ this works to skip no id or the overlay on add widget page
+      // if (this.unalteredState['inheritFrom'] == undefined) {
+        // but this doesn't work and resets my line is resetting on reload.  Why?
+
+        this.state['inheritFrom'] = {}
+        this.state['inheritFrom'][`${id}_start`] = ["x->startx","y->starty"]
+        this.state['inheritFrom'][`${id}_control1`] = ["x->cp1x","y->cp1y"]
+        this.state['inheritFrom'][`${id}_control2`] = ["x->cp2x","y->cp2y"]
+        this.state['inheritFrom'][`${id}_end`] = ["x->endx","y->endy"]
+        this.state['movable'] = false
+        this.state['movableInEdit'] = false
+        addWidgetLocal({
+          type: "button",
+          id: id+"_start",
+          x: 50,
+          y: 50,
+          width: 30,
+          height: 30,
+          movable: true,
+          movableInEdit: true,
+          borderRadius: '50%',
+          text: "Start",
+        });
+        addWidgetLocal({
+          type: "button",
+          id: id+"_end",
+          x: 100,
+          y: 100,
+          width: 30,
+          height: 30,
+          movable: true,
+          movableInEdit: true,
+          borderRadius: '50%',
+          text: "End",
+        });
+        addWidgetLocal({
+          type: "button",
+          id: id+"_control1",
+          x: 50,
+          y: 100,
+          width: 20,
+          height: 20,
+          movable: true,
+          movableInEdit: true,
+          borderRadius: '50%',
+          text: "Control1",
+        });
+        addWidgetLocal({
+          type: "button",
+          id: id+"_control2",
+          x: 100,
+          y: 50,
+          width: 20,
+          height: 20,
+          movable: true,
+          movableInEdit: true,
+          borderRadius: '50%',
+          text: "Control2",
+        });
+      //}
+    }
+  }
+  
+  applyDeltaToDOM(delta) {
+    super.applyDeltaToDOM(delta);
+    // we should filter this down, but still figuring out the right bits to do that
+    // ala if(delta.endy !== undefined || delta.starty !== undefined, etc...
+    this.createChildNodes();
+  }
+  
+  createChildNodes() {
+    const childNodes = [...this.domElement.childNodes];
+
+    const bezierCoordinates = {
+      start: { x: 10, y: 10 },
+      control1: { x: 80, y: 50 },
+      control2: { x: 120, y: 150 },
+      end: { x: 190, y: 100 },
+    };
+
+    const updates = {
+      start: { x: this.get('startx'), y: this.get('starty') },
+      end: { x: this.get('endx'), y: this.get('endy') },
+      control1: { x: this.get('cp1x'), y: this.get('cp1y') },
+      control2: { x: this.get('cp2x'), y: this.get('cp2y') },
+    };
+
+    for (const key in updates) {
+        for (const coord in updates[key]) {
+            if (updates[key][coord]) {
+                bezierCoordinates[key][coord] = updates[key][coord] + 15;
+            }
+        }
+    }
+
+    // so I was using t (time on curve) for figuring out the rider spots
+    // but it turns out spot equidistant along the path is more game-design friendly
+
+    let riders = this.get("riders") || 3
+    let stroke = this.state.stroke || 'blue'
+    let fill = this.state.fill|| 'none'
+    let strokeWidth = this.state.strokeWidth || 2
+
+    const ns = 'http://www.w3.org/2000/svg'
+    let svg = document.createElementNS(ns, 'svg');
+    svg.setAttribute("style", `position: relative; top: 0 ; left: 0`);
+
+    let spots = {}
+    // Append the path to the SVG container
+    svg, spots = this.makeBezierCurveonPath(ns, svg, bezierCoordinates, riders, stroke, fill, strokeWidth, strokeWidth)
+
+    for (let i = 1; i <= riders; i++) {
+      let spot_id_x = `spot_${i}_x`
+      let spot_id_y = `spot_${i}_y`
+      this.state[spot_id_x] = Math.round(spots[i].x)
+      this.state[spot_id_y] = Math.round(spots[i].y)
+    }
+
+    // have to check size of curve roughly to set dimensions
+    let bounding = this.getApproxBezierBoundingBox(bezierCoordinates, riders)
+    let width = bounding.maxX
+    let height = bounding.maxY
+    this.state.width = width
+    this.state.height = height
+    svg.setAttribute("width", width);
+    svg.setAttribute("height", height);
+
+    this.domElement.innerHTML = '';
+    this.domElement.appendChild(svg);
+
+    for(const child of childNodes)
+      if(String(child.className).match(/widget/))
+        this.domElement.appendChild(child);
+
+  }
+
+  // need this to get bbox before we render it in browser to get appropriate sizing
+  getApproxBezierBoundingBox(bezierCoordinates, checkpoints=3) {
+    const tValues = Array.from({ length: checkpoints }, (_, i) => (i + 1) / (checkpoints + 1));
+    const samplePoints = tValues.map(t => this.deCasteljau(bezierCoordinates, t));    
+    const { start, control1, control2, end } = bezierCoordinates;
+    const controlPoints = [start, control1, control2, end];
+    // Combine sample points and control points
+    const allPoints = [...samplePoints, ...controlPoints];
+    
+    // Use reduce to calculate bounds
+    const { minX, minY, maxX, maxY } = allPoints.reduce(
+      (bounds, { x, y }) => ({
+        minX: Math.min(bounds.minX, x),
+        minY: Math.min(bounds.minY, y),
+        maxX: Math.max(bounds.maxX, x),
+        maxY: Math.max(bounds.maxY, y),
+      }),
+      {
+        minX: Infinity,
+        minY: Infinity,
+        maxX: -Infinity,
+        maxY: -Infinity,
+      }
+    );
+    
+    return { minX, minY, maxX, maxY, samplePoints};
+  }
+ 
+  makeBezierCurveonPath(ns, svg, bezierCoordinates, riders, stroke='blue', fill='none', strokeWidth=2, radius=4) {
+    // Create a path element for the bezier curve
+    const path = document.createElementNS(ns, "path");
+    path.setAttribute("d", `M${bezierCoordinates.start.x},${bezierCoordinates.start.y} 
+                            C${bezierCoordinates.control1.x},${bezierCoordinates.control1.y}, 
+                            ${bezierCoordinates.control2.x},${bezierCoordinates.control2.y}, 
+                            ${bezierCoordinates.end.x},${bezierCoordinates.end.y}`);
+    path.setAttribute("stroke", stroke);
+    path.setAttribute("fill", fill);
+    path.setAttribute("stroke-width", strokeWidth);
+    svg.appendChild(path)
+    
+    const pathLength = path.getTotalLength()
+    const points = Array.from({ length: riders }, (_, i) => (i + 1) / (riders + 1));
+    
+    let equalspots = {}
+    let index = 1
+
+    points.forEach(spot => {
+      const point = path.getPointAtLength(spot * pathLength);
+      equalspots[index] = {"x": point.x, "y": point.y}
+      index++
+      // Create a circle element for the point
+      const circle = document.createElementNS(ns, 'circle');
+      circle.setAttribute('cx', point.x);
+      circle.setAttribute('cy', point.y);
+      circle.setAttribute('r', radius); // Radius of the circle
+      circle.setAttribute("stroke", stroke);
+      circle.setAttribute("fill", fill);
+      circle.setAttribute("stroke-width", strokeWidth);
+      // Add the circle to the SVG
+      svg.appendChild(circle)
+    })
+    return svg, equalspots
+  }
+
+
+  //  Calculates a point on a cubic Bézier curve using De Casteljau’s algorithm.
+  //  @param {Object} start - The start point {x, y}.
+  //  @param {Object} control1 - The first control point {x, y}.
+  //  @param {Object} control2 - The second control point {x, y}.
+  //  @param {Object} end - The end point {x, y}.
+  //  @param {number} t - The parameter (0 <= t <= 1).
+  //  @returns {Object} The point on the curve at t {x, y}.
+
+  deCasteljau(bezierCoordinates, t=.5) {
+    const { start, control1, control2, end } = bezierCoordinates;
+    if (t < 0 || t > 1) {
+      throw new Error("t must be between 0 and 1.");
+    }
+
+    // Linear interpolation between two points
+    const lerp = (a, b, t) => ({
+      x: (1 - t) * a.x + t * b.x,
+      y: (1 - t) * a.y + t * b.y
+    });
+
+    // First level of interpolation
+    const q0 = lerp(start, control1, t);
+    const q1 = lerp(control1, control2, t);
+    const q2 = lerp(control2, end, t);
+
+    // Second level of interpolation
+    const r0 = lerp(q0, q1, t);
+    const r1 = lerp(q1, q2, t);
+
+    // Final interpolation to get the point on the curve
+    return lerp(r0, r1, t);
+  }
+
+  // alternative code, simpler math but less clear what it is doing...
+  // Compute Bézier point for a given t
+  bezierPoint(bezierCoordinates, t=.5) {
+    const { start, control1, control2, end } = bezierCoordinates;
+    const mt = 1 - t;
+    point = {
+      x: mt * mt * mt * start.x +
+        3 * mt * mt * t * control1.x +
+        3 * mt * t * t * control2.x +
+        t * t * t * end.x,
+      y: mt * mt * mt * start.y +
+        3 * mt * mt * t * control1.y +
+        3 * mt * t * t * control2.y +
+        t * t * t * end.y
+    }
+    return point
+  }
+}

--- a/client/js/widgets/line.js
+++ b/client/js/widgets/line.js
@@ -1,4 +1,4 @@
-class Line extends Widget {
+export class Line extends Widget {
 
   constructor(id) {
     super(id);
@@ -9,70 +9,7 @@ class Line extends Widget {
       stroke: 'blue',
       fill: 'none',
       strokeWidth: 2,
-      z: -1000000,
     });
-    if (id !== undefined && id !== "curvy_overlay") {
-      // ^ this works to skip no id or the overlay on add widget page
-      // if (this.unalteredState['inheritFrom'] == undefined) {
-        // but this doesn't work and resets my line is resetting on reload.  Why?
-
-        this.state['inheritFrom'] = {}
-        this.state['inheritFrom'][`${id}_start`] = ["x->startx","y->starty"]
-        this.state['inheritFrom'][`${id}_control1`] = ["x->cp1x","y->cp1y"]
-        this.state['inheritFrom'][`${id}_control2`] = ["x->cp2x","y->cp2y"]
-        this.state['inheritFrom'][`${id}_end`] = ["x->endx","y->endy"]
-        this.state['movable'] = false
-        this.state['movableInEdit'] = false
-        addWidgetLocal({
-          type: "button",
-          id: id+"_start",
-          x: 50,
-          y: 50,
-          width: 30,
-          height: 30,
-          movable: true,
-          movableInEdit: true,
-          borderRadius: '50%',
-          text: "Start",
-        });
-        addWidgetLocal({
-          type: "button",
-          id: id+"_end",
-          x: 100,
-          y: 100,
-          width: 30,
-          height: 30,
-          movable: true,
-          movableInEdit: true,
-          borderRadius: '50%',
-          text: "End",
-        });
-        addWidgetLocal({
-          type: "button",
-          id: id+"_control1",
-          x: 50,
-          y: 100,
-          width: 20,
-          height: 20,
-          movable: true,
-          movableInEdit: true,
-          borderRadius: '50%',
-          text: "Control1",
-        });
-        addWidgetLocal({
-          type: "button",
-          id: id+"_control2",
-          x: 100,
-          y: 50,
-          width: 20,
-          height: 20,
-          movable: true,
-          movableInEdit: true,
-          borderRadius: '50%',
-          text: "Control2",
-        });
-      //}
-    }
   }
   
   applyDeltaToDOM(delta) {

--- a/client/js/widgets/line.js
+++ b/client/js/widgets/line.js
@@ -15,7 +15,6 @@ class Line extends Widget {
       // ^ this works to skip no id or the overlay on add widget page
       // if (this.unalteredState['inheritFrom'] == undefined) {
         // but this doesn't work and resets my line is resetting on reload.  Why?
-        //LawDawg test; just to see if I have Git configured correctly
 
         this.state['inheritFrom'] = {}
         this.state['inheritFrom'][`${id}_start`] = ["x->startx","y->starty"]
@@ -142,6 +141,10 @@ class Line extends Widget {
 
     this.domElement.innerHTML = '';
     this.domElement.appendChild(svg);
+
+    // Get the bounding box of the path
+    const path = svg.querySelector('path');
+    const bbox = path.getBBox();
 
     for(const child of childNodes)
       if(String(child.className).match(/widget/))

--- a/client/js/widgets/line.js
+++ b/client/js/widgets/line.js
@@ -5,10 +5,14 @@ export class Line extends Widget {
     let riders = this.get('riders') || 3
     this.addDefaults({
       typeClasses: 'widget line',
-      riders: riders,
-      stroke: 'blue',
+      strokeWidth: 5,
+      stroke: '#1f5ca6',
       fill: 'none',
-      strokeWidth: 2,
+      riders: 3,
+      spotRadius: 4,
+      spotStroke: '#1f5ca6',
+      spotFill: '#a9c6e8',
+      spotStrokeWidth: 2,
     });
   }
   
@@ -47,10 +51,14 @@ export class Line extends Widget {
     // so I was using t (time on curve) for figuring out the rider spots
     // but it turns out spot equidistant along the path is more game-design friendly
 
-    let riders = this.get("riders") || 3
-    let stroke = this.state.stroke || 'blue'
-    let fill = this.state.fill|| 'none'
-    let strokeWidth = this.state.strokeWidth || 2
+    let riders = this.get("riders");
+    let stroke = this.get("stroke");
+    let fill = this.get("fill");
+    let strokeWidth = this.get("strokeWidth");
+    let spotRadius = this.get("spotRadius");
+    let spotStroke = this.get('spotStroke');
+    let spotFill = this.get('spotFill');
+    let spotStrokeWidth = this.get('spotStrokeWidth');
 
     const ns = 'http://www.w3.org/2000/svg'
     let svg = document.createElementNS(ns, 'svg');
@@ -58,7 +66,7 @@ export class Line extends Widget {
 
     let spots = {}
     // Append the path to the SVG container
-    svg, spots = this.makeBezierCurveonPath(ns, svg, bezierCoordinates, riders, stroke, fill, strokeWidth, strokeWidth)
+    svg, spots = this.makeBezierCurveonPath(ns, svg, bezierCoordinates, riders, stroke, fill, strokeWidth, spotRadius, spotStroke, spotFill, spotStrokeWidth)
 
     for (let i = 1; i <= riders; i++) {
       let spot_id_x = `spot_${i}_x`
@@ -117,7 +125,7 @@ export class Line extends Widget {
     return { minX, minY, maxX, maxY, samplePoints};
   }
  
-  makeBezierCurveonPath(ns, svg, bezierCoordinates, riders, stroke='blue', fill='none', strokeWidth=2, radius=4) {
+  makeBezierCurveonPath(ns, svg, bezierCoordinates, riders, stroke, fill, strokeWidth, spotRadius, spotStroke, spotFill, spotStrokeWidth) {
     // Create a path element for the bezier curve
     const path = document.createElementNS(ns, "path");
     path.setAttribute("d", `M${bezierCoordinates.start.x},${bezierCoordinates.start.y} 
@@ -143,10 +151,10 @@ export class Line extends Widget {
       const circle = document.createElementNS(ns, 'circle');
       circle.setAttribute('cx', point.x);
       circle.setAttribute('cy', point.y);
-      circle.setAttribute('r', radius); // Radius of the circle
-      circle.setAttribute("stroke", stroke);
-      circle.setAttribute("fill", fill);
-      circle.setAttribute("stroke-width", strokeWidth);
+      circle.setAttribute('r', spotRadius); // Radius of the circle
+      circle.setAttribute("stroke", spotStroke);
+      circle.setAttribute("fill", spotFill);
+      circle.setAttribute("stroke-width", spotStrokeWidth);
       // Add the circle to the SVG
       svg.appendChild(circle)
     })

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -295,10 +295,26 @@ export class Widget extends StateManaged {
   }
 
   applyInheritedValuesToObject(inheritDefinition, sourceDelta, targetDelta, targetWidget) {
-    for(const key in sourceDelta)
-      if(this.inheritFromIsValid(inheritDefinition, key) && targetWidget.state[key] === undefined)
-        targetDelta[key] = JSON.stringify(sourceDelta[key]) === JSON.stringify(this.defaults[key]) ? null : sourceDelta[key];
-  }
+    for(const key in sourceDelta) {
+        if(typeof inheritDefinition === 'string' && inheritDefinition === '*') {
+            if(targetWidget.state[key] === undefined) {
+                targetDelta[key] = JSON.stringify(sourceDelta[key]) === JSON.stringify(this.defaults[key]) ? null : sourceDelta[key];
+            }
+        } else {
+            const properties = asArray(inheritDefinition);
+            for(const prop of properties) {
+                if(prop.includes('->')) {
+                    const [sourceProp, targetProp] = prop.split('->');
+                    if(sourceProp === key && targetWidget.state[targetProp] === undefined) {
+                        targetDelta[targetProp] = JSON.stringify(sourceDelta[sourceProp]) === JSON.stringify(this.defaults[sourceProp]) ? null : sourceDelta[sourceProp];
+                    }
+                } else if(prop === key && targetWidget.state[key] === undefined) {
+                    targetDelta[key] = JSON.stringify(sourceDelta[key]) === JSON.stringify(this.defaults[key]) ? null : sourceDelta[key];
+                }
+            }
+        }
+    }
+}
 
   applyInheritedValuesToDOM(inheritFrom, pushasArray) {
     const delta = {};

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -32,6 +32,7 @@ export default async function minifyHTML() {
     'client/css/widgets/dice.css',
     'client/css/widgets/holder.css',
     'client/css/widgets/label.css',
+    'client/css/widgets/line.css',
     'client/css/widgets/pile.css',
     'client/css/widgets/scoreboard.css',
     'client/css/widgets/seat.css',

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -67,6 +67,7 @@ export default async function minifyHTML() {
     'client/js/widgets/dice.js',
     'client/js/widgets/holder.js',
     'client/js/widgets/label.js',
+    'client/js/widgets/line.js',
     'client/js/widgets/pile.js',
     'client/js/widgets/scoreboard.js',
     'client/js/widgets/seat.js',


### PR DESCRIPTION
This works enough to share now...

There are rough spots.  The InheritFrom added to json doesn't do something right, and I have to cut/paste it back, and then it does work.  It also resets the line on a reload (code in constructor needs work), and delta code could be improved to handle what to update...   the spot stuff gets added, but not recognized as changing, so that's needed still.

But you can add a Line Widget, cut and then repaste the inheritFrom, and then play with the widgets and it'll work.

Includes the changes to allow inheritFrom to take a -> syntax.  This was the least 'breaking change' I found, and if it's replaced with something better, awesome, but the goal was proof of concept.  

Doing inheritFrom y->x now works and will translate up/down to left/right, so adding that as usage demo in Tutorial should be easy to add, once we make this solid enough.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2430/pr-test (or any other room on that server)

To do:

- [ ] Fix whatever is broken in inheritFrom: 1) Default behavior that if the property is set in the widget, the inheritFrom is lost. Would be nice to have option to override that. 2) There is some strange updating/not updating behavior in the PR test room.   3) Chained inheritFrom
- [ ] Inherit enable.  right now you need to cut/paste to 'kickstart it'
- [ ] Spot_N_x properties update but not in json editor, or able to be seen by widget, you can connect one, but if spot moves, the object fails to see change. (add new location, then remove it, and if using Inherit, it'll 'pop' them, so it can see it, but it's not getting to Delta I think.
- [x] Fix reset of items on room reload or if someone else enters room
- [x] How to properly access properties (.get('property) vs this.state['property'] vs undefined but appears in console.log(). I suspect 2-4 are connected, 1 is some trick I'm missing, and 3 is related to understanding how to say "nah, we're setup, don't do this"
- [ ] Replace Delta handling with OnPropertyChange code
- [x] Calculate size of bounding box
- [ ] Fix location of selection box for line widget
- [x] Update spot coordinates to reflect location of selection box (which represents the line location in the room)
- [x] Calculate slope to determine rotation for riders
- [x] Default css for line, end points, and control points
- [ ] UI Options when adding line from overlay (number of inner control points 0, 1, 2? number of rider spots? enter or select `id` of end points? line color?)
- [ ] Layer management for line widget
- [ ] When deleting line, its inner control points should also be deleted. Not sure about the end points?
- [ ] How to handle the control point visibility when there are many lines in the room.  Will get crowded and confusing. Maybe a JSON Editor button to turn them all off except for those attached to currently selected line?
- [ ] Add "linkedToLine" property to control points to help with both of the 2 issues above
- [ ] Check that id changes automatically updated across line widgets
- [ ] Moving line should move all the control points. Once you make the shape you want, you should be able to grab the line and just move it. Can be done in edit mode by selecting all 4 points, but that is a lot of work.
- [x] Riders only accepts a number for equally spaced. Should allow dev to specify location?
- [ ] Maybe give the spots their own spotCSS (like handleCSS for piles).  Would allow for different shapes, could add background images, etc). This would require making them widgets; right now they are just an svg