### PR TITLE
fixed unnecessary image requests for font icons

### DIFF
--- a/client/css/widgets/imagewidget.css
+++ b/client/css/widgets/imagewidget.css
@@ -56,6 +56,7 @@
 }
 
 .autoIconAlignFont {
+  background-image: none !important;
   font-family: "Material Symbols";
   font-weight: normal;
   line-height: 1;


### PR DESCRIPTION
Fixes #2725. When using a font-based icon for `icon`, it would still set `background-image: url(_)` which lead to requests to a new room whenever the icon was hovered.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2726/pr-test (or any other room on that server)