### PR TITLE
PL Delicious Deliveries: Fix 2-4p supply setup issue

### DIFF
--- a/library/games/Delicious Deliveries/0.json
+++ b/library/games/Delicious Deliveries/0.json
@@ -463,8 +463,8 @@
         "collection": [
           "scoreboard"
         ],
-        "property": "y",
-        "value": -1000
+        "property": "display",
+        "value": false
       },
       {
         "func": "CALL",


### PR DESCRIPTION
Fix some issues from PL game Delicious Deliveries (similar to Fresh Fish):
- Supply tiles were being placed on the 5p board even if there were fewer than 5 seated players
- The scoreboard became unusable after a game reset (because code to reset it had not been updated to set its 'display' instead of 'y' property)

Also remove the `width` and `height` properties on the decks in the game to stop the Debug panel validator complaining quite so much.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2716/pr-test (or any other room on that server)