### PR TITLE
Add keepOrder option to SWAPHANDS

### DIFF
--- a/.github/workflows/testcafe-chrome.yml
+++ b/.github/workflows/testcafe-chrome.yml
@@ -27,6 +27,7 @@ jobs:
           - publiclibrary-2.js
           - publiclibrary-3.js
           - publiclibrary-4.js
+          - routines.js
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/testcafe-firefox.yml
+++ b/.github/workflows/testcafe-firefox.yml
@@ -27,6 +27,7 @@ jobs:
           - publiclibrary-2.js
           - publiclibrary-3.js
           - publiclibrary-4.js
+          - routines.js
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3050,7 +3050,7 @@ function jeLoggingJSON(obj) {
 }
 
 export function jeLoggingRoutineStart(widget, property, initialVariables, initialCollections, byReference) {
-  if( jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine'].indexOf( jeHTMLStack[0][3] ) == -1 ) {
+  if( jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine', 'Moves'].indexOf( jeHTMLStack[0][3] ) == -1 ) {
     if(jeRoutineResetOnNextLog) {
       jeLoggingHTML = '';
       jeRoutineResetOnNextLog = false;
@@ -3068,7 +3068,7 @@ export function jeLoggingRoutineStart(widget, property, initialVariables, initia
 }
 
 export function jeLoggingRoutineEnd(variables, collections) {
-  if( jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine'].indexOf( jeHTMLStack[0][3] ) == -1 ) jeLoggingHTML += '</div></div>';
+  if( jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine', 'Moves'].indexOf( jeHTMLStack[0][3] ) == -1 ) jeLoggingHTML += '</div></div>';
   --jeLoggingDepth;
   if(!jeLoggingDepth) {
     $('#jeLog').innerHTML = jeLoggingHTML + '</div></div>';

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1389,7 +1389,7 @@ function jeAddCommands() {
   jeAddRoutineOperationCommands('SET', { collection: 'DEFAULT', property: 'parent', relation: '=', value: null });
   jeAddRoutineOperationCommands('SHUFFLE', { holder: null, collection: 'DEFAULT', mode: 'true random', modeValue: 1 });
   jeAddRoutineOperationCommands('SORT', { key: 'value', reverse: false, rearrange: false, locales: null, options: null, holder: null, collection: 'DEFAULT' });
-  jeAddRoutineOperationCommands('SWAPHANDS', { interval: 1, direction: 'forward', source: 'all' });
+  jeAddRoutineOperationCommands('SWAPHANDS', { interval: 1, direction: 'forward', source: 'all', keepOrder: false });
   jeAddRoutineOperationCommands('TIMER', { value: 0, seconds: 0, mode: 'toggle', timer: null, collection: 'DEFAULT' });
   jeAddRoutineOperationCommands('TURN', { turn: 1, turnCycle: 'forward', source: 'all', collection: 'TURN' });
   jeAddRoutineOperationCommands('UPLOAD', { variable: 'uploadedFileName', fileTypes: [ '.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.json', '.mp3', '.wav', '.ogg', '.m4a' ] });

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2050,8 +2050,9 @@ export class Widget extends StateManaged {
               [c[i], c[rand]] = [c[rand], c[i]];
             }
           }
+          // all hands are collected before anything is moved so that a hand does not
+          // pick up the widgets an earlier seat just passed to it
           let moves = [];
-          let shadowedCollections = {};
           for (let i = 0; i < c.length; i++) {
             let source = c[i];
             let target = c[(i + a.interval) % c.length];
@@ -2061,44 +2062,49 @@ export class Widget extends StateManaged {
               let contents = widgets.get(hand).children().reduce(
                 function (collect, w) {
                   if (!perOwner || w.get('owner') == source.get('player')) {
-                    collect.unshift(w.get('id'));
+                    collect.unshift(w);
                   }
                   return collect
                 },
                 []
               );
+              moves.push({ source, contents, to: target.get('id') });
+            }
+          }
+          if(moves.length) {
+            if(jeRoutineLogging)
+              jeLoggingRoutineOperationStart("Moves", "Moves");
+            for(const move of moves) {
               // the collection is named after the seat it comes from so that the
               // generated MOVE reads like "from 'hand of seat1' to 'seat2'" in the log.
               // a collection of the surrounding routine that happens to use the same
-              // name is put back once the moves are done
-              const collection = `hand of ${source.get('id')}`;
-              shadowedCollections[collection] = collections[collection];
-              // an array of IDs is turned into a collection by widgetFilter, which
-              // returns the widgets in creation order - keepOrder uses a collection
-              // that is already sorted like the hand instead so the order is kept
+              // name is shadowed only while its MOVE runs and then put back
+              const collection = `hand of ${move.source.get('id')}`;
+              const shadowed = collections[collection];
+              // the widgets are looked up right before their own MOVE so that one which
+              // a routine of an earlier MOVE removed is left alone, exactly like when
+              // the generated MOVE still received a list of IDs. keepOrder keeps the
+              // order of the hand, the default is the creation order because that is
+              // the order widgetFilter - and with it MOVE - used all along
               collections[collection] = a.keepOrder
-                ? contents.map(id=>widgets.get(id))
-                : widgetFilter(w=>contents.indexOf(w.get('id')) != -1);
-              moves.push({
-                func: "MOVE",
-                collection: collection,
-                to: target.get('id'),
-              });
+                ? move.contents.filter(w=>!w.isBeingRemoved)
+                : widgetFilter(w=>move.contents.indexOf(w) != -1);
+              try {
+                await this.evaluateRoutine([ { func: 'MOVE', collection, to: move.to } ], variables, collections, (depth || 0) + 1, true);
+              } finally {
+                if(shadowed === undefined)
+                  delete collections[collection];
+                else
+                  collections[collection] = shadowed;
+              }
             }
+            if(jeRoutineLogging)
+              jeLoggingRoutineOperationEnd([], variables, collections, false);
           }
-          if(jeRoutineLogging)
-            jeLoggingRoutineOperationStart("Moves", "Moves");
-          await this.evaluateRoutine(moves, variables, collections, (depth || 0) + 1, true);
-          for(const [ name, shadowed ] of Object.entries(shadowedCollections)) {
-            if(shadowed === undefined)
-              delete collections[name];
-            else
-              collections[name] = shadowed;
+          if(jeRoutineLogging) {
+            const how = a.direction == 'random' ? `hands in a random seat order by ${a.interval}` : `hands ${a.direction} by ${a.interval}`;
+            jeLoggingRoutineOperationSummary(moves.length ? `${how}${a.keepOrder ? ', keeping the card order' : ''}` : 'no seat with a player has a valid hand, nothing to swap');
           }
-          if(jeRoutineLogging)
-            jeLoggingRoutineOperationEnd([], variables, collections, false);
-          if(jeRoutineLogging)
-            jeLoggingRoutineOperationSummary(`hands ${a.direction} by ${a.interval}${a.keepOrder ? ', keeping the card order' : ''}`);
         } else if(jeRoutineLogging) {
           jeLoggingRoutineOperationSummary('less than two seats with a player, nothing to swap');
         }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2066,14 +2066,15 @@ export class Widget extends StateManaged {
                 },
                 []
               );
-              let collection = contents;
-              if(a.keepOrder) {
-                // an array of IDs is turned into a collection by widgetFilter, which
-                // returns the widgets in creation order - pass a collection that is
-                // already sorted like the hand instead so the order is kept
-                collection = `$swaphands_${i}`;
-                collections[collection] = contents.map(id=>widgets.get(id));
-              }
+              // the collection is named after the seat it comes from so that the
+              // generated MOVE reads like "from 'hand of seat1' to 'seat2'" in the log
+              const collection = `hand of ${source.get('id')}`;
+              // an array of IDs is turned into a collection by widgetFilter, which
+              // returns the widgets in creation order - keepOrder uses a collection
+              // that is already sorted like the hand instead so the order is kept
+              collections[collection] = a.keepOrder
+                ? contents.map(id=>widgets.get(id))
+                : widgetFilter(w=>contents.indexOf(w.get('id')) != -1);
               moves.push({
                 func: "MOVE",
                 collection: collection,
@@ -2081,13 +2082,13 @@ export class Widget extends StateManaged {
               });
             }
           }
-          if(jeRoutineLogging) {
+          if(jeRoutineLogging)
             jeLoggingRoutineOperationStart("Moves", "Moves");
-          }
           await this.evaluateRoutine(moves, variables, collections, (depth || 0) + 1, true);
-          if(jeRoutineLogging) {
-          jeLoggingRoutineOperationEnd([], variables, collections, false);
-          }
+          for(const move of moves)
+            delete collections[move.collection];
+          if(jeRoutineLogging)
+            jeLoggingRoutineOperationEnd([], variables, collections, false);
           if(jeRoutineLogging)
             jeLoggingRoutineOperationSummary(`hands ${a.direction} by ${a.interval}${a.keepOrder ? ', keeping the card order' : ''}`);
         } else if(jeRoutineLogging) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2051,6 +2051,7 @@ export class Widget extends StateManaged {
             }
           }
           let moves = [];
+          let shadowedCollections = {};
           for (let i = 0; i < c.length; i++) {
             let source = c[i];
             let target = c[(i + a.interval) % c.length];
@@ -2067,8 +2068,11 @@ export class Widget extends StateManaged {
                 []
               );
               // the collection is named after the seat it comes from so that the
-              // generated MOVE reads like "from 'hand of seat1' to 'seat2'" in the log
+              // generated MOVE reads like "from 'hand of seat1' to 'seat2'" in the log.
+              // a collection of the surrounding routine that happens to use the same
+              // name is put back once the moves are done
               const collection = `hand of ${source.get('id')}`;
+              shadowedCollections[collection] = collections[collection];
               // an array of IDs is turned into a collection by widgetFilter, which
               // returns the widgets in creation order - keepOrder uses a collection
               // that is already sorted like the hand instead so the order is kept
@@ -2085,8 +2089,12 @@ export class Widget extends StateManaged {
           if(jeRoutineLogging)
             jeLoggingRoutineOperationStart("Moves", "Moves");
           await this.evaluateRoutine(moves, variables, collections, (depth || 0) + 1, true);
-          for(const move of moves)
-            delete collections[move.collection];
+          for(const [ name, shadowed ] of Object.entries(shadowedCollections)) {
+            if(shadowed === undefined)
+              delete collections[name];
+            else
+              collections[name] = shadowed;
+          }
           if(jeRoutineLogging)
             jeLoggingRoutineOperationEnd([], variables, collections, false);
           if(jeRoutineLogging)

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2032,7 +2032,7 @@ export class Widget extends StateManaged {
       }
 
       if(a.func == 'SWAPHANDS') {
-        setDefaults(a, { interval: 1, direction: 'forward', source: 'all' });
+        setDefaults(a, { interval: 1, direction: 'forward', source: 'all', keepOrder: false });
         if(['forward', 'backward', 'random'].indexOf(a.direction) == -1) {
           problems.push(`Warning: direction ${a.direction} interpreted as forward.`);
           a.direction = 'forward'
@@ -2066,11 +2066,22 @@ export class Widget extends StateManaged {
                 },
                 []
               );
-              moves.push({
-                func: "MOVE",
-                collection: contents,
-                to: target.get('id'),
-              });
+              if(a.keepOrder) {
+                // a MOVE collection is processed in widget creation order, so move
+                // the cards one by one to have them arrive in the order of the hand
+                for(const id of contents)
+                  moves.push({
+                    func: "MOVE",
+                    collection: [ id ],
+                    to: target.get('id'),
+                  });
+              } else {
+                moves.push({
+                  func: "MOVE",
+                  collection: contents,
+                  to: target.get('id'),
+                });
+              }
             }
           }
           if(jeRoutineLogging) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2066,22 +2066,19 @@ export class Widget extends StateManaged {
                 },
                 []
               );
+              let collection = contents;
               if(a.keepOrder) {
-                // a MOVE collection is processed in widget creation order, so move
-                // the cards one by one to have them arrive in the order of the hand
-                for(const id of contents)
-                  moves.push({
-                    func: "MOVE",
-                    collection: [ id ],
-                    to: target.get('id'),
-                  });
-              } else {
-                moves.push({
-                  func: "MOVE",
-                  collection: contents,
-                  to: target.get('id'),
-                });
+                // an array of IDs is turned into a collection by widgetFilter, which
+                // returns the widgets in creation order - pass a collection that is
+                // already sorted like the hand instead so the order is kept
+                collection = `$swaphands_${i}`;
+                collections[collection] = contents.map(id=>widgets.get(id));
               }
+              moves.push({
+                func: "MOVE",
+                collection: collection,
+                to: target.get('id'),
+              });
             }
           }
           if(jeRoutineLogging) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2088,6 +2088,10 @@ export class Widget extends StateManaged {
           if(jeRoutineLogging) {
           jeLoggingRoutineOperationEnd([], variables, collections, false);
           }
+          if(jeRoutineLogging)
+            jeLoggingRoutineOperationSummary(`hands ${a.direction} by ${a.interval}${a.keepOrder ? ', keeping the card order' : ''}`);
+        } else if(jeRoutineLogging) {
+          jeLoggingRoutineOperationSummary('less than two seats with a player, nothing to swap');
         }
       }
 

--- a/library/tutorials/Functions - SWAPHANDS/0.json
+++ b/library/tutorials/Functions - SWAPHANDS/0.json
@@ -678,7 +678,7 @@
     "css": {
       "font-size": "25px"
     },
-    "text": "SWAPHANDS is used to swap the contents of the hands of the given collection of seats. This is especially useful for games which use pick-and-pass card drafting, but also in any situation where one or more players need to exchange hands.\n\nIt's possible to use this in a scenario where all seats share one hand with childrenPerOwner: true, but here separate hands are shown for each user to make the effect clearer.\n\nYou can also sit in multiple seats at once in this room, to test out the different buttons."
+    "text": "SWAPHANDS is used to swap the contents of the hands of the given collection of seats. This is especially useful for games which use pick-and-pass card drafting, but also in any situation where one or more players need to exchange hands.\n\nIt's possible to use this in a scenario where all seats share one hand with childrenPerOwner: true, but here separate hands are shown for each user to make the effect clearer.\n\nYou can also sit in multiple seats at once in this room, to test out the different buttons. The keepOrder button in the bottom middle will, for all buttons, either keep the order of the cards as they are passed the same (if true) or not (if false). Even if keepOrder is false, the order may not change, but setting it to true ensures they will not change."
   },
   "seat-p1": {
     "type": "seat",
@@ -1097,7 +1097,8 @@
     "text": "Forward",
     "clickRoutine": [
       {
-        "func": "SWAPHANDS"
+        "func": "SWAPHANDS",
+        "keepOrder": "${PROPERTY keepOrder OF button-keepOrder}"
       }
     ]
   },
