### PR TITLE
fixed text highlighting in Chrome

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -105,6 +105,10 @@
 #jeText {
   padding-left: calc(var(--linenumbers-digits) * 8px + 2px);
 }
+#jeText::selection {
+  background-color: var(--backgroundHighlightColor1);
+  color: var(--textColor);
+}
 
 /**** End of line number styles ****/
 


### PR DESCRIPTION
Something changed in Chrome 135 that made highlighted text in the editor invisible. This should fix it.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2543/pr-test (or any other room on that server)