### PR TITLE
Add spinner tutorial page: CSS selectors, hover & hue-rotate arrows

### DIFF
--- a/library/tutorials/Types - Spinners/5.json
+++ b/library/tutorials/Types - Spinners/5.json
@@ -1,626 +1,4 @@
 {
-  "8fr3": {
-    "type": "label",
-    "text": "Spinners: Automations",
-    "css": "font-size: 60px",
-    "height": 150,
-    "width": 1000,
-    "x": -182,
-    "z": 270,
-    "id": "8fr3",
-    "y": 1
-  },
-  "lm3y": {
-    "type": "label",
-    "text": "click",
-    "css": "font-size: 40px",
-    "height": 50,
-    "width": 200,
-    "x": 65,
-    "y": 164,
-    "z": 244,
-    "id": "lm3y"
-  },
-  "nhi3": {
-    "type": "label",
-    "text": "sorting",
-    "css": "font-size: 40px",
-    "height": 50,
-    "width": 200,
-    "x": 1246,
-    "z": 253,
-    "id": "nhi3",
-    "y": 20
-  },
-  "8gdg": {
-    "type": "label",
-    "text": "reseting",
-    "css": "font-size: 40px",
-    "height": 50,
-    "width": 200,
-    "x": 604,
-    "y": 165,
-    "z": 284,
-    "id": "8gdg"
-  },
-  "poit": {
-    "type": "label",
-    "text": "sum",
-    "css": "font-size: 40px",
-    "height": 50,
-    "width": 200,
-    "x": 154,
-    "y": 590,
-    "z": 278,
-    "id": "poit"
-  },
-  "igpg": {
-    "type": "label",
-    "text": "Click on spinners (selected by custom property).",
-    "x": 20,
-    "y": 211,
-    "z": 18,
-    "width": 300,
-    "height": 60,
-    "id": "igpg"
-  },
-  "6pv6": {
-    "type": "spinner",
-    "value": 2,
-    "options": [
-      1,
-      2,
-      3,
-      4,
-      5,
-      6
-    ],
-    "x": 174,
-    "y": 345,
-    "z": 11,
-    "id": "6pv6",
-    "angle": 64910,
-    "myCustomKey": "roll"
-  },
-  "yqpn": {
-    "type": "button",
-    "text": "CLICK",
-    "clickRoutine": [
-      {
-        "func": "SELECT",
-        "property": "myCustomKey",
-        "value": "roll"
-      },
-      {
-        "func": "CLICK"
-      }
-    ],
-    "x": 23,
-    "y": 360,
-    "z": 14,
-    "id": "yqpn"
-  },
-  "j545": {
-    "type": "spinner",
-    "value": 6,
-    "options": [
-      1,
-      2,
-      3,
-      4,
-      5,
-      6
-    ],
-    "x": 277,
-    "y": 407,
-    "z": 12,
-    "id": "j545",
-    "angle": 65111,
-    "myCustomKey": "roll"
-  },
-  "ncsa": {
-    "type": "spinner",
-    "value": 4,
-    "options": [
-      1,
-      2,
-      3,
-      4,
-      5,
-      6
-    ],
-    "x": 277,
-    "y": 284,
-    "z": 10,
-    "id": "ncsa",
-    "angle": 63956,
-    "myCustomKey": "roll"
-  },
-  "all1": {
-    "type": "holder",
-    "x": 1172,
-    "y": 260,
-    "z": 2,
-    "id": "all1",
-    "stackOffsetX": 114,
-    "dropTarget": {
-      "myCustomKey": "set1"
-    },
-    "width": 348,
-    "height": 118
-  },
-  "nm5a": {
-    "type": "button",
-    "text": "ROLL",
-    "clickRoutine": [
-      {
-        "func": "SELECT",
-        "property": "myCustomKey",
-        "value": "sort"
-      },
-      {
-        "func": "CLICK"
-      }
-    ],
-    "x": 1501,
-    "y": 649,
-    "z": 20,
-    "id": "nm5a"
-  },
-  "62x9": {
-    "type": "button",
-    "text": "SORT",
-    "clickRoutine": [
-      {
-        "func": "SELECT",
-        "property": "myCustomKey",
-        "value": "sort"
-      },
-      {
-        "func": "SELECT",
-        "property": "value",
-        "value": 1,
-        "source": "DEFAULT",
-        "mode": "set",
-        "collection": "all1"
-      },
-      {
-        "func": "SET",
-        "property": "parent",
-        "value": "all1",
-        "collection": "all1"
-      },
-      {
-        "func": "SELECT",
-        "property": "value",
-        "value": 2,
-        "source": "DEFAULT",
-        "mode": "set",
-        "collection": "all2"
-      },
-      {
-        "func": "SET",
-        "property": "parent",
-        "value": "all2",
-        "collection": "all2"
-      },
-      {
-        "func": "SELECT",
-        "property": "value",
-        "value": 3,
-        "source": "DEFAULT",
-        "mode": "set",
-        "collection": "all3"
-      },
-      {
-        "func": "SET",
-        "property": "parent",
-        "value": "all3",
-        "collection": "all3"
-      }
-    ],
-    "x": 1501,
-    "y": 740,
-    "z": 19,
-    "id": "62x9"
-  },
-  "all2": {
-    "type": "holder",
-    "x": 1172,
-    "y": 383,
-    "z": 3,
-    "stackOffsetX": 114,
-    "dropTarget": {
-      "myCustomKey": "set1"
-    },
-    "width": 348,
-    "height": 118,
-    "id": "all2"
-  },
-  "all3": {
-    "type": "holder",
-    "x": 1172,
-    "y": 506,
-    "z": 4,
-    "stackOffsetX": 114,
-    "dropTarget": {
-      "myCustomKey": "set1"
-    },
-    "width": 348,
-    "height": 118,
-    "id": "all3"
-  },
-  "d9qo": {
-    "type": "spinner",
-    "value": 2,
-    "options": [
-      1,
-      2,
-      3
-    ],
-    "x": 234,
-    "y": 4,
-    "z": 64,
-    "myCustomKey": "sort",
-    "angle": 159643,
-    "id": "d9qo",
-    "parent": "all2"
-  },
-  "6v3u": {
-    "type": "spinner",
-    "value": 1,
-    "options": [
-      1,
-      2,
-      3
-    ],
-    "x": 4,
-    "y": 4,
-    "z": 1,
-    "myCustomKey": "sort",
-    "angle": 159538,
-    "parent": "all1",
-    "id": "6v3u"
-  },
-  "qucw": {
-    "type": "spinner",
-    "value": 2,
-    "options": [
-      1,
-      2,
-      3
-    ],
-    "x": 119,
-    "y": 4,
-    "z": 63,
-    "myCustomKey": "sort",
-    "angle": 159286,
-    "id": "qucw",
-    "parent": "all2"
-  },
-  "ucpe": {
-    "type": "spinner",
-    "value": 1,
-    "options": [
-      1,
-      2,
-      3,
-      4,
-      5,
-      6
-    ],
-    "x": 1337,
-    "y": 858,
-    "z": 59,
-    "id": "ucpe",
-    "angle": 3659,
-    "scale": 0.8
-  },
-  "ygix": {
-    "type": "spinner",
-    "value": 1,
-    "options": [
-      1,
-      2,
-      3,
-      4,
-      5,
-      6
-    ],
-    "x": 1222,
-    "y": 860,
-    "z": 58,
-    "id": "ygix",
-    "angle": 3964,
-    "scale": 0.8
-  },
-  "ovnb": {
-    "type": "label",
-    "text": "Unaffected because they don't have 'myCustomKey' set to 'sort'",
-    "x": 1096,
-    "y": 965,
-    "z": 274,
-    "id": "ovnb",
-    "width": 500
-  },
-  "lbh7": {
-    "type": "label",
-    "text": "The affected spinners have a custom property 'myCustomKey' set to 'sort'. This by itself doesn't do anything and both strings can be anything\n\nThe holders have a property 'dropTarget' which says that only widgets can be dropped into them that have 'myCustomKey' set to 'set1'. This is not necessary for the buttons; only for manual interaction.",
-    "x": 1096,
-    "y": 90,
-    "z": 285,
-    "id": "lbh7",
-    "width": 500,
-    "editable": true,
-    "height": 200
-  },
-  "h9ji": {
-    "type": "label",
-    "text": "The ROLL button SELECTs all widgets that have 'myCustomKey' set to 'sort'. Then it CLICKs them.",
-    "x": 1096,
-    "y": 649,
-    "z": 272,
-    "width": 400,
-    "height": 100,
-    "id": "h9ji"
-  },
-  "1r5z": {
-    "type": "label",
-    "text": "The SORT button first selects the same widgets. Then for each value 1-6 it filters those widgets by their 'value' property and for each of those matched subselections, it moves all widgets to the holder for the value by\nsetting their 'parent' property.",
-    "x": 1096,
-    "y": 740,
-    "z": 273,
-    "width": 400,
-    "height": 150,
-    "id": "1r5z",
-    "editable": true
-  },
-  "8y1u": {
-    "type": "label",
-    "text": "the click and sorting example were taken from other tutorials made by the community. Atributions and links available in this variant's notes",
-    "css": "font-size: 15px",
-    "height": 50,
-    "width": 1000,
-    "x": -22,
-    "z": 271,
-    "y": 78,
-    "id": "8y1u"
-  },
-  "5v10": {
-    "type": "label",
-    "text": "adapted",
-    "css": "font-size: 15px",
-    "height": 150,
-    "width": 100,
-    "x": 1394,
-    "z": 289,
-    "y": 37,
-    "id": "5v10"
-  },
-  "6pv6-copy001": {
-    "type": "spinner",
-    "value": 4,
-    "options": [
-      1,
-      2,
-      3,
-      4,
-      5,
-      6
-    ],
-    "x": 57,
-    "y": 746,
-    "id": "6pv6-copy001",
-    "angle": 75812,
-    "myCustomKey": "sum",
-    "z": 282
-  },
-  "yqpn-copy001": {
-    "type": "button",
-    "text": "Click and get sum",
-    "clickRoutine": [
-      {
-        "func": "SELECT",
-        "property": "myCustomKey",
-        "value": "sum"
-      },
-      {
-        "func": "CLICK"
-      },
-      {
-        "func": "GET",
-        "aggregation": "sum",
-        "property": "value",
-        "comment": "the value property in a spinner stores the the result of the spin",
-        "variable": "sumResult"
-      },
-      {
-        "func": "LABEL",
-        "label": "rz15",
-        "applyVariables": [
-          {
-            "parameter": "value",
-            "variable": "sumResult"
-          }
-        ]
-      }
-    ],
-    "x": 83,
-    "y": 648,
-    "id": "yqpn-copy001",
-    "z": 280
-  },
-  "j545-copy001": {
-    "type": "spinner",
-    "value": 1,
-    "options": [
-      1,
-      2,
-      3,
-      4,
-      5,
-      6
-    ],
-    "x": 347,
-    "y": 746,
-    "id": "j545-copy001",
-    "angle": 74908,
-    "myCustomKey": "sum",
-    "z": 284
-  },
-  "ncsa-copy001": {
-    "type": "spinner",
-    "value": 3,
-    "options": [
-      1,
-      2,
-      3,
-      4,
-      5,
-      6
-    ],
-    "x": 202,
-    "y": 746,
-    "id": "ncsa-copy001",
-    "angle": 73957,
-    "myCustomKey": "sum",
-    "z": 283
-  },
-  "6pv6-copy001-copy001": {
-    "type": "spinner",
-    "value": 6,
-    "options": [
-      1,
-      2,
-      3,
-      4,
-      5,
-      6
-    ],
-    "x": 57,
-    "y": 878,
-    "id": "6pv6-copy001-copy001",
-    "angle": 75205,
-    "myCustomKey": "sum",
-    "z": 285
-  },
-  "j545-copy001-copy001": {
-    "type": "spinner",
-    "value": 5,
-    "options": [
-      1,
-      2,
-      3,
-      4,
-      5,
-      6
-    ],
-    "x": 347,
-    "y": 878,
-    "id": "j545-copy001-copy001",
-    "angle": 74779,
-    "myCustomKey": "sum",
-    "z": 286
-  },
-  "ncsa-copy001-copy001": {
-    "type": "spinner",
-    "value": 3,
-    "options": [
-      1,
-      2,
-      3,
-      4,
-      5,
-      6
-    ],
-    "x": 202,
-    "y": 878,
-    "id": "ncsa-copy001-copy001",
-    "angle": 73921,
-    "myCustomKey": "sum",
-    "z": 287
-  },
-  "e3w9": {
-    "type": "label",
-    "text": "result:",
-    "css": "font-size: 30px",
-    "height": 42,
-    "x": 206,
-    "y": 668,
-    "z": 283,
-    "id": "e3w9",
-    "width": 110
-  },
-  "rz15": {
-    "type": "label",
-    "css": "font-size: 30px",
-    "height": 42,
-    "width": 57,
-    "x": 295.5,
-    "y": 670,
-    "z": 293,
-    "id": "rz15",
-    "text": 22
-  },
-  "6pv6-copy002": {
-    "type": "spinner",
-    "options": [
-      1,
-      2,
-      3,
-      4,
-      5,
-      6
-    ],
-    "x": 724,
-    "y": 305,
-    "id": "6pv6-copy002",
-    "myCustomKey": "reset",
-    "z": 294
-  },
-  "yqpn-copy002": {
-    "type": "button",
-    "text": "Reset",
-    "clickRoutine": [
-      {
-        "func": "SELECT",
-        "property": "myCustomKey",
-        "value": "reset"
-      },
-      {
-        "func": "SET",
-        "property": "angle",
-        "value": 0
-      },
-      {
-        "func": "SET",
-        "property": "value",
-        "value": null
-      }
-    ],
-    "x": 576,
-    "y": 263,
-    "id": "yqpn-copy002",
-    "z": 295
-  },
-  "d20o": {
-    "type": "button",
-    "text": "Roll",
-    "clickRoutine": [
-      {
-        "func": "SELECT",
-        "property": "myCustomKey",
-        "value": "reset"
-      },
-      {
-        "func": "CLICK"
-      }
-    ],
-    "x": 576,
-    "y": 376,
-    "z": 296,
-    "id": "d20o"
-  },
   "_meta": {
     "version": 1,
     "info": {
@@ -631,9 +9,9 @@
       "year": "2021",
       "mode": "Tutorial",
       "time": "0",
-      "attribution": "Background color CSS: https://www.w3schools.com/cssref/pr_background-color.asp\nFont color CSS: https://www.w3schools.com/cssref/pr_text_color.asp\nBorder color CSS: https://www.w3schools.com/cssref/pr_border-color.asp",
+      "attribution": "Background color CSS: https://www.w3schools.com/cssref/pr_background-color.asp\nFont color CSS: https://www.w3schools.com/cssref/pr_text_color.asp\nBorder color CSS: https://www.w3schools.com/cssref/pr_border-color.asp\nhue-rotate() filter: https://developer.mozilla.org/en-US/docs/Web/CSS/filter-function/hue-rotate",
       "showName": false,
-      "lastUpdate": 1748992129606,
+      "lastUpdate": 1784500000000,
       "skill": "",
       "description": "",
       "similarImage": "",
@@ -643,9 +21,366 @@
       "helpText": "",
       "similarDesigner": "",
       "variantImage": "",
-      "variant": "Automations",
+      "variant": "CSS Selectors & Hover",
       "language": "en-US",
       "players": "1"
     }
+  },
+  "8fr3": {
+    "type": "label",
+    "text": "Spinners:\nCSS Selectors & Hover",
+    "css": "font-size: 60px",
+    "x": 27,
+    "y": 26,
+    "z": 241,
+    "width": 1000,
+    "height": 150,
+    "id": "8fr3"
+  },
+  "j713": {
+    "type": "label",
+    "text": "   Every layer of a spinner can be styled straight from the widget's normal \"css\" property, without the shorthand \"backgroundCSS\", \"spinnerCSS\" and \"valueCSS\" properties.\n\n   Give \"css\" an object whose keys are CSS selectors and whose values are objects of CSS declarations - VirtualTabletop turns that into a small stylesheet just for this spinner. Each layer sits inside the widget, so start the selector with a space:\n\n      \" .background\"   - the SVG with the options   (= backgroundCSS)\n      \" .spinningPart\" - the rotating arrow          (= spinnerCSS)\n      \" .value\"        - the central result          (= valueCSS)\n\n   Real selectors let you do things the shorthand cannot, for example react to \":hover .spinningPart\".\n\n   Tip: you do NOT need a new image to recolor the arrow - just apply \"filter: hue-rotate(...)\" to the \" .spinningPart\" layer. See the row of examples below.",
+    "css": "font-size: 24px; text-align: left;",
+    "x": 40,
+    "y": 178,
+    "z": 240,
+    "width": 900,
+    "height": 470,
+    "id": "j713",
+    "editable": true
+  },
+  "aHdr": {
+    "type": "label",
+    "text": "Same result - two ways",
+    "css": "font-size: 32px",
+    "x": 1000,
+    "y": 26,
+    "z": 232,
+    "width": 540,
+    "height": 60,
+    "id": "aHdr"
+  },
+  "aShort": {
+    "type": "spinner",
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "value": 3,
+    "angle": 850,
+    "x": 1050,
+    "y": 110,
+    "z": 30,
+    "id": "aShort",
+    "backgroundCSS": "border: 5px solid #1f5ca6 !important;",
+    "valueCSS": "background-color: #52bbae; color: #ffffff !important;"
+  },
+  "aShortL": {
+    "type": "label",
+    "text": "Shorthand properties:\nbackgroundCSS + valueCSS",
+    "css": "font-size: 18px",
+    "x": 1000,
+    "y": 235,
+    "z": 233,
+    "width": 250,
+    "height": 110,
+    "id": "aShortL"
+  },
+  "aCss": {
+    "type": "spinner",
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "value": 3,
+    "angle": 850,
+    "x": 1330,
+    "y": 110,
+    "z": 31,
+    "id": "aCss",
+    "css": {
+      " .background": {
+        "border": "5px solid #1f5ca6 !important"
+      },
+      " .value": {
+        "background-color": "#52bbae",
+        "color": "#ffffff !important"
+      }
+    }
+  },
+  "aCssL": {
+    "type": "label",
+    "text": "Same look via a css object:\n{ \" .background\": {..}, \" .value\": {..} }",
+    "css": "font-size: 18px",
+    "x": 1285,
+    "y": 235,
+    "z": 234,
+    "width": 260,
+    "height": 110,
+    "id": "aCssL"
+  },
+  "bHdr": {
+    "type": "label",
+    "text": "React to hover",
+    "css": "font-size: 32px",
+    "x": 1000,
+    "y": 355,
+    "z": 235,
+    "width": 540,
+    "height": 60,
+    "id": "bHdr"
+  },
+  "bHover": {
+    "type": "spinner",
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "value": 2,
+    "angle": 500,
+    "x": 1050,
+    "y": 430,
+    "z": 32,
+    "id": "bHover",
+    "css": {
+      " .spinningPart": {
+        "transition": "filter 0.3s"
+      },
+      ":hover .spinningPart": {
+        "filter": "hue-rotate(130deg)"
+      }
+    }
+  },
+  "bHoverL": {
+    "type": "label",
+    "text": "Hover the spinner ->\n\ncss:\n{ \":hover .spinningPart\":\n    { \"filter\": \"hue-rotate(130deg)\" } }",
+    "css": "font-size: 20px",
+    "x": 1220,
+    "y": 430,
+    "z": 236,
+    "width": 320,
+    "height": 200,
+    "id": "bHoverL"
+  },
+  "cHdr": {
+    "type": "label",
+    "text": "Recolor the default arrow with \"filter: hue-rotate()\" on \".spinningPart\" - no new image needed:",
+    "css": "font-size: 26px",
+    "x": 40,
+    "y": 668,
+    "z": 237,
+    "width": 1500,
+    "height": 60,
+    "id": "cHdr"
+  },
+  "cHue0": {
+    "type": "spinner",
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "value": 6,
+    "angle": 0,
+    "x": 90,
+    "y": 760,
+    "z": 40,
+    "id": "cHue0",
+    "css": {
+      " .spinningPart": {
+        "filter": "hue-rotate(0deg)"
+      }
+    }
+  },
+  "cHueL0": {
+    "type": "label",
+    "text": "0deg\nblue (default)",
+    "css": "font-size: 20px; text-align: center;",
+    "x": 70,
+    "y": 880,
+    "z": 250,
+    "width": 190,
+    "height": 90,
+    "id": "cHueL0"
+  },
+  "cHue1": {
+    "type": "spinner",
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "value": 2,
+    "angle": 60,
+    "x": 325,
+    "y": 760,
+    "z": 41,
+    "id": "cHue1",
+    "css": {
+      " .spinningPart": {
+        "filter": "hue-rotate(95deg)"
+      }
+    }
+  },
+  "cHueL1": {
+    "type": "label",
+    "text": "95deg\nmagenta",
+    "css": "font-size: 20px; text-align: center;",
+    "x": 305,
+    "y": 880,
+    "z": 251,
+    "width": 190,
+    "height": 90,
+    "id": "cHueL1"
+  },
+  "cHue2": {
+    "type": "spinner",
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "value": 5,
+    "angle": 130,
+    "x": 560,
+    "y": 760,
+    "z": 42,
+    "id": "cHue2",
+    "css": {
+      " .spinningPart": {
+        "filter": "hue-rotate(130deg)"
+      }
+    }
+  },
+  "cHueL2": {
+    "type": "label",
+    "text": "130deg\nred",
+    "css": "font-size: 20px; text-align: center;",
+    "x": 540,
+    "y": 880,
+    "z": 252,
+    "width": 190,
+    "height": 90,
+    "id": "cHueL2"
+  },
+  "cHue3": {
+    "type": "spinner",
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "value": 1,
+    "angle": 200,
+    "x": 795,
+    "y": 760,
+    "z": 43,
+    "id": "cHue3",
+    "css": {
+      " .spinningPart": {
+        "filter": "hue-rotate(165deg)"
+      }
+    }
+  },
+  "cHueL3": {
+    "type": "label",
+    "text": "165deg\norange",
+    "css": "font-size: 20px; text-align: center;",
+    "x": 775,
+    "y": 880,
+    "z": 253,
+    "width": 190,
+    "height": 90,
+    "id": "cHueL3"
+  },
+  "cHue4": {
+    "type": "spinner",
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "value": 3,
+    "angle": 260,
+    "x": 1030,
+    "y": 760,
+    "z": 44,
+    "id": "cHue4",
+    "css": {
+      " .spinningPart": {
+        "filter": "hue-rotate(275deg)"
+      }
+    }
+  },
+  "cHueL4": {
+    "type": "label",
+    "text": "275deg\ngreen",
+    "css": "font-size: 20px; text-align: center;",
+    "x": 1010,
+    "y": 880,
+    "z": 254,
+    "width": 190,
+    "height": 90,
+    "id": "cHueL4"
+  },
+  "cHue5": {
+    "type": "spinner",
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "value": 4,
+    "angle": 320,
+    "x": 1265,
+    "y": 760,
+    "z": 45,
+    "id": "cHue5",
+    "css": {
+      " .spinningPart": {
+        "filter": "hue-rotate(320deg)"
+      }
+    }
+  },
+  "cHueL5": {
+    "type": "label",
+    "text": "320deg\nteal",
+    "css": "font-size: 20px; text-align: center;",
+    "x": 1245,
+    "y": 880,
+    "z": 255,
+    "width": 190,
+    "height": 90,
+    "id": "cHueL5"
   }
 }