@@ -1112,7 +1113,8 @@
     "clickRoutine": [
       {
         "func": "SWAPHANDS",
-        "direction": "backward"
+        "direction": "backward",
+        "keepOrder": "${PROPERTY keepOrder OF button-keepOrder}"
       }
     ]
   },
@@ -1127,7 +1129,8 @@
     "clickRoutine": [
       {
         "func": "SWAPHANDS",
-        "direction": "random"
+        "direction": "random",
+        "keepOrder": "${PROPERTY keepOrder OF button-keepOrder}"
       }
     ]
   },
@@ -1145,7 +1148,8 @@
         "source": [
           "seat-p1",
           "seat-p2"
-        ]
+        ],
+        "keepOrder": "${PROPERTY keepOrder OF button-keepOrder}"
       }
     ]
   },
@@ -1163,7 +1167,8 @@
         "source": [
           "seat-p1",
           "seat-p3"
-        ]
+        ],
+        "keepOrder": "${PROPERTY keepOrder OF button-keepOrder}"
       }
     ]
   },
@@ -1181,7 +1186,8 @@
         "source": [
           "seat-p1",
           "seat-p4"
-        ]
+        ],
+        "keepOrder": "${PROPERTY keepOrder OF button-keepOrder}"
       }
     ]
   },
