### PR TITLE
clear public library flag when importing game

### DIFF
--- a/server/room.mjs
+++ b/server/room.mjs
@@ -112,6 +112,8 @@ export default class Room {
           delete Room.publicLibrary;
           this.publicLibraryUpdatedCallback();
           return;
+        } else {
+          delete meta.publicLibrary;
         }
 
         if(type != 'link' || meta.importerTemp)


### PR DESCRIPTION
Fixes #2838. Game metadata contains a `publicLibrary` flag if it is a public library game. But when importing a game file, the flag should be deleted so the game does not show up as a public library game.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2841/pr-test (or any other room on that server)