### PR TITLE
added 2x zoom mode

### DIFF
--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -23,6 +23,9 @@
   --positiveInput: #009502;
   --negativeInput: #950000;
   --neutralInput: #1f5ca6;
+  --roomZoom: 1;
+  --roomPanX: 0px;
+  --roomPanY: 0px;
 }
 
 body {
@@ -473,6 +476,10 @@ body.aspectTooGood.hiddenToolbar {
       content: '[volume_up]';
     }
 
+    #zoom2xButton::before {
+      content: '[zoom_in]';
+    }
+
     html:not(:fullscreen) #fullscreenButton::before {
       content: '[enter_fullscreen]';
     }
@@ -746,6 +753,15 @@ div[icon] .buttons {
 
 #room {
   transform: scale(var(--scale));
+  transform-origin: left top;
+}
+
+body.zoom2x #roomArea {
+  overflow: hidden;
+}
+
+body.zoom2x #room {
+  transform: scale(calc(var(--scale) * var(--roomZoom))) translate(var(--roomPanX), var(--roomPanY));
   transform-origin: left top;
 }
 

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -590,6 +590,59 @@ onLoad(function() {
       $('body').classList.add('lightsOff');
   });
 
+  // Zoom 2x functionality
+  let zoom2xActive = false;
+  let zoom2xMouseHandler = null;
+  let originalScale = 1;
+
+  on('#zoom2xButton', 'click', function(e){
+    zoom2xActive = !zoom2xActive;
+    
+    if(zoom2xActive) {
+      $('body').classList.add('zoom2x');
+      originalScale = scale;
+      enableZoom2xPanning(e);
+    } else {
+      $('body').classList.remove('zoom2x');
+      disableZoom2xPanning();
+      setScale();
+    }
+  });
+
+  function enableZoom2xPanning(e) {
+    zoom2xMouseHandler = function(e) {
+      if (!$('body').classList.contains('zoom2x')) return;
+      
+      const roomRect = $('#roomArea').getBoundingClientRect();
+      const mouseX = e.clientX - roomRect.left;
+      const mouseY = e.clientY - roomRect.top;
+      
+      // Calculate pan offset based on mouse position
+      // Mouse at top-left (0,0) should show top-left of room
+      // Mouse at bottom-right should show bottom-right of room
+      const panX = (mouseX / roomRect.width) * 1600 * 0.5; // 0.5 because we're showing 2x zoom
+      const panY = (mouseY / roomRect.height) * 1000 * 0.5;
+      
+      // Apply 2x zoom with panning
+      document.documentElement.style.setProperty('--roomZoom', 2);
+      document.documentElement.style.setProperty('--roomPanX', -panX + 'px');
+      document.documentElement.style.setProperty('--roomPanY', -panY + 'px');
+    };
+    
+    document.addEventListener('mousemove', zoom2xMouseHandler);
+    zoom2xMouseHandler(e);
+  }
+
+  function disableZoom2xPanning() {
+    if (zoom2xMouseHandler) {
+      document.removeEventListener('mousemove', zoom2xMouseHandler);
+      zoom2xMouseHandler = null;
+    }
+    document.documentElement.style.setProperty('--roomZoom', 1);
+    document.documentElement.style.setProperty('--roomPanX', '0px');
+    document.documentElement.style.setProperty('--roomPanY', '0px');
+  }
+
   on('#optionsButton', 'click', function(){
     if(optionsHidden) {
       $('#options').classList.remove('hidden');

--- a/client/room.html
+++ b/client/room.html
@@ -34,6 +34,7 @@
     <div id="optionsAnchor"><div id="options" class="hidden"><button id="muteButton" class="toolbarButton"></button><input id="volume" type="range" min="0" max="100" value="30"></div></div>
     <button id="optionsButton" class="toolbarButton"><span class="tooltip">Sound</span></button>
     <button id="lightsButton" class="toolbarButton"><span class="tooltip">Lights</span></button>
+    <button id="zoom2xButton" class="toolbarButton"><span class="tooltip">2x Zoom</span></button>
     <button id="fullscreenButton" class="toolbarButton"><span class="tooltip">Fullscreen</span></button>
     <button id="hideToolbarButton" class="toolbarButton"><span class="tooltip">Hide Toolbar</span></button>
   </div>


### PR DESCRIPTION
While #2677 should be nice for zooming on mobile, this PR is one idea for zooming in desktop browsers. A button in the toolbar toggles a 2x zoom mode that applies to the room area only. It automatically pans depending on the mouse position.

This is a one-prompt-AI-implementation (crazy times). If we like this, I would make some changes:
- Only 2x seems too harsh. Maybe make it a slider or add 1.5x or something.
- The room should not pan further than its area. It currently reveals the background when the cursor is outside the room area.
- It should not require the mouse to move all the way to the edge to reach it. It should show the right edge of the room when the mouse is only 80% there or something.

I got the AI to fix the last two things but it made widgets jump when moving them. But it was kinda close and definitely an improvement for the panning.