### PR TITLE
fixed empty `display` for seats

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -438,7 +438,7 @@ export class Widget extends StateManaged {
     if(this.get('enlarge'))
       className += ' enlarge';
 
-    if(!this.get('display'))
+    if(!this.get('display') && this.get('type') != 'seat') // seats already have a display property that does something else
       className += ' hidden';
 
     if(this.isHighlighted)


### PR DESCRIPTION
When we introduced `display` in #2167, we did not notice that seats already had a `display` property.

This lead to `display: ""` on seats changing from showing a blank seat to hiding the seat completely.

This PR should make them blank again.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2523/pr-test (or any other room on that server)