### PR TITLE
Fix Symbol Picker Client Crash

### DIFF
--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -606,6 +606,9 @@ export function addRichtextControls(dom) {
   loadSymbolPicker();
 
   $('[icon=format_size]', controls).onclick = function() {
+    const selection = window.getSelection();
+    if (!selection.rangeCount)
+      return;
     const parent = window.getSelection().getRangeAt(0).startContainer.parentNode.closest('h4');
     if(parent)
       parent.replaceWith(...parent.children);
@@ -614,6 +617,9 @@ export function addRichtextControls(dom) {
     dom.focus();
   };
   $('[icon=palette]', controls).onclick = function() {
+    const selection = window.getSelection();
+    if (!selection.rangeCount)
+      return;
     const range = window.getSelection().getRangeAt(0);
     document.execCommand('forecolor', false, '#000000');
     const input = document.createElement('input');
@@ -650,6 +656,9 @@ export function addRichtextControls(dom) {
     }
   };
   $('[icon=add_reaction]', controls).onclick = async function() {
+    const selection = window.getSelection();
+    if (!selection.rangeCount)
+      return;
     const range = window.getSelection().getRangeAt(0);
 
     showStatesOverlay('symbolPickerOverlay');


### PR DESCRIPTION
Fixes #2433.

The problem exists on 3 buttons. This solution simply checks if the cursor is in a textbox and does not open the overlay if it is not.  A better solution would somehow find which textbox the button is associated with and put the cursor at the end of any text that is there and then open the overlay.  But I couldn't figure that out.

This does not impact game play, only editing certain game metadata, so not a critical bug, but one we should fix.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2434/pr-test (or any other room on that server)