### PR TITLE
Fix "too much recursion" when dragging a pile onto one of its own cards

### DIFF
--- a/client/js/main.js
+++ b/client/js/main.js
@@ -36,7 +36,7 @@ function compareDropTarget(widget, t, exclude){
   return false;
 }
 
-function getValidDropTargets(widget) {
+function getValidDropTargets(widget, dragged = widget) {
   const targets = [];
   for(const [ _, t ] of dropTargets) {
     if(!t.isVisible())
@@ -52,7 +52,7 @@ function getValidDropTargets(widget) {
 
     let tt = t;
     while(isValid) {
-      if(widget == tt) {
+      if(widget == tt || dragged == tt) {
         isValid = false;
         break;
       }

--- a/client/js/tracing.js
+++ b/client/js/tracing.js
@@ -47,8 +47,8 @@ onLoad(function() {
       error: String(error.message) + '\n' + String(error.stack),
       undoProtocol,
       delta,
-      mouseStatus,
-      mouseTarget,
+      mouseStatus: Object.fromEntries(Object.entries(mouseStatus).map(([id, ms]) => [id, {...ms, moveTarget: ms.moveTarget ? ms.moveTarget.get('id') : null}])),
+      mouseTarget: mouseTarget && mouseTarget.id ? unescapeID(mouseTarget.id.slice(2)) : null,
       jeLoggingData: typeof jeLoggingRoutineGetData == 'function' ? jeLoggingRoutineGetData() : null,
       lastExecutedOperation,
       bodyClass: $('body').className,
@@ -69,10 +69,21 @@ onLoad(function() {
     $('#clientErrorOverlay button').addEventListener('click', async function() {
       try {
         details.message = $('#clientErrorOverlay textarea').value;
+        const ancestors = [];
+        const body = JSON.stringify(details, function(key, value) {
+          if(typeof value != 'object' || value === null)
+            return value;
+          while(ancestors.length && ancestors[ancestors.length-1] != this)
+            ancestors.pop();
+          if(ancestors.includes(value))
+            return '[cyclic]';
+          ancestors.push(value);
+          return value;
+        });
         const res = await fetch('clientError', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(details)
+          body
         });
         const text = await res.text();
         if(text.match(/^[a-z0-9]{8}$/))

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -275,6 +275,6 @@ class Pile extends Widget {
   }
 
   validDropTargets() {
-    return this.children().length ? getValidDropTargets(this.children()[0]) : [];
+    return this.children().length ? getValidDropTargets(this.children()[0], this) : [];
   }
 }


### PR DESCRIPTION
## Problem

Reported on Discord:

> I *tried*, it says "submitting the error failed"
> ```
> Submitting the error failed. Please report this on Discord or GitHub:
>
> too much recursion
> coordParentFromCoordGlobal@https://virtualtabletop.io/h08h:1:330112
> coordLocalFromCoordGlobal@https://virtualtabletop.io/h08h:1:329943
> ...(truncated)...
>
> cyclic object value
> e/<@https://virtualtabletop.io/h08h:1:254007
> ```
> — [rei_torikal](https://discord.com/channels/770758631146782780/793626590848352306/1530462045357735946)

> should look like this, reproduce by dragging the yellow cards pile.
> — [rei_torikal](https://discord.com/channels/770758631146782780/793626590848352306/1530462756262903939)

The reporter's game makes cards act as drop targets for each other
(`cardDefaults: {"dropTarget": {"type": "card"}, "dropLimit": 1}`, used to
build a "37"-style stacking pile). Their current workaround is
`"onPileCreation": {"movable": false}`, which stops the crash but also
stops players from ever dragging a formed pile.

Repro save (from the report) and a screenshot of the intended layout:
- https://agent.virtualtabletop.io/reports/pr/1530463521626652733/repro.vtt
- https://agent.virtualtabletop.io/reports/pr/1530463521626652733/repro.png

## Root cause

**Bug 1 — the crash itself.** `Pile.validDropTargets()`
(`client/js/widgets/pile.js`) calls `getValidDropTargets(this.children()[0])`,
passing one child card as the "widget being tested" instead of the pile
itself. `getValidDropTargets` (`client/js/main.js`) has a guard that walks a
candidate target's ancestor chain and rejects it if the chain reaches back to
that widget — but since it only ever compares against `children()[0]`, every
*other* card already inside the dragged pile still passes as a valid drop
target for the pile. Dragging the pile can then hover directly over one of
its own sibling cards; on drop, `moveToHolder` sets the pile's parent to that
card, which is itself a descendant of the pile. That's a parent cycle, and
the mutually-recursive `coordLocalFromCoordGlobal` /
`coordParentFromCoordGlobal` (`client/js/widgets/widget.js`) recurse forever
walking up parents — "too much recursion", client crash.

Fix: `getValidDropTargets` now takes an optional second `dragged` argument
(defaulting to `widget`, so every other caller is unaffected) and rejects a
candidate target whose ancestor chain reaches `dragged` too.
`Pile.validDropTargets()` passes the pile itself as `dragged`, so no card
inside the pile being dragged can ever become its own drop target again.

**Bug 2 — the error report can't be submitted.** Independently, the
"Submitting the error failed... cyclic object value" part of the same
report is a second bug: `client/js/tracing.js`'s crash handler builds a
`details` object straight from `mouseStatus`/`mouseTarget`, which hold live
Widget instances mid-drag, and then does `JSON.stringify(details)`. Widgets
have cyclic references (child/parent, DOM element, etc.), so the stringify
throws and the crash report — needed most for exactly this kind of bug —
can never reach the server. Fixed by reducing `mouseStatus`/`mouseTarget` to
plain widget IDs before reporting, and making the final `JSON.stringify`
cycle-tolerant as a backstop for any other stray circular reference.

## Testing

- `npm test` — all 44 existing jest tests pass.
- Reproduced the exact crash with Playwright against the reporter's save
  file on unpatched code (dragging the pile's handle throws `Maximum call
  stack size exceeded` and shows the client error overlay), then confirmed
  it's gone after the fix (no error, pile survives the drag).
- Regression-checked that dragging the same pile onto a normal holder still
  re-parents it correctly.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3050/pr-test (or any other room on that server)