### PR TITLE
fixed crash in icon commands for properties starting with `icon`

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -316,6 +316,14 @@ const jeCommands = [
     id: 'je_symbolPickerAsset',
     name: 'pick an asset from the symbol picker',
     context: '.*"(/assets/[0-9_-]+|/i/[^"]+)"|^.* ↦ image$|^deck ↦ faceTemplates ↦ [0-9]+ ↦ objects ↦ [0-9]+ ↦ value$',
+    show: function() {
+      const current = jeGetValueAt('objects');
+      if(Array.isArray(current)) {
+        const index = jeGetKeyAfter('objects') || 0;
+        return typeof current[index] == 'object' && current[index] !== null && current[index].type == 'image';
+      }
+      return true;
+    },
     call: async function() {
       const a = await pickSymbol('images');
       if(a) {


### PR DESCRIPTION
The JSON editor commands only work for `icon` but the context matching was not explicit enough.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2633/pr-test (or any other room on that server)