--- a/library/tutorials/Types - Spinners/5.json
+++ b/library/tutorials/Types - Spinners/5.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "version": 1,
+    "version": 21,
     "info": {
       "name": "Types - Spinner",
       "image": "/assets/797406932_11103",
@@ -24,6 +24,9 @@
       "variant": "CSS Selectors & Hover",
       "language": "en-US",
       "players": "1"
+    },
+    "gameSettings": {
+      "legacyModes": {}
     }
   },
   "8fr3": {

--- a/library/tutorials/Types - Spinners/6.json
+++ b/library/tutorials/Types - Spinners/6.json
@@ -1,0 +1,651 @@
+{
+  "8fr3": {
+    "type": "label",
+    "text": "Spinners: Automations",
+    "css": "font-size: 60px",
+    "height": 150,
+    "width": 1000,
+    "x": -182,
+    "z": 270,
+    "id": "8fr3",
+    "y": 1
+  },
+  "lm3y": {
+    "type": "label",
+    "text": "click",
+    "css": "font-size: 40px",
+    "height": 50,
+    "width": 200,
+    "x": 65,
+    "y": 164,
+    "z": 244,
+    "id": "lm3y"
+  },
+  "nhi3": {
+    "type": "label",
+    "text": "sorting",
+    "css": "font-size: 40px",
+    "height": 50,
+    "width": 200,
+    "x": 1246,
+    "z": 253,
+    "id": "nhi3",
+    "y": 20
+  },
+  "8gdg": {
+    "type": "label",
+    "text": "reseting",
+    "css": "font-size: 40px",
+    "height": 50,
+    "width": 200,
+    "x": 604,
+    "y": 165,
+    "z": 284,
+    "id": "8gdg"
+  },
+  "poit": {
+    "type": "label",
+    "text": "sum",
+    "css": "font-size: 40px",
+    "height": 50,
+    "width": 200,
+    "x": 154,
+    "y": 590,
+    "z": 278,
+    "id": "poit"
+  },
+  "igpg": {
+    "type": "label",
+    "text": "Click on spinners (selected by custom property).",
+    "x": 20,
+    "y": 211,
+    "z": 18,
+    "width": 300,
+    "height": 60,
+    "id": "igpg"
+  },
+  "6pv6": {
+    "type": "spinner",
+    "value": 2,
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "x": 174,
+    "y": 345,
+    "z": 11,
+    "id": "6pv6",
+    "angle": 64910,
+    "myCustomKey": "roll"
+  },
+  "yqpn": {
+    "type": "button",
+    "text": "CLICK",
+    "clickRoutine": [
+      {
+        "func": "SELECT",
+        "property": "myCustomKey",
+        "value": "roll"
+      },
+      {
+        "func": "CLICK"
+      }
+    ],
+    "x": 23,
+    "y": 360,
+    "z": 14,
+    "id": "yqpn"
+  },
+  "j545": {
+    "type": "spinner",
+    "value": 6,
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "x": 277,
+    "y": 407,
+    "z": 12,
+    "id": "j545",
+    "angle": 65111,
+    "myCustomKey": "roll"
+  },
+  "ncsa": {
+    "type": "spinner",
+    "value": 4,
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "x": 277,
+    "y": 284,
+    "z": 10,
+    "id": "ncsa",
+    "angle": 63956,
+    "myCustomKey": "roll"
+  },
+  "all1": {
+    "type": "holder",
+    "x": 1172,
+    "y": 260,
+    "z": 2,
+    "id": "all1",
+    "stackOffsetX": 114,
+    "dropTarget": {
+      "myCustomKey": "set1"
+    },
+    "width": 348,
+    "height": 118
+  },
+  "nm5a": {
+    "type": "button",
+    "text": "ROLL",
+    "clickRoutine": [
+      {
+        "func": "SELECT",
+        "property": "myCustomKey",
+        "value": "sort"
+      },
+      {
+        "func": "CLICK"
+      }
+    ],
+    "x": 1501,
+    "y": 649,
+    "z": 20,
+    "id": "nm5a"
+  },
+  "62x9": {
+    "type": "button",
+    "text": "SORT",
+    "clickRoutine": [
+      {
+        "func": "SELECT",
+        "property": "myCustomKey",
+        "value": "sort"
+      },
+      {
+        "func": "SELECT",
+        "property": "value",
+        "value": 1,
+        "source": "DEFAULT",
+        "mode": "set",
+        "collection": "all1"
+      },
+      {
+        "func": "SET",
+        "property": "parent",
+        "value": "all1",
+        "collection": "all1"
+      },
+      {
+        "func": "SELECT",
+        "property": "value",
+        "value": 2,
+        "source": "DEFAULT",
+        "mode": "set",
+        "collection": "all2"
+      },
+      {
+        "func": "SET",
+        "property": "parent",
+        "value": "all2",
+        "collection": "all2"
+      },
+      {
+        "func": "SELECT",
+        "property": "value",
+        "value": 3,
+        "source": "DEFAULT",
+        "mode": "set",
+        "collection": "all3"
+      },
+      {
+        "func": "SET",
+        "property": "parent",
+        "value": "all3",
+        "collection": "all3"
+      }
+    ],
+    "x": 1501,
+    "y": 740,
+    "z": 19,
+    "id": "62x9"
+  },
+  "all2": {
+    "type": "holder",
+    "x": 1172,
+    "y": 383,
+    "z": 3,
+    "stackOffsetX": 114,
+    "dropTarget": {
+      "myCustomKey": "set1"
+    },
+    "width": 348,
+    "height": 118,
+    "id": "all2"
+  },
+  "all3": {
+    "type": "holder",
+    "x": 1172,
+    "y": 506,
+    "z": 4,
+    "stackOffsetX": 114,
+    "dropTarget": {
+      "myCustomKey": "set1"
+    },
+    "width": 348,
+    "height": 118,
+    "id": "all3"
+  },
+  "d9qo": {
+    "type": "spinner",
+    "value": 2,
+    "options": [
+      1,
+      2,
+      3
+    ],
+    "x": 234,
+    "y": 4,
+    "z": 64,
+    "myCustomKey": "sort",
+    "angle": 159643,
+    "id": "d9qo",
+    "parent": "all2"
+  },
+  "6v3u": {
+    "type": "spinner",
+    "value": 1,
+    "options": [
+      1,
+      2,
+      3
+    ],
+    "x": 4,
+    "y": 4,
+    "z": 1,
+    "myCustomKey": "sort",
+    "angle": 159538,
+    "parent": "all1",
+    "id": "6v3u"
+  },
+  "qucw": {
+    "type": "spinner",
+    "value": 2,
+    "options": [
+      1,
+      2,
+      3
+    ],
+    "x": 119,
+    "y": 4,
+    "z": 63,
+    "myCustomKey": "sort",
+    "angle": 159286,
+    "id": "qucw",
+    "parent": "all2"
+  },
+  "ucpe": {
+    "type": "spinner",
+    "value": 1,
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "x": 1337,
+    "y": 858,
+    "z": 59,
+    "id": "ucpe",
+    "angle": 3659,
+    "scale": 0.8
+  },
+  "ygix": {
+    "type": "spinner",
+    "value": 1,
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "x": 1222,
+    "y": 860,
+    "z": 58,
+    "id": "ygix",
+    "angle": 3964,
+    "scale": 0.8
+  },
+  "ovnb": {
+    "type": "label",
+    "text": "Unaffected because they don't have 'myCustomKey' set to 'sort'",
+    "x": 1096,
+    "y": 965,
+    "z": 274,
+    "id": "ovnb",
+    "width": 500
+  },
+  "lbh7": {
+    "type": "label",
+    "text": "The affected spinners have a custom property 'myCustomKey' set to 'sort'. This by itself doesn't do anything and both strings can be anything\n\nThe holders have a property 'dropTarget' which says that only widgets can be dropped into them that have 'myCustomKey' set to 'set1'. This is not necessary for the buttons; only for manual interaction.",
+    "x": 1096,
+    "y": 90,
+    "z": 285,
+    "id": "lbh7",
+    "width": 500,
+    "editable": true,
+    "height": 200
+  },
+  "h9ji": {
+    "type": "label",
+    "text": "The ROLL button SELECTs all widgets that have 'myCustomKey' set to 'sort'. Then it CLICKs them.",
+    "x": 1096,
+    "y": 649,
+    "z": 272,
+    "width": 400,
+    "height": 100,
+    "id": "h9ji"
+  },
+  "1r5z": {
+    "type": "label",
+    "text": "The SORT button first selects the same widgets. Then for each value 1-6 it filters those widgets by their 'value' property and for each of those matched subselections, it moves all widgets to the holder for the value by\nsetting their 'parent' property.",
+    "x": 1096,
+    "y": 740,
+    "z": 273,
+    "width": 400,
+    "height": 150,
+    "id": "1r5z",
+    "editable": true
+  },
+  "8y1u": {
+    "type": "label",
+    "text": "the click and sorting example were taken from other tutorials made by the community. Atributions and links available in this variant's notes",
+    "css": "font-size: 15px",
+    "height": 50,
+    "width": 1000,
+    "x": -22,
+    "z": 271,
+    "y": 78,
+    "id": "8y1u"
+  },
+  "5v10": {
+    "type": "label",
+    "text": "adapted",
+    "css": "font-size: 15px",
+    "height": 150,
+    "width": 100,
+    "x": 1394,
+    "z": 289,
+    "y": 37,
+    "id": "5v10"
+  },
+  "6pv6-copy001": {
+    "type": "spinner",
+    "value": 4,
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "x": 57,
+    "y": 746,
+    "id": "6pv6-copy001",
+    "angle": 75812,
+    "myCustomKey": "sum",
+    "z": 282
+  },
+  "yqpn-copy001": {
+    "type": "button",
+    "text": "Click and get sum",
+    "clickRoutine": [
+      {
+        "func": "SELECT",
+        "property": "myCustomKey",
+        "value": "sum"
+      },
+      {
+        "func": "CLICK"
+      },
+      {
+        "func": "GET",
+        "aggregation": "sum",
+        "property": "value",
+        "comment": "the value property in a spinner stores the the result of the spin",
+        "variable": "sumResult"
+      },
+      {
+        "func": "LABEL",
+        "label": "rz15",
+        "applyVariables": [
+          {
+            "parameter": "value",
+            "variable": "sumResult"
+          }
+        ]
+      }
+    ],
+    "x": 83,
+    "y": 648,
+    "id": "yqpn-copy001",
+    "z": 280
+  },
+  "j545-copy001": {
+    "type": "spinner",
+    "value": 1,
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "x": 347,
+    "y": 746,
+    "id": "j545-copy001",
+    "angle": 74908,
+    "myCustomKey": "sum",
+    "z": 284
+  },
+  "ncsa-copy001": {
+    "type": "spinner",
+    "value": 3,
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "x": 202,
+    "y": 746,
+    "id": "ncsa-copy001",
+    "angle": 73957,
+    "myCustomKey": "sum",
+    "z": 283
+  },
+  "6pv6-copy001-copy001": {
+    "type": "spinner",
+    "value": 6,
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "x": 57,
+    "y": 878,
+    "id": "6pv6-copy001-copy001",
+    "angle": 75205,
+    "myCustomKey": "sum",
+    "z": 285
+  },
+  "j545-copy001-copy001": {
+    "type": "spinner",
+    "value": 5,
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "x": 347,
+    "y": 878,
+    "id": "j545-copy001-copy001",
+    "angle": 74779,
+    "myCustomKey": "sum",
+    "z": 286
+  },
+  "ncsa-copy001-copy001": {
+    "type": "spinner",
+    "value": 3,
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "x": 202,
+    "y": 878,
+    "id": "ncsa-copy001-copy001",
+    "angle": 73921,
+    "myCustomKey": "sum",
+    "z": 287
+  },
+  "e3w9": {
+    "type": "label",
+    "text": "result:",
+    "css": "font-size: 30px",
+    "height": 42,
+    "x": 206,
+    "y": 668,
+    "z": 283,
+    "id": "e3w9",
+    "width": 110
+  },
+  "rz15": {
+    "type": "label",
+    "css": "font-size: 30px",
+    "height": 42,
+    "width": 57,
+    "x": 295.5,
+    "y": 670,
+    "z": 293,
+    "id": "rz15",
+    "text": 22
+  },
+  "6pv6-copy002": {
+    "type": "spinner",
+    "options": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "x": 724,
+    "y": 305,
+    "id": "6pv6-copy002",
+    "myCustomKey": "reset",
+    "z": 294
+  },
+  "yqpn-copy002": {
+    "type": "button",
+    "text": "Reset",
+    "clickRoutine": [
+      {
+        "func": "SELECT",
+        "property": "myCustomKey",
+        "value": "reset"
+      },
+      {
+        "func": "SET",
+        "property": "angle",
+        "value": 0
+      },
+      {
+        "func": "SET",
+        "property": "value",
+        "value": null
+      }
+    ],
+    "x": 576,
+    "y": 263,
+    "id": "yqpn-copy002",
+    "z": 295
+  },
+  "d20o": {
+    "type": "button",
+    "text": "Roll",
+    "clickRoutine": [
+      {
+        "func": "SELECT",
+        "property": "myCustomKey",
+        "value": "reset"
+      },
+      {
+        "func": "CLICK"
+      }
+    ],
+    "x": 576,
+    "y": 376,
+    "z": 296,
+    "id": "d20o"
+  },
+  "_meta": {
+    "version": 1,
+    "info": {
+      "name": "Types - Spinner",
+      "image": "/assets/797406932_11103",
+      "rules": "",
+      "bgg": "",
+      "year": "2021",
+      "mode": "Tutorial",
+      "time": "0",
+      "attribution": "Background color CSS: https://www.w3schools.com/cssref/pr_background-color.asp\nFont color CSS: https://www.w3schools.com/cssref/pr_text_color.asp\nBorder color CSS: https://www.w3schools.com/cssref/pr_border-color.asp",
+      "showName": false,
+      "lastUpdate": 1748992129606,
+      "skill": "",
+      "description": "",
+      "similarImage": "",
+      "similarName": "",
+      "similarAwards": "",
+      "ruleText": "",
+      "helpText": "",
+      "similarDesigner": "",
+      "variantImage": "",
+      "variant": "Automations",
+      "language": "en-US",
+      "players": "1"
+    }
+  }
+}

--- a/library/tutorials/Types - Spinners/6.json
+++ b/library/tutorials/Types - Spinners/6.json
@@ -181,7 +181,6 @@
         "property": "value",
         "value": 1,
         "source": "DEFAULT",
-        "mode": "set",
         "collection": "all1"
       },
       {
@@ -195,7 +194,6 @@
         "property": "value",
         "value": 2,
         "source": "DEFAULT",
-        "mode": "set",
         "collection": "all2"
       },
       {
@@ -209,7 +207,6 @@
         "property": "value",
         "value": 3,
         "source": "DEFAULT",
-        "mode": "set",
         "collection": "all3"
       },
       {
@@ -437,12 +434,7 @@
       {
         "func": "LABEL",
         "label": "rz15",
-        "applyVariables": [
-          {
-            "parameter": "value",
-            "variable": "sumResult"
-          }
-        ]
+        "value": "${sumResult}"
       }
     ],
     "x": 83,
