### PR TITLE
Add regex to Labels

### DIFF
--- a/client/css/widgets/label.css
+++ b/client/css/widgets/label.css
@@ -23,3 +23,21 @@
   pointer-events: none;
 }
 
+.widget.label > textarea.invalid {
+  background-color: #fff5f5;
+}
+
+.widget.label .validation-error {
+  position: absolute;
+  background: #ff4444;
+  color: white;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  z-index: 1000;
+  top: 100%;
+  left: 0;
+  white-space: nowrap;
+  margin-top: 2px;
+}
+


### PR DESCRIPTION
Fixes #2319.  Implements #1450. This allows regex limits on labels similar to what is done for INPUT functions.  It also fixes a problem with leading zeros perhaps not in the simplest way.  But I used this opportunity to also make labels handle numbers is a better and more intuitive way.

Although it is not directly related, #2595 would also benefit from these changes and that was part of the reason that I did this now.