### PR TITLE
added Docker image without library

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,3 +21,12 @@ jobs:
         with:
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/virtualtabletop:latest
+
+      - name: Remove library files
+        run: rm -rf library/*/*
+
+      - name: Build and push without library
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/virtualtabletop:without-public-library

--- a/README-DOCKER.md
+++ b/README-DOCKER.md
@@ -6,6 +6,12 @@ Like the production site, the docker image is automatically updated for every co
 
 
 
+# Tags
+
+If you don't want to use the included public library of virtualtabletop, you use the tag `without-public-library`, which makes the image a lot smaller.
+
+
+
 # Examples
 
 Run a local-only server on http://localhost:8272 with all default config:


### PR DESCRIPTION
This PR _should_ (hard to test) create a second tag for the official Docker image that excludes the public library. If somebody does not want to use the library, it is a lot of unnecessary data.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2515/pr-test (or any other room on that server)