### PR TITLE
Widgets with display:false are no longer valid dropTargets

### DIFF
--- a/client/js/main.js
+++ b/client/js/main.js
@@ -39,7 +39,7 @@ function compareDropTarget(widget, t, exclude){
 function getValidDropTargets(widget) {
   const targets = [];
   for(const [ _, t ] of dropTargets) {
-    if(t.isInvisible())
+    if(!t.isVisible())
       continue;
 
     // if the holder has a drop limit and it's reached, skip the holder

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -39,7 +39,7 @@ function compareDropTarget(widget, t, exclude){
 function getValidDropTargets(widget) {
   const targets = [];
   for(const [ _, t ] of dropTargets) {
-    if(!t.get('display'))
+    if(t.isInvisible())
       continue;
 
     // if the holder has a drop limit and it's reached, skip the holder

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -39,6 +39,9 @@ function compareDropTarget(widget, t, exclude){
 function getValidDropTargets(widget) {
   const targets = [];
   for(const [ _, t ] of dropTargets) {
+    if(!t.get('display'))
+      continue;
+
     // if the holder has a drop limit and it's reached, skip the holder
     if(t.get('dropLimit') > -1 && t.get('dropLimit') <= t.children().length)
       // don't skip it if the dragged widget is already its child

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2303,6 +2303,11 @@ export class Widget extends StateManaged {
   }
 
   isVisible() {
+    if(!this.get('display'))
+      return false;
+    if(this.get('parent') && widgets.has(this.get('parent')) && !widgets.get(this.get('parent')).isVisible())
+      return false;
+
     // Ensure the element exists
     if (!this.domElement) return false;
 
@@ -2328,10 +2333,6 @@ export class Widget extends StateManaged {
       rect.bottom > roomRect.top &&
       rect.right > roomRect.left
     );
-  }
-
-  isInvisible() {
-    return !this.get('display') || this.get('parent') && widgets.has(this.get('parent')) && widgets.get(this.get('parent')).isInvisible();
   }
 
   async moveToHolder(holder) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2330,6 +2330,10 @@ export class Widget extends StateManaged {
     );
   }
 
+  isInvisible() {
+    return !this.get('display') || this.get('parent') && widgets.has(this.get('parent')) && widgets.get(this.get('parent')).isInvisible();
+  }
+
   async moveToHolder(holder) {
     if(this.inRemovalQueue)
       return;

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2303,11 +2303,6 @@ export class Widget extends StateManaged {
   }
 
   isVisible() {
-    if(!this.get('display'))
-      return false;
-    if(this.get('parent') && widgets.has(this.get('parent')) && !widgets.get(this.get('parent')).isVisible())
-      return false;
-
     // Ensure the element exists
     if (!this.domElement) return false;
 


### PR DESCRIPTION
This adds a check to ensure that holders are visible before allowing them to accept dropped children. Functions like MOVE and SET are not impacted.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2969/pr-test (or any other room on that server)