### PR TITLE
Add support for resetProperties

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1107,6 +1107,7 @@ function jeAddCommands() {
   jeAddRoutineOperationCommands('MOVE', { count: 1, face: null, from: null, to: null, fillTo: null, collection: 'DEFAULT' });
   jeAddRoutineOperationCommands('MOVEXY', { count: 1, face: null, from: null, x: 0, y: 0, snapToGrid: true, resetOwner: true });
   jeAddRoutineOperationCommands('RECALL', { owned: true, inHolder: true, holder: null, excludeCollection: null });
+  jeAddRoutineOperationCommands('RESET', { property: 'resetProperties', collection: 'DEFAULT' });
   jeAddRoutineOperationCommands('ROTATE', { count: 1, angle: 90, mode: 'add', holder: null, collection: 'DEFAULT' });
   jeAddRoutineOperationCommands('SCORE', { mode: 'set', property: 'score', seats: null, round: null, value: null });
   jeAddRoutineOperationCommands('SELECT', { type: 'all', property: 'parent', relation: '==', value: null, max: 999999, collection: 'DEFAULT', mode: 'set', source: 'all', sortBy: '###SEE jeAddRoutineOperation###'});
@@ -1148,6 +1149,15 @@ function jeAddCommands() {
   // Default max limits are computed dynamically.
   jeAddLimitCommand('maxX');
   jeAddLimitCommand('maxY');
+
+  // Default values computed dynamically.
+  jeAddResetPropertiesCommand('parent');
+  jeAddResetPropertiesCommand('x');
+  jeAddResetPropertiesCommand('y');
+  jeAddResetPropertiesCommand('rotation');
+  jeAddResetPropertiesCommand('activeFace');
+  jeAddResetPropertiesCommand('scale');
+  jeAddResetPropertiesCommand('display');
 
   jeAddFieldCommand('text', 'subtitle|title|text', '');
   jeAddFieldCommand('label', 'checkbox|choose|color|number|palette|select|string|switch', '');
@@ -1480,6 +1490,21 @@ function jeAddNumberCommand(name, key, callback) {
       const newValue = callback(jeGetValue()[jeGetLastKey()]);
       jeGetValue()[jeGetLastKey()] = '###SELECT ME###';
       jeSetAndSelect(newValue);
+    }
+  });
+}
+
+function jeAddResetPropertiesCommand(key) {
+  jeCommands.push({
+    id: 'rProp_' + key,
+    name: key,
+    context: '^[^ ]* ↦ resetProperties',
+    show: _=>typeof jeStateNow.resetProperties == "object" && jeStateNow.resetProperties !== null && !(key in jeStateNow.resetProperties),
+    call: async function() {
+      const w = widgets.get(jeStateNow.id);
+      jeStateNow.resetProperties[key] = '###SELECT ME###';
+      let rProp = w.get(key);
+      jeSetAndSelect(rProp);
     }
   });
 }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -90,7 +90,8 @@ export class Widget extends StateManaged {
       gameStartRoutine: null,
       hotkey: null,
 
-      animatePropertyChange: []
+      animatePropertyChange: [],
+      resetProperties: {},
     });
     this.domElement.timer = false
 
@@ -1617,6 +1618,24 @@ export class Widget extends StateManaged {
           if(jeRoutineLogging) {
             jeLoggingRoutineOperationSummary(`'${a.holder}' ${a.owned ? ' (including hands)' : ''}`);
           }
+        }
+      }
+
+      if (a.func == 'RESET') {
+        setDefaults(a, { property: 'resetProperties' });
+      
+        const widgetsToReset = Array.from(widgets.values()).filter(widget => {
+          const propertyValue = widget.get(a.property) ?? {};
+          return Object.keys(propertyValue).length > 0;
+        });
+        for (const widget of widgetsToReset) {
+          const propertyValue = widget.get(a.property) ?? {};
+          for (const [key, value] of Object.entries(propertyValue)) {
+            await widget.set(key, value);
+          }
+        }      
+        if (jeRoutineLogging) {
+          jeLoggingRoutineOperationSummary(`Reset properties for widgets with property '${a.property}'`);
         }
       }
 


### PR DESCRIPTION
This was an idea I had after a recent discussion about the resetProperties technique.

This PR does 2 things.  It adds JSON Editor support for resetProperties.  This is the reason I did the PR.  I wanted an easy way to capture the current parent, x, y, and a few other common properties.

The other things it does is adds a RESET function.  This is not absolutely necessary, but it simplifies the process and makes a useful tool available to average users with the click of a button.  I would be okay if we don't implement the function, but I would like the JSON Editor support.