### PR TITLE
fixed JSON editor commands adding to wrong operation

### DIFF
--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1189,13 +1189,16 @@ const jeCommands = [
   }
 ];
 
-function jeRoutineCall(callback, synchronous) {
+function jeRoutineCall(callback, synchronous, command) {
   const f = function() {
     let routineIndex = -1;
+    let commandFound = !command;
     for(let i=jeContext.length-1; i>=0; --i) {
-      if(String(jeContext[i]).match(/Routine$/)) {
+      if(commandFound && String(jeContext[i]).match(/Routine$/)) {
         routineIndex = i;
         break;
+      } else if(!commandFound && String(jeContext[i]) == `(${command})`) {
+        commandFound = true;
       }
     }
 
@@ -1333,10 +1336,10 @@ function jeAddRoutineOperationCommands(command, defaults) {
             "reverse": false
           };
           jeSetAndSelect('z');
-        }) :
+        }, false, command) :
         jeRoutineCall(function(routineIndex, routine, operationIndex, operation) {
           jeInsert(jeContext.slice(1, routineIndex+2), property, defaults[property]);
-        }),
+        }, false, command),
       show: jeRoutineCall(function(routineIndex, routine, operationIndex, operation) {
         return operation && operation[property] === undefined;
       }, true)


### PR DESCRIPTION
Fixes #2830. When in a nested routine (for example `thenRoutine`), it would operate on the wrong routine.

```JSON
    "clickRoutine": [
      {
        "func": "IF",
        "thenRoutine": [
          {
            "func": "FLIP" <cursor>
          }
        ]
      }
    ]
```

Press `elseRoutine` JSON editor command button.

```JSON
    "clickRoutine": [
      {
        "func": "IF",
        "thenRoutine": [
          {
            "func": "FLIP",
            "elseRoutine": []
          }
        ]
      }
    ]
```

After this PR it should be:

```JSON
    "clickRoutine": [
      {
        "func": "IF",
        "thenRoutine": [
          {
            "func": "FLIP"
          }
        ],
        "elseRoutine": []
      }
    ]
```

I hope it doesn't break too much other stuf..

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2840/pr-test (or any other room on that server)