### PR TITLE
Expand metadata fields included in search filter

### DIFF
--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -522,7 +522,11 @@ function fillStatesList(states, starred, activeState, returnServer, activePlayer
     entry.dataset.year = state.year;
     entry.dataset.stars = state.stars;
     entry.dataset.timePlayed = state.timePlayed;
-    entry.dataset.text = `${state.name} ${state.similarName} ${state.description} ${state.similarDesigner} ${state.similarAwards} ${state.savePlayers} ${state.helpText} ${state.attribution}`.toLowerCase();
+    const variantText = Object.values(state.variants || {}).map(v => {
+      const variant = v.plStateID && states[v.plStateID] ? states[v.plStateID].variants[v.plVariantID] : v;
+      return variant && variant.variant;
+    }).filter(Boolean).join(' ');
+    entry.dataset.text = `${state.name} ${state.similarName} ${state.description} ${state.similarDesigner} ${state.similarAwards} ${state.savePlayers} ${state.helpText} ${state.attribution} ${variantText}`.toLowerCase();
     entry.dataset.players = validPlayers.join();
     entry.dataset.lastUpdate = state.saveDate || state.lastUpdate || 0;
     entry.dataset.duration = String(state.time).replace(/.*[^0-9]/, '');


### PR DESCRIPTION
This adds the `helpText` field (aka How To Use This Implememtation).  This may add a good bit of extra information, but will allow the Card Games mod to search the available games there. Also adds the `attribution` field so you can search by the game dev name. And it adds the `variant` name field.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2772/pr-test (or any other room on that server)