### PR TITLE
Add a public rooms section: publish claimed rooms with a description

### DIFF
--- a/client/css/overlays/rooms.css
+++ b/client/css/overlays/rooms.css
@@ -4,11 +4,11 @@
 
 /* flex items shrink to fit the overlay by default, which squeezes/hides
    these sections instead of letting the overlay scroll to show them */
-#roomsOverlay > .heading, #roomsOverlay > #roomsList, #roomsOverlay > #roomsCollectionBox {
+#roomsOverlay > .heading, #roomsOverlay > #roomsList, #roomsOverlay > #publicRoomsSection, #roomsOverlay > #roomsCollectionBox {
   flex-shrink: 0;
 }
 
-#roomsList {
+#roomsList, #publicRoomsList {
   display: flex;
   flex-wrap: wrap;
   align-content: flex-start;
@@ -16,10 +16,14 @@
   padding: 16px 0;
 }
 
-#emptyRoomsList {
+#emptyRoomsList, #emptyPublicRoomsList {
   display: none;
   font-style: italic;
   color: black;
+}
+
+#publicRoomsSection h2 {
+  margin: 10px 0 5px 0;
 }
 
 .roomTile {
@@ -76,6 +80,20 @@
   padding: 3px 8px 4px 8px;
   margin: 0;
   background: #00000061;
+}
+
+.roomTile .details .description {
+  font-size: .75rem;
+  max-height: 3.4em;
+  overflow: hidden;
+  padding: 3px 8px 4px 8px;
+  margin: 0;
+  background: #00000061;
+  overflow-wrap: anywhere;
+}
+
+.roomTile .details .description.hidden {
+  display: none;
 }
 
 .roomTile .roomIcons {

--- a/client/js/overlays/rooms.js
+++ b/client/js/overlays/rooms.js
@@ -83,7 +83,7 @@ function switchRoom(newRoomID, pushHistory=true) {
   toServer('room', { playerName, roomID: newRoomID, collection: getCollectionID(), password: getRoomPassword(newRoomID) });
 }
 
-function createRoomTile(room) {
+function createRoomTile(room, isPublicTile) {
   const tile = domByTemplate('template-roomslist-entry');
   tile.className = 'roomTile';
   if(!room.image)
@@ -93,10 +93,18 @@ function createRoomTile(room) {
 
   $('h3', tile).textContent = room.name;
   $('h4', tile).textContent = room.gameName || 'No game loaded';
+  if(isPublicTile) {
+    $('h4', tile).textContent += ` — ${room.players} ${room.players == 1 ? 'player' : 'players'} online`;
+    if(room.description) {
+      $('.description', tile).textContent = room.description;
+      $('.description', tile).classList.remove('hidden');
+    }
+  }
   if(room.image)
     $('img', tile).src = mapAssetURLs(room.image);
   toggleClass($('.lockedIcon', tile), 'hidden', !room.locked);
   toggleClass($('.passwordIcon', tile), 'hidden', !room.hasPassword);
+  toggleClass($('.publicIcon', tile), 'hidden', !room.isPublic || !!isPublicTile);
   toggleClass($('.adminIcon', tile), 'hidden', !room.isAdmin);
 
   const menu = $('.roomMenu', tile);
@@ -137,6 +145,15 @@ function createRoomTile(room) {
       if(password !== null)
         roomAction(room.id, 'setPassword', { password });
     });
+    addMenuButton('public', room.isPublic ? 'Edit public listing' : 'Make room public', null, function() {
+      const description = prompt('Enter a description for the public rooms list so people know what to expect in your room:', room.description || '');
+      if(description !== null)
+        roomAction(room.id, 'setPublic', { public: true, description });
+    });
+    if(room.isPublic)
+      addMenuButton('public_off', 'Make room private', null, function() {
+        roomAction(room.id, 'setPublic', { public: false });
+      });
     addMenuButton('remove_moderator', 'Release claim', null, function() {
       roomAction(room.id, 'unclaim');
     });
@@ -156,14 +173,15 @@ function createRoomTile(room) {
         showOverlay('roomsOverlay');
       }
     });
-  addMenuButton('visibility_off', 'Remove from list', null, async function() {
-    await fetch(`api/roomcollection/${getCollectionID()}/remove/${room.id}`, { method: 'PUT' });
-    await refreshRoomsList();
-  });
+  if(!isPublicTile)
+    addMenuButton('visibility_off', 'Remove from list', null, async function() {
+      await fetch(`api/roomcollection/${getCollectionID()}/remove/${room.id}`, { method: 'PUT' });
+      await refreshRoomsList();
+    });
 
   $('.menuButton', tile).onclick = function(e) {
     const wasHidden = menu.classList.contains('hidden');
-    for(const m of $a('#roomsList .roomMenu'))
+    for(const m of $a('#roomsOverlay .roomMenu'))
       m.classList.add('hidden');
     toggleClass(menu, 'hidden', !wasHidden);
     e.stopPropagation();
@@ -184,22 +202,40 @@ function createRoomTile(room) {
 async function refreshRoomsList() {
   $('#collectionIDinput').value = getCollectionID();
   let rooms = null;
+  let publicRooms = null;
   try {
     const result = await fetch(`api/roomcollection/${getCollectionID()}`);
     if(result.ok)
       rooms = (await result.json()).rooms;
   } catch(e) {}
-  removeFromDOM('#roomsList .roomTile');
+  try {
+    const result = await fetch(`api/publicrooms?collection=${getCollectionID()}`);
+    if(result.ok)
+      publicRooms = (await result.json()).rooms;
+  } catch(e) {}
+  removeFromDOM('#roomsOverlay .roomTile');
+
   if(rooms === null) {
     $('#emptyRoomsList').textContent = 'Could not load your room collection. Please try again.';
     $('#emptyRoomsList').style.display = 'block';
-    return;
+  } else {
+    rooms.sort((a, b)=>(b.id == roomID) - (a.id == roomID));
+    for(const room of rooms)
+      $('#roomsList').appendChild(createRoomTile(room));
+    $('#emptyRoomsList').style.display = rooms.length ? 'none' : 'block';
+    $('#emptyRoomsList').textContent = 'No rooms yet. Rooms you visit with this browser show up here automatically.';
   }
-  rooms.sort((a, b)=>(b.id == roomID) - (a.id == roomID));
-  for(const room of rooms)
-    $('#roomsList').appendChild(createRoomTile(room));
-  $('#emptyRoomsList').style.display = rooms.length ? 'none' : 'block';
-  $('#emptyRoomsList').textContent = 'No rooms yet. Rooms you visit with this browser show up here automatically.';
+
+  if(publicRooms === null) {
+    $('#emptyPublicRoomsList').textContent = 'Could not load the public rooms. Please try again.';
+    $('#emptyPublicRoomsList').style.display = 'block';
+  } else {
+    publicRooms.sort((a, b)=>b.players - a.players);
+    for(const room of publicRooms)
+      $('#publicRoomsList').appendChild(createRoomTile(room, true));
+    $('#emptyPublicRoomsList').style.display = publicRooms.length ? 'none' : 'block';
+    $('#emptyPublicRoomsList').textContent = 'No public rooms right now.';
+  }
 }
 
 onLoad(function() {
@@ -272,7 +308,7 @@ onLoad(function() {
   });
 
   document.addEventListener('click', function() {
-    for(const m of $a('#roomsList .roomMenu'))
+    for(const m of $a('#roomsOverlay .roomMenu'))
       m.classList.add('hidden');
   });
 

--- a/client/js/overlays/rooms.js
+++ b/client/js/overlays/rooms.js
@@ -94,7 +94,7 @@ function createRoomTile(room, isPublicTile) {
   $('h3', tile).textContent = room.name;
   $('h4', tile).textContent = room.gameName || 'No game loaded';
   if(isPublicTile) {
-    $('h4', tile).textContent += ` — ${room.players} ${room.players == 1 ? 'player' : 'players'} online`;
+    $('h4', tile).textContent += ` — ${room.playerCount} ${room.playerCount == 1 ? 'player' : 'players'} online`;
     if(room.description) {
       $('.description', tile).textContent = room.description;
       $('.description', tile).classList.remove('hidden');
@@ -217,7 +217,7 @@ async function refreshRoomsList() {
       rooms = (await result.json()).rooms;
   } catch(e) {}
   try {
-    const result = await fetch(`api/publicrooms?collection=${getCollectionID()}`);
+    const result = await fetch('api/publicrooms');
     if(result.ok)
       publicRooms = (await result.json()).rooms;
   } catch(e) {}
@@ -238,7 +238,11 @@ async function refreshRoomsList() {
     $('#emptyPublicRoomsList').textContent = 'Could not load the public rooms. Please try again.';
     $('#emptyPublicRoomsList').style.display = 'block';
   } else {
-    publicRooms.sort((a, b)=>b.players - a.players);
+    // the public listing is anonymous, so admin status comes from the user's own collection
+    const adminRoomIDs = new Set((rooms || []).filter(r=>r.isAdmin).map(r=>r.id));
+    for(const room of publicRooms)
+      room.isAdmin = adminRoomIDs.has(room.id);
+    publicRooms.sort((a, b)=>b.playerCount - a.playerCount);
     for(const room of publicRooms)
       $('#publicRoomsList').appendChild(createRoomTile(room, true));
     $('#emptyPublicRoomsList').style.display = publicRooms.length ? 'none' : 'block';

--- a/client/room.html
+++ b/client/room.html
@@ -106,6 +106,7 @@
           <div class="roomIcons">
             <i class="material-symbols lockedIcon" title="This room is locked.">lock</i>
             <i class="material-symbols passwordIcon" title="This room is password protected.">key</i>
+            <i class="material-symbols publicIcon" title="This room is listed in the public rooms.">public</i>
             <i class="material-symbols adminIcon" title="This room is claimed by your collection.">verified_user</i>
           </div>
           <button icon="more_vert" class="menuButton"></button>
@@ -113,10 +114,18 @@
           <div class="details">
             <h3>Name</h3>
             <h4>Game</h4>
+            <p class="description hidden"></p>
           </div>
           <button icon="login" class="switchButton">Switch to this room</button>
         </template>
         <p id="emptyRoomsList"></p>
+      </div>
+      <div id="publicRoomsSection">
+        <h2>Public rooms</h2>
+        <div class="instructionalText">These rooms were made public by their admins &mdash; anybody can join them and play. Claim a room and use "Make room public" in its tile menu to list your own room here.</div>
+        <div id="publicRoomsList">
+          <p id="emptyPublicRoomsList"></p>
+        </div>
       </div>
       <div id="roomsCollectionBox" icon="key">
         <h2>Collection ID</h2>

--- a/server.mjs
+++ b/server.mjs
@@ -15,6 +15,7 @@ import TTS        from './server/ttsimport.mjs';
 import Player     from './server/player.mjs';
 import Room       from './server/room.mjs';
 import Collections from './server/collections.mjs';
+import PublicRooms from './server/publicrooms.mjs';
 import LibraryDecks from './server/librarydecks.mjs';
 import MinifyHTML from './server/minify.mjs';
 import Logging    from './server/logging.mjs';
@@ -373,6 +374,28 @@ MinifyHTML().then(function(result) {
           continue;
         if(await ensureRoomIsLoaded(roomID))
           rooms.push(await activeRooms.get(roomID).getRoomDetails(req.params.collection));
+      }
+      res.setHeader('Content-Type', 'application/json');
+      res.send(JSON.stringify({ rooms }));
+    })().catch(next);
+  });
+
+  router.get('/api/publicrooms', function(req, res, next) {
+    (async function() {
+      const collection = typeof req.query.collection == 'string' ? req.query.collection : null;
+      const rooms = [];
+      for(const roomID of PublicRooms.get()) {
+        // heal the list when a published room was deleted or its file was removed
+        if(!roomExists(roomID)) {
+          PublicRooms.remove(roomID);
+          continue;
+        }
+        if(await ensureRoomIsLoaded(roomID)) {
+          if(activeRooms.get(roomID).isPublic())
+            rooms.push(await activeRooms.get(roomID).getRoomDetails(collection));
+          else
+            PublicRooms.remove(roomID);
+        }
       }
       res.setHeader('Content-Type', 'application/json');
       res.send(JSON.stringify({ rooms }));

--- a/server.mjs
+++ b/server.mjs
@@ -380,25 +380,37 @@ MinifyHTML().then(function(result) {
     })().catch(next);
   });
 
+  // the response is the same for everyone, so cache it briefly: it makes the anonymous
+  // endpoint cheap to poll and keeps idle public rooms from being loaded from disk on every request
+  let publicRoomsCache = null;
   router.get('/api/publicrooms', function(req, res, next) {
     (async function() {
-      const collection = typeof req.query.collection == 'string' ? req.query.collection : null;
-      const rooms = [];
-      for(const roomID of PublicRooms.get()) {
-        // heal the list when a published room was deleted or its file was removed
-        if(!roomExists(roomID)) {
-          PublicRooms.remove(roomID);
-          continue;
+      if(!publicRoomsCache || publicRoomsCache.time < Date.now() - 10000) {
+        const rooms = [];
+        for(const roomID of PublicRooms.get()) {
+          try {
+            // heal the list when a published room was deleted or its file was removed
+            if(!roomExists(roomID)) {
+              PublicRooms.remove(roomID);
+              continue;
+            }
+            if(await ensureRoomIsLoaded(roomID)) {
+              if(activeRooms.get(roomID).isPublic()) {
+                const details = await activeRooms.get(roomID).getRoomDetails(null);
+                delete details.players; // the anonymous listing only gets the count, not who is playing
+                rooms.push(details);
+              } else {
+                PublicRooms.remove(roomID);
+              }
+            }
+          } catch(e) {
+            Logging.log(`ERROR: skipping room ${roomID} in the public rooms listing: ${e}`);
+          }
         }
-        if(await ensureRoomIsLoaded(roomID)) {
-          if(activeRooms.get(roomID).isPublic())
-            rooms.push(await activeRooms.get(roomID).getRoomDetails(collection));
-          else
-            PublicRooms.remove(roomID);
-        }
+        publicRoomsCache = { time: Date.now(), body: JSON.stringify({ rooms }) };
       }
       res.setHeader('Content-Type', 'application/json');
-      res.send(JSON.stringify({ rooms }));
+      res.send(publicRoomsCache.body);
     })().catch(next);
   });
 
@@ -424,6 +436,7 @@ MinifyHTML().then(function(result) {
       if(!isLoaded)
         return res.status(404).send('Invalid room.');
       await activeRooms.get(req.params.room).collectionAction(req.params.action, req.body || {});
+      publicRoomsCache = null; // publish/unpublish/rename/delete should show up immediately
       res.send('OK');
     }).catch(next);
   });

--- a/server/publicrooms.mjs
+++ b/server/publicrooms.mjs
@@ -1,0 +1,37 @@
+import fs from 'fs';
+
+import Config from './config.mjs';
+
+// A list of room IDs whose admins made them publicly visible in the rooms overlay.
+
+function filename() {
+  return Config.directory('save') + '/publicRooms.json';
+}
+
+export default {
+  get() {
+    try {
+      const rooms = JSON.parse(fs.readFileSync(filename()));
+      if(Array.isArray(rooms))
+        return rooms;
+    } catch(e) {}
+    return [];
+  },
+
+  add(roomID) {
+    const rooms = this.get();
+    if(rooms.indexOf(roomID) == -1) {
+      if(rooms.length >= 500)
+        return false;
+      rooms.push(roomID);
+      fs.writeFileSync(filename(), JSON.stringify(rooms));
+    }
+    return true;
+  },
+
+  remove(roomID) {
+    const rooms = this.get();
+    if(rooms.indexOf(roomID) != -1)
+      fs.writeFileSync(filename(), JSON.stringify(rooms.filter(r=>r!=roomID)));
+  }
+};

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -8,6 +8,7 @@ import FileUpdater from './fileupdater.mjs';
 import Logging from './logging.mjs';
 import Config from './config.mjs';
 import { randomHue } from '../client/js/color.js';
+import PublicRooms from './publicrooms.mjs';
 import Statistics from './statistics.mjs';
 
 export default class Room {
@@ -293,8 +294,21 @@ export default class Room {
       Logging.log(`room ${this.id} was claimed by collection ${this.claimedBy().substring(0, 8)}…`);
     } else if(action == 'unclaim') {
       await requireAdmin();
+      PublicRooms.remove(this.id);
       delete this.state._meta.security;
       delete this.state._meta.locked;
+      delete this.state._meta.public;
+    } else if(action == 'setPublic') {
+      await requireAdmin();
+      if(args.public) {
+        const description = String(args.description || '').trim().substring(0, 500);
+        if(!PublicRooms.add(this.id))
+          throw new Logging.UserError(400, 'The public rooms list is full.');
+        this.state._meta.public = { description };
+      } else {
+        PublicRooms.remove(this.id);
+        delete this.state._meta.public;
+      }
     } else if(action == 'setName') {
       await requireAdmin();
       const name = String(args.name || '').trim().substring(0, 64);
@@ -335,6 +349,7 @@ export default class Room {
     copy._meta.players = {};
     delete copy._meta.security;
     delete copy._meta.locked;
+    delete copy._meta.public;
     delete copy._meta.linkSourceRoom;
     delete copy._meta.tracingEnabled;
     delete copy._meta.redirectTo;
@@ -361,6 +376,7 @@ export default class Room {
 
   async deleteRoom() {
     Logging.log(`deleting room ${this.id}`);
+    PublicRooms.remove(this.id);
     for(const [ stateID, state ] of Object.entries(this.state._meta.states)) {
       if(String(stateID).match(/^PL:/))
         continue;
@@ -408,6 +424,8 @@ export default class Room {
       locked: !!meta.locked,
       hasPassword: !!(meta.security && meta.security.joinPassword),
       autoLink: !!meta.linkSourceRoom,
+      isPublic: this.isPublic(),
+      description: this.isPublic() && meta.public.description || null,
       players: this.players.length
     };
   }
@@ -438,6 +456,10 @@ export default class Room {
     if(!this.claimedBy() || !collection)
       return false;
     return await this.hashSecret(collection) == this.claimedBy();
+  }
+
+  isPublic() {
+    return !!(this.claimedBy() && this.state._meta.public);
   }
 
   async linkFromRoom(sourceRoom, autoLink) {
@@ -1404,7 +1426,7 @@ export default class Room {
   unload() {
     if(this.state && this.state._meta && this.state._meta.states && typeof this.state._meta.states == 'object' && this.state._meta.starred && typeof this.state._meta.starred == 'object') {
       const nonPLgames = Object.keys(this.state._meta.states).filter(i=>!i.match(/^PL:/));
-      const hasCollectionData = this.state._meta.security && Object.keys(this.state._meta.security).length || this.state._meta.roomName || this.state._meta.linkSourceRoom || this.state._meta.locked;
+      const hasCollectionData = this.state._meta.security && Object.keys(this.state._meta.security).length || this.state._meta.roomName || this.state._meta.linkSourceRoom || this.state._meta.locked || this.state._meta.public;
       if(Object.keys(this.state).length > 1 || nonPLgames.length || Object.keys(this.state._meta.starred).length || this.state._meta.redirectTo || this.state._meta.returnServer || hasCollectionData) {
         Logging.log(`unloading room ${this.id}`);
         this.writeToFilesystem();

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -302,6 +302,8 @@ export default class Room {
       await requireAdmin();
       if(args.public) {
         const description = String(args.description || '').trim().substring(0, 500);
+        if(!description)
+          throw new Logging.UserError(400, 'Please enter a description for the public rooms list.');
         if(!PublicRooms.add(this.id))
           throw new Logging.UserError(400, 'The public rooms list is full.');
         this.state._meta.public = { description };
@@ -414,6 +416,7 @@ export default class Room {
     for(const id of [ active.saveStateID, active.stateID, active.linkStateID ])
       if(!game && id !== undefined && meta.states[id])
         game = meta.states[id];
+    const playerNames = [...new Set(this.players.map(player=>player.name))];
     return {
       id: this.id,
       name: meta.roomName || this.id,
@@ -426,7 +429,8 @@ export default class Room {
       autoLink: !!meta.linkSourceRoom,
       isPublic: this.isPublic(),
       description: this.isPublic() && meta.public.description || null,
-      players: [...new Set(this.players.map(player=>player.name))].map(name=>({ name, color: meta.players[name] || null }))
+      playerCount: playerNames.length,
+      players: playerNames.map(name=>({ name, color: meta.players[name] || null }))
     };
   }
 

--- a/tests/server/security.test.js
+++ b/tests/server/security.test.js
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 
 import Collections from '../../server/collections.mjs';
 import Config from '../../server/config.mjs';
+import PublicRooms from '../../server/publicrooms.mjs';
 import Room from '../../server/room.mjs';
 import Player from '../../server/player.mjs';
 
@@ -154,6 +155,75 @@ describe('Room security', () => {
     expect(await room.mayJoin('admin-collection', undefined)).toBe(true); // admins bypass the password
     await room.collectionAction('setPassword', { collection: 'admin-collection', password: '' });
     expect(await room.mayJoin(undefined, undefined)).toBe(true);
+  });
+});
+
+describe('Public rooms', () => {
+  const roomID = 'jest-test-public-room';
+  let room;
+
+  beforeEach(() => {
+    room = testRoom(roomID);
+    room.players.push({ name: 'admin', collection: 'admin-collection', send() {} });
+  });
+
+  afterEach(() => {
+    PublicRooms.remove(roomID);
+  });
+
+  afterAll(() => {
+    if(fs.existsSync(savedir + '/rooms/' + roomID + '.json'))
+      fs.unlinkSync(savedir + '/rooms/' + roomID + '.json');
+  });
+
+  test('registry adds and removes rooms', () => {
+    expect(PublicRooms.get()).not.toContain(roomID);
+    expect(PublicRooms.add(roomID)).toBe(true);
+    expect(PublicRooms.add(roomID)).toBe(true); // idempotent
+    expect(PublicRooms.get()).toContain(roomID);
+    PublicRooms.remove(roomID);
+    expect(PublicRooms.get()).not.toContain(roomID);
+  });
+
+  test('only admins can publish a room', async () => {
+    await expect(room.collectionAction('setPublic', { collection: 'other-collection', public: true, description: 'x' })).rejects.toThrow(/not the admin/);
+    expect(room.isPublic()).toBe(false);
+    await room.collectionAction('claim', { collection: 'admin-collection' });
+    await room.collectionAction('setPublic', { collection: 'admin-collection', public: true, description: '  Come play with us!  ' });
+    expect(room.isPublic()).toBe(true);
+    expect(room.state._meta.public.description).toBe('Come play with us!');
+    expect(PublicRooms.get()).toContain(roomID);
+    expect((await room.getRoomDetails('admin-collection')).isPublic).toBe(true);
+    expect((await room.getRoomDetails('admin-collection')).description).toBe('Come play with us!');
+  });
+
+  test('descriptions are capped at 500 characters', async () => {
+    await room.collectionAction('claim', { collection: 'admin-collection' });
+    await room.collectionAction('setPublic', { collection: 'admin-collection', public: true, description: 'x'.repeat(600) });
+    expect(room.state._meta.public.description.length).toBe(500);
+  });
+
+  test('unpublishing and unclaiming remove the room from the public list', async () => {
+    await room.collectionAction('claim', { collection: 'admin-collection' });
+    await room.collectionAction('setPublic', { collection: 'admin-collection', public: true, description: 'x' });
+    await room.collectionAction('setPublic', { collection: 'admin-collection', public: false });
+    expect(room.isPublic()).toBe(false);
+    expect(room.state._meta.public).toBeUndefined();
+    expect(PublicRooms.get()).not.toContain(roomID);
+
+    await room.collectionAction('setPublic', { collection: 'admin-collection', public: true, description: 'x' });
+    await room.collectionAction('unclaim', { collection: 'admin-collection' });
+    expect(room.isPublic()).toBe(false);
+    expect(room.state._meta.public).toBeUndefined();
+    expect(PublicRooms.get()).not.toContain(roomID);
+  });
+
+  test('deleting a room removes it from the public list', async () => {
+    await room.collectionAction('claim', { collection: 'admin-collection' });
+    await room.collectionAction('setPublic', { collection: 'admin-collection', public: true, description: 'x' });
+    await room.collectionAction('delete', { collection: 'admin-collection' });
+    expect(room.isPublic()).toBe(false);
+    expect(PublicRooms.get()).not.toContain(roomID);
   });
 });
 

--- a/tests/server/security.test.js
+++ b/tests/server/security.test.js
@@ -203,6 +203,13 @@ describe('Public rooms', () => {
     expect(room.state._meta.public.description.length).toBe(500);
   });
 
+  test('publishing requires a description', async () => {
+    await room.collectionAction('claim', { collection: 'admin-collection' });
+    await expect(room.collectionAction('setPublic', { collection: 'admin-collection', public: true, description: '   ' })).rejects.toThrow(/description/);
+    expect(room.isPublic()).toBe(false);
+    expect(PublicRooms.get()).not.toContain(roomID);
+  });
+
   test('unpublishing and unclaiming remove the room from the public list', async () => {
     await room.collectionAction('claim', { collection: 'admin-collection' });
     await room.collectionAction('setPublic', { collection: 'admin-collection', public: true, description: 'x' });


### PR DESCRIPTION
## Goal

Builds on #3018 (targets its `rooms-collection` branch): any claimed (owned) room can be **made public** with a description. It is then listed in a new **Public rooms** section of the Rooms tab, where anybody can see it and join.

## What this adds

### Publishing (room admins)
- The tile menu of a claimed room gets **Make room public**: the admin enters a description (required, trimmed, capped at 500 characters server-side) and the room appears in the public list. **Edit public listing** updates the description, **Make room private** removes the listing again.
- The listing is stored as `_meta.public = { description }` on the room plus an entry in a server-side registry (`save/publicRooms.json`, new `server/publicrooms.mjs`, capped at 500 rooms).
- The listing is automatically removed when the claim is released, when the room is deleted, and it is not carried over by **Copy room** (a copy starts private). The listing endpoint also lazily heals the registry when a listed room no longer exists or is no longer public, and skips (with a log entry) rooms that fail to load instead of failing the whole listing.

### Public rooms section (everyone)
- New **Public rooms** section in the Rooms overlay below the user's own rooms, fed by the new anonymous `GET /api/publicrooms` endpoint. Tiles reuse the existing room-tile design and additionally show the **description** and the **number of players currently online**; the list is sorted by player count.
- Anybody can join a public room with the tile's existing switch button; visiting it adds it to their own collection as usual. Public tiles offer copy/link in the menu, but not "Remove from list" (they are not part of the viewer's collection); admins of a public room still get their management menu there — the client flags admin tiles by matching room IDs against its own collection listing, so no secret is sent to the public endpoint.
- The user's own tiles show a "public" globe icon when the room is published.

### Security & abuse considerations
- `setPublic` is a new action of the existing `POST /api/room/:room/:action` endpoint and requires admin (claimed collection), like rename/lock/password.
- `isPublic()` only reports rooms that are still claimed, so stray `_meta.public` data without a claim never gets listed.
- The anonymous listing is **viewer-independent**: it takes no collection parameter (no scrypt work, no secret in query strings/access logs) and **strips connected players' names**, exposing only a `playerCount` — players didn't opt into being listed publicly. Own-collection tiles still show the name chips from #3018's base branch.
- The response is cached server-side for 10 seconds (invalidated by room management actions, so publish/unpublish show up immediately), which keeps the endpoint cheap to poll and bounds the disk churn of loading idle rooms.
- Password-protected rooms can be published; the key icon shows that joining needs the password.

## Testing
- `npm test` (jest) passes (25/25); added a **Public rooms** describe block to `tests/server/security.test.js`: registry add/remove, publish requires admin and a non-empty description, description trimming/capping, and unpublish/unclaim/delete all remove the listing.
- Manual end-to-end verification with Playwright against a local server: claim → publish with description → globe icon appears; a second, fresh browser profile sees the room in the public section with description and player count (and no admin menu entries), joins it via the switch button and lands in the room; unpublishing removes the tile immediately; the raw anonymous API response contains no player names; the admin sees their management menu on their own public tile.
- Screenshots: [admin view](https://agent.virtualtabletop.io/reports/pr/1527730406948868156/screenshot-admin.png) (own tile with player chip + globe/admin icons, public tile with count and description), [guest view](https://agent.virtualtabletop.io/reports/pr/1527730406948868156/screenshot-guest.png) (public tile with description, player count and non-admin menu).
- Like #3018, the TestCafe suite could not be run meaningfully in the sandbox; relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)