### PR TITLE
Prevent client stack overflow on cyclic widget parent chains

### DIFF
--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -1308,7 +1308,14 @@ async function duplicateWidget(widget, recursive, inheritFrom, inheritProperties
       return l.substr(0, l.length-zs-1) + String.fromCharCode(l.charCodeAt(l.length-zs-1)+1) + [...Array(zs)].map(l=>'A').join('');
   };
 
-  const clone = async function(widget, recursive, newParent, xOffset, yOffset) {
+  // on a cyclic parent chain a copy can end up as the child of a source widget that is copied later, so the copies are never cloned again themselves
+  const createdIDs = new Set();
+
+  const clone = async function(widget, recursive, newParent, xOffset, yOffset, copied=new Set()) {
+    if(copied.has(widget)) // a cyclic parent chain would make the recursive copy revisit the same source widgets forever
+      return [];
+    copied.add(widget);
+
     let currentWidget = JSON.parse(JSON.stringify(widget.state))
 
     if(inheritFrom) {
@@ -1376,11 +1383,12 @@ async function duplicateWidget(widget, recursive, inheritFrom, inheritProperties
         problems.push(`Could not add duplicate of card ${widget.id} with non-existent cardType ${currentWidget.cardType}.`);
     } else {
       const currentId = await addWidgetLocal(currentWidget);
+      createdIDs.add(currentId);
 
       const clonedWidgets = [ widgets.get(currentId) ];
       if(recursive)
-        for(const child of widgetFilter(w=>w.get('parent')==widget.id))
-          clonedWidgets.push(...await clone(child, true, currentId, 0, 0));
+        for(const child of widgetFilter(w=>w.get('parent')==widget.id && !createdIDs.has(w.get('id'))))
+          clonedWidgets.push(...await clone(child, true, currentId, 0, 0, copied));
 
       return clonedWidgets;
     }

--- a/client/js/geometry.js
+++ b/client/js/geometry.js
@@ -103,6 +103,8 @@ export function getElementTransformRelativeTo(elem, parent) {
   let transform = getElementTransform(elem);
   while (elem.offsetParent != ancestor) {
     elem = elem.offsetParent;
+    if (!elem)
+      return null; // parent is a descendant of elem so there is no path up to it
     transform.preMultiplySelf(getElementTransform(elem));
   }
   let destTransform = new DOMMatrix();

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3808,7 +3808,7 @@ function jeInitEventListeners() {
 
     hoveredWidgets.sort(function(w1,w2) {
       const hiddenParent =  function(widget) {
-        return widget ? widget.domElement.classList.contains('foreign') || hiddenParent(widgets.get(widget.get('parent'))) : false;
+        return widget ? widget.ancestors().some(w=>w.domElement.classList.contains('foreign')) : false;
       };
       const w1card = w1.get('type') == 'card';
       const w2card = w2.get('type') == 'card';

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -36,7 +36,7 @@ function compareDropTarget(widget, t, exclude){
   return false;
 }
 
-function getValidDropTargets(widget) {
+export function getValidDropTargets(widget) {
   const targets = [];
   for(const [ _, t ] of dropTargets) {
     if(!t.isVisible())
@@ -50,18 +50,8 @@ function getValidDropTargets(widget) {
 
     let isValid = compareDropTarget(widget, t);
 
-    let tt = t;
-    while(isValid) {
-      if(widget == tt) {
-        isValid = false;
-        break;
-      }
-
-      if(tt.get('parent'))
-        tt = widgets.get(tt.get('parent'));
-      else
-        break;
-    }
+    if(isValid && t.ancestors().includes(widget))
+      isValid = false;
 
     if (jeEnabled && getComputedStyle(t.domElement).getPropertyValue('--foreign') == 'true')
       continue;

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -79,18 +79,9 @@ async function inputHandler(name, e) {
         moveTarget: widget
       };
       const ms = mouseStatus[target.id];
-      let movable = ms.moveTarget.get(editMovable ? 'movableInEdit' : 'movable');
-      while (ms.moveTarget && !movable) {
-        let parent = ms.moveTarget.get('parent');
-        if(parent && widgets.has(parent)) {
-          ms.moveTarget = widgets.get(parent);
-          movable = ms.moveTarget.get(editMovable ? 'movableInEdit' : 'movable');
-        } else {
-          ms.moveTarget = null;
-          movable = false;
-        }
-      }
-      if (movable) {
+      const movableProperty = editMovable ? 'movableInEdit' : 'movable';
+      ms.moveTarget = ms.moveTarget.ancestors().find(w=>w.get(movableProperty));
+      if (ms.moveTarget) {
         ms.localAnchor = ms.moveTarget.coordLocalFromCoordClient({x: coords.clientX, y: coords.clientY});
       }
     } else if(name == 'mouseup' || (name == 'touchend' || name == 'touchcancel') && mouseStatus[target.id]) {

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -474,8 +474,9 @@ function receiveStateFromServer(args) {
   mouseTarget = null;
   deltaID = args._meta.deltaID;
   const topSurface = $('#topSurface');
+  const removed = new Set();
   for(const widget of widgetFilter(w=>w.domElement.parentElement === topSurface))
-    widget.applyRemoveRecursive();
+    widget.applyRemoveRecursive(removed);
   widgets.clear();
   dropTargets.clear();
   maxZ = {};

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -566,14 +566,14 @@ function removeWidget(widgetID) {
   dropTargets.delete(widgetID);
 }
 
-async function removeWidgetLocal(widgetID, keepChildren) {
+export async function removeWidgetLocal(widgetID, keepChildren) {
   function getWidgetsToRemove(widgetID) {
+    widgets.get(widgetID).inRemovalQueue = true;
     const children = [];
     if(!keepChildren)
       for(const [ childWidgetID, childWidget ] of widgets)
         if(!childWidget.inRemovalQueue && (childWidget.get('parent') == widgetID || childWidget.get('deck') == widgetID))
           children.push(...getWidgetsToRemove(childWidgetID));
-    widgets.get(widgetID).inRemovalQueue = true;
     children.push(widgets.get(widgetID));
     return children;
   }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -354,9 +354,13 @@ export class Widget extends StateManaged {
     this.globalUpdateListenersUnregister();
   }
 
-  applyRemoveRecursive() {
+  applyRemoveRecursive(removed=new Set()) {
+    // tracking the already removed widgets keeps tearing down the room terminating even if the child graph became cyclic
+    if(removed.has(this))
+      return;
+    removed.add(this);
     for(const child of Widget.prototype.children.call(this)) // use Widget.children even for holders so it doesn't filter
-      child.applyRemoveRecursive();
+      child.applyRemoveRecursive(removed);
     this.applyRemove();
   }
 
@@ -2539,6 +2543,9 @@ export class Widget extends StateManaged {
   }
 
   async onChildAdd(child, oldParentID) {
+    // a child that already is an ancestor would close a cycle in the child graph which recursive walks like applyRemoveRecursive could not terminate on
+    if(this.ancestors().includes(child))
+      return;
     this.childArray = this.childArray.filter(c=>c!=child);
     this.childArray.push(child);
     await this.onChildAddAlign(child, oldParentID);
@@ -2605,14 +2612,15 @@ export class Widget extends StateManaged {
     return this;
   }
 
-  renderReadonlyCopy(propertyOverride, target, includeChildren=false, isChild=false) {
+  renderReadonlyCopy(propertyOverride, target, includeChildren=false, isChild=false, copied=new Set()) {
     const newID = generateUniqueWidgetID();
     const newWidget = new this.constructor(newID);
     newWidget.renderReadonlyCopyRaw(Object.assign({}, this.state, propertyOverride), target, isChild);
+    copied.add(this);
     if(includeChildren)
       for(const child of widgetFilter(w=>w.get('parent') == this.id))
-        if(this.get('type') != 'holder' || !compareDropTarget(child, this) || includeChildren == 'all')
-          child.renderReadonlyCopy({}, newWidget.domElement, includeChildren, true);
+        if(!copied.has(child) && (this.get('type') != 'holder' || !compareDropTarget(child, this) || includeChildren == 'all'))
+          child.renderReadonlyCopy({}, newWidget.domElement, includeChildren, true, copied);
     return newWidget;
   }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -130,6 +130,16 @@ export class Widget extends StateManaged {
     return this.coordGlobalFromCoordParent({x:this.get('x'),y:this.get('y')})[coord]
   }
 
+  ancestors() {
+    // walks up the parent chain (starting with the widget itself) and stops on
+    // cycles which can appear in the room state (e.g. two widgets being each
+    // other's parent) and would otherwise cause infinite recursion
+    const chain = [];
+    for(let w = this; w && !chain.includes(w); w = widgets.get(w.get('parent')))
+      chain.push(w);
+    return chain;
+  }
+
   animateProperties() {
     return asArray(JSON.parse(JSON.stringify(this.get('animatePropertyChange'))));
   }
@@ -181,7 +191,11 @@ export class Widget extends StateManaged {
     let newParent = undefined;
     if(delta.parent !== undefined) {
       newParent = delta.parent && widgets.has(delta.parent) ? widgets.get(delta.parent).domElement : $('#topSurface');
-      this.setLimbo(delta.parent && !widgets.has(delta.parent));
+      // the DOM cannot represent cyclic parent chains so if the new parent is inside this widget, display it at the top level as a limbo widget
+      const cyclicParent = this.domElement.contains(newParent);
+      if(cyclicParent)
+        newParent = $('#topSurface');
+      this.setLimbo(delta.parent && (!widgets.has(delta.parent) || cyclicParent));
       // If the widget wasn't newly created, transition from its previous location.
       if (delta.id === undefined)
         fromTransform = getElementTransformRelativeTo(this.domElement, newParent);
@@ -527,7 +541,9 @@ export class Widget extends StateManaged {
   }
 
   coordGlobalFromCoordLocal(coord) {
-    return this.coordGlobalFromCoordParent(this.coordParentFromCoordLocal(coord));
+    for(const widget of this.ancestors())
+      coord = widget.coordParentFromCoordLocal(coord);
+    return coord;
   }
   coordGlobalFromCoordParent(coord) {
     const p = this.get('parent');
@@ -542,7 +558,9 @@ export class Widget extends StateManaged {
     return result || new DOMPoint();
   }
   coordLocalFromCoordGlobal(coord) {
-    return this.coordLocalFromCoordParent(this.coordParentFromCoordGlobal(coord));
+    for(const widget of this.ancestors().reverse())
+      coord = widget.coordLocalFromCoordParent(coord);
+    return coord;
   }
   coordLocalFromCoordParent(coord) {
     const result = getPointOnPlane(getElementTransform(this.domElement), coord.x, coord.y);
@@ -2193,18 +2211,24 @@ export class Widget extends StateManaged {
     if(!readOnlyProperties.has(property)) {
       return super.get(property);
     } else {
-      const p = this.get('parent');
       switch(property) {
         case '_absoluteRotation':
-          return this.get('rotation') + (widgets.has(p)? widgets.get(p).get('_absoluteRotation') : 0);
+          return this.ancestors().reduce((sum, w)=>sum + w.get('rotation'), 0);
         case '_absoluteScale':
-          return this.get('scale') * (widgets.has(p)? widgets.get(p).get('_absoluteScale') : 1);
+          return this.ancestors().reduce((product, w)=>product * w.get('scale'), 1);
         case '_absoluteX':
           return this.coordGlobalFromCoordParent({x:this.get('x'),y:this.get('y')})['x'];
         case '_absoluteY':
           return this.coordGlobalFromCoordParent({x:this.get('x'),y:this.get('y')})['y'];
-        case '_ancestor':
-          return (widgets.has(p) && widgets.get(p).get('type')=='pile') ? widgets.get(p).get('_ancestor') : p;
+        case '_ancestor': {
+          let w = this;
+          for(const a of this.ancestors().slice(1)) {
+            if(a.get('type') != 'pile')
+              break;
+            w = a;
+          }
+          return w.get('parent');
+        }
         case '_centerAbsoluteX':
           return this.coordGlobalFromCoordParent({x:this.get('x')+this.get('width')/2,y:this.get('y')+this.get('height')/2})['x'];
         case '_centerAbsoluteY':
@@ -2265,32 +2289,25 @@ export class Widget extends StateManaged {
   }
 
   inheritSeatVisibility(seatVisibility) {
-    if (this.get('hoverInheritVisibleForSeat')) {
-      const widgetSeatVisibility = this.get('onlyVisibleForSeat');
-      if (widgetSeatVisibility) {
-        // Filter seatVisibility by current widgets seats.
-        if (!seatVisibility) {
-          seatVisibility = widgetSeatVisibility;
-        } else {
-          let filterTo = new Set(asArray(widgetSeatVisibility));
-          seatVisibility = asArray(seatVisibility).filter((seatId) => { return filterTo.has(seatId); });
+    for(const widget of this.ancestors()) {
+      if (widget.get('hoverInheritVisibleForSeat')) {
+        const widgetSeatVisibility = widget.get('onlyVisibleForSeat');
+        if (widgetSeatVisibility) {
+          // Filter seatVisibility by current widgets seats.
+          if (!seatVisibility) {
+            seatVisibility = widgetSeatVisibility;
+          } else {
+            let filterTo = new Set(asArray(widgetSeatVisibility));
+            seatVisibility = asArray(seatVisibility).filter((seatId) => { return filterTo.has(seatId); });
+          }
         }
       }
     }
-    const thisParent = this.get('parent');
-    if (thisParent && widgets.has(thisParent))
-      seatVisibility = widgets.get(thisParent).inheritSeatVisibility(seatVisibility);
     return seatVisibility;
   }
 
   isDescendantOf(widget) {
-    if (this.get('parent') == widget.get('id')) {
-      return true;
-    }
-    if (widgets.has(this.get('parent'))) {
-      return widgets.get(this.get('parent')).isDescendantOf(widget);
-    }
-    return false;
+    return this.ancestors().some(w=>w.get('parent') == widget.get('id'));
   }
 
   isValidID(id, problems) {
@@ -2597,12 +2614,12 @@ export class Widget extends StateManaged {
   }
 
   requiresHiddenCursor() {
-    if(this.get('hidePlayerCursors'))
-      return true;
-    if(this.get('parent') && widgets.has(this.get('parent')))
-      return widgets.get(this.get('parent')).requiresHiddenCursor();
-    if(this.get('hoverParent') && widgets.has(this.get('hoverParent')))
-      return widgets.get(this.get('hoverParent')).requiresHiddenCursor();
+    const seen = new Set();
+    for(let w = this; w && !seen.has(w); w = widgets.get(w.get('parent')) || widgets.get(w.get('hoverParent'))) {
+      if(w.get('hidePlayerCursors'))
+        return true;
+      seen.add(w);
+    }
     return false;
   }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -546,6 +546,7 @@ export class Widget extends StateManaged {
     return coord;
   }
   coordGlobalFromCoordParent(coord) {
+    // recurses one hop into the cycle-safe coordGlobalFromCoordLocal, so a cyclic parent chain terminates there rather than here
     const p = this.get('parent');
     return (widgets.has(p)) ? widgets.get(p).coordGlobalFromCoordLocal(coord) : coord;
   }
@@ -567,6 +568,7 @@ export class Widget extends StateManaged {
     return result || new DOMPoint();
   }
   coordParentFromCoordGlobal(coord) {
+    // recurses one hop into the cycle-safe coordLocalFromCoordGlobal, so a cyclic parent chain terminates there rather than here
     const p = this.get('parent');
     return (widgets.has(p)) ? widgets.get(p).coordLocalFromCoordGlobal(coord) : coord;
   }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -189,10 +189,11 @@ export class Widget extends StateManaged {
 
     let fromTransform = null;
     let newParent = undefined;
+    let cyclicParent = false;
     if(delta.parent !== undefined) {
       newParent = delta.parent && widgets.has(delta.parent) ? widgets.get(delta.parent).domElement : $('#topSurface');
       // the DOM cannot represent cyclic parent chains so if the new parent is inside this widget, display it at the top level as a limbo widget
-      const cyclicParent = this.domElement.contains(newParent);
+      cyclicParent = this.domElement.contains(newParent);
       if(cyclicParent)
         newParent = $('#topSurface');
       this.setLimbo(delta.parent && (!widgets.has(delta.parent) || cyclicParent));
@@ -224,7 +225,7 @@ export class Widget extends StateManaged {
         this.domElement.style.transform = this.targetTransform;
       }
 
-      if(delta.parent !== null && widgets.has(delta.parent)) {
+      if(!cyclicParent && delta.parent !== null && widgets.has(delta.parent)) {
         this.parent = widgets.get(delta.parent);
         this.parent.applyChildAdd(this);
       } else {

--- a/tests/client/setup.js
+++ b/tests/client/setup.js
@@ -12,3 +12,62 @@ if (!process.env.UNHANDLED_REJECTION_INITIALIZED) {
   })
   process.env.UNHANDLED_REJECTION_INITIALIZED = true
 }
+
+// jsdom implements neither DOMPoint nor DOMMatrix, so client code computing element
+// transforms cannot run in tests. Since jsdom has no layout, every transform is a 2D
+// affine one and these stand-ins only need to cover that case.
+if(typeof globalThis.DOMPoint == 'undefined') {
+  globalThis.DOMPoint = class DOMPoint {
+    constructor(x=0, y=0, z=0, w=1) {
+      Object.assign(this, { x, y, z, w });
+    }
+  };
+}
+
+if(typeof globalThis.DOMMatrix == 'undefined') {
+  globalThis.DOMMatrix = class DOMMatrix {
+    constructor(init) {
+      Object.assign(this, { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 });
+      if(typeof init == 'string') {
+        const match = init.match(/^\s*matrix\(([^)]*)\)\s*$/);
+        if(match)
+          [ this.a, this.b, this.c, this.d, this.e, this.f ] = match[1].split(',').map(v=>parseFloat(v));
+      } else if(Array.isArray(init) && init.length == 6) {
+        [ this.a, this.b, this.c, this.d, this.e, this.f ] = init;
+      } else if(Array.isArray(init) && init.length == 16) {
+        [ this.a, this.b, this.c, this.d, this.e, this.f ] = [ init[0], init[1], init[4], init[5], init[12], init[13] ];
+      }
+    }
+    multiplySelf(m) {
+      return Object.assign(this, {
+        a: this.a*m.a + this.c*m.b,
+        b: this.b*m.a + this.d*m.b,
+        c: this.a*m.c + this.c*m.d,
+        d: this.b*m.c + this.d*m.d,
+        e: this.a*m.e + this.c*m.f + this.e,
+        f: this.b*m.e + this.d*m.f + this.f
+      });
+    }
+    preMultiplySelf(m) {
+      return this.multiplySelf.call(new DOMMatrix([ m.a, m.b, m.c, m.d, m.e, m.f ]), this).copyInto(this);
+    }
+    translateSelf(x=0, y=0) {
+      return this.multiplySelf(new DOMMatrix([ 1, 0, 0, 1, x, y ]));
+    }
+    copyInto(target) {
+      return Object.assign(target, { a: this.a, b: this.b, c: this.c, d: this.d, e: this.e, f: this.f });
+    }
+    inverse() {
+      const det = this.a*this.d - this.b*this.c;
+      if(!det)
+        return new DOMMatrix([ NaN, NaN, NaN, NaN, NaN, NaN ]);
+      return new DOMMatrix([ this.d/det, -this.b/det, -this.c/det, this.a/det, (this.c*this.f - this.d*this.e)/det, (this.b*this.e - this.a*this.f)/det ]);
+    }
+    transformPoint(p) {
+      return new DOMPoint(this.a*p.x + this.c*p.y + this.e*p.w, this.b*p.x + this.d*p.y + this.f*p.w, p.z, p.w);
+    }
+    toString() {
+      return `matrix(${this.a}, ${this.b}, ${this.c}, ${this.d}, ${this.e}, ${this.f})`;
+    }
+  };
+}

--- a/tests/client/widget-cyclic-parent.test.js
+++ b/tests/client/widget-cyclic-parent.test.js
@@ -1,4 +1,5 @@
 import { createWidget, removeWidget } from './client-util.js';
+import { dropTargets, getValidDropTargets } from '../../client/js/main.js';
 
 // Regression test for the "Maximum call stack size exceeded" crash that happened
 // when the room state contained a cycle in the parent chain (e.g. two widgets
@@ -50,5 +51,14 @@ describe("Cyclic parent chains", () => {
     }
     expect(w1.isDescendantOf(w2)).toBe(true);
     expect(w3.isDescendantOf(w3)).toBe(true);
+  });
+
+  test("drop-target checks terminate on cyclic target ancestry", () => {
+    w1.state.dropTarget = {};
+    w1.isVisible = () => true;
+    dropTargets.set(w1.get('id'), w1);
+
+    expect(getValidDropTargets(w3)).toContain(w1);
+    expect(getValidDropTargets(w2)).not.toContain(w1);
   });
 });

--- a/tests/client/widget-cyclic-parent.test.js
+++ b/tests/client/widget-cyclic-parent.test.js
@@ -1,21 +1,24 @@
 import { createWidget, removeWidget } from './client-util.js';
 import { dropTargets, getValidDropTargets } from '../../client/js/main.js';
+import { removeWidgetLocal, widgets } from '../../client/js/serverstate.js';
 
 // Regression test for the "Maximum call stack size exceeded" crash that happened
 // when the room state contained a cycle in the parent chain (e.g. two widgets
 // being each other's parent). Every method that walks the parent chain by
 // following the 'parent' property must terminate instead of recursing forever.
 //
-// The cycle is manufactured directly in each widget's state: going through
-// set('parent') would trigger geometry helpers that rely on DOMMatrix, which
-// jsdom does not implement. The recursion guard being tested here is independent
-// of that geometry, so a state-level cycle is enough to exercise it.
+// Most tests manufacture the cycle directly in each widget's state because the
+// parent-walk guards are independent of geometry. The runtime graph regression
+// applies the same parent changes through applyDelta().
 
 describe("Cyclic parent chains", () => {
   const testName = "cyclic-parent";
   let w1, w2, w3;
 
   beforeEach(() => {
+    window.jeRoutineLogging = false;
+    window.removeWidgetLocal = removeWidgetLocal;
+    window.dropTargets = dropTargets;
     w1 = createWidget({ id: `${testName}-1`, type: "widget" });
     w2 = createWidget({ id: `${testName}-2`, type: "widget" });
     w3 = createWidget({ id: `${testName}-3`, type: "widget" });
@@ -26,7 +29,8 @@ describe("Cyclic parent chains", () => {
   });
   afterEach(() => {
     for(const w of [ w1, w2, w3 ])
-      removeWidget(w.get('id'));
+      if(widgets.has(w.get('id')))
+        removeWidget(w.get('id'));
   });
 
   test("ancestors() stops on the cycle and lists each widget once", () => {
@@ -60,5 +64,34 @@ describe("Cyclic parent chains", () => {
 
     expect(getValidDropTargets(w3)).toContain(w1);
     expect(getValidDropTargets(w2)).not.toContain(w1);
+  });
+
+  test("cyclic parent deltas keep the runtime child graph acyclic", () => {
+    delete w1.state.parent;
+    delete w2.state.parent;
+
+    w2.applyDelta({ parent: w1.get('id') });
+    w1.applyDelta({ parent: w2.get('id') });
+
+    expect(w1.get('parent')).toBe(w2.get('id'));
+    expect(w2.get('parent')).toBe(w1.get('id'));
+    expect(w1.parent).toBeUndefined();
+    expect(w2.parent).toBe(w1);
+    expect(w1.childArray).toEqual([ w2 ]);
+    expect(w2.childArray).toEqual([]);
+    expect(() => w1.applyRemoveRecursive()).not.toThrow();
+    widgets.delete(w1.get('id'));
+    widgets.delete(w2.get('id'));
+  });
+
+  test("DELETE terminates on cyclic parent state", async () => {
+    await expect(w1.evaluateRoutine(
+      [{ func: 'DELETE', collection: 'cyclicWidgets' }],
+      {},
+      { cyclicWidgets: [ w1 ] }
+    )).resolves.toEqual(expect.any(Object));
+
+    expect(widgets.has(w1.get('id'))).toBe(false);
+    expect(widgets.has(w2.get('id'))).toBe(false);
   });
 });

--- a/tests/client/widget-cyclic-parent.test.js
+++ b/tests/client/widget-cyclic-parent.test.js
@@ -8,17 +8,22 @@ import { removeWidgetLocal, widgets } from '../../client/js/serverstate.js';
 // following the 'parent' property must terminate instead of recursing forever.
 //
 // Most tests manufacture the cycle directly in each widget's state because the
-// parent-walk guards are independent of geometry. The runtime graph regression
-// applies the same parent changes through applyDelta().
+// parent-walk guards are independent of geometry. The runtime graph regressions
+// apply the same parent changes through applyDelta() and set() instead, because
+// both have to keep the parent/childArray graph acyclic.
 
 describe("Cyclic parent chains", () => {
   const testName = "cyclic-parent";
   let w1, w2, w3;
+  let copyCount = 0;
 
   beforeEach(() => {
     window.jeRoutineLogging = false;
     window.removeWidgetLocal = removeWidgetLocal;
     window.dropTargets = dropTargets;
+    window.generateUniqueWidgetID = ()=>`${testName}-copy-${++copyCount}`;
+    // the widget classes are globals provided by main.js at runtime, none of the test widgets is a card
+    window.Card = class Card {};
     w1 = createWidget({ id: `${testName}-1`, type: "widget" });
     w2 = createWidget({ id: `${testName}-2`, type: "widget" });
     w3 = createWidget({ id: `${testName}-3`, type: "widget" });
@@ -82,6 +87,32 @@ describe("Cyclic parent chains", () => {
     expect(() => w1.applyRemoveRecursive()).not.toThrow();
     widgets.delete(w1.get('id'));
     widgets.delete(w2.get('id'));
+  });
+
+  test("setting a cyclic parent keeps the runtime child graph acyclic", async () => {
+    delete w1.state.parent;
+    delete w2.state.parent;
+
+    await w2.set('parent', w1.get('id'));
+    await w1.set('parent', w2.get('id'));
+
+    expect(w1.get('parent')).toBe(w2.get('id'));
+    expect(w2.get('parent')).toBe(w1.get('id'));
+    // the edge closing the cycle is not linked into the child graph on the client that set the property either
+    expect(w1.childArray).toEqual([ w2 ]);
+    expect(w2.childArray).toEqual([]);
+
+    // replacing the room state tears every top level widget down recursively
+    const removed = new Set();
+    for(const w of [ w1, w2 ])
+      expect(() => w.applyRemoveRecursive(removed)).not.toThrow();
+    widgets.delete(w1.get('id'));
+    widgets.delete(w2.get('id'));
+  });
+
+  test("recursive readonly copies terminate on a cyclic parent chain", () => {
+    for(const w of [ w1, w3 ])
+      expect(() => w.renderReadonlyCopy({}, document.body, 'all').domElement.remove()).not.toThrow();
   });
 
   test("DELETE terminates on cyclic parent state", async () => {

--- a/tests/client/widget-cyclic-parent.test.js
+++ b/tests/client/widget-cyclic-parent.test.js
@@ -1,0 +1,54 @@
+import { createWidget, removeWidget } from './client-util.js';
+
+// Regression test for the "Maximum call stack size exceeded" crash that happened
+// when the room state contained a cycle in the parent chain (e.g. two widgets
+// being each other's parent). Every method that walks the parent chain by
+// following the 'parent' property must terminate instead of recursing forever.
+//
+// The cycle is manufactured directly in each widget's state: going through
+// set('parent') would trigger geometry helpers that rely on DOMMatrix, which
+// jsdom does not implement. The recursion guard being tested here is independent
+// of that geometry, so a state-level cycle is enough to exercise it.
+
+describe("Cyclic parent chains", () => {
+  const testName = "cyclic-parent";
+  let w1, w2, w3;
+
+  beforeEach(() => {
+    w1 = createWidget({ id: `${testName}-1`, type: "widget" });
+    w2 = createWidget({ id: `${testName}-2`, type: "widget" });
+    w3 = createWidget({ id: `${testName}-3`, type: "widget" });
+    // mutual cycle w1 <-> w2 and a self-referencing widget w3
+    w1.state.parent = w2.get('id');
+    w2.state.parent = w1.get('id');
+    w3.state.parent = w3.get('id');
+  });
+  afterEach(() => {
+    for(const w of [ w1, w2, w3 ])
+      removeWidget(w.get('id'));
+  });
+
+  test("ancestors() stops on the cycle and lists each widget once", () => {
+    for(const w of [ w1, w2, w3 ]) {
+      const chain = w.ancestors();
+      expect(chain).toContain(w);
+      // no widget appears twice - the walk terminated at the cycle
+      expect(chain.length).toBe(new Set(chain).size);
+    }
+    expect(w1.ancestors()).toEqual([ w1, w2 ]);
+    expect(w3.ancestors()).toEqual([ w3 ]);
+  });
+
+  test("parent-chain methods terminate instead of overflowing the stack", () => {
+    for(const w of [ w1, w2, w3 ]) {
+      expect(() => w.get('_absoluteRotation')).not.toThrow();
+      expect(() => w.get('_absoluteScale')).not.toThrow();
+      expect(() => w.get('_ancestor')).not.toThrow();
+      expect(() => w.isDescendantOf(w2)).not.toThrow();
+      expect(() => w.inheritSeatVisibility(null)).not.toThrow();
+      expect(() => w.requiresHiddenCursor()).not.toThrow();
+    }
+    expect(w1.isDescendantOf(w2)).toBe(true);
+    expect(w3.isDescendantOf(w3)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Fixes a client crash reported from the main server: `RangeError: Maximum call stack size exceeded` with `coordLocalFromCoordGlobal` and `coordParentFromCoordGlobal` alternating endlessly on a holder widget.

## Cause

Nothing prevents the room state from containing a **cycle in the `parent` chain** (e.g. two widgets that are each other's parent, or a widget that is its own parent) — a routine that sets the `parent` property can create one. Several client methods walk the parent chain by recursion and never terminate on such a state, crashing on every mouse move or drag once the room is in that condition.

## Fix

- New cycle-safe `Widget.ancestors()` helper that walks up the parent chain and stops when it sees a widget twice.
- All parent-chain walks now use it (or an equivalent guarded loop): `coordLocalFromCoordGlobal`, `coordGlobalFromCoordLocal`, `_absoluteRotation`, `_absoluteScale`, `_ancestor`, `isDescendantOf`, `inheritSeatVisibility`, `requiresHiddenCursor`, `getValidDropTargets`, the mouse-down movable-ancestor lookup and the JSON editor's `hiddenParent`. Behavior is unchanged for acyclic states.
- Applying a delta that creates a cycle no longer breaks the client halfway through `receiveDelta`:
  - `getElementTransformRelativeTo` returns `null` instead of walking past the DOM root when the target element is a descendant of the source.
  - `applyDeltaToDOM` cannot mirror a cyclic parent into the DOM, so the widget is shown as a *limbo* widget (the existing "Invalid Parent" treatment) instead of throwing `HierarchyRequestError` on `appendChild`.
- The runtime `parent`/`childArray` graph stays acyclic even on the client that sets the property: `onChildAdd` refuses an edge whose child already is an ancestor. Tearing the room down survives a cyclic graph regardless: `applyRemoveRecursive` and `removeWidgetLocal` track what they already visited, so a full state message (load, restore, resync) still replaces the room.
- Recursive duplication in edit mode and `renderReadonlyCopy` walk the state parent chain too and hung the tab on a cyclic room; both skip widgets they already copied, and duplication additionally ignores the copies it just created — on a cyclic chain a copy can otherwise come back to it as a child of a widget that is still to be copied.

## Verification

- Reproduced the exact reported stack trace on `main` with a Playwright-driven room where a button routine sets one holder's `parent` to a holder inside it; hovering/dragging then overflows the stack.
- With this PR, the same scenario produces **zero** client errors: the delta applies cleanly, the cyclic widgets render as limbo ("Invalid Parent", hidden outside edit mode), dragging a card over/onto them works, and a fresh page load of the cyclic room also survives (widgets deferred, as before).
- Two clients in one room: the client that runs the cycle-creating routine keeps an acyclic `childArray` and loads the next full state normally; before, it overflowed the stack and stayed on the stale room.
- Edit mode: clone-dragging a cyclic holder terminates (it used to hang the tab); a control clone-drag of a normal three-level tree still copies the whole subtree exactly once.
- `tests/client/widget-cyclic-parent.test.js` covers all of it (parent-chain walks, drop targets, `DELETE`, cyclic deltas, cycles created through `set('parent')`, recursive readonly copies). `tests/client/setup.js` gained minimal `DOMMatrix`/`DOMPoint` stand-ins because jsdom implements neither and `set('parent')` needs them.
- jest passes; TestCafe `editor.js` and `publiclibrary-3/4` pass locally, `publiclibrary-1/2` pass except `Reversi`, which is nondeterministic on this machine on the unmodified branch as well.

Repro scripts and logs: <https://agent.virtualtabletop.io/reports/pr/1525330699429871778/repro/README.md>
A demo room named **Cyclic parent chains** is on this PR's test server (`pr-test-ai`) — one button makes a holder a child of the holder inside it; the board has to stay usable afterwards. It lives on the test server only, not in `library/`, and can be added to `library/tutorials/` on request.

No creator-facing property or routine semantics change.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3027/pr-test (or any other room on that server)