@@ -622,7 +614,7 @@
     "id": "d20o"
   },
   "_meta": {
-    "version": 1,
+    "version": 21,
     "info": {
       "name": "Types - Spinner",
       "image": "/assets/797406932_11103",
@@ -646,6 +638,9 @@
       "variant": "Automations",
       "language": "en-US",
       "players": "1"
+    },
+    "gameSettings": {
+      "legacyModes": {}
     }
   }
 }


### PR DESCRIPTION
## What & why

The **Types – Spinner** tutorial's customization guidance was outdated: it only taught the `backgroundCSS` / `spinnerCSS` / `valueCSS` shorthands, and to get differently‑coloured arrows it told creators to upload individually recoloured SVG files.

This adds a new **"CSS Selectors & Hover"** page (inserted before the existing "Automations" page) that modernizes the customization story:

- **Both approaches, side by side.** Styling every layer straight from the widget's own `css` object with layer selectors (`" .background"`, `" .spinningPart"`, `" .value"`) is shown next to the equivalent shorthand properties, producing an identical spinner — so both ways are documented.
- **A `:hover` example.** One spinner's arrow changes colour on hover via `{ ":hover .spinningPart": { "filter": "hue-rotate(130deg)" } }` — something the shorthand properties cannot express.
- **`filter: hue-rotate()` for arrow colours.** A row of spinners recolours the built‑in blue arrow across a full spectrum (magenta → red → orange → green → teal) with **no new image assets** — the easy modern alternative to uploading recoloured SVGs.

## How it fits the tutorial

Tutorial pages are the numbered variant files scanned from the folder, so the new page is added as `5.json` and the existing "Automations" page moves to `6.json`; page order becomes: The Basics → Recoloring → Customizing the Arrow → Custom Background → Styling Examples → **CSS Selectors & Hover** → Automations. No widget properties or routine operations were added/renamed, so no validator / JSON‑editor / engine changes are needed.

## Verification

Loaded the page in a running server and confirmed in the real engine that:
- the `css`‑object selectors apply (shorthand and object‑form spinners render pixel‑identical — same `background` border, same `value` background);
- hovering toggles the arrow filter from `none` → `hue-rotate(130deg)`;
- each hue‑rotate spinner gets its distinct arrow colour.

`npm test` passes (15/15).

Rendered page and a playable demo:
- Screenshot: https://agent.virtualtabletop.io/reports/pr/1528420727211167955/spinner-css-tutorial.png
- Demo game (`.vtt`): https://agent.virtualtabletop.io/reports/pr/1528420727211167955/demo.vtt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3042/pr-test (or any other room on that server)