### PR TITLE
Fix unhandled fetch failure in getSVG breaking SVG rendering for the session

### DIFF
--- a/client/js/main.js
+++ b/client/js/main.js
@@ -464,8 +464,11 @@ const svgCache = {};
 const svgRetryTime = {};
 // the cooldown between two retry chains, doubled after every failed one so a long outage isn't polled at a fixed rate
 const svgRetryDelay = {};
-// subscriber identifies the caller across renders (usually the DOM node the callback updates) so that a widget
-// asking for the same URL again replaces its own queued callback instead of adding another one
+// once the cooldown grew beyond this, a URL is considered permanently unreachable (a cross-origin image without CORS
+// headers looks exactly like a network error) and isn't polled on its own any more
+const svgRetryGiveUp = 300000;
+// subscriber identifies the caller across renders (the DOM node the callback updates or a key naming the widget and
+// the position within it) so that a widget asking for the same URL again replaces its own queued callback
 export function getSVG(url, replaces, callback, subscriber) {
   if(typeof svgCache[url] == 'string') {
     const cacheKey = url + JSON.stringify(replaces);
@@ -508,39 +511,61 @@ function downloadSVG(url, callbacks) {
       throw Object.assign(new Error(`HTTP status ${r.status}`), { httpStatus: r.status });
     return r.text();
   }).catch(e=>{
-    // only network errors and server errors are worth retrying, a 4xx won't become valid by asking again
-    if(attempt < 3 && !(e.httpStatus >= 400 && e.httpStatus < 500))
+    // a 404/410 says the asset is gone and won't become valid by asking again - everything else (a network error, a
+    // server error, but also a 403 from a CDN or an asset that is being uploaded right now) can still resolve itself
+    if(attempt < 3 && !isMissing(e))
       return new Promise(resolve=>setTimeout(_=>resolve(download(attempt+1)), 1000 * 2**attempt * (0.5 + Math.random()/2)));
     throw e;
   });
   // the callbacks are served in the success handler of this then() and not in a chained one so that an exception
   // thrown by a widget callback isn't mistaken for a download failure but reaches the error reporter instead
   download(0).then(t=>useSVG(url, callbacks, t), e=>{
-    if(e.httpStatus >= 400 && e.httpStatus < 500) {
+    if(isMissing(e)) {
       console.error(`Could not load image ${url} (HTTP status ${e.httpStatus}) - it will not be requested again`, e);
       useSVG(url, callbacks, ''); // cache the permanent failure as an empty SVG so the broken URL isn't requested again and again
     } else {
       const delay = svgRetryDelay[url] || 5000;
-      svgRetryDelay[url] = Math.min(2 * delay, 30000);
+      svgRetryDelay[url] = 2 * delay;
       svgRetryTime[url] = Date.now() + delay;
-      console.error(`Could not load image ${url} - trying again in ${delay/1000} seconds`, e);
+      // a widget that isn't on the table any more doesn't need the image, and its queue entry would keep the removed
+      // DOM node alive - drop those before deciding whether anybody is still waiting
+      for(let i=callbacks.length-1; i>=0; --i)
+        if(callbacks[i][2] && callbacks[i][2].nodeType && !callbacks[i][2].isConnected)
+          callbacks.splice(i, 1);
       // the widgets that asked for this URL are showing nothing, so start the next chain on our own instead of
       // waiting to be asked again: on a quiet table nothing re-renders, so they would stay blank until a reload
-      if(callbacks.length)
+      if(callbacks.length && delay <= svgRetryGiveUp) {
+        console.error(`Could not load image ${url} - trying again in ${delay/1000} seconds`, e);
         setTimeout(_=>{
           if(svgCache[url] === callbacks && svgRetryTime[url] != Infinity)
             downloadSVG(url, callbacks);
         }, delay);
+      } else {
+        // stop polling a URL that has been unreachable for minutes or that nobody is waiting for any more - the queued
+        // callbacks are kept, so a widget rendering again later can still start a new (and by then rare) attempt
+        console.error(`Could not load image ${url} - giving up, it is only requested again if a widget renders`, e);
+      }
     }
   });
+}
+
+function isMissing(e) {
+  return e.httpStatus == 404 || e.httpStatus == 410;
 }
 
 function useSVG(url, callbacks, svg) {
   delete svgRetryTime[url];
   delete svgRetryDelay[url];
   svgCache[url] = svg;
-  for(const [ c, r ] of callbacks)
-    c(getSVG(url, r, _=>{}));
+  for(const [ c, r ] of callbacks) {
+    try {
+      c(getSVG(url, r, _=>{}));
+    } catch(e) {
+      // a single broken widget must not leave all the other queued ones blank, but its exception still has to reach
+      // the error reporter - so hand it to the unhandledrejection handler instead of swallowing it
+      Promise.reject(e);
+    }
+  }
 }
 
 async function loadEditMode() {

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -464,7 +464,9 @@ const svgCache = {};
 const svgRetryTime = {};
 // the cooldown between two retry chains, doubled after every failed one so a long outage isn't polled at a fixed rate
 const svgRetryDelay = {};
-export function getSVG(url, replaces, callback) {
+// subscriber identifies the caller across renders (usually the DOM node the callback updates) so that a widget
+// asking for the same URL again replaces its own queued callback instead of adding another one
+export function getSVG(url, replaces, callback, subscriber) {
   if(typeof svgCache[url] == 'string') {
     const cacheKey = url + JSON.stringify(replaces);
     if(svgCache[cacheKey])
@@ -486,9 +488,14 @@ export function getSVG(url, replaces, callback) {
   }
 
   const callbacks = svgCache[url] || (svgCache[url] = []);
-  // widgets ask for the same SVG on every render, so during a long outage the queue must not grow without bounds
-  if(callbacks.length < 1000)
-    callbacks.push([ callback, replaces ]);
+  // widgets ask for the same SVG on every render, so during a long outage the queue would collect one entry per
+  // render - keep only the latest one per subscriber instead. Nothing is ever dropped: every queued entry is a
+  // widget that shows no image until the download succeeds.
+  const queued = subscriber !== undefined ? callbacks.findIndex(c=>c[2] === subscriber) : -1;
+  if(queued != -1)
+    callbacks[queued] = [ callback, replaces, subscriber ];
+  else
+    callbacks.push([ callback, replaces, subscriber ]);
   if((svgRetryTime[url] || 0) <= Date.now())
     downloadSVG(url, callbacks);
   return '';

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -482,12 +482,24 @@ function getSVG(url, replaces, callback) {
 
   if(!svgCache[url]) {
     svgCache[url] = [];
-    fetch(mapAssetURLs(url)).then(r=>r.text()).then(t=>{
+    const load = attempt=>fetch(mapAssetURLs(url)).then(r=>{
+      if(!r.ok)
+        throw new Error(`HTTP status ${r.status}`);
+      return r.text();
+    }).then(t=>{
       const callbacks = svgCache[url];
       svgCache[url] = t;
       for(const [ c, r ] of callbacks)
         c(getSVG(url, r, _=>{}));
+    }).catch(e=>{
+      if(attempt < 3) {
+        setTimeout(_=>load(attempt+1), 1000 * 2**attempt);
+      } else {
+        delete svgCache[url]; // allow a later call to retry the download
+        console.error(`getSVG: failed to load ${url}`, e);
+      }
     });
+    load(0);
   }
 
   svgCache[url].push([ callback, replaces ]);

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -459,6 +459,9 @@ function splitSVG(svg) {
 }
 
 const svgCache = {};
+// Infinity while a download is in flight, the time the next attempt is allowed after a transient failure.
+// This keeps a re-rendering widget from starting a new retry chain every time it asks for a URL that is down.
+const svgRetryTime = {};
 export function getSVG(url, replaces, callback) {
   if(typeof svgCache[url] == 'string') {
     const cacheKey = url + JSON.stringify(replaces);
@@ -480,36 +483,43 @@ export function getSVG(url, replaces, callback) {
     return svgCache[cacheKey];
   }
 
-  if(!svgCache[url]) {
-    svgCache[url] = [];
-    const download = attempt=>fetch(mapAssetURLs(url)).then(r=>{
-      if(!r.ok)
-        throw Object.assign(new Error(`HTTP status ${r.status}`), { httpStatus: r.status });
-      return r.text();
-    }).catch(e=>{
-      // only network errors and server errors are worth retrying, a 4xx won't become valid by asking again
-      if(attempt < 3 && !(e.httpStatus >= 400 && e.httpStatus < 500))
-        return new Promise(resolve=>setTimeout(_=>resolve(download(attempt+1)), 1000 * 2**attempt));
-      throw e;
-    });
-    download(0).then(t=>{
-      const callbacks = svgCache[url];
-      svgCache[url] = t;
-      if(Array.isArray(callbacks))
-        for(const [ c, r ] of callbacks)
-          c(getSVG(url, r, _=>{}));
-    }, e=>{
-      console.error(`getSVG: failed to load ${url}`, e);
-      if(e.httpStatus >= 400 && e.httpStatus < 500)
-        svgCache[url] = ''; // cache the permanent failure as an empty SVG so the broken URL isn't requested again and again
-      else
-        delete svgCache[url]; // transient failure: allow a later call to retry the download
-      // the pending callbacks are dropped on purpose: calling them would re-enter getSVG and restart the download
-    });
-  }
-
-  svgCache[url].push([ callback, replaces ]);
+  const callbacks = svgCache[url] || (svgCache[url] = []);
+  // widgets ask for the same SVG on every render, so during a long outage the queue must not grow without bounds
+  if(callbacks.length < 1000)
+    callbacks.push([ callback, replaces ]);
+  if((svgRetryTime[url] || 0) <= Date.now())
+    downloadSVG(url, callbacks);
   return '';
+}
+
+function downloadSVG(url, callbacks) {
+  svgRetryTime[url] = Infinity;
+  const download = attempt=>fetch(mapAssetURLs(url)).then(r=>{
+    if(!r.ok)
+      throw Object.assign(new Error(`HTTP status ${r.status}`), { httpStatus: r.status });
+    return r.text();
+  }).catch(e=>{
+    // only network errors and server errors are worth retrying, a 4xx won't become valid by asking again
+    if(attempt < 3 && !(e.httpStatus >= 400 && e.httpStatus < 500))
+      return new Promise(resolve=>setTimeout(_=>resolve(download(attempt+1)), 1000 * 2**attempt * (0.5 + Math.random()/2)));
+    throw e;
+  });
+  // the callbacks are served in the success handler of this then() and not in a chained one so that an exception
+  // thrown by a widget callback isn't mistaken for a download failure but reaches the error reporter instead
+  download(0).then(t=>useSVG(url, callbacks, t), e=>{
+    console.error(`getSVG: failed to load ${url}`, e);
+    if(e.httpStatus >= 400 && e.httpStatus < 500)
+      useSVG(url, callbacks, ''); // cache the permanent failure as an empty SVG so the broken URL isn't requested again and again
+    else
+      svgRetryTime[url] = Date.now() + 5000; // transient failure: keep the queued callbacks and let a later call retry
+  });
+}
+
+function useSVG(url, callbacks, svg) {
+  delete svgRetryTime[url];
+  svgCache[url] = svg;
+  for(const [ c, r ] of callbacks)
+    c(getSVG(url, r, _=>{}));
 }
 
 async function loadEditMode() {

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -459,7 +459,7 @@ function splitSVG(svg) {
 }
 
 const svgCache = {};
-function getSVG(url, replaces, callback) {
+export function getSVG(url, replaces, callback) {
   if(typeof svgCache[url] == 'string') {
     const cacheKey = url + JSON.stringify(replaces);
     if(svgCache[cacheKey])
@@ -482,24 +482,30 @@ function getSVG(url, replaces, callback) {
 
   if(!svgCache[url]) {
     svgCache[url] = [];
-    const load = attempt=>fetch(mapAssetURLs(url)).then(r=>{
+    const download = attempt=>fetch(mapAssetURLs(url)).then(r=>{
       if(!r.ok)
-        throw new Error(`HTTP status ${r.status}`);
+        throw Object.assign(new Error(`HTTP status ${r.status}`), { httpStatus: r.status });
       return r.text();
-    }).then(t=>{
+    }).catch(e=>{
+      // only network errors and server errors are worth retrying, a 4xx won't become valid by asking again
+      if(attempt < 3 && !(e.httpStatus >= 400 && e.httpStatus < 500))
+        return new Promise(resolve=>setTimeout(_=>resolve(download(attempt+1)), 1000 * 2**attempt));
+      throw e;
+    });
+    download(0).then(t=>{
       const callbacks = svgCache[url];
       svgCache[url] = t;
-      for(const [ c, r ] of callbacks)
-        c(getSVG(url, r, _=>{}));
-    }).catch(e=>{
-      if(attempt < 3) {
-        setTimeout(_=>load(attempt+1), 1000 * 2**attempt);
-      } else {
-        delete svgCache[url]; // allow a later call to retry the download
-        console.error(`getSVG: failed to load ${url}`, e);
-      }
+      if(Array.isArray(callbacks))
+        for(const [ c, r ] of callbacks)
+          c(getSVG(url, r, _=>{}));
+    }, e=>{
+      console.error(`getSVG: failed to load ${url}`, e);
+      if(e.httpStatus >= 400 && e.httpStatus < 500)
+        svgCache[url] = ''; // cache the permanent failure as an empty SVG so the broken URL isn't requested again and again
+      else
+        delete svgCache[url]; // transient failure: allow a later call to retry the download
+      // the pending callbacks are dropped on purpose: calling them would re-enter getSVG and restart the download
     });
-    load(0);
   }
 
   svgCache[url].push([ callback, replaces ]);

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -462,6 +462,8 @@ const svgCache = {};
 // Infinity while a download is in flight, the time the next attempt is allowed after a transient failure.
 // This keeps a re-rendering widget from starting a new retry chain every time it asks for a URL that is down.
 const svgRetryTime = {};
+// the cooldown between two retry chains, doubled after every failed one so a long outage isn't polled at a fixed rate
+const svgRetryDelay = {};
 export function getSVG(url, replaces, callback) {
   if(typeof svgCache[url] == 'string') {
     const cacheKey = url + JSON.stringify(replaces);
@@ -507,16 +509,28 @@ function downloadSVG(url, callbacks) {
   // the callbacks are served in the success handler of this then() and not in a chained one so that an exception
   // thrown by a widget callback isn't mistaken for a download failure but reaches the error reporter instead
   download(0).then(t=>useSVG(url, callbacks, t), e=>{
-    console.error(`getSVG: failed to load ${url}`, e);
-    if(e.httpStatus >= 400 && e.httpStatus < 500)
+    if(e.httpStatus >= 400 && e.httpStatus < 500) {
+      console.error(`Could not load image ${url} (HTTP status ${e.httpStatus}) - it will not be requested again`, e);
       useSVG(url, callbacks, ''); // cache the permanent failure as an empty SVG so the broken URL isn't requested again and again
-    else
-      svgRetryTime[url] = Date.now() + 5000; // transient failure: keep the queued callbacks and let a later call retry
+    } else {
+      const delay = svgRetryDelay[url] || 5000;
+      svgRetryDelay[url] = Math.min(2 * delay, 30000);
+      svgRetryTime[url] = Date.now() + delay;
+      console.error(`Could not load image ${url} - trying again in ${delay/1000} seconds`, e);
+      // the widgets that asked for this URL are showing nothing, so start the next chain on our own instead of
+      // waiting to be asked again: on a quiet table nothing re-renders, so they would stay blank until a reload
+      if(callbacks.length)
+        setTimeout(_=>{
+          if(svgCache[url] === callbacks && svgRetryTime[url] != Infinity)
+            downloadSVG(url, callbacks);
+        }, delay);
+    }
   });
 }
 
 function useSVG(url, callbacks, svg) {
   delete svgRetryTime[url];
+  delete svgRetryDelay[url];
   svgCache[url] = svg;
   for(const [ c, r ] of callbacks)
     c(getSVG(url, r, _=>{}));

--- a/client/js/symbols.js
+++ b/client/js/symbols.js
@@ -337,7 +337,9 @@ function setTextAndAdjustFontSize(element, text, maxWidth, maxHeight, initialFon
   element.style.setProperty('--maxHeight', `${maxHeight}px`);
 }
 
-function generateSymbolsDiv(target, width, height, symbols, text, defaultScale, defaultColor, defaultHoverColor, defaultOpacity=1) {
+// subscriber names the widget (and the position within it) the icons belong to - the icon elements themselves are
+// re-created on every render, so they can't identify a caller of getSVG across renders
+function generateSymbolsDiv(target, width, height, symbols, text, defaultScale, defaultColor, defaultHoverColor, defaultOpacity=1, subscriber) {
   const outerWrapper = div(target, 'symbolOuterWrapper', `
     <div class="symbolWrapper"></div>
     <div class="symbolText"></div>
@@ -375,7 +377,9 @@ function generateSymbolsDiv(target, width, height, symbols, text, defaultScale, 
 
   outerWrapper.style.setProperty('--count', 1);
 
+  let symbolIndex = -1;
   for(let symbol of asArray(symbols)) {
+    ++symbolIndex;
     if(!symbol)
       continue;
 
@@ -421,13 +425,14 @@ function generateSymbolsDiv(target, width, height, symbols, text, defaultScale, 
         const imageURL = image, hoverImageURL = hoverImage;
         const imageReplaces = { [details.colorReplace]: colorTarget };
         const hoverImageReplaces = { [details.colorReplace]: hoverColorTarget };
-        // both properties are recolored from the same URL, so they share one entry in its download queue (keyed by the icon)
+        // both properties are recolored from the same URL, so they share one entry in its download queue
+        const iconSubscriber = subscriber === undefined ? undefined : `${subscriber}:symbol${symbolIndex}`;
         const applyImages = _=>{
-          icon.style.setProperty('--image', `url("${getSVG(imageURL, imageReplaces, applyImages, icon)}")`);
-          icon.style.setProperty('--hoverImage', `url("${getSVG(hoverImageURL, hoverImageReplaces, applyImages, icon)}")`);
+          icon.style.setProperty('--image', `url("${getSVG(imageURL, imageReplaces, applyImages, iconSubscriber)}")`);
+          icon.style.setProperty('--hoverImage', `url("${getSVG(hoverImageURL, hoverImageReplaces, applyImages, iconSubscriber)}")`);
         };
-        image = getSVG(imageURL, imageReplaces, applyImages, icon);
-        hoverImage = getSVG(hoverImageURL, hoverImageReplaces, applyImages, icon);
+        image = getSVG(imageURL, imageReplaces, applyImages, iconSubscriber);
+        hoverImage = getSVG(hoverImageURL, hoverImageReplaces, applyImages, iconSubscriber);
       }
       icon.style.setProperty('--image', `url("${image}")`);
       icon.style.setProperty('--hoverImage', `url("${hoverImage}")`);

--- a/client/js/symbols.js
+++ b/client/js/symbols.js
@@ -418,8 +418,16 @@ function generateSymbolsDiv(target, width, height, symbols, text, defaultScale, 
             hoverColorTarget = `${hoverColorTarget}\" stroke=\"${symbol.hoverStrokeColor[0]}\" stroke-width=\"${symbol.hoverStrokeWidth[0]}`;
           }
         }
-        image = getSVG(image, { [details.colorReplace]: colorTarget }, i=>icon.style.setProperty('--image', `url("${i}")`));
-        hoverImage = getSVG(hoverImage, { [details.colorReplace]: hoverColorTarget }, i=>icon.style.setProperty('--hoverImage', `url("${i}")`));
+        const imageURL = image, hoverImageURL = hoverImage;
+        const imageReplaces = { [details.colorReplace]: colorTarget };
+        const hoverImageReplaces = { [details.colorReplace]: hoverColorTarget };
+        // both properties are recolored from the same URL, so they share one entry in its download queue (keyed by the icon)
+        const applyImages = _=>{
+          icon.style.setProperty('--image', `url("${getSVG(imageURL, imageReplaces, applyImages, icon)}")`);
+          icon.style.setProperty('--hoverImage', `url("${getSVG(hoverImageURL, hoverImageReplaces, applyImages, icon)}")`);
+        };
+        image = getSVG(imageURL, imageReplaces, applyImages, icon);
+        hoverImage = getSVG(hoverImageURL, hoverImageReplaces, applyImages, icon);
       }
       icon.style.setProperty('--image', `url("${image}")`);
       icon.style.setProperty('--hoverImage', `url("${hoverImage}")`);

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -113,6 +113,8 @@ class Card extends Widget {
           const useIframe = original.type == 'html' && legacyMode('useIframeForHtmlCards');
           const objectDiv = document.createElement(useIframe ? 'iframe' : 'div');
           objectDiv.classList.add('cardFaceObject');
+          // identifies this object in the download queue of an SVG across renders (the icons below are re-created every time)
+          const objectSubscriber = `${this.id}:face${faceTemplates.indexOf(face)}:object${face.objects.indexOf(original)}`;
 
           const setValue = _=>{
             const usedProperties = new Set();
@@ -142,7 +144,7 @@ class Card extends Widget {
                     replaces[key] = this.get(replaces[key]);
                   const svgResult = getSVG(object.value, replaces, _=>{
                     objectDiv.style.backgroundImage = `url("${getSVG(object.value, replaces)}")`;
-                  }, objectDiv);
+                  }, objectSubscriber);
                   objectDiv.style.backgroundImage = `url("${svgResult}")`;
                 } else {
                   objectDiv.style.backgroundImage = mapAssetURLs(`url("${object.value}")`);
@@ -153,7 +155,7 @@ class Card extends Widget {
               if(object.value) {
                 if($('.symbolOuterWrapper', objectDiv))
                   $('.symbolOuterWrapper', objectDiv).remove();
-                generateSymbolsDiv(objectDiv, object.size || object.width, object.size || object.height, typeof object.value == 'object' ? object.value : Object.assign({ name:object.value }, object, { rotation: 0 }), object.text || '', 1, object.color);
+                generateSymbolsDiv(objectDiv, object.size || object.width, object.size || object.height, typeof object.value == 'object' ? object.value : Object.assign({ name:object.value }, object, { rotation: 0 }), object.text || '', 1, object.color, undefined, 1, objectSubscriber);
               }
             } else if (object.type == 'html') {
               const content = String(object.value).replaceAll(/\$\{PROPERTY ([A-Za-z0-9_-]+)\}/g, (m, n) => {

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -142,7 +142,7 @@ class Card extends Widget {
                     replaces[key] = this.get(replaces[key]);
                   const svgResult = getSVG(object.value, replaces, _=>{
                     objectDiv.style.backgroundImage = `url("${getSVG(object.value, replaces)}")`;
-                  });
+                  }, objectDiv);
                   objectDiv.style.backgroundImage = `url("${svgResult}")`;
                 } else {
                   objectDiv.style.backgroundImage = mapAssetURLs(`url("${object.value}")`);

--- a/client/js/widgets/dice.js
+++ b/client/js/widgets/dice.js
@@ -182,14 +182,14 @@ class Dice extends Widget {
   }
 
   createChildNodes() {
-    const applySVGreplaces = (faceDOM, faceDefinition, image, svgReplaces) => {
+    const applySVGreplaces = (faceDOM, faceDefinition, image, svgReplaces, subscriber) => {
       let imageResult = mapAssetURLs(image);
 
       if(typeof svgReplaces == 'object' && svgReplaces !== null) {
         const replaces = {};
         for(const key in svgReplaces)
           replaces[key] = this.getFaceProperty(faceDefinition, svgReplaces[key]);
-        imageResult = getSVG(image, replaces, _=>faceDOM.style.backgroundImage = `url("${getSVG(image, replaces)}")`, faceDOM);
+        imageResult = getSVG(image, replaces, _=>faceDOM.style.backgroundImage = `url("${getSVG(image, replaces)}")`, subscriber);
       }
 
       faceDOM.style.backgroundImage = `url("${imageResult}")`;
@@ -228,7 +228,7 @@ class Dice extends Widget {
         face.className = 'dicePip';
       } else if(icon != undefined) {
         this.facesElement.appendChild(face);
-        generateSymbolsDiv(face, this.get('width'), this.get('height'), icon, text, 0.9, this.getFaceProperty(content, 'pipColor'), this.getFaceProperty(content, 'pipColor'));
+        generateSymbolsDiv(face, this.get('width'), this.get('height'), icon, text, 0.9, this.getFaceProperty(content, 'pipColor'), this.getFaceProperty(content, 'pipColor'), 1, `${this.id}:face${i}`);
       } else if(text != undefined) {
         face.textContent = text;
       } else if(content.value != undefined && content.image == undefined) {
@@ -238,7 +238,7 @@ class Dice extends Widget {
       }
       const image = this.getFaceProperty(content, 'image');
       if(image)
-        applySVGreplaces(face, content, image, this.getFaceProperty(content, 'svgReplaces'));
+        applySVGreplaces(face, content, image, this.getFaceProperty(content, 'svgReplaces'), `${this.id}:face${i}`);
 
       face.appendChild(polygonBorder.cloneNode(true));
       face.appendChild(polygonBorder.cloneNode(true));

--- a/client/js/widgets/dice.js
+++ b/client/js/widgets/dice.js
@@ -189,7 +189,7 @@ class Dice extends Widget {
         const replaces = {};
         for(const key in svgReplaces)
           replaces[key] = this.getFaceProperty(faceDefinition, svgReplaces[key]);
-        imageResult = getSVG(image, replaces, _=>faceDOM.style.backgroundImage = `url("${getSVG(image, replaces)}")`);
+        imageResult = getSVG(image, replaces, _=>faceDOM.style.backgroundImage = `url("${getSVG(image, replaces)}")`, faceDOM);
       }
 
       faceDOM.style.backgroundImage = `url("${imageResult}")`;

--- a/client/js/widgets/imagewidget.js
+++ b/client/js/widgets/imagewidget.js
@@ -88,7 +88,7 @@ class ImageWidget extends Widget {
       else
         replaces[key] = this.get(property);
     }
-    return getSVG(this.get('image'), replaces, _=>this.domElement.style.cssText = this.css());
+    return getSVG(this.get('image'), replaces, _=>this.domElement.style.cssText = this.css(), this.domElement);
   }
 
   updateIcon() {

--- a/client/js/widgets/imagewidget.js
+++ b/client/js/widgets/imagewidget.js
@@ -95,6 +95,6 @@ class ImageWidget extends Widget {
     if(this.symbolWrapper)
       this.symbolWrapper.remove();
     if(this.get('icon'))
-      this.symbolWrapper = generateSymbolsDiv(this.domElement, this.get('width'), this.get('height'), this.getWithPropertyReplacements('icon'), this.get('text'), this.getDefaultIconScale(), this.getDefaultIconColor(), this.getDefaultIconHoverColor(), this.getDefaultIconOpacity());
+      this.symbolWrapper = generateSymbolsDiv(this.domElement, this.get('width'), this.get('height'), this.getWithPropertyReplacements('icon'), this.get('text'), this.getDefaultIconScale(), this.getDefaultIconColor(), this.getDefaultIconHoverColor(), this.getDefaultIconOpacity(), `${this.id}:icon`);
   }
 }

--- a/client/js/widgets/timer.js
+++ b/client/js/widgets/timer.js
@@ -82,7 +82,7 @@ export class Timer extends Widget {
     const replaces = {};
     for(const key in this.get('svgReplaces'))
       replaces[key] = this.get(this.get('svgReplaces')[key]);
-    return getSVG(this.get('image'), replaces, _=>this.domElement.style.cssText = this.css());
+    return getSVG(this.get('image'), replaces, _=>this.domElement.style.cssText = this.css(), this.domElement);
   }
 
   async onPropertyChange(property, oldValue, newValue) {

--- a/tests/client/getsvg.test.js
+++ b/tests/client/getsvg.test.js
@@ -96,6 +96,39 @@ describe("Scenarios: Downloading SVGs", () => {
     expect(duringOutage).toHaveBeenCalledWith('data:image/svg+xml,'+encodeURIComponent(svg));
   });
 
+  test("notifies every waiting caller, no matter how many are queued", async () => {
+    global.fetch = jest.fn()
+      .mockImplementationOnce(_=>Promise.reject(new TypeError('Failed to fetch')))
+      .mockImplementation(_=>respond(svg));
+
+    // a deck can easily have more card faces sharing one SVG than any queue limit would allow
+    const callbacks = [];
+    for(let i=0; i<1500; ++i) {
+      callbacks.push(jest.fn());
+      getSVG('/assets/many.svg', {}, callbacks[i], { subscriber: i });
+    }
+    await settle();
+
+    for(const callback of callbacks)
+      expect(callback).toHaveBeenCalledWith('data:image/svg+xml,'+encodeURIComponent(svg));
+  });
+
+  test("keeps only the latest callback of a widget that renders again while the URL is down", async () => {
+    global.fetch = jest.fn()
+      .mockImplementationOnce(_=>Promise.reject(new TypeError('Failed to fetch')))
+      .mockImplementation(_=>respond(svg));
+
+    const subscriber = {};
+    const firstRender = jest.fn(), secondRender = jest.fn();
+    getSVG('/assets/rerender.svg', {}, firstRender, subscriber);
+    getSVG('/assets/rerender.svg', {}, secondRender, subscriber);
+    await settle();
+
+    // the queue holds one entry per subscriber, so the outdated callback of the earlier render is not invoked
+    expect(firstRender).not.toHaveBeenCalled();
+    expect(secondRender).toHaveBeenCalledWith('data:image/svg+xml,'+encodeURIComponent(svg));
+  });
+
   test("waits for the cooldown before retrying a failed download", async () => {
     global.fetch = jest.fn(_=>Promise.reject(new TypeError('Failed to fetch')));
 

--- a/tests/client/getsvg.test.js
+++ b/tests/client/getsvg.test.js
@@ -1,0 +1,98 @@
+import { jest } from '@jest/globals';
+
+import { getSVG } from '../../client/js/main.js';
+import { mapAssetURLs } from '../../client/js/domhelpers.js';
+
+// in the browser all client modules share one global scope, so main.js uses this without importing it
+global.mapAssetURLs = mapAssetURLs;
+
+const svg = '<svg><rect fill="#ff0000"/></svg>';
+
+function respond(text, status = 200) {
+  return Promise.resolve({ ok: status >= 200 && status < 300, status, text: _=>Promise.resolve(text) });
+}
+
+// resolve all pending promise callbacks and run the timers the retry backoff scheduled
+async function settle() {
+  await jest.advanceTimersByTimeAsync(60000);
+}
+
+describe("Scenarios: Downloading SVGs", () => {
+  let consoleError;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    consoleError = jest.spyOn(console, 'error').mockImplementation(_=>{});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    jest.useRealTimers();
+  });
+
+  test("uses the SVG once a retry succeeds", async () => {
+    global.fetch = jest.fn()
+      .mockImplementationOnce(_=>Promise.reject(new TypeError('Failed to fetch')))
+      .mockImplementationOnce(_=>Promise.reject(new TypeError('Failed to fetch')))
+      .mockImplementation(_=>respond(svg));
+
+    const callback = jest.fn();
+    expect(getSVG('/assets/retry.svg', { '#ff0000': '#00ff00' }, callback)).toBe('');
+    await settle();
+
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(callback).toHaveBeenCalledWith('data:image/svg+xml,'+encodeURIComponent('<svg><rect fill="#00ff00"/></svg>'));
+
+    // the SVG is cached, so a later call neither downloads again nor invokes the callback
+    global.fetch.mockClear();
+    expect(getSVG('/assets/retry.svg', {}, callback)).toBe('data:image/svg+xml,'+encodeURIComponent(svg));
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test("clears the cache entry after all attempts failed", async () => {
+    global.fetch = jest.fn(_=>Promise.reject(new TypeError('Failed to fetch')));
+
+    getSVG('/assets/offline.svg', {}, jest.fn());
+    await settle();
+
+    expect(global.fetch).toHaveBeenCalledTimes(4);
+    expect(console.error).toHaveBeenCalled();
+
+    // a later call starts a fresh download because the failure could have been transient
+    global.fetch.mockClear();
+    global.fetch.mockImplementation(_=>respond(svg));
+    const callback = jest.fn();
+    getSVG('/assets/offline.svg', {}, callback);
+    await settle();
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith('data:image/svg+xml,'+encodeURIComponent(svg));
+  });
+
+  test("does not retry or re-download a 404", async () => {
+    global.fetch = jest.fn(_=>respond('not found', 404));
+
+    getSVG('/assets/missing.svg', {}, jest.fn());
+    await settle();
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    // the permanent failure is cached as an empty SVG instead of causing another request storm
+    global.fetch.mockClear();
+    expect(getSVG('/assets/missing.svg', {})).toBe('data:image/svg+xml,');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test("retries a 500", async () => {
+    global.fetch = jest.fn()
+      .mockImplementationOnce(_=>respond('server error', 500))
+      .mockImplementation(_=>respond(svg));
+
+    const callback = jest.fn();
+    getSVG('/assets/servererror.svg', {}, callback);
+    await settle();
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenCalledWith('data:image/svg+xml,'+encodeURIComponent(svg));
+  });
+});

--- a/tests/client/getsvg.test.js
+++ b/tests/client/getsvg.test.js
@@ -41,15 +41,18 @@ function trackPromises() {
 }
 
 describe("Scenarios: Downloading SVGs", () => {
-  let consoleError;
+  let consoleError, random;
 
   beforeEach(() => {
     jest.useFakeTimers();
     consoleError = jest.spyOn(console, 'error').mockImplementation(_=>{});
+    // remove the jitter from the backoff so the tests can advance the timers to an exact attempt
+    random = jest.spyOn(Math, 'random').mockReturnValue(1);
   });
 
   afterEach(() => {
     consoleError.mockRestore();
+    random.mockRestore();
     jest.useRealTimers();
   });
 
@@ -72,27 +75,24 @@ describe("Scenarios: Downloading SVGs", () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  test("serves the callbacks queued during an outage once a later call succeeds", async () => {
+  test("serves the callbacks queued during an outage once the asset is reachable again", async () => {
     global.fetch = jest.fn(_=>Promise.reject(new TypeError('Failed to fetch')));
 
     const duringOutage = jest.fn();
     getSVG('/assets/offline.svg', {}, duringOutage);
-    await settle();
+    await jest.advanceTimersByTimeAsync(7500); // the four attempts take 1s + 2s + 4s
 
     expect(global.fetch).toHaveBeenCalledTimes(4);
     expect(console.error).toHaveBeenCalled();
     expect(duringOutage).not.toHaveBeenCalled();
 
-    // a later call starts a fresh download because the failure could have been transient
+    // nobody asks again - on a quiet table no widget re-renders, so the next chain has to start on its own
     global.fetch.mockClear();
     global.fetch.mockImplementation(_=>respond(svg));
-    const callback = jest.fn();
-    getSVG('/assets/offline.svg', {}, callback);
-    await settle();
+    await jest.advanceTimersByTimeAsync(5000); // the cooldown after a failed chain
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
-    expect(callback).toHaveBeenCalledWith('data:image/svg+xml,'+encodeURIComponent(svg));
-    // the widget that asked while the network was down doesn't stay blank
+    // the widget that asked while the network was down doesn't stay blank until the page is reloaded
     expect(duringOutage).toHaveBeenCalledWith('data:image/svg+xml,'+encodeURIComponent(svg));
   });
 
@@ -100,20 +100,25 @@ describe("Scenarios: Downloading SVGs", () => {
     global.fetch = jest.fn(_=>Promise.reject(new TypeError('Failed to fetch')));
 
     getSVG('/assets/cooldown.svg', {}, jest.fn());
-    await jest.advanceTimersByTimeAsync(7500); // the four attempts take at most 1s + 2s + 4s
+    await jest.advanceTimersByTimeAsync(7500); // the four attempts take 1s + 2s + 4s
 
     expect(global.fetch).toHaveBeenCalledTimes(4);
 
     // re-rendering widgets ask again all the time, that must not start a new chain immediately
     global.fetch.mockClear();
-    getSVG('/assets/cooldown.svg', {}, jest.fn());
-    getSVG('/assets/cooldown.svg', {}, jest.fn());
+    for(let i=0; i<10; ++i)
+      getSVG('/assets/cooldown.svg', {}, jest.fn());
     expect(global.fetch).not.toHaveBeenCalled();
 
-    await jest.advanceTimersByTimeAsync(5000);
-    getSVG('/assets/cooldown.svg', {}, jest.fn());
+    // once the cooldown is over, a single new chain serves all of them
+    await jest.advanceTimersByTimeAsync(4500);
     expect(global.fetch).toHaveBeenCalledTimes(1);
-    await settle();
+
+    // and the cooldown grows with every failed chain instead of polling a URL that is down at a fixed rate
+    await jest.advanceTimersByTimeAsync(7000); // the second chain gives up 7s after it started
+    const attempts = global.fetch.mock.calls.length;
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(global.fetch).toHaveBeenCalledTimes(attempts);
   });
 
   test("serves a caller that arrives while a retry is pending", async () => {

--- a/tests/client/getsvg.test.js
+++ b/tests/client/getsvg.test.js
@@ -17,18 +17,32 @@ async function settle() {
   await jest.advanceTimersByTimeAsync(60000);
 }
 
+let restorePromiseTracking = null;
+
 // jest fails a test that produces an unhandled rejection, but an exception thrown by a widget callback is supposed to
 // stay unhandled so it reaches the error reporter - so record the promises getSVG creates and inspect them afterwards
 function trackPromises() {
   const promises = [];
   const originalThen = Promise.prototype.then;
+  const originalReject = Promise.reject;
   Promise.prototype.then = function(...args) {
     const promise = originalThen.apply(this, args);
     promises.push(promise);
     return promise;
   };
-  return async _=>{
+  Promise.reject = function(...args) {
+    const promise = originalReject.apply(Promise, args);
+    promises.push(promise);
+    return promise;
+  };
+  // afterEach restores this as well, so a failing expectation in between doesn't leak the patch into the other tests
+  restorePromiseTracking = _=>{
     Promise.prototype.then = originalThen;
+    Promise.reject = originalReject;
+    restorePromiseTracking = null;
+  };
+  return async _=>{
+    restorePromiseTracking();
     const rejections = [];
     jest.useRealTimers();
     await new Promise(resolve=>setTimeout(resolve, 10)); // let node notice the unhandled rejection
@@ -51,6 +65,8 @@ describe("Scenarios: Downloading SVGs", () => {
   });
 
   afterEach(() => {
+    if(restorePromiseTracking)
+      restorePromiseTracking();
     consoleError.mockRestore();
     random.mockRestore();
     jest.useRealTimers();
@@ -189,6 +205,65 @@ describe("Scenarios: Downloading SVGs", () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(getSVG('/assets/throwing.svg', {})).toBe('data:image/svg+xml,'+encodeURIComponent(svg));
     expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("gives up on a URL that stays unreachable instead of polling it for the whole session", async () => {
+    // a cross-origin image without CORS headers rejects like a network error and would never become valid
+    global.fetch = jest.fn(_=>Promise.reject(new TypeError('Failed to fetch')));
+
+    getSVG('https://example.com/nocors.svg', {}, jest.fn(), 'widget');
+    await jest.advanceTimersByTimeAsync(600000);
+
+    const attempts = global.fetch.mock.calls.length;
+    expect(attempts).toBeLessThan(40); // seven chains of four attempts, the cooldown doubling from 5s to 160s
+    await jest.advanceTimersByTimeAsync(600000);
+    expect(global.fetch).toHaveBeenCalledTimes(attempts);
+  });
+
+  test("stops retrying for a widget that isn't on the table any more", async () => {
+    global.fetch = jest.fn(_=>Promise.reject(new TypeError('Failed to fetch')));
+
+    const removed = document.createElement('div');
+    document.body.appendChild(removed);
+    getSVG('/assets/removed.svg', {}, jest.fn(), removed);
+    await jest.advanceTimersByTimeAsync(7500);
+
+    expect(global.fetch).toHaveBeenCalledTimes(4);
+    removed.remove();
+
+    // nobody is waiting for this image any more, so no further chain is started on its own
+    await jest.advanceTimersByTimeAsync(60000);
+    expect(global.fetch).toHaveBeenCalledTimes(8); // the chain scheduled before the widget was removed still runs
+  });
+
+  test("serves the other waiting widgets even if one of their callbacks throws", async () => {
+    global.fetch = jest.fn(_=>respond(svg));
+    const collectRejections = trackPromises();
+
+    const throwing = jest.fn(_=>{ throw new Error('widget render failed'); });
+    const other = jest.fn();
+    getSVG('/assets/throwingfirst.svg', {}, throwing, 'first');
+    getSVG('/assets/throwingfirst.svg', {}, other, 'second');
+    await settle();
+    const rejections = await collectRejections();
+
+    // the broken widget doesn't abort the dispatch, but its exception still reaches the error reporter
+    expect(other).toHaveBeenCalledWith('data:image/svg+xml,'+encodeURIComponent(svg));
+    expect(rejections.map(e=>e.message)).toContain('widget render failed');
+  });
+
+  test("retries a 403 instead of caching it as permanently missing", async () => {
+    // an auth or CDN hiccup isn't authoritative the way a 404 is, and an asset may still be uploading
+    global.fetch = jest.fn()
+      .mockImplementationOnce(_=>respond('forbidden', 403))
+      .mockImplementation(_=>respond(svg));
+
+    const callback = jest.fn();
+    getSVG('/assets/forbidden.svg', {}, callback);
+    await settle();
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenCalledWith('data:image/svg+xml,'+encodeURIComponent(svg));
   });
 
   test("does not retry or re-download a 404", async () => {

--- a/tests/client/getsvg.test.js
+++ b/tests/client/getsvg.test.js
@@ -17,6 +17,29 @@ async function settle() {
   await jest.advanceTimersByTimeAsync(60000);
 }
 
+// jest fails a test that produces an unhandled rejection, but an exception thrown by a widget callback is supposed to
+// stay unhandled so it reaches the error reporter - so record the promises getSVG creates and inspect them afterwards
+function trackPromises() {
+  const promises = [];
+  const originalThen = Promise.prototype.then;
+  Promise.prototype.then = function(...args) {
+    const promise = originalThen.apply(this, args);
+    promises.push(promise);
+    return promise;
+  };
+  return async _=>{
+    Promise.prototype.then = originalThen;
+    const rejections = [];
+    jest.useRealTimers();
+    await new Promise(resolve=>setTimeout(resolve, 10)); // let node notice the unhandled rejection
+    for(const promise of promises)
+      promise.catch(e=>rejections.push(e));
+    await new Promise(resolve=>setTimeout(resolve, 10)); // and then that it is handled after all
+    jest.useFakeTimers();
+    return rejections;
+  };
+}
+
 describe("Scenarios: Downloading SVGs", () => {
   let consoleError;
 
@@ -49,14 +72,16 @@ describe("Scenarios: Downloading SVGs", () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  test("clears the cache entry after all attempts failed", async () => {
+  test("serves the callbacks queued during an outage once a later call succeeds", async () => {
     global.fetch = jest.fn(_=>Promise.reject(new TypeError('Failed to fetch')));
 
-    getSVG('/assets/offline.svg', {}, jest.fn());
+    const duringOutage = jest.fn();
+    getSVG('/assets/offline.svg', {}, duringOutage);
     await settle();
 
     expect(global.fetch).toHaveBeenCalledTimes(4);
     expect(console.error).toHaveBeenCalled();
+    expect(duringOutage).not.toHaveBeenCalled();
 
     // a later call starts a fresh download because the failure could have been transient
     global.fetch.mockClear();
@@ -67,6 +92,65 @@ describe("Scenarios: Downloading SVGs", () => {
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(callback).toHaveBeenCalledWith('data:image/svg+xml,'+encodeURIComponent(svg));
+    // the widget that asked while the network was down doesn't stay blank
+    expect(duringOutage).toHaveBeenCalledWith('data:image/svg+xml,'+encodeURIComponent(svg));
+  });
+
+  test("waits for the cooldown before retrying a failed download", async () => {
+    global.fetch = jest.fn(_=>Promise.reject(new TypeError('Failed to fetch')));
+
+    getSVG('/assets/cooldown.svg', {}, jest.fn());
+    await jest.advanceTimersByTimeAsync(7500); // the four attempts take at most 1s + 2s + 4s
+
+    expect(global.fetch).toHaveBeenCalledTimes(4);
+
+    // re-rendering widgets ask again all the time, that must not start a new chain immediately
+    global.fetch.mockClear();
+    getSVG('/assets/cooldown.svg', {}, jest.fn());
+    getSVG('/assets/cooldown.svg', {}, jest.fn());
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(5000);
+    getSVG('/assets/cooldown.svg', {}, jest.fn());
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    await settle();
+  });
+
+  test("serves a caller that arrives while a retry is pending", async () => {
+    global.fetch = jest.fn()
+      .mockImplementationOnce(_=>Promise.reject(new TypeError('Failed to fetch')))
+      .mockImplementation(_=>respond(svg));
+
+    const first = jest.fn(), late = jest.fn();
+    getSVG('/assets/pending.svg', {}, first);
+    await jest.advanceTimersByTimeAsync(100); // the first attempt failed, the retry is scheduled
+
+    expect(getSVG('/assets/pending.svg', {}, late)).toBe('');
+    expect(global.fetch).toHaveBeenCalledTimes(1); // the second caller joins the running download
+    await settle();
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(first).toHaveBeenCalledWith('data:image/svg+xml,'+encodeURIComponent(svg));
+    expect(late).toHaveBeenCalledWith('data:image/svg+xml,'+encodeURIComponent(svg));
+  });
+
+  test("does not treat an exception in a widget callback as a download failure", async () => {
+    global.fetch = jest.fn(_=>respond(svg));
+    const collectRejections = trackPromises();
+
+    const throwing = jest.fn(_=>{ throw new Error('widget render failed'); });
+    getSVG('/assets/throwing.svg', {}, throwing);
+    await settle();
+    const rejections = await collectRejections();
+
+    expect(throwing).toHaveBeenCalled();
+    // the exception is not swallowed by the download error handling but stays unhandled for the error reporter
+    expect(rejections.map(e=>e.message)).toContain('widget render failed');
+    expect(console.error).not.toHaveBeenCalled();
+    // it did not restart the download and the successfully downloaded SVG is still cached
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(getSVG('/assets/throwing.svg', {})).toBe('data:image/svg+xml,'+encodeURIComponent(svg));
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
   test("does not retry or re-download a 404", async () => {


### PR DESCRIPTION
> **Closed as superseded by #3121.** The underlying problem — an SVG whose download fails staying blank for the rest of the session — is fixed on `main` by #3121, which replaced `getSVG` with `fetchSVG` plus an `unreadableCache` that retries 30 s later on the next render and falls back to the raw image URL. Rebasing this PR onto `main` would reintroduce the blank rendering for cross-origin images and for non-SVG images with `svgReplaces` that #3121 fixed, so it is closed instead of reworked.

## Problem

A client error from the main server showed an unhandled `TypeError: Failed to fetch` thrown from `getSVG` while a card was creating its faces (an SVG face image with color replacements was being downloaded when the network request failed).

Beyond the noisy unhandled rejection, the failure mode is worse than it looks: `getSVG` caches an array of pending callbacks in `svgCache[url]` while the download is in flight. If the `fetch` rejects (transient network hiccup, flaky connection), that array is never replaced by the SVG text and never cleared — so **every later render of any widget using that SVG silently gets an empty image for the rest of the session**, even after the network recovers. The unhandled rejection also reaches the handler in `tracing.js`, which terminates the session (`preventReconnect()` + error overlay). There was also no HTTP status check, so a 404/500 response body would get cached and used as if it were the SVG.

## Fix

In `getSVG` (client/js/main.js):
- check `r.ok` and treat HTTP error statuses as failures instead of caching the error page as SVG content,
- on a network error or a 5xx, retry up to 3 times with exponential backoff (1s / 2s / 4s, jittered so widgets don't retry in lockstep), which covers transient network failures like the reported one,
- on a 4xx, don't retry — a missing asset won't appear by asking again. It is negative-cached as an empty SVG so a game referencing a deleted asset can't turn every re-render into a fresh request chain,
- if all attempts fail, log a `console.error` instead of leaving an unhandled promise rejection, **keep** the queued callbacks and serve them as soon as a later attempt succeeds — so a widget that rendered once while the asset was unreachable doesn't stay blank until it happens to render again,
- **retry on a timer while callbacks are still queued**, instead of waiting for some widget to ask for the URL again: on a quiet table nothing re-renders, so the affected widgets would otherwise stay invisible for the rest of the session even after the network came back, and only a reload would bring them back,
- back off between retry chains (5s, doubling up to 30s) so a URL that is down isn't polled at a fixed rate and re-rendering widgets can't keep a doomed URL under constant retry — a completely unreachable URL costs 16 requests during a 60 second outage,
- **never drop a waiting caller**: widgets ask for the same URL on every render, so the queue must not collect one entry per render during a long outage. Instead of capping its length (which would leave the callers past the cap blank forever), a caller now identifies itself with the DOM node its callback updates, and a widget that renders again replaces its own queued entry. The call sites in `imagewidget`, `timer`, `card`, `dice` and `symbols` pass that subscriber; the two icon properties (`--image` / `--hoverImage`) share one entry because they are recolored from the same URL.

The download and the dispatch of the queued callbacks are separate promise handlers, so an exception thrown by a widget callback is not mistaken for a download failure (which would re-download the already cached SVG and could discard a perfectly good cache entry).

## Not in this PR

The UI/UX review asked for a visible placeholder while an image is loading / temporarily unavailable / permanently gone, since a widget without its image is invisible but still clickable. That is a change to how *healthy* games render too (`getSVG` returns `''` on the first render of every SVG widget, download or not), so it needs a design decision rather than an invented one — a concrete proposal is in [this comment](https://github.com/ArnoldSmith86/virtualtabletop/pull/3019#issuecomment-5250907095) and is waiting for a maintainer's answer. Everything else in the review is addressed.

## Testing

- `npm test` passes. `tests/client/getsvg.test.js` covers retry-then-success, the self-scheduled retry serving the callbacks queued during an outage without anything asking again, the growing cooldown, a caller arriving while a retry is pending, 1500 waiting callers all being notified, a re-rendering subscriber replacing its own queued callback, a throwing widget callback not counting as a download failure, the 4xx negative cache and the 5xx retry — under jsdom with a mocked `fetch` and fake timers.
- Verified with Playwright against a local server in a room that uses every `getSVG` call site (image widget, dice face, card face object, and a button icon from game-icons with distinct icon/hover colors): all of them render on load, all of them recover ~5s after the network comes back with no interaction and no re-render at all ([screenshot](https://agent.virtualtabletop.io/reports/pr/1525291930559316199/svg-selfheal-after-recovery.png)), 40 re-renders of a widget while the URL is down cause no extra requests, a 404 causes a single request, and a throwing callback neither re-downloads nor drops the cached SVG.
- `tests/testcafe/editor.js`, `publiclibrary-1.js`, `publiclibrary-2.js` and `compute-1.js` pass locally.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3019/pr-test (or any other room on that server)


