### PR TITLE
[debug only, will close] Dump state on Compute hash mismatch

### DIFF
--- a/tests/testcafe/test-util.js
+++ b/tests/testcafe/test-util.js
@@ -78,6 +78,10 @@ export async function compareState(t, md5) {
   if(!process.env.REFERENCE && fs.existsSync(refFile))
     console.log(diffString(JSON.parse(fs.readFileSync(refFile)), JSON.parse(state)));
 
+  console.log(`DEBUG_MISMATCH_START expected=${md5} actual=${hash}`);
+  console.log(state);
+  console.log('DEBUG_MISMATCH_END');
+
   await t.expect(hash).eql(md5);
 }
 


### PR DESCRIPTION
Temporary debug PR (not for merging) to capture the exact state/value causing the Chrome-version Compute test hash mismatch seen in PR #3005. Adds an unconditional console.log of the full room state whenever compareState() finds a hash mismatch, so the CI log shows the actual offending values. Will be closed and the branch deleted once the data is captured.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3007/pr-test (or any other room on that server)