### PR TITLE
fixed crash for newer Node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,13 +52,15 @@
     "@node-minify/no-compress": "^9.0.1",
     "@node-minify/uglify-es": "^9.0.1",
     "bson": "^6.10.3",
-    "crawler-user-agents": "^1.2.0",
     "crc-32": "^1.2.2",
     "dompurify": "^3.2.5",
     "express": "^5.1.0",
     "jszip": "^3.10.1",
     "node-fetch": "^2.7.0",
     "ws": "^8.18.2"
+  },
+  "optionalDependencies": {
+    "crawler-user-agents": "^1.2.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server.mjs
+++ b/server.mjs
@@ -7,7 +7,6 @@ import bodyParser from 'body-parser';
 import http from 'http';
 import CRC32 from 'crc-32';
 import fetch from 'node-fetch';
-import crawlers from 'crawler-user-agents' assert { type: 'json' };;
 
 import WebSocket  from './server/websocket.mjs';
 import Player     from './server/player.mjs';
@@ -16,6 +15,9 @@ import MinifyHTML from './server/minify.mjs';
 import Logging    from './server/logging.mjs';
 import Config     from './server/config.mjs';
 import Statistics from './server/statistics.mjs';
+
+let crawlers = [];
+try { crawlers = JSON.parse(fs.readFileSync('node_modules/crawler-user-agents/crawler-user-agents.json', 'utf8')); } catch {}
 
 const app = express();
 const server = http.Server(app);
@@ -311,6 +313,9 @@ MinifyHTML().then(function(result) {
   });
 
   function createBotPattern(crawlers) {
+    if(crawlers.length == 0)
+      return new RegExp('^$');
+
     // Join all the patterns using the | operator
     const combinedPattern = crawlers.filter(c => c.pattern!='HeadlessChrome').map(c => c.pattern).join('|');
 


### PR DESCRIPTION
The syntax for importing a JSON module changed at some point. There does not seem to be a syntax that works for all versions so I changed it to simply read the JSON file instead.

At the same time this makes the dependency on the crawler thingy optional. It is only necessary so that Discord and others show a nice link preview.