### PR TITLE
Remove crowned property from checkers

### DIFF
--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -409,66 +409,6 @@ function populateAddWidgetOverlay() {
     return id
   });
 
-/* Don't add old-style game pieces; replaced by svg
-  // Populate the game panel pieces. The real piece choosing happens in popups.
-  addPieceToAddWidgetOverlay( new BasicWidget('add-pin0'), {
-    classes: 'pinPiece',
-    color: VTTblue,
-    width: 35.85,
-    height: 43.83,
-    x: 380,
-    y: 80
-  });
-  addPieceToAddWidgetOverlay( new BasicWidget('add-checkers0'), {
-    faces: [
-      { classes: "checkersPiece"         },
-      { classes: "checkersPiece crowned" }
-    ],
-    color: VTTblue,
-    width: 73.5,
-    height: 73.5,
-    x: 380 + 60,
-    y: 80 + Math.round((43.83 - 73.5)/2)
-  });
-  addPieceToAddWidgetOverlay( new BasicWidget('add-classic0'), {
-    classes: 'classicPiece',
-    color: VTTblue,
-    width: 56,
-    height: 84,
-    x: 380 + 150,
-    y: 80 + Math.round((43.83 - 84)/2)
-  });
-*/
-
-/* Don't add the unicode symbols
-  // Next the unicode symbols
-  const centerStyle = 'color:black;display:flex;justify-content:center;align-items:center;text-align:center;';
-  addWidgetToAddWidgetOverlay(new BasicWidget('add-unicodeS'), {
-    text: '🐻',
-    css: 'font-size:25px;'+centerStyle,
-    width: 25,
-    height: 25,
-    x: 380,
-    y: 175
-  });
-
-  addWidgetToAddWidgetOverlay(new BasicWidget('add-unicodeM'), {
-    text: '🔥',
-    css: 'font-size:50px;'+centerStyle,
-    width: 50,
-    height: 50,
-    x: 440,
-    y: 175
-  });
-
-  addWidgetToAddWidgetOverlay(new BasicWidget('add-unicodeL'), {
-    text: '♞',
-    css: 'font-size:100px;'+centerStyle,
-    x: 500,
-    y: 150
-  });
-*/
-
   //Add svg game pieces
   // First row
   addPieceToAddWidgetOverlay(new BasicWidget('Pawn3DSVG'), {
@@ -583,7 +523,6 @@ function populateAddWidgetOverlay() {
 
     borderColor: "#000000",
     borderWidth: 1,
-    crowned: true,
     secondaryColor: "#ffffff"
   });
 
@@ -616,7 +555,6 @@ function populateAddWidgetOverlay() {
 
     borderColor: "#000000",
     borderWidth: 1,
-    crowned: true,
     secondaryColor: "#ffffff"
   });
 


### PR DESCRIPTION
Fixes #2585. 

Also removes commented out code for classic/legacy game pieces on the Add Widget overlay.