@@ -1199,7 +1205,8 @@
         "source": [
           "seat-p4",
           "seat-p1"
-        ]
+        ],
+        "keepOrder": "${PROPERTY keepOrder OF button-keepOrder}"
       }
     ]
   },
@@ -1217,7 +1224,8 @@
         "source": [
           "seat-p4",
           "seat-p2"
-        ]
+        ],
+        "keepOrder": "${PROPERTY keepOrder OF button-keepOrder}"
       }
     ]
   },
@@ -1235,7 +1243,8 @@
         "source": [
           "seat-p4",
           "seat-p3"
-        ]
+        ],
+        "keepOrder": "${PROPERTY keepOrder OF button-keepOrder}"
       }
     ]
   },
@@ -1253,7 +1262,8 @@
         "source": [
           "seat-p2",
           "seat-p1"
-        ]
+        ],
+        "keepOrder": "${PROPERTY keepOrder OF button-keepOrder}"
       }
     ]
   },
@@ -1271,7 +1281,8 @@
         "source": [
           "seat-p2",
           "seat-p3"
-        ]
+        ],
+        "keepOrder": "${PROPERTY keepOrder OF button-keepOrder}"
       }
     ]
   },
@@ -1289,7 +1300,8 @@
         "source": [
           "seat-p2",
           "seat-p4"
-        ]
+        ],
+        "keepOrder": "${PROPERTY keepOrder OF button-keepOrder}"
       }
     ]
   },
