### PR TITLE
fixed crash when re-opening Undo panel

### DIFF
--- a/client/js/editor/sidebar/undo.js
+++ b/client/js/editor/sidebar/undo.js
@@ -7,6 +7,7 @@ class UndoModule extends SidebarModule {
 
   onClose() {
     this.lastRenderedIndex = -2;
+    this.latestEntryDOM = null;
   }
 
   onDeltaReceivedWhileActive(delta) {


### PR DESCRIPTION
When closing the Undo panel, the code did not reset a reference to a previously rendered entry.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2766/pr-test (or any other room on that server)