### PR TITLE
added new widget type `zoomy`

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1124,6 +1124,7 @@ function jeAddCommands() {
   widgetTypes.push(jeAddWidgetPropertyCommands(new Seat(), widgetBase));
   widgetTypes.push(jeAddWidgetPropertyCommands(new Spinner(), widgetBase));
   widgetTypes.push(jeAddWidgetPropertyCommands(new Timer(), widgetBase));
+  widgetTypes.push(jeAddWidgetPropertyCommands(new Zoomy(), widgetBase));
 
   jeAddRoutineOperationCommands('AUDIO', { source: '', maxVolume: 1.0, length: null, player: null, silence: false, count: 1 });
   jeAddRoutineOperationCommands('CALL', { widget: 'id', routine: 'clickRoutine', return: true, arguments: {}, variable: 'result' });

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -385,7 +385,7 @@ async function loadEditMode() {
       uploadAsset, _uploadAsset, mapAssetURLs, pickSymbol, selectFile, triggerDownload,
       config, getPlayerDetails, roomID, getDeltaID, widgets, widgetFilter, isOverlayActive,
       html, formField,
-      Widget, BasicWidget, Button, Canvas, Card, Deck, Dice, Holder, Label, Pile, Scoreboard, Seat, Spinner, Timer,
+      Widget, BasicWidget, Button, Canvas, Card, Deck, Dice, Holder, Label, Pile, Scoreboard, Seat, Spinner, Timer, Zoomy,
       toHex, contrastAnyColor,
       asArray, compute_ops,
       eventCoords

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -82,6 +82,8 @@ export function addWidget(widget, instance) {
     w = new Spinner(id);
   } else if(widget.type == 'timer') {
     w = new Timer(id);
+  } else if(widget.type == 'zoomy') {
+    w = new Zoomy(id);
   } else {
     w = new BasicWidget(id);
   }

--- a/client/js/widgets/zoomy.js
+++ b/client/js/widgets/zoomy.js
@@ -1,0 +1,73 @@
+import { Widget } from './widget.js';
+
+export class Zoomy extends Widget {
+  constructor(id) {
+    super(id);
+
+    this.isBig = false;
+    this.addDefaults({
+      movable: false,
+      layer: -2,
+      typeClasses: 'widget zoomy',
+
+      zoomedX: 0,
+      zoomedY: 0,
+      zoomedScale: 2,
+      zoomedRotation: 0
+    });
+
+    this.domElement.innerHTML = `
+      <button class="zoomy-button">+</button>
+    `;
+
+    $('.zoomy-button', this.domElement).addEventListener('click', () => {
+      this.isBig = !this.isBig;
+      this.updateScale();
+    });
+  }
+
+  cssTransform() {
+    const x        = this.isBig ? this.get('zoomedX'       ) : this.get('x'       );
+    const y        = this.isBig ? this.get('zoomedY'       ) : this.get('y'       );
+    const scale    = this.isBig ? this.get('zoomedScale'   ) : this.get('scale'   );
+    const rotation = this.isBig ? this.get('zoomedRotation') : this.get('rotation');
+
+    let transform = `translate(${x}px, ${y}px)`;
+
+    if(rotation)
+      transform += ` rotate(${rotation}deg)`;
+    if(scale != 1)
+      transform += ` scale(${scale})`;
+
+    return transform;
+  }
+
+  cssTransformProperties() {
+    const properties = super.cssTransformProperties();
+
+    properties.push('zoomedX', 'zoomedY', 'zoomedScale', 'zoomedRotation');
+
+    return properties;
+  }
+
+  set(property, value) {
+    if(this.isBig) {
+      if(property == 'x')
+        this.set('zoomedX', value);
+      else if(property == 'y')
+        this.set('zoomedY', value);
+      else if(property == 'scale')
+        this.set('zoomedScale', value);
+      else if(property == 'rotation')
+        this.set('zoomedRotation', value);
+      else
+        super.set(property, value);
+    } else {
+      super.set(property, value);
+    }
+  }
+
+  updateScale() {
+    this.targetTransform = this.domElement.style.transform = this.cssTransform();
+  }
+}

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -72,6 +72,7 @@ export default async function minifyHTML() {
     'client/js/widgets/seat.js',
     'client/js/widgets/spinner.js',
     'client/js/widgets/timer.js',
+    'client/js/widgets/zoomy.js',
 
     'client/js/main.js'
   ]);


### PR DESCRIPTION
Alright, maybe `zoomy` is not the final name. The problem with experimenting with a new widget type is that the very first thing you have to do is come up with a name.

The idea: it is a widget with a zoom button. When you press the button, you toggle between a zoomed state and a normal state. But: only on your client. So you can have a miniaturized area in your room that players can zoom into and interact with without forcing other players to zoom into it as well.

Initial tests suggest that this is somwhat working. Play around with it and give feedback, please.