@@ -1307,7 +1319,8 @@
         "source": [
           "seat-p3",
           "seat-p1"
-        ]
+        ],
+        "keepOrder": "${PROPERTY keepOrder OF button-keepOrder}"
       }
     ]
   },
@@ -1325,7 +1338,8 @@
         "source": [
           "seat-p3",
           "seat-p2"
-        ]
+        ],
+        "keepOrder": "${PROPERTY keepOrder OF button-keepOrder}"
       }
     ]
   },
@@ -1343,7 +1357,8 @@
         "source": [
           "seat-p3",
           "seat-p4"
-        ]
+        ],
+        "keepOrder": "${PROPERTY keepOrder OF button-keepOrder}"
       }
     ]
   },
@@ -1356,7 +1371,10 @@
     "parent": "holder-deck"
   },
   "_meta": {
-    "version": 20,
+    "version": 21,
+    "gameSettings": {
+      "legacyModes": {}
+    },
     "info": {
       "name": "Functions - SWAPHANDS",
       "image": "/assets/-407492963_4703",
@@ -1366,7 +1384,7 @@
       "mode": "Tutorial",
       "time": "0",
       "attribution": "",
-      "lastUpdate": 1768621533542,
+      "lastUpdate": 1785106704884,
       "showName": false,
       "skill": "",
       "description": "",
@@ -1379,10 +1397,52 @@
       "players": "1",
       "language": "",
       "variant": "Basics",
-      "variantImage": ""
-    },
-    "gameSettings": {
-      "legacyModes": {}
+      "variantImage": "",
+      "usesAIImagery": false
     }
+  },
+  "button-keepOrder": {
+    "type": "button",
+    "id": "button-keepOrder",
+    "x": 740,
+    "y": 736,
+    "width": 120,
+    "height": 50,
+    "text": "keepOrder true",
+    "clickRoutine": [
+      {
+        "func": "IF",
+        "condition": "${PROPERTY keepOrder}",
+        "thenRoutine": [
+          {
+            "func": "SET",
+            "collection": "thisButton",
+            "property": "keepOrder",
+            "value": false
+          },
+          {
+            "func": "SET",
+            "collection": "thisButton",
+            "property": "text",
+            "value": "keepOrder false"
+          }
+        ],
+        "elseRoutine": [
+          {
+            "func": "SET",
+            "collection": "thisButton",
+            "property": "keepOrder",
+            "value": true
+          },
+          {
+            "func": "SET",
+            "collection": "thisButton",
+            "property": "text",
+            "value": "keepOrder true"
+          }
+        ]
+      }
+    ],
+    "keepOrder": true
   }
 }

