### PR TITLE
fixed widget buffer removing too much

### DIFF
--- a/client/js/editor/sidebar/toolbox.js
+++ b/client/js/editor/sidebar/toolbox.js
@@ -62,7 +62,7 @@ class ToolboxModule extends SidebarModule {
     batchStart();
     setDeltaCause(`${getPlayerDetails().playerName} loaded widgets from the widget buffer in editor`);
     for(const state of widgetBuffer) {
-      if(!widgetBuffer.filter(w=>w.id==state.parent).length && !widgets.has(state.parent)) {
+      if(state.parent && !widgetBuffer.filter(w=>w.id==state.parent).length && !widgets.has(state.parent)) {
         delete state.parent;
         delete state.x;
         delete state.y;


### PR DESCRIPTION
When putting widgets from the buffer into the room, it removes `parent`, `x` and `y` from any widget that does not have a valid parent (assuming that the parent wasn't part of the copied widgets). Turns out it does not check if a `parent` is set at all.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2710/pr-test (or any other room on that server)