### PR TITLE
fixed widget position when becoming visible while changing parent

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2538,9 +2538,10 @@ export class Widget extends StateManaged {
     if(this.isLimbo == isLimbo)
       return;
     if(isLimbo) {
-      const topTransform = getElementTransformRelativeTo(this.domElement, $('#topSurface')) || 'none';
+      const topTransform = getElementTransformRelativeTo(this.domElement, $('#topSurface'));
       $('#topSurface').appendChild(this.domElement);
-      this.domElement.style.transform = topTransform;
+      if(topTransform)
+        this.domElement.style.transform = topTransform;
     }
     this.domElement.classList.toggle('limbo', isLimbo);
     this.isLimbo = isLimbo;


### PR DESCRIPTION
For animation purposes, the widget position is being juggled while changing parents. But if the widget was invisible at the old parent, this did not work. Now it will not set the animation position in that case.