### PR TITLE
fixed showInactiveFaceToSeat sometimes showing wrong face

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -453,7 +453,7 @@ export class Widget extends StateManaged {
   }
 
   classesProperties() {
-    return [ 'classes', 'display', 'dragging', 'dropShadowOwner', 'hoverTarget', 'linkedToSeat', 'onlyVisibleForSeat', 'owner', 'typeClasses', 'movable', 'enlarge', 'clickable' ];
+    return [ 'classes', 'display', 'dragging', 'dropShadowOwner', 'hoverTarget', 'hoverParent', 'linkedToSeat', 'onlyVisibleForSeat', 'owner', 'typeClasses', 'movable', 'enlarge', 'clickable' ];
   }
 
   async click(mode='respect') {


### PR DESCRIPTION
Fixes #2833 (I hope). There is special code that makes sure the correct face is shown when just hovering a holder with `showInactiveFaceToSeat`. It sets a special CSS class on the card when its `hoverParent` has `showInactiveFaceToSeat` but `hoverParent` was not listed as a property that changes the class. So changes to `hoverParent` did not force an update to the card class.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2835/pr-test (or any other room on that server)