### PR TITLE
Don't crash the client on an unparseable server message

### DIFF
--- a/client/js/connection.js
+++ b/client/js/connection.js
@@ -42,7 +42,18 @@ export function startWebSocket() {
   };
 
   connection.onmessage = (e) => {
-    const { func, args } = JSON.parse(e.data);
+    let func, args;
+    try {
+      ({ func, args } = JSON.parse(e.data));
+    } catch(error) {
+      // A message that fails to parse was corrupted or truncated in transit
+      // (some browsers occasionally deliver incomplete WebSocket frames).
+      // Instead of crashing the whole client with an uncaught error, drop the
+      // connection so the existing reconnect logic re-syncs the full room state.
+      console.error('Could not parse message from server. Reconnecting.', error);
+      connection.close();
+      return;
+    }
 
     if(func == 'serverStart') {
       if(serverStart != null && serverStart != args) {


### PR DESCRIPTION
## Problem

A client error was reported from the main server (Safari): `JSON Parse error: Unterminated string`, thrown from the WebSocket message handler during normal room use.

The client's `connection.onmessage` handler parsed incoming frames with a bare `JSON.parse(e.data)` and **no error handling**:

```js
connection.onmessage = (e) => {
  const { func, args } = JSON.parse(e.data);
  ...
```

If a frame arrives corrupted or truncated in transit (some browsers occasionally deliver incomplete WebSocket frames — the "unterminated string" symptom), `JSON.parse` throws an uncaught exception. That propagates to the global `window.onerror` handler in `tracing.js`, which shows the **fatal client-error overlay, closes the connection, and prevents reconnection** — ending the player's session over a single bad frame.

Notably the server side already guards against this: `server/connection.mjs` wraps its own `JSON.parse` of incoming messages in a `try/catch`. The client half was missing the symmetric guard.

## Fix

Wrap the client's `JSON.parse` in a `try/catch`. On a parse failure, log it and close the connection so the existing auto-reconnect logic re-establishes the session and re-syncs the full room state — instead of crashing with a fatal, unrecoverable error overlay.

## Testing

- `npm test` — all jest suites pass.
- Change is confined to the WebSocket message handler; server frames (always produced via `JSON.stringify`) parse exactly as before, so the happy path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3040/pr-test (or any other room on that server)