### PR TITLE
Fix Game Validation Button

### DIFF
--- a/client/css/editor/sidebarModules.css
+++ b/client/css/editor/sidebarModules.css
@@ -250,7 +250,7 @@
 }
 
 .pest_control.editorModule .validation-time {
-  color: var(--textDimColor1);
+  color: var(--textColor);
   font-size: 12px;
   font-style: italic;
 }

--- a/client/js/editor/sidebar/json.js
+++ b/client/js/editor/sidebar/json.js
@@ -162,7 +162,7 @@ class DebugModule extends SidebarModule {
 
     div(target, 'staticErrors', `
       <div class="validation-controls" style="margin-top: 10px; display: none;">
-        <button id="runValidationButton" class="ui-button">Run Validation</button>
+        <button id="runValidationButton" icon=data_check>Run Validation</button>
         <span class="validation-time"></span>
       </div>
       <div class="success">No validation problems found!</div>
@@ -180,6 +180,7 @@ class DebugModule extends SidebarModule {
     `);
 
     on('#runValidationButton', 'click', e=>this.button_runValidation());
+    this.lastValidationTime = 0;
     this.updateValidation();
   }
 


### PR DESCRIPTION
The button that shows up when the validation is taking too long disappeared after clicking away from the debugger.  This fixes that and the accompanying text now supports light and dark mode.