### PR TITLE
fixed html whitespace behavior for certain games

### DIFF
--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -38,8 +38,6 @@ function computeGlobalProperties(state, v) {
   }
 
   v<20 && v20WhiteSpacePreWrapRoutineCheck(state, globalProperties);
-  if(globalProperties.v20WhiteSpacePreWrapForAllHtml)
-    console.log('Detected v20WhiteSpacePreWrapForAllHtml');
 
   return globalProperties;
 }


### PR DESCRIPTION
#2738 changed the default `white-space` for basic widgets. A file updater applied the old css when necessary so that old games did not change. But the file updater did not catch cases where `html` was inherited or changed by `SET`.

This PR improves the file updater but still will not detect _everything_. Just adding the `css` to every basic widget ever would be way too much overkill though so I hope that this is good enough.

We specifically noticed a problem in Trajectory where the game log was now missing line breaks.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2773/pr-test (or any other room on that server)