### PR TITLE
Add Claude review workflow triggered by !review comments

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,30 @@
+# Lets anyone request a Claude Code review on an issue or PR by commenting
+# "!review" (no need to @-mention the bot). Triggers from any comment,
+# inline PR review comment, or PR review submission.
+name: Claude Review
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          trigger_phrase: "!review"
+          allowed_non_write_users: "*"
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Goal

Let anyone request an automated Claude Code review, from any channel, without needing write access or an @-mention.

## Change

Adds `.github/workflows/claude-review.yml`, which wires up [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) with:

- **Any channel**: triggers on `issue_comment`, `pull_request_review_comment`, and `pull_request_review` events, so it fires from a plain comment, an inline PR review comment, or a full PR review submission.
- **Any user**: `allowed_non_write_users: "*"` so commenters don't need write access to the repo to request a review.
- **No mention necessary**: `trigger_phrase: "!review"` instead of the default `@claude`, so typing `!review` anywhere is enough.

Per the action's own security guidance for `allowed_non_write_users`, the workflow keeps things tightly scoped:
- Uses the short-lived `secrets.GITHUB_TOKEN` (never a long-lived PAT).
- Job permissions are minimal (`contents: read`, `pull-requests: write`, `issues: write`, `id-token: write`).
- `claude_args` restricts tool access to read-only/comment-only actions (`gh pr diff`, `gh pr view`, `gh pr comment`, and inline review comments) — a `!review` request from an untrusted user can leave feedback but cannot edit files or push commits.

## Setup required

For this to run, the repo needs an `ANTHROPIC_API_KEY` (or `CLAUDE_CODE_OAUTH_TOKEN`) secret configured, same as any other `claude-code-action` workflow.

## Testing

Workflow YAML validated locally (structure mirrors the action's documented "Automatic PR Code Review" and interactive tag-mode examples). Not exercised end-to-end since it depends on repo secrets that only get set on the real repo.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3008/pr-test (or any other room on that server)