### PR TITLE
less unneeded debug logging

### DIFF
--- a/client/js/editor/layout.js
+++ b/client/js/editor/layout.js
@@ -87,7 +87,6 @@ function metaReceived(data) {
 }
 
 export function openEditor() {
-  setJEroutineLogging(jeRoutineLogging = true);
   for(const module of sidebarModules)
     module.onEditorOpen();
   for(const button of toolbarButtons)

--- a/client/js/editor/sidebar/json.js
+++ b/client/js/editor/sidebar/json.js
@@ -136,6 +136,7 @@ class DebugModule extends SidebarModule {
   }
 
   onClose() {
+    setJEroutineLogging(jeRoutineLogging = false);
     $('#jsonEditor').append($('#jeLog'));
   }
 
@@ -159,6 +160,8 @@ class DebugModule extends SidebarModule {
     on('#jeLogFilter', 'input', e=>this.button_filter());
     on('#autoClearLog', 'change', e=>this.button_clearCheckbox());
     on('#clearLogButton', 'click', e=>this.button_clearButton());
+
+    setJEroutineLogging(jeRoutineLogging = true);
 
     div(target, 'staticErrors', `
       <div class="validation-controls" style="margin-top: 10px; display: none;">

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -2631,7 +2631,7 @@ export function jeLoggingRoutineEnd(variables, collections) {
       }
     }
   }
-  if($('#jeLogFilter'))
+  if($('#jeLogFilter') && $('#jeLogFilter').value)
     jeLoggingFilterLog($('#jeLogFilter').value);
 }
 

--- a/tests/testcafe/functions.js
+++ b/tests/testcafe/functions.js
@@ -150,10 +150,10 @@ test('Dynamic expressions', async t => {
     .click('#editButton')
     .click('#editorToolbar > div > [icon=add]')
     .click('#addBasicWidget')
-    .click(Selector('button').withAttribute('icon', 'data_object'))
+    .click('button[icon="data_object"]')
     .typeText('#jeText', button, { replace: true, paste: true })
+    .click('button[icon="pest_control"]')
     .rightClick('#w_jyo6')
-    .click(Selector('button').withAttribute('icon', 'pest_control'))
   const log = await Selector('#jeLog').textContent
   for (let i=0; i<ops.length; i++) {
     const logContains = log.includes('"'+ops[i][1]+'": '+ops[i][2]);


### PR DESCRIPTION
Writing the routine debug output is very slow for more complex routines. This PR only enables the debug logging when the Debug sidebar is actually active.

It also not longer calls the function to apply the current log filter to new debug output when no filter is set.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2635/pr-test (or any other room on that server)