### PR TITLE
fixed crash when CANVAS collection contains non-canvas

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1413,7 +1413,7 @@ function jeAddCommands() {
   jeAddEnumCommands('^.*\\(TURN\\) ↦ turnCycle', [ 'forward', 'backward', 'random', 'position', 'seat']);
   jeAddEnumCommands('^.*\\([A-Z]+\\) ↦ property', [ 'id', 'parent', 'type', 'rotation' ]);
 
-  jeAddEnumCommands('^.*\\((CLICK|COUNT|DELETE|FLIP|GET|LABEL|ROTATE|SET|SORT|SHUFFLE|TIMER)\\) ↦ collection', collectionNames.slice(1));
+  jeAddEnumCommands('^.*\\((CANVAS|CLICK|COUNT|DELETE|FLIP|GET|LABEL|ROTATE|SET|SORT|SHUFFLE|TIMER)\\) ↦ collection', collectionNames.slice(1));
   jeAddEnumCommands('^.*\\(CLONE\\) ↦ source', collectionNames.slice(1));
   jeAddEnumCommands('^.*\\((SELECT|TURN)\\) ↦ source', collectionNames);
   jeAddEnumCommands('^.*\\(COUNT\\) ↦ owner', [ '${}' ]);

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1113,8 +1113,8 @@ export class Widget extends StateManaged {
         }
 
         const execute = async function(widget) {
-          const cm = widget.getColorMap();
           if(widget.get('type') == 'canvas') {
+            const cm = widget.getColorMap();
             if(a.mode == 'setPixel') {
               const res = widget.getResolution();
               if(a.x >= 0 && a.y >= 0 && a.x < res && a.y < res) {


### PR DESCRIPTION
The code was reading the canvas color map before making sure it was a canvas. It also adds the default collection buttons to `CANVAS.collection` in the JSON editor.

Easy way to reproduce the problem/fix:

```JSON
{
  "type": "button",
  "id": "button",
  "clickRoutine": [
    {
      "func": "CANVAS",
      "collection": "thisButton"
    }
  ]
}
```

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2768/pr-test (or any other room on that server)