### PR TITLE
fixed crash with `image` inside routine

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -2532,7 +2532,8 @@ function jeInsert(context, key, value) {
 function jeGetValueAt(key) {
   let pointer = jeStateNow;
   for(const k of jeContext.slice(1)) {
-    pointer = pointer[k];
+    if(typeof pointer[k] != 'undefined')
+      pointer = pointer[k];
     if(key == k)
       return pointer;
   }
@@ -2543,7 +2544,8 @@ async function jeSetValueAt(key, value, selectValue) {
   for(const k of jeContext.slice(1)) {
     if(key == k)
       break;
-    pointer = pointer[k];
+    if(typeof pointer[k] != 'undefined')
+      pointer = pointer[k];
   }
   if(selectValue !== undefined) {
     pointer[key] = value;


### PR DESCRIPTION
When having an `image` property somewhere in a routine operation, a context check led to a crash because the context contains a virtual `(SET)`. This PR makes affected functions skip those virtual context entries.

I came across this in Frontiers, `Base Map Button New` line 554 for example. It `SET`s a `grid` property that in turn contains `image` properties.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2638/pr-test (or any other room on that server)