### PR TITLE
Reduce ignoreZoom hot-path overhead on reparent (#2988 review)

### DIFF
--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -700,7 +700,14 @@ export class Widget extends StateManaged {
   }
 
   cssTransformProperties() {
-    return [ 'rotation', 'scale', 'x', 'y', 'ignoreZoom', 'parent' ];
+    // Only ignoreZoom widgets have a transform that depends on their parent (the
+    // inverse-zoom compensation looks at the ancestor chain), so only they need
+    // to recompute it on reparent. Keeping 'parent' out of the list for everyone
+    // else avoids a redundant transform write on every card move/drop.
+    const properties = [ 'rotation', 'scale', 'x', 'y', 'ignoreZoom' ];
+    if(this.get('ignoreZoom'))
+      properties.push('parent');
+    return properties;
   }
 
   refreshIgnoreZoomDescendants() {


### PR DESCRIPTION
## What

Follow-up to the review of #2988 (`fix-recursiveIgnoreZoom`), addressing **minor issue 1 (hot-path overhead)**.

That PR added `parent` to `cssTransformProperties()`, which made **every** widget recompute and rewrite its CSS transform on **every** reparent — i.e. on every card move/drop — even though only widgets using `ignoreZoom` have a transform that actually depends on their parent (the inverse-zoom compensation walks the ancestor chain via `hasIgnoreZoomAncestor()`).

This PR gates `parent` behind `ignoreZoom`:

```js
cssTransformProperties() {
  const properties = [ 'rotation', 'scale', 'x', 'y', 'ignoreZoom' ];
  if(this.get('ignoreZoom'))
    properties.push('parent');
  return properties;
}
```

## Why

For the common case (widgets without `ignoreZoom`, which is the vast majority) the transform is parent-independent, so recomputing it on reparent is pure overhead: a redundant `domElement.style.transform` write during the drag/drop hot path. Excluding `parent` for those widgets removes that write.

`ignoreZoom` widgets still include `parent`, so they keep recomputing their compensation on reparent exactly as before — and because that recompute still happens in the `applyCSS()` call *before* the transition block in `applyDeltaToDOM()`, the smooth reparent animation timing is preserved.

The other two overheads noted in the review are already bounded: the `hasIgnoreZoomAncestor()` ancestor walk in `cssTransform()` is short-circuited behind `this.get('ignoreZoom') &&` (so non-ignoreZoom widgets never walk), and `refreshIgnoreZoomDescendants()` is a no-op empty loop for leaf widgets (cards).

## Testing

`npm test` (jest) passes. Change is purely client-side CSS-transform behavior; no room-state hash impact, so the TestCafe suite is unaffected. Behavior is identical for `ignoreZoom` widgets — verify on the PR test server that a parent + child both with `ignoreZoom: true` still follow the parent 1:1 when zoomed.

## Note

Based on the `fix-recursiveIgnoreZoom` branch and targets it, so it can be merged into #2988 before that PR lands (or rebased onto `main` if #2988 merges first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3012/pr-test (or any other room on that server)