--- a/tests/testcafe/routines.js
+++ b/tests/testcafe/routines.js
@@ -1,0 +1,59 @@
+import { ClientFunction } from 'testcafe';
+
+import { getState, prepareClient, setName, setRoomState, setupTestEnvironment } from './test-util.js';
+
+setupTestEnvironment();
+
+// the cards are created in an order that differs from the order they sit in the hand
+const cardZ = { card1: 3, card2: 1, card3: 2 };
+const creationOrder = [ 'card1', 'card2', 'card3' ];
+const handOrder = [ 'card2', 'card3', 'card1' ];
+
+function swapHandsRoom(swapHands) {
+  const state = {
+    deck: { id: 'deck', type: 'deck', cardTypes: { plain: {} }, x: 50, y: 400 },
+    hand1: { id: 'hand1', type: 'holder', stackOffsetX: 40, x: 50, y: 600, width: 700, height: 180 },
+    hand2: { id: 'hand2', type: 'holder', stackOffsetX: 40, x: 50, y: 800, width: 700, height: 180 },
+    seat1: { id: 'seat1', type: 'seat', index: 1, player: 'Player 1', hand: 'hand1', x: 800, y: 600 },
+    seat2: { id: 'seat2', type: 'seat', index: 2, player: 'Player 2', hand: 'hand2', x: 800, y: 800 },
+    swap: { id: 'swap', type: 'button', text: 'swap', x: 800, y: 400, clickRoutine: [ swapHands ] }
+  };
+  for(const [ card, z ] of Object.entries(cardZ))
+    state[card] = { id: card, type: 'card', deck: 'deck', cardType: 'plain', parent: 'hand1', z };
+  return state;
+}
+
+// a hand is filled from the bottom up, so its order is the one of ascending z
+async function cardsInHand(hand) {
+  return Object.values(JSON.parse(await getState())).filter(w=>w.parent == hand).sort((a, b)=>a.z-b.z).map(w=>w.id);
+}
+
+async function expectCardsInHand(t, hand, expected) {
+  let inHand = null;
+  for(let wait=50; wait<1000; wait*=2) {
+    inHand = await cardsInHand(hand);
+    if(JSON.stringify(inHand) == JSON.stringify(expected))
+      break;
+    await new Promise(resolve=>setTimeout(resolve, wait));
+  }
+  await t.expect(inHand).eql(expected);
+}
+
+async function clickSwap(t, swapHands) {
+  await setRoomState(swapHandsRoom(swapHands));
+  await ClientFunction(prepareClient)();
+  await setName(t);
+  await expectCardsInHand(t, 'hand1', handOrder);
+  await t.click('#w_swap');
+  await expectCardsInHand(t, 'hand1', []);
+}
+
+test('SWAPHANDS passes the cards on in widget creation order', async t => {
+  await clickSwap(t, { func: 'SWAPHANDS' });
+  await expectCardsInHand(t, 'hand2', creationOrder);
+});
+
+test('SWAPHANDS with keepOrder passes the cards on in the order of the hand', async t => {
+  await clickSwap(t, { func: 'SWAPHANDS', keepOrder: true });
+  await expectCardsInHand(t, 'hand2', handOrder);
+});

