### PR TITLE
removed "add card widget" JSON editor button

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1714,7 +1714,7 @@ function jeAddWidgetPropertyCommands(object, widgetBase) {
     if(property != 'typeClasses' && !property.match(/^c[0-9]{2}$/))
       jeAddWidgetPropertyCommand(object, widgetBase, property);
   const type = object.defaults.typeClasses.replace(/widget /, '');
-  if(type != 'card') {
+  if(type != 'card' && type != 'pile') {
     jeCommands.push({
       id: 'addWidget_' + type,
       name: `add ${type} widget`,


### PR DESCRIPTION
It was auto-generated for all widget types but adding a card would crash the client because it needs a deck to be valid.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2767/pr-test (or any other room on that server)