### PR TITLE
Security: Privacy: Full DOM Exposed in Error Reports

### DIFF
--- a/client/js/tracing.js
+++ b/client/js/tracing.js
@@ -58,8 +58,7 @@ onLoad(function() {
       widgetsState: [...widgets.keys()].map(id=>widgets.get(id).state),
       url: location.href,
       userAgent: navigator.userAgent,
-      playerName,
-      html: document.documentElement.outerHTML
+      playerName
     };
     preventReconnect();
     connection.close();


### PR DESCRIPTION
## Summary

Security: Privacy: Full DOM Exposed in Error Reports

## Problem

**Severity**: `Medium` | **File**: `client/js/tracing.js:L44`

In client/js/tracing.js, the error handler includes the entire page HTML (`html: document.documentElement.outerHTML`) in error reports sent to the server. This could expose sensitive user data, session information, or private room content in error logs.

## Solution

Remove the html field from error details or sanitize it to exclude sensitive information. Consider only sending relevant widget states or a sanitized excerpt instead of the full DOM.

## Changes

- `client/js/tracing.js` (modified)

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-2975/pr-test (or any other room on that server)