### PR TITLE
Add iconColor property to holders

### DIFF
--- a/client/js/symbols.js
+++ b/client/js/symbols.js
@@ -337,7 +337,7 @@ function setTextAndAdjustFontSize(element, text, maxWidth, maxHeight, initialFon
   element.style.setProperty('--maxHeight', `${maxHeight}px`);
 }
 
-function generateSymbolsDiv(target, width, height, symbols, text, defaultScale, defaultColor, defaultHoverColor, defaultOpacity=1) {
+function generateSymbolsDiv(target, width, height, symbols, text, defaultScale, defaultColor, defaultHoverColor, defaultOpacity=1, defaultTextColor=defaultColor, defaultTextHoverColor=defaultHoverColor) {
   const outerWrapper = div(target, 'symbolOuterWrapper', `
     <div class="symbolWrapper"></div>
     <div class="symbolText"></div>
@@ -367,8 +367,8 @@ function generateSymbolsDiv(target, width, height, symbols, text, defaultScale, 
     }
     wrapper.style.setProperty('--width', `${iconsWidth}px`);
     wrapper.style.setProperty('--height', `${iconsHeight}px`);
-    $('.symbolText', outerWrapper).style.setProperty('--color', `${defaultColor}`);
-    $('.symbolText', outerWrapper).style.setProperty('--hoverColor', `${defaultHoverColor}`);
+    $('.symbolText', outerWrapper).style.setProperty('--color', `${defaultTextColor}`);
+    $('.symbolText', outerWrapper).style.setProperty('--hoverColor', `${defaultTextHoverColor}`);
     setTextAndAdjustFontSize($('.symbolText', outerWrapper), normalizedText, textWidth, textHeight);
   }
   const maxSize = optimalSquareSize(asArray(symbols).length, iconsWidth, iconsHeight);

--- a/client/js/widgets/holder.js
+++ b/client/js/widgets/holder.js
@@ -273,7 +273,7 @@ class Holder extends ImageWidget {
       if(this.symbolWrapper)
         this.symbolWrapper.remove();
       if(this.get('icon'))
-        this.symbolWrapper = generateSymbolsDiv(this.domElement, this.get('width'), this.get('height'), this.getIconWithColorOverride(), this.get('text'), this.getDefaultIconScale(), this.getDefaultIconColor(), this.getDefaultIconHoverColor(), this.getDefaultIconOpacity());
+        this.symbolWrapper = generateSymbolsDiv(this.domElement, this.get('width'), this.get('height'), this.getIconWithColorOverride(), this.get('text'), this.getDefaultIconScale(), this.getDefaultIconColor(), this.getDefaultIconHoverColor(), this.getDefaultIconOpacity(), this.get('textColor'), this.get('textColor'));
     }
   }
 }

--- a/client/js/widgets/holder.js
+++ b/client/js/widgets/holder.js
@@ -12,6 +12,7 @@ class Holder extends ImageWidget {
       typeClasses: 'widget holder',
       color: 'white',
       textColor: '#0004',
+      iconColor: null,
 
       dropTarget: { type: 'card' },
       dropOffsetX: 4,
@@ -33,6 +34,8 @@ class Holder extends ImageWidget {
 
   applyDeltaToDOM(delta) {
     this.base.applyDeltaToDOM.call(this, delta, true);
+    if(delta.iconColor !== undefined)
+      this.updateIcon();
     if(this.textWrapper && !this.get('text')) {
       this.textWrapper.remove();
       this.textWrapper = null;
@@ -113,8 +116,29 @@ class Holder extends ImageWidget {
     return 0.85;
   }
 
+  getDefaultIconColor() {
+    return this.get('iconColor') || super.getDefaultIconColor();
+  }
+
   getDefaultIconOpacity() {
+    if(this.get('iconColor') !== null && this.get('iconColor') !== undefined)
+      return 1;
     return 0.2;
+  }
+
+  getIconWithColorOverride() {
+    const icon = this.getWithPropertyReplacements('icon');
+    const iconColor = this.get('iconColor');
+    if(iconColor === null || iconColor === undefined || icon === null || icon === undefined)
+      return icon;
+
+    const overrideColor = symbol=>{
+      if(typeof symbol == 'object' && symbol !== null)
+        return Object.assign({}, symbol, { color: iconColor, opacity: 1 });
+      return { name: symbol, color: iconColor, opacity: 1 };
+    };
+
+    return Array.isArray(icon) ? icon.map(overrideColor) : overrideColor(icon);
   }
 
   async onChildAdd(child, oldParentID) {
@@ -246,7 +270,10 @@ class Holder extends ImageWidget {
 
       setTextAndAdjustFontSize(this.textWrapper, this.get('text'), this.textWrapper.clientWidth, this.textWrapper.clientHeight, 25, 1);
     } else {
-      super.updateIcon();
+      if(this.symbolWrapper)
+        this.symbolWrapper.remove();
+      if(this.get('icon'))
+        this.symbolWrapper = generateSymbolsDiv(this.domElement, this.get('width'), this.get('height'), this.getIconWithColorOverride(), this.get('text'), this.getDefaultIconScale(), this.getDefaultIconColor(), this.getDefaultIconHoverColor(), this.getDefaultIconOpacity());
     }
   }
 }

--- a/validator/validate_gamefile.js
+++ b/validator/validate_gamefile.js
@@ -129,7 +129,7 @@ const WIDGET_PROPERTIES = {
     },
     Holder: {
         ...COMMON_PROPERTIES,
-        movable: 'boolean', layer: 'number', dropTarget: 'any', dropOffsetX: 'number', dropOffsetY: 'number', dropShadow: 'any', alignChildren: 'any', preventPiles: 'any', childrenPerOwner: 'any', showInactiveFaceToSeat: 'any', onEnter: 'object', onLeave: 'object', stackOffsetX: 'number', stackOffsetY: 'number', borderRadius: 'any', color: 'string', svgReplaces: 'any', text: 'any', textColor: 'any', icon: 'any', image: 'asset'
+        movable: 'boolean', layer: 'number', dropTarget: 'any', dropOffsetX: 'number', dropOffsetY: 'number', dropShadow: 'any', alignChildren: 'any', preventPiles: 'any', childrenPerOwner: 'any', showInactiveFaceToSeat: 'any', onEnter: 'object', onLeave: 'object', stackOffsetX: 'number', stackOffsetY: 'number', borderRadius: 'any', color: 'string', svgReplaces: 'any', text: 'any', textColor: 'any', iconColor: 'any', icon: 'any', image: 'asset'
     },
     Label: {
         ...COMMON_PROPERTIES,


### PR DESCRIPTION
This adds an iconColor property to holders. If used, it overrides anything set in the advanced icon property for both color and opacity.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2966/pr-test (or any other room on that server)