--- a/tests/testcafe/routines.js
+++ b/tests/testcafe/routines.js
@@ -23,6 +23,31 @@ function swapHandsRoom(clickRoutine) {
   return state;
 }
 
+// three seats, and the middle hand removes the only card of the last hand as soon as
+// it receives one - so the last hand would pass on a card that no longer exists.
+// the witness is marked by the first hand's enterRoutine, so it stays unmarked as
+// long as nothing arrives there
+function removeOnEnterRoom() {
+  const state = {
+    deck: { id: 'deck', type: 'deck', cardTypes: { plain: {} }, x: 50, y: 400 },
+    witness: { id: 'witness', type: 'basic', x: 1000, y: 400 },
+    swap: { id: 'swap', type: 'button', text: 'swap', x: 800, y: 400, clickRoutine: [
+      { func: 'SWAPHANDS' },
+      { func: 'SELECT', property: 'id', value: 'card1' },
+      { func: 'SET', property: 'marked', value: true }
+    ] },
+    card1: { id: 'card1', type: 'card', deck: 'deck', cardType: 'plain', parent: 'hand1' },
+    doomed: { id: 'doomed', type: 'card', deck: 'deck', cardType: 'plain', parent: 'hand3' }
+  };
+  for(const index of [ 1, 2, 3 ]) {
+    state[`hand${index}`] = { id: `hand${index}`, type: 'holder', x: 50, y: 200*index, width: 700, height: 180 };
+    state[`seat${index}`] = { id: `seat${index}`, type: 'seat', index, player: `Player ${index}`, hand: `hand${index}`, x: 800, y: 200*index };
+  }
+  state.hand1.enterRoutine = [ { func: 'SELECT', property: 'id', value: 'witness' }, { func: 'SET', property: 'marked', value: true } ];
+  state.hand2.enterRoutine = [ { func: 'SELECT', property: 'id', value: 'doomed' }, { func: 'DELETE' } ];
+  return state;
+}
+
 async function expectEventually(t, get, expected) {
   let actual = null;
   for(let wait=50; wait<1000; wait*=2) {
@@ -40,7 +65,11 @@ async function cardsInHand(hand) {
 }
 
 async function markedWidgets() {
-  return Object.values(JSON.parse(await getState())).filter(w=>w.marked).map(w=>w.id);
+  return Object.values(JSON.parse(await getState())).filter(w=>w.marked).map(w=>w.id).sort();
+}
+
+async function widgetExists(id) {
+  return Object.keys(JSON.parse(await getState())).indexOf(id) != -1;
 }
 
 async function clickSwap(t, clickRoutine) {
@@ -71,5 +100,17 @@ test('SWAPHANDS leaves a collection of the surrounding routine intact', async t 
     { func: 'SET', collection: 'hand of seat1', property: 'marked', value: true }
   ]);
   await expectEventually(t, ()=>cardsInHand('hand2'), creationOrder);
+  await expectEventually(t, markedWidgets, [ 'card1' ]);
+});
+
+test('SWAPHANDS does not pass on a card that a routine of an earlier move removed', async t => {
+  await setRoomState(removeOnEnterRoom());
+  await ClientFunction(prepareClient)();
+  await setName(t);
+  await expectEventually(t, ()=>cardsInHand('hand3'), [ 'doomed' ]);
+  await t.click('#w_swap');
+  await expectEventually(t, ()=>cardsInHand('hand2'), [ 'card1' ]);
+  await expectEventually(t, ()=>widgetExists('doomed'), false);
+  await expectEventually(t, ()=>cardsInHand('hand1'), []);
   await expectEventually(t, markedWidgets, [ 'card1' ]);
 });

--- a/tests/testcafe/routines.js
+++ b/tests/testcafe/routines.js
@@ -9,18 +9,29 @@ const cardZ = { card1: 3, card2: 1, card3: 2 };
 const creationOrder = [ 'card1', 'card2', 'card3' ];
 const handOrder = [ 'card2', 'card3', 'card1' ];
 
-function swapHandsRoom(swapHands) {
+function swapHandsRoom(clickRoutine) {
   const state = {
     deck: { id: 'deck', type: 'deck', cardTypes: { plain: {} }, x: 50, y: 400 },
     hand1: { id: 'hand1', type: 'holder', stackOffsetX: 40, x: 50, y: 600, width: 700, height: 180 },
     hand2: { id: 'hand2', type: 'holder', stackOffsetX: 40, x: 50, y: 800, width: 700, height: 180 },
     seat1: { id: 'seat1', type: 'seat', index: 1, player: 'Player 1', hand: 'hand1', x: 800, y: 600 },
     seat2: { id: 'seat2', type: 'seat', index: 2, player: 'Player 2', hand: 'hand2', x: 800, y: 800 },
-    swap: { id: 'swap', type: 'button', text: 'swap', x: 800, y: 400, clickRoutine: [ swapHands ] }
+    swap: { id: 'swap', type: 'button', text: 'swap', x: 800, y: 400, clickRoutine }
   };
   for(const [ card, z ] of Object.entries(cardZ))
     state[card] = { id: card, type: 'card', deck: 'deck', cardType: 'plain', parent: 'hand1', z };
   return state;
+}
+
+async function expectEventually(t, get, expected) {
+  let actual = null;
+  for(let wait=50; wait<1000; wait*=2) {
+    actual = await get();
+    if(JSON.stringify(actual) == JSON.stringify(expected))
+      break;
+    await new Promise(resolve=>setTimeout(resolve, wait));
+  }
+  await t.expect(actual).eql(expected);
 }
 
 // a hand is filled from the bottom up, so its order is the one of ascending z
@@ -28,32 +39,37 @@ async function cardsInHand(hand) {
   return Object.values(JSON.parse(await getState())).filter(w=>w.parent == hand).sort((a, b)=>a.z-b.z).map(w=>w.id);
 }
 
-async function expectCardsInHand(t, hand, expected) {
-  let inHand = null;
-  for(let wait=50; wait<1000; wait*=2) {
-    inHand = await cardsInHand(hand);
-    if(JSON.stringify(inHand) == JSON.stringify(expected))
-      break;
-    await new Promise(resolve=>setTimeout(resolve, wait));
-  }
-  await t.expect(inHand).eql(expected);
+async function markedWidgets() {
+  return Object.values(JSON.parse(await getState())).filter(w=>w.marked).map(w=>w.id);
 }
 
-async function clickSwap(t, swapHands) {
-  await setRoomState(swapHandsRoom(swapHands));
+async function clickSwap(t, clickRoutine) {
+  await setRoomState(swapHandsRoom(clickRoutine));
   await ClientFunction(prepareClient)();
   await setName(t);
-  await expectCardsInHand(t, 'hand1', handOrder);
+  await expectEventually(t, ()=>cardsInHand('hand1'), handOrder);
   await t.click('#w_swap');
-  await expectCardsInHand(t, 'hand1', []);
+  await expectEventually(t, ()=>cardsInHand('hand1'), []);
 }
 
 test('SWAPHANDS passes the cards on in widget creation order', async t => {
-  await clickSwap(t, { func: 'SWAPHANDS' });
-  await expectCardsInHand(t, 'hand2', creationOrder);
+  await clickSwap(t, [ { func: 'SWAPHANDS' } ]);
+  await expectEventually(t, ()=>cardsInHand('hand2'), creationOrder);
 });
 
 test('SWAPHANDS with keepOrder passes the cards on in the order of the hand', async t => {
-  await clickSwap(t, { func: 'SWAPHANDS', keepOrder: true });
-  await expectCardsInHand(t, 'hand2', handOrder);
+  await clickSwap(t, [ { func: 'SWAPHANDS', keepOrder: true } ]);
+  await expectEventually(t, ()=>cardsInHand('hand2'), handOrder);
+});
+
+// SWAPHANDS names its temporary collections after the seats they come from, so a
+// collection of the surrounding routine using such a name has to survive the operation
+test('SWAPHANDS leaves a collection of the surrounding routine intact', async t => {
+  await clickSwap(t, [
+    { func: 'SELECT', property: 'id', value: 'card1', collection: 'hand of seat1' },
+    { func: 'SWAPHANDS' },
+    { func: 'SET', collection: 'hand of seat1', property: 'marked', value: true }
+  ]);
+  await expectEventually(t, ()=>cardsInHand('hand2'), creationOrder);
+  await expectEventually(t, markedWidgets, [ 'card1' ]);
 });

--- a/validator/validate_gamefile.js
+++ b/validator/validate_gamefile.js
@@ -790,7 +790,8 @@ const operationProps = {
     'SWAPHANDS': {
         'interval': v=>typeof v === 'number' && Number.isInteger(v),
         'direction': getEnumValidator(['forward','backward','random']),
-        'source': 'inCollection'
+        'source': 'inCollection',
+        'keepOrder': 'boolean'
     },
     'TIMER': {
         'timer': 'idArray',


### PR DESCRIPTION
## Goal

> Update the function SWAPHANDS so there is a way to keep the same order of the cards when passing them. Regression is not permitted, so if necessary, add a property so this is a selectable option moving forward.

(Request by lawdawg96 on [Discord](https://discord.com/channels/770758631146782780/1530705522301472931/1530711896381067284).)

## What was wrong

`SWAPHANDS` reads the cards of a hand via `children()`, so it *does* collect them in the order they are in that hand — but it then passes that list to a generated `MOVE` operation as a collection array. An array collection is resolved by `getCollection()` through `widgetFilter()`, which iterates the global widget map, so the cards are moved in **widget creation order** and not in the order of the array.

The receiving player therefore always gets the cards in the order the card widgets were created in (usually the original deck order), losing the arrangement the previous player had made in their hand.

## What changed

* new boolean property `keepOrder` for `SWAPHANDS` (default `false`, so nothing changes for existing games): when set, the cards of each hand are handed to the generated `MOVE` as an already ordered collection instead of as an array of IDs, so they arrive at the next seat in exactly the order they were in the hand (`MOVE` itself iterates its collection in array order — only an array of IDs gets re-resolved through `widgetFilter`)
* `validator/validate_gamefile.js`: `keepOrder` added to the `SWAPHANDS` operation properties
* `client/js/jsonedit.js`: `keepOrder` added to the context-sensitive insert buttons for `SWAPHANDS`
* the routine log now summarizes what `SWAPHANDS` did (`hands forward by 1, keeping the card order`) — it had no summary at all before, and with two possible behaviours the DEBUG panel should name which one ran. The generated moves are grouped under a `Moves` entry and each one gets a collection named after the seat it comes from, so the log reads `MOVE all widgets from 'hand of seat1' to 'seat2'`
* those temporary collections are filled right before their own `MOVE` and removed again afterwards: a collection of the surrounding routine that happens to use the same name is restored (even if a `MOVE` throws), and a widget that a routine of an earlier move removed is not passed on
* `tests/testcafe/routines.js`: new fixture (registered in both TestCafe workflow matrices) that pins the resulting card order down for both variants

This is creator-facing, so the wiki page **Functions** would need a line about `keepOrder` for `SWAPHANDS`, along the lines of: *when `true`, each hand's cards arrive at the next seat in the exact order they were in, instead of the order the card widgets were created in. Leave it off to keep the behaviour of existing games unchanged.*

## Verification

* `npm test` passes, TestCafe `editor.js` and the new `routines.js` (4 tests) pass locally — the fixture has two seated hands and three cards whose creation order differs from their order in the hand: the default variant asserts the unchanged legacy result (creation order), the `keepOrder` variant asserts the order of the hand, a third test keeps a `hand of seat1` collection of the calling routine alive across the operation and a fourth one covers three seats whose hands have `enterRoutine`s that delete cards. Disabling the `keepOrder` branch makes only the second test fail, dropping the collection restore makes only the third one fail
* the fixture asserts explicit widget IDs instead of comparing an md5 through `compareState()` (the usual convention in `docs/testcafe.md`), because the whole point is *which order* the cards are in — so it writes no reference state file
* validated a game file using `keepOrder` with `node validator/validate_gamefile_node.js` (no "unknown property", and an intentionally misspelled property is still reported)
* driven in a real browser (playwright): a hand arranged as `E A B C D` (cards created as `A B C D E`) arrives at the next seat as `A B C D E` with the unchanged default and as `E A B C D` with `keepOrder: true`

Playable example: [swaphands-keeporder-demo.vtt](https://agent.virtualtabletop.io/reports/pr/1530705522301472931/swaphands-keeporder-demo.vtt) — two seated hands, drag the cards inside a hand into any order, then compare the `SWAPHANDS` button with the `SWAPHANDS keepOrder` button (`reset` puts everything back).


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3052/pr-test (or any other room on that server)
