### PR TITLE
Routine editor: touch multi-select, drops into IF/FOREACH blocks and an always-visible Routines section

### DIFF
--- a/client/css/editor/controls/routine.css
+++ b/client/css/editor/controls/routine.css
@@ -9,8 +9,8 @@
    background shows as a rounded cutout that reaches the parent's right border
    while the operation cards inside keep their normal size */
 .routine-editor .routine-editor {
-  margin: 4px -60px 4px 12px;
-  padding: 5px 25px 5px 5px;
+  margin: 4px -8px 4px 12px;
+  padding: 5px;
   background: var(--backgroundColor);
   border-radius: 10px 0 0 10px;
 }
@@ -20,9 +20,22 @@
   background: var(--backgroundHighlightColor1);
   border-left: 3px solid var(--VTTblue);
   border-radius: 4px 4px 4px 0;
-  padding: 5px 60px 5px 8px; /* room on the right for the move/delete icons */
+  padding: 5px 8px;
   line-height: 1.8;
   font-size: 13px;
+}
+
+/* the summary and the move/delete icons sit next to each other so the icons
+   never cover the text, however narrow the editor gets */
+.routine-editor-operation-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.routine-editor-operation-body {
+  flex: 1;
+  min-width: 0;
 }
 
 .routine-editor-operation-parameter {
@@ -120,11 +133,10 @@ body.edit.darkMode .routine-editor-parameter-widget {
   vertical-align: middle;
 }
 
-/* the raw-JSON button in the top right of an expanded operation */
+/* the raw-JSON button next to the summary of an expanded operation */
 .routine-editor-operation-json {
-  position: absolute;
-  top: 5px;
-  right: 62px;
+  flex-shrink: 0;
+  margin-top: 3px;
   font-size: 15px;
   color: gray;
   cursor: pointer;
@@ -167,10 +179,12 @@ body.edit.darkMode .routine-editor-parameter-missing {
 }
 
 .routine-editor-operation-buttons {
-  position: absolute;
-  top: 5px;
-  right: 4px;
+  flex-shrink: 0;
   display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  max-width: 45%;
+  margin-top: 3px;
   gap: 3px;
 }
 
@@ -195,9 +209,23 @@ body.edit.darkMode .routine-editor-parameter-missing {
   color: var(--VTTblue);
 }
 
-/* drag-and-drop reordering: a grip to grab, Ctrl-click to select several cards */
+/* touch needs bigger, further apart targets than a mouse pointer */
+@media (pointer: coarse) {
+  .routine-editor-operation-buttons {
+    gap: 9px;
+  }
+
+  .routine-editor-operation-buttons .material-symbols,
+  .routine-editor-operation-buttons .routine-editor-block-arrow {
+    font-size: 19px;
+  }
+}
+
+/* drag-and-drop reordering: a grip to grab, Ctrl-click (long press on touch) to
+   select several cards; touch-action keeps a drag from scrolling the sidebar */
 .routine-editor-operation-buttons .routine-editor-drag-handle {
   cursor: grab;
+  touch-action: none;
 }
 
 .routine-editor-operation-selected {
@@ -216,6 +244,12 @@ body.edit.darkMode .routine-editor-parameter-missing {
 
 .routine-editor-drop-after {
   box-shadow: 0 3px 0 -1px var(--VTTblue);
+}
+
+/* dropping into a block that has no operation card to aim at yet */
+.routine-editor-drop-into {
+  outline: 2px dashed var(--VTTblue);
+  outline-offset: -2px;
 }
 
 .routine-editor-empty,

--- a/client/js/editor/controls/events.js
+++ b/client/js/editor/controls/events.js
@@ -59,7 +59,7 @@ function describeEventProperty(property) {
   return {
     property,
     label: property.replace(/Routine$/, ''),
-    description: 'Custom event. It does not fire on its own: run it from any routine using the CALL function with this name as the routine parameter.'
+    description: 'Custom routine. It does not run on its own: call it from any routine using the CALL function with this name as the routine parameter.'
   };
 }
 
@@ -98,7 +98,7 @@ class AddEventPopup extends Popup {
 
   show() {
     super.show();
-    this.setTitle('Add Event');
+    this.setTitle('Add Routine');
 
     let available = predefinedEvents.filter(e=>this.existingProperties.indexOf(e.property) == -1);
     // enter/leave events mostly matter for holders, so list them last elsewhere
@@ -107,7 +107,7 @@ class AddEventPopup extends Popup {
       available = [ ...available.filter(e=>!holderish(e)), ...available.filter(holderish) ];
     }
     if(available.length) {
-      const [ , predefinedContent ] = this.addAccordionSection('Predefined Events');
+      const [ , predefinedContent ] = this.addAccordionSection('Predefined Routines');
       for(const event of available) {
         const entry = div(predefinedContent, 'add-event-entry');
         button(entry, event.label, _=>{
@@ -118,8 +118,8 @@ class AddEventPopup extends Popup {
       }
     }
 
-    const [ , customContent ] = this.addAccordionSection('Custom Event');
-    div(customContent, 'add-event-description').textContent = 'Custom events are run from other routines using the CALL function. You can also use names like fooChangeRoutine or fooGlobalUpdateRoutine to react to changes of the property foo.';
+    const [ , customContent ] = this.addAccordionSection('Custom Routine');
+    div(customContent, 'add-event-description').textContent = 'Custom routines are run from other routines using the CALL function. You can also use names like fooChangeRoutine or fooGlobalUpdateRoutine to react to changes of the property foo.';
     const nameInput = document.createElement('input');
     nameInput.type = 'text';
     nameInput.placeholder = 'dealCardsRoutine';
@@ -213,7 +213,7 @@ class EventsEditor {
   render() {
     this.domElement.innerHTML = '';
 
-    div(this.domElement, 'events-editor-group').textContent = 'Events';
+    div(this.domElement, 'events-editor-group').textContent = 'Routines';
 
     for(const property of this.eventProperties()) {
       const event = describeEventProperty(property);
@@ -252,7 +252,7 @@ class EventsEditor {
       const removeButton = document.createElement('span');
       removeButton.className = 'material-symbols events-editor-remove';
       removeButton.textContent = 'delete';
-      removeButton.title = 'Remove this event handler';
+      removeButton.title = 'Remove this routine';
       removeButton.addEventListener('click', e=>{
         e.stopPropagation();
         if(confirm(`Remove ${property} and all its operations?`)) {
@@ -286,11 +286,11 @@ class EventsEditor {
     if(!this.eventProperties().length) {
       const emptyHint = document.createElement('div');
       emptyHint.className = 'events-editor-empty';
-      emptyHint.textContent = 'This widget does not react to any events yet.';
+      emptyHint.textContent = 'This widget has no routines yet.';
       this.domElement.append(emptyHint);
     }
 
-    const addButton = button(this.domElement, 'Add Event', _=>{
+    const addButton = button(this.domElement, 'Add Routine', _=>{
       const widgetType = typeof this.widget.get == 'function' ? this.widget.get('type') : this.widget.state.type;
       const popup = new AddEventPopup(addButton, this.eventProperties(), property=>{
         this.expandedEvents[property] = true;

--- a/client/js/editor/controls/events.js
+++ b/client/js/editor/controls/events.js
@@ -12,7 +12,7 @@ const predefinedEvents = [
   {
     property: 'changeRoutine',
     label: 'property changed',
-    description: 'Runs whenever any property of this widget changes. The routine receives the variables property, oldValue and value. Use a property-specific event like fooChangeRoutine to only react to changes of the property foo.'
+    description: 'Runs whenever any property of this widget changes. The routine receives the variables property, oldValue and value. Use a property-specific routine like fooChangeRoutine to only react to changes of the property foo.'
   },
   {
     property: 'enterRoutine',
@@ -32,7 +32,7 @@ const predefinedEvents = [
   {
     property: 'globalUpdateRoutine',
     label: 'any widget changed',
-    description: 'Runs when any property of any widget changes. The routine receives the variables widgetID, property, oldValue and value plus the collection widget. Use a property-specific event like fooGlobalUpdateRoutine to only react to changes of the property foo.'
+    description: 'Runs when any property of any widget changes. The routine receives the variables widgetID, property, oldValue and value plus the collection widget. Use a property-specific routine like fooGlobalUpdateRoutine to only react to changes of the property foo.'
   }
 ];
 

--- a/client/js/editor/controls/popup.js
+++ b/client/js/editor/controls/popup.js
@@ -459,37 +459,59 @@ class RoutineEnumPopup extends RoutinePopup {
   }
 }
 
+const routineWidgetPickerKey = 'routineWidgets';
+
 class RoutineWidgetIDPopup extends RoutinePopup {
   constructor() {
     super();
+    this.workingIDs = [];
   }
 
   hide() {
-    // this popup starts widget selections, so end them when it goes away;
-    // other popups (e.g. info popups) must not interfere with a running selection
-    endCustomSelection();
+    // this popup starts in-room picks, so end them when it goes away; other
+    // popups (e.g. info popups) must not interfere with a running pick
+    if(isWidgetPickerActive(null, routineWidgetPickerKey))
+      stopWidgetPicker();
     super.hide();
+  }
+
+  onOutsideClick(e) {
+    // clicking widgets in the room is how this popup's picker works
+    if(isWidgetPickerActive(null, routineWidgetPickerKey))
+      return;
+    super.onOutsideClick(e);
   }
 
   show(showCollections=false) {
     // the picker is the primary input here, so it comes first and open
-    const [ title, content ] = this.addAccordionSection('Holders')
-    // seed the picker with the widgets the parameter already holds so using it
-    // without changes keeps the current value instead of clearing it
+    const [ title, content ] = this.addAccordionSection('Widgets');
+    infoButton(title, `
+      Search widgets by their id, filter them by type or pick them in the room, then apply the selection.
+      The type filter also applies to picking in the room: with the type set to holder, a click on a card selects the holder it lies on.
+    `);
+    // seed the picker with the widgets the parameter already holds so applying
+    // it without changes keeps the current value instead of clearing it
     const currentValue = this.operation && typeof this.operation == 'object' ? this.operation[this.parameterNames[0]] : null;
     const currentIDs = Array.isArray(currentValue) ? currentValue : (typeof currentValue == 'string' ? [ currentValue ] : []);
-    this.holderSelection = new WidgetSelection(currentIDs.filter(id=>widgets.has(id)).map(id=>widgets.get(id)), pickedWidgets=>{
-      this.setNewValue(pickedWidgets.map(w=>w.id));
-    }, pickedWidget=>{
-      // holders are usually covered by their cards or piles, so a click on one
-      // of those almost always means the holder underneath
-      let resolved = pickedWidget;
-      while(resolved && [ 'card', 'pile' ].indexOf(resolved.get('type')) != -1 && widgets.has(resolved.get('parent')))
-        resolved = widgets.get(resolved.get('parent'));
-      return resolved;
+    // a collection name looks like a widget id but is none, so only keep ids
+    // that exist - applying the picker must not turn a collection into widgets
+    this.workingIDs = currentIDs.filter(id=>typeof id == 'string' && widgets.has(id));
+
+    // the properties module's picker CSS is scoped to .editorModule, so render
+    // into a matching wrapper to inherit its sizing
+    const host = div(content, 'editorModule');
+    renderWidgetSelectPopout(host, this.widget, {
+      pickerKey: routineWidgetPickerKey,
+      inline: true,
+      multiple: true,
+      allowSelf: true, // a routine regularly acts on the widget it belongs to
+      resolveCovering: true, // holders are usually covered by their cards
+      getSelectedIDs: _=>this.workingIDs,
+      apply: widgetIDs=>this.workingIDs = widgetIDs,
+      onClear: _=>this.workingIDs = [],
+      clearLabel: 'Select none'
     });
-    this.holderSelection.render();
-    content.appendChild(this.holderSelection.domElement);
+    button(content, 'Use these widgets', _=>this.setNewValue([ ...this.workingIDs ]));
     super.show(false, showCollections);
   }
 }

--- a/client/js/editor/controls/popup.js
+++ b/client/js/editor/controls/popup.js
@@ -216,6 +216,8 @@ const predefinedCollectionDescriptions = {
   thisButton: 'the widget that contains the routine (not necessarily a button)'
 };
 
+const routineWidgetPickerKey = 'routineWidgets';
+
 class RoutinePopup extends Popup {
   constructor(source) {
     super(source);
@@ -224,6 +226,10 @@ class RoutinePopup extends Popup {
   hide() {
     if(openRoutinePopup === this)
       openRoutinePopup = null;
+    // a popup that offers the widget picker starts in-room picks, so end them
+    // when it goes away; other popups (e.g. info popups) must not interfere
+    if(isWidgetPickerActive(null, routineWidgetPickerKey))
+      stopWidgetPicker();
     super.hide();
   }
 
@@ -232,6 +238,13 @@ class RoutinePopup extends Popup {
   }
 
   onClick(e) {
+  }
+
+  onOutsideClick(e) {
+    // clicking widgets in the room is how the widget picker works
+    if(isWidgetPickerActive(null, routineWidgetPickerKey))
+      return;
+    super.onOutsideClick(e);
   }
 
   setNewCollectionValue(value) {
@@ -440,6 +453,23 @@ class RoutineNumberPopup extends RoutinePopup {
       valueContent.append(text);
     }
 
+    // a few number parameters name a widget instead (TURN turn takes a seat id),
+    // so offer the picker for those as well
+    if(this.options.widgetType) {
+      const [ widgetTitle, widgetContent ] = this.addAccordionSection('Widgets');
+      infoButton(widgetTitle, 'Use the id of a widget instead of a number: search it by id or pick it in the room.');
+      // the properties module's picker CSS is scoped to .editorModule
+      const host = div(widgetContent, 'editorModule');
+      renderWidgetSelectPopout(host, this.widget, {
+        pickerKey: routineWidgetPickerKey,
+        inline: true,
+        allowSelf: true,
+        typeFilter: this.options.widgetType,
+        getSelectedIDs: _=>typeof currentValue == 'string' ? [ currentValue ] : [],
+        apply: widgetID=>this.setNewValue(widgetID)
+      });
+    }
+
     super.show(true, false);
   }
 }
@@ -459,27 +489,11 @@ class RoutineEnumPopup extends RoutinePopup {
   }
 }
 
-const routineWidgetPickerKey = 'routineWidgets';
-
 class RoutineWidgetIDPopup extends RoutinePopup {
-  constructor() {
+  constructor(options={}) {
     super();
+    this.options = options;
     this.workingIDs = [];
-  }
-
-  hide() {
-    // this popup starts in-room picks, so end them when it goes away; other
-    // popups (e.g. info popups) must not interfere with a running pick
-    if(isWidgetPickerActive(null, routineWidgetPickerKey))
-      stopWidgetPicker();
-    super.hide();
-  }
-
-  onOutsideClick(e) {
-    // clicking widgets in the room is how this popup's picker works
-    if(isWidgetPickerActive(null, routineWidgetPickerKey))
-      return;
-    super.onOutsideClick(e);
   }
 
   show(showCollections=false) {
@@ -506,19 +520,22 @@ class RoutineWidgetIDPopup extends RoutinePopup {
       multiple: true,
       allowSelf: true, // a routine regularly acts on the widget it belongs to
       resolveCovering: true, // holders are usually covered by their cards
+      typeFilter: this.options.widgetType, // preset from the parameter, changeable in the picker
       getSelectedIDs: _=>this.workingIDs,
       apply: widgetIDs=>this.workingIDs = widgetIDs,
       onClear: _=>this.workingIDs = [],
       clearLabel: 'Select none'
     });
     button(content, 'Use these widgets', _=>this.setNewValue([ ...this.workingIDs ]));
-    super.show(false, showCollections);
+    // a widget parameter takes a widget id, which a variable or widget property
+    // can provide as well - e.g. ${PROPERTY parent} for the holder a button sits on
+    super.show(true, showCollections);
   }
 }
 
 class RoutineHoldersOrCollectionSourcePopup extends RoutineWidgetIDPopup {
-  constructor() {
-    super();
+  constructor(options={}) {
+    super(options);
   }
 
   setNewCollectionValue(value) {
@@ -535,8 +552,9 @@ class RoutineHoldersOrCollectionSourcePopup extends RoutineWidgetIDPopup {
 
   setNewValue(value) {
     // widget ids arrive as an array and belong to the first (holder-like) parameter;
+    // a variable or widget property resolves to a widget id, so it goes there too;
     // collection names are strings and belong to the second parameter if there is one
-    if(Array.isArray(value)) {
+    if(Array.isArray(value) || typeof value == 'string' && value.match(/\$\{[^}]+\}/)) {
       const holderParameter = this.parameterNames[0];
       const collectionParameter = this.parameterNames[1];
       // clear the sibling collection (mirror of setNewCollectionValue) so a leftover

--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -359,6 +359,95 @@ function operationUIState(operation) {
   return routineEditorUIState.get(operation);
 }
 
+// The drag currently in progress, as { editor, indices }. It is module level so
+// a drop can move operations between routine levels: into a nested IF/FOREACH
+// block, back out into the parent routine or into a sibling block.
+let activeRoutineDrag = null;
+
+// every routine editor registers its container here so a point on the screen
+// can be resolved to the routine level that owns it
+const routineEditorsByElement = new WeakMap();
+
+function routineEditorAtPoint(x, y) {
+  let element = document.elementFromPoint(x, y);
+  while(element) {
+    if(routineEditorsByElement.has(element))
+      return routineEditorsByElement.get(element);
+    element = element.parentElement;
+  }
+  return null;
+}
+
+function routineDropTargetAtPoint(x, y) {
+  const editor = routineEditorAtPoint(x, y);
+  return editor && editor.acceptsActiveDrag() ? editor.dropTargetAtPoint(x, y) : null;
+}
+
+// highlights where the dragged operations would land: a line at the edge of the
+// hovered card, or the whole block when it has no cards to aim at
+function showRoutineDropIndicator(target) {
+  const shown = activeRoutineDrag && activeRoutineDrag.indicator;
+  if(shown && target && shown.card === target.card && shown.editor === target.editor && shown.after === target.after)
+    return;
+  clearRoutineDropIndicator();
+  if(!target || !activeRoutineDrag)
+    return;
+  if(target.card)
+    target.card.classList.add(target.after ? 'routine-editor-drop-after' : 'routine-editor-drop-before');
+  else
+    target.editor.domElement.classList.add('routine-editor-drop-into');
+  activeRoutineDrag.indicator = target;
+}
+
+function clearRoutineDropIndicator() {
+  const shown = activeRoutineDrag && activeRoutineDrag.indicator;
+  if(!shown)
+    return;
+  if(shown.card)
+    shown.card.classList.remove('routine-editor-drop-before', 'routine-editor-drop-after');
+  else
+    shown.editor.domElement.classList.remove('routine-editor-drop-into');
+  activeRoutineDrag.indicator = null;
+}
+
+// the drop listeners live on the document, so a drag is resolved once no matter
+// how many nested routine editors the event would bubble through
+function routineDragOver(e) {
+  const target = routineDropTargetAtPoint(e.clientX, e.clientY);
+  showRoutineDropIndicator(target);
+  if(!target)
+    return;
+  e.preventDefault();
+  e.dataTransfer.dropEffect = 'move';
+}
+
+function routineDrop(e) {
+  const target = routineDropTargetAtPoint(e.clientX, e.clientY);
+  clearRoutineDropIndicator();
+  if(target) {
+    e.preventDefault();
+    target.editor.performDrag(target.index, target.after);
+  }
+  endRoutineDrag();
+}
+
+function beginRoutineDrag(editor, indices, cards) {
+  activeRoutineDrag = { editor, indices, cards, indicator: null };
+  for(const card of cards)
+    card.classList.add('routine-editor-operation-dragging');
+  document.addEventListener('dragover', routineDragOver);
+  document.addEventListener('drop', routineDrop);
+}
+
+function endRoutineDrag() {
+  clearRoutineDropIndicator();
+  for(const card of (activeRoutineDrag && activeRoutineDrag.cards) || [])
+    card.classList.remove('routine-editor-operation-dragging');
+  document.removeEventListener('dragover', routineDragOver);
+  document.removeEventListener('drop', routineDrop);
+  activeRoutineDrag = null;
+}
+
 class RoutineEditor {
   constructor(widget, routine, variables=[], collections=[], options={}) {
     this.domElement = document.createElement('div');
@@ -369,10 +458,14 @@ class RoutineEditor {
     this.emptyHint = options.emptyHint || 'No operations yet.';
     // set for nested routines: hoists an operation out of this block into the parent
     this.onHoist = options.onHoist || null;
+    // the routine editor one level up, so a cross-level drag can re-render (and
+    // save) from the top instead of from a level that no longer owns the operation
+    this.parentEditor = options.parentEditor || null;
     this.changeListeners = [];
-    // indices (into this level's routine) of the operations Ctrl-selected for a
+    // indices (into this level's routine) of the operations selected for a
     // multi-drag; reset whenever the routine changes structurally (see setRoutine)
     this.selectedIndices = new Set();
+    routineEditorsByElement.set(this.domElement, this);
     // drag-and-drop reordering lives on the stable container so it survives the
     // per-operation DOM swaps the sentence/list view toggle does
     this.setupDragAndDrop();
@@ -396,6 +489,15 @@ class RoutineEditor {
 
   registerChangeListener(listener) {
     this.changeListeners.push(listener);
+  }
+
+  // the outermost routine editor: the only level that can safely re-render after
+  // operations moved between two routine levels
+  rootEditor() {
+    let editor = this;
+    while(editor.parentEditor)
+      editor = editor.parentEditor;
+    return editor;
   }
 
   // called by nested editors and chips after they mutated the routine in place
@@ -426,6 +528,7 @@ class RoutineEditor {
         this.routine.splice((at < 0 ? this.routine.length-1 : at) + 1, 0, op);
         this.routineChanged();
       };
+      editor.routineEditor = this;
 
       variables = [ ...new Set([ ...variables, ...editor.getDefinedVariables() ]) ];
       collections = [ ...new Set([ ...collections, ...editor.getDefinedCollections() ]) ];
@@ -449,14 +552,16 @@ class RoutineEditor {
       const buttonsDOM = document.createElement('span');
       buttonsDOM.className = 'routine-editor-operation-buttons';
 
-      // a grip that starts a drag; Ctrl-clicking cards selects several to move at once
+      // a grip that starts a drag; Ctrl-clicking (long pressing on touch) cards
+      // selects several to move at once
       const dragHandle = document.createElement('span');
       dragHandle.className = 'material-symbols routine-editor-drag-handle';
       dragHandle.textContent = 'drag_indicator';
-      dragHandle.title = 'Drag to reorder (Ctrl+click operations to move several at once)';
+      dragHandle.title = 'Drag into another position or into an IF/FOREACH block (Ctrl+click or long press operations to move several at once)';
       dragHandle.draggable = true;
       dragHandle.addEventListener('dragstart', e=>this.onOperationDragStart(e, dragHandle));
-      dragHandle.addEventListener('dragend', _=>this.onOperationDragEnd());
+      dragHandle.addEventListener('dragend', _=>endRoutineDrag());
+      dragHandle.addEventListener('pointerdown', e=>this.onDragHandlePointerDown(e, dragHandle));
       buttonsDOM.append(dragHandle);
       const operationButton = (icon, title, onClick, glyphClass='material-symbols')=>{
         const buttonDOM = document.createElement('span');
@@ -508,7 +613,7 @@ class RoutineEditor {
         this.routine.splice(index, 1);
         this.routineChanged();
       });
-      operationDOM.append(buttonsDOM);
+      ($('.routine-editor-operation-header', operationDOM) || operationDOM).append(buttonsDOM);
 
       this.domElement.append(operationDOM);
     }
@@ -549,122 +654,186 @@ class RoutineEditor {
     return el && el.classList && el.classList.contains('routine-editor-operation') ? el : null;
   }
 
+  // toggles a card of this level in and out of the multi-selection
+  toggleSelection(card) {
+    const index = this.directChildCards().indexOf(card);
+    if(index < 0)
+      return;
+    if(this.selectedIndices.has(index))
+      this.selectedIndices.delete(index);
+    else
+      this.selectedIndices.add(index);
+    card.classList.toggle('routine-editor-operation-selected', this.selectedIndices.has(index));
+  }
+
+  // the card of THIS level the event happened in, or null when a nested level
+  // owns it (events from nested cards bubble up here too)
+  ownCardFromEvent(e) {
+    const card = this.cardFromEvent(e);
+    return card && e.target.closest('.routine-editor-operation') === card ? card : null;
+  }
+
   setupDragAndDrop() {
     // Ctrl/Cmd-click a card to add it to the multi-selection (chips and buttons
     // stopPropagation their own clicks, so this only fires on the card body)
     this.domElement.addEventListener('click', e=>{
+      if(this.suppressClick) {
+        // the click that ends a long press must not also open a parameter popup
+        this.suppressClick = false;
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
       if(!(e.ctrlKey || e.metaKey))
         return;
-      const card = this.cardFromEvent(e);
-      // a click inside a nested card bubbles up here too - let that level own it
-      if(!card || e.target.closest('.routine-editor-operation') !== card)
+      const card = this.ownCardFromEvent(e);
+      if(!card)
         return;
       e.preventDefault();
-      const index = this.directChildCards().indexOf(card);
-      if(this.selectedIndices.has(index))
-        this.selectedIndices.delete(index);
-      else
-        this.selectedIndices.add(index);
-      card.classList.toggle('routine-editor-operation-selected', this.selectedIndices.has(index));
-    });
+      e.stopPropagation(); // a Ctrl+click on a chip selects instead of editing it
+      this.toggleSelection(card);
+    }, true);
 
-    this.domElement.addEventListener('dragover', e=>{
-      const target = this.dropTargetFromEvent(e);
-      if(!target)
+    // touch has no Ctrl key, so a long press on a card toggles the selection
+    this.domElement.addEventListener('pointerdown', e=>{
+      if(e.pointerType == 'mouse' || e.target.closest('.routine-editor-drag-handle'))
         return;
-      e.preventDefault();
-      e.dataTransfer.dropEffect = 'move';
-      this.showDropIndicator(target.card, target.after);
-    });
-    this.domElement.addEventListener('drop', e=>{
-      const target = this.dropTargetFromEvent(e);
-      this.clearDropIndicator();
-      if(!target)
+      const card = this.ownCardFromEvent(e);
+      if(!card)
         return;
-      e.preventDefault();
-      this.performDrag(target.index, target.after);
-    });
-    this.domElement.addEventListener('dragleave', e=>{
-      if(e.target === this.domElement)
-        this.clearDropIndicator();
+      const startX = e.clientX, startY = e.clientY;
+      const timer = setTimeout(_=>{
+        cancel();
+        this.suppressClick = true;
+        this.toggleSelection(card);
+      }, 500);
+      const move = ev=>{
+        if(Math.abs(ev.clientX-startX) > 10 || Math.abs(ev.clientY-startY) > 10)
+          cancel();
+      };
+      const cancel = _=>{
+        clearTimeout(timer);
+        document.removeEventListener('pointermove', move);
+        document.removeEventListener('pointerup', cancel);
+        document.removeEventListener('pointercancel', cancel);
+      };
+      document.addEventListener('pointermove', move);
+      document.addEventListener('pointerup', cancel);
+      document.addEventListener('pointercancel', cancel);
     });
   }
 
   onOperationDragStart(e, handle) {
-    const card = handle.closest('.routine-editor-operation');
-    const cards = this.directChildCards();
-    const index = cards.indexOf(card);
-    if(index < 0)
+    if(!this.beginDrag(handle))
       return;
-    // dragging a selected card moves the whole selection; an unselected one moves alone
-    this.dragIndices = (this.selectedIndices.has(index) ? [ ...this.selectedIndices ] : [ index ]).sort((a, b)=>a-b);
     e.dataTransfer.effectAllowed = 'move';
     e.dataTransfer.setData('text/plain', 'routine-operation'); // Firefox needs data to start a drag
-    try { e.dataTransfer.setDragImage(card, 12, 12); } catch(err) {}
-    this.draggingCards = this.dragIndices.map(i=>cards[i]).filter(Boolean);
-    for(const c of this.draggingCards)
-      c.classList.add('routine-editor-operation-dragging');
+    try { e.dataTransfer.setDragImage(handle.closest('.routine-editor-operation'), 12, 12); } catch(err) {}
   }
 
-  onOperationDragEnd() {
-    for(const c of this.draggingCards || [])
-      c.classList.remove('routine-editor-operation-dragging');
-    this.draggingCards = null;
-    this.dragIndices = null;
-    this.clearDropIndicator();
-  }
-
-  // where a drop would land: the hovered card, its index and whether it goes after
-  // it; null while no drag of this editor's own operations is in progress
-  dropTargetFromEvent(e) {
-    if(!this.dragIndices)
-      return null;
-    const card = this.cardFromEvent(e);
-    if(!card)
-      return null;
-    const index = this.directChildCards().indexOf(card);
-    const rect = card.getBoundingClientRect();
-    return { card, index, after: e.clientY > rect.top + rect.height/2 };
-  }
-
-  showDropIndicator(card, after) {
-    if(this.dropCard === card && this.dropAfter === after)
+  // the browser does not turn a touch into a native drag, so follow the pointer
+  // ourselves and drop where it is released
+  onDragHandlePointerDown(e, handle) {
+    if(e.pointerType == 'mouse' || !this.beginDrag(handle))
       return;
-    this.clearDropIndicator();
-    card.classList.add(after ? 'routine-editor-drop-after' : 'routine-editor-drop-before');
-    this.dropCard = card;
-    this.dropAfter = after;
+    e.preventDefault();
+    try { handle.setPointerCapture(e.pointerId); } catch(err) {}
+    const move = ev=>{
+      ev.preventDefault();
+      showRoutineDropIndicator(routineDropTargetAtPoint(ev.clientX, ev.clientY));
+    };
+    const up = ev=>{
+      handle.removeEventListener('pointermove', move);
+      handle.removeEventListener('pointerup', up);
+      handle.removeEventListener('pointercancel', up);
+      const target = ev.type == 'pointerup' ? routineDropTargetAtPoint(ev.clientX, ev.clientY) : null;
+      clearRoutineDropIndicator();
+      if(target)
+        target.editor.performDrag(target.index, target.after);
+      endRoutineDrag();
+    };
+    handle.addEventListener('pointermove', move);
+    handle.addEventListener('pointerup', up);
+    handle.addEventListener('pointercancel', up);
   }
 
-  clearDropIndicator() {
-    if(this.dropCard) {
-      this.dropCard.classList.remove('routine-editor-drop-before', 'routine-editor-drop-after');
-      this.dropCard = null;
-      this.dropAfter = undefined;
-    }
+  // start dragging the card the handle belongs to; a selected card takes the
+  // whole selection along, an unselected one moves alone
+  beginDrag(handle) {
+    const cards = this.directChildCards();
+    const index = cards.indexOf(handle.closest('.routine-editor-operation'));
+    if(index < 0)
+      return false;
+    const indices = (this.selectedIndices.has(index) ? [ ...this.selectedIndices ] : [ index ]).sort((a, b)=>a-b);
+    beginRoutineDrag(this, indices, indices.map(i=>cards[i]).filter(Boolean));
+    return true;
   }
 
-  // move the operations at this.dragIndices to before/after targetIndex, working
-  // by index so duplicate primitive operations (comments, var statements) stay put
-  performDrag(targetIndex, after) {
-    const moveSet = new Set(this.dragIndices);
-    if(moveSet.has(targetIndex))
-      return; // dropped onto one of the operations being moved: nothing to do
-    const moving = this.dragIndices.map(i=>this.routine[i]);
-    const result = [];
-    for(let i = 0; i < this.routine.length; i++) {
-      if(moveSet.has(i))
-        continue;
-      if(i === targetIndex && !after)
-        result.push(...moving);
-      result.push(this.routine[i]);
-      if(i === targetIndex && after)
-        result.push(...moving);
+  // a block nested inside one of the dragged operations cannot receive them:
+  // that would detach the routine from the widget
+  acceptsActiveDrag() {
+    if(!activeRoutineDrag)
+      return false;
+    const containsThisRoutine = operation=>{
+      if(!operation || typeof operation != 'object')
+        return false;
+      for(const key of [ 'thenRoutine', 'elseRoutine', 'loopRoutine' ])
+        if(Array.isArray(operation[key]) && (operation[key] === this.routine || operation[key].some(containsThisRoutine)))
+          return true;
+      return false;
+    };
+    return !activeRoutineDrag.indices.some(i=>containsThisRoutine(activeRoutineDrag.editor.routine[i]));
+  }
+
+  // where a drop at this point would land in THIS routine: the hovered card and
+  // whether it goes after it; empty space below the cards appends at the end
+  dropTargetAtPoint(x, y) {
+    const cards = this.directChildCards();
+    let element = document.elementFromPoint(x, y);
+    while(element && element.parentElement !== this.domElement)
+      element = element.parentElement;
+    const card = element && element.classList && element.classList.contains('routine-editor-operation') ? element : null;
+    if(!card)
+      return { editor: this, card: cards[cards.length-1] || null, index: cards.length-1, after: true };
+    const rect = card.getBoundingClientRect();
+    return { editor: this, card, index: cards.indexOf(card), after: y > rect.top + rect.height/2 };
+  }
+
+  // move the dragged operations to before/after targetIndex of this routine. They
+  // are addressed by index so that duplicate primitive operations (comments, var
+  // statements) stay put, and they may come from another routine level.
+  performDrag(targetIndex, after, drag = activeRoutineDrag) {
+    if(!drag || !drag.indices.length)
+      return;
+    const source = drag.editor;
+    if(source === this) {
+      const moveSet = new Set(drag.indices);
+      if(moveSet.has(targetIndex) || targetIndex < 0)
+        return; // dropped onto one of the operations being moved: nothing to do
+      const moving = drag.indices.map(i=>this.routine[i]);
+      const result = [];
+      for(let i = 0; i < this.routine.length; i++) {
+        if(moveSet.has(i))
+          continue;
+        if(i === targetIndex && !after)
+          result.push(...moving);
+        result.push(this.routine[i]);
+        if(i === targetIndex && after)
+          result.push(...moving);
+      }
+      // keep the array reference: nested editors and change listeners hold onto it
+      this.routine.length = 0;
+      this.routine.push(...result);
+      this.routineChanged();
+      return;
     }
-    // keep the array reference: nested editors and change listeners hold onto it
-    this.routine.length = 0;
-    this.routine.push(...result);
-    this.routineChanged();
+    const moving = drag.indices.map(i=>source.routine[i]);
+    for(const i of [ ...drag.indices ].sort((a, b)=>b-a))
+      source.routine.splice(i, 1);
+    this.routine.splice(targetIndex < 0 ? this.routine.length : targetIndex + (after ? 1 : 0), 0, ...moving);
+    source.selectedIndices = new Set();
+    // two levels changed, so only the outermost editor can re-render consistently
+    this.rootEditor().routineChanged();
   }
 }
 
@@ -673,6 +842,7 @@ class RoutineOperationEditor {
     this.func = func;
     this.metadata = routineOperationMetadata[func] || { template: '{func}', parameters: {} };
     this.changeListeners = [];
+    this.subroutineEditors = {};
   }
 
   classifyParameter(parameterName, value) {
@@ -830,15 +1000,20 @@ class RoutineOperationEditor {
     if(uiState.listView)
       dom.classList.add('list-view');
 
+    // the header holds the summary and, appended by the routine editor, the
+    // move/delete buttons: laid out side by side they can never overlap
+    const header = div(dom, 'routine-editor-operation-header');
+    const body = div(header, 'routine-editor-operation-body');
+
     if(uiState.listView)
-      this.renderListView(dom);
+      this.renderListView(body);
     else
-      this.renderSentenceView(dom);
+      this.renderSentenceView(body);
 
     if(this.isExpandable())
-      ($('.routine-editor-parameter-row', dom) || dom).prepend(this.renderViewToggle());
+      ($('.routine-editor-parameter-row', body) || body).prepend(this.renderViewToggle());
 
-    // in the expanded view, a top-right button shows the operation as raw JSON
+    // in the expanded view, a button next to the summary shows the raw JSON
     if(uiState.listView && this.operation && typeof this.operation == 'object') {
       const jsonButton = document.createElement('span');
       jsonButton.className = 'material-symbols routine-editor-operation-json';
@@ -853,7 +1028,7 @@ class RoutineOperationEditor {
         if(values !== undefined)
           this.onNewValue(values);
       });
-      dom.append(jsonButton);
+      header.append(jsonButton);
     }
 
     for(const span of $a('span[data-parameter]', dom)) {
@@ -935,10 +1110,11 @@ class RoutineOperationEditor {
       const oldDom = this.domElement;
       const newDom = this.render();
       // keep the move/delete buttons the routine editor appended to the old node
-      // (direct children only - nested operations have their own button clusters)
-      const buttons = [ ...oldDom.children ].find(c=>c.classList.contains('routine-editor-operation-buttons'));
+      // (own header only - nested operations have their own button clusters)
+      const oldHeader = [ ...oldDom.children ].find(c=>c.classList.contains('routine-editor-operation-header'));
+      const buttons = oldHeader && [ ...oldHeader.children ].find(c=>c.classList.contains('routine-editor-operation-buttons'));
       if(buttons)
-        newDom.append(buttons);
+        [ ...newDom.children ].find(c=>c.classList.contains('routine-editor-operation-header')).append(buttons);
       oldDom.replaceWith(newDom);
     });
     return toggle;
@@ -949,12 +1125,13 @@ class RoutineOperationEditor {
     const routine = Array.isArray(this.operation[property]) ? this.operation[property] : [];
     // hoisting out of a nested block means removing from here and asking the
     // parent routine (via the container editor) to re-insert after the container
-    options = { ...options, onHoist: op=>this.hoistIntoParent && this.hoistIntoParent(op) };
+    options = { ...options, onHoist: op=>this.hoistIntoParent && this.hoistIntoParent(op), parentEditor: this.routineEditor };
     const routineEditor = new RoutineEditor(this.widget, routine, this.variables, this.collections, options);
     routineEditor.registerChangeListener(v=>{
       this.operation[property] = v;
       this.notifyChangeListeners(this.operation);
     });
+    this.subroutineEditors[property] = routineEditor;
     dom.append(routineEditor.render());
   }
 

--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -458,6 +458,10 @@ class RoutineEditor {
     this.emptyHint = options.emptyHint || 'No operations yet.';
     // set for nested routines: hoists an operation out of this block into the parent
     this.onHoist = options.onHoist || null;
+    // set for nested routines: writes this level's array back into its operation.
+    // An empty block is not part of the operation JSON (see renderSubroutine), so
+    // operations dropped into one would land in an array nothing else can see.
+    this.attachRoutine = options.attachRoutine || null;
     // the routine editor one level up, so a cross-level drag can re-render (and
     // save) from the top instead of from a level that no longer owns the operation
     this.parentEditor = options.parentEditor || null;
@@ -831,6 +835,8 @@ class RoutineEditor {
     for(const i of [ ...drag.indices ].sort((a, b)=>b-a))
       source.routine.splice(i, 1);
     this.routine.splice(targetIndex < 0 ? this.routine.length : targetIndex + (after ? 1 : 0), 0, ...moving);
+    if(this.attachRoutine)
+      this.attachRoutine();
     source.selectedIndices = new Set();
     // two levels changed, so only the outermost editor can re-render consistently
     this.rootEditor().routineChanged();
@@ -1125,7 +1131,12 @@ class RoutineOperationEditor {
     const routine = Array.isArray(this.operation[property]) ? this.operation[property] : [];
     // hoisting out of a nested block means removing from here and asking the
     // parent routine (via the container editor) to re-insert after the container
-    options = { ...options, onHoist: op=>this.hoistIntoParent && this.hoistIntoParent(op), parentEditor: this.routineEditor };
+    options = {
+      ...options,
+      onHoist: op=>this.hoistIntoParent && this.hoistIntoParent(op),
+      parentEditor: this.routineEditor,
+      attachRoutine: _=>{ this.operation[property] = routine; }
+    };
     const routineEditor = new RoutineEditor(this.widget, routine, this.variables, this.collections, options);
     routineEditor.registerChangeListener(v=>{
       this.operation[property] = v;

--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -13,6 +13,11 @@
 // Parameter types decide which popup opens: number, enum (with values),
 // string, json, widgets (pick widgets in the room), collection (pick widgets
 // or a collection name).
+//
+// widgetType presets the picker's type filter for parameters that almost always
+// name a widget of one type (SHUFFLE holder is a holder, TIMER timer a timer).
+// It is only the initial value of the filter dropdown - the type can be changed
+// to any other one (or to "any type") in the picker.
 const routineOperationMetadata = {
   AUDIO: {
     template: '{func}: play {source} at volume {maxVolume}[ to {player}][; {count} time(s)]',
@@ -42,7 +47,7 @@ const routineOperationMetadata = {
     template: '{func}: {mode} on {collection}[ using value {value}][ and color {color}]',
     parameters: {
       mode: { type: 'enum', values: [ 'set', 'inc', 'dec', 'change', 'reset', 'setPixel' ], default: 'reset' },
-      collection: { type: 'collection', default: 'DEFAULT' },
+      collection: { type: 'collection', default: 'DEFAULT', widgetType: 'canvas' },
       value: { type: 'number', default: 1 },
       color: { type: 'color', default: '#1F5CA6' },
       x: { type: 'number', default: 0 },
@@ -74,7 +79,7 @@ const routineOperationMetadata = {
     template: '{func} widgets[ owned by {owner}] in {holder,collection} and store as {variable}',
     parameters: {
       owner: { type: 'string', default: null, display: { 'null': 'anyone' } },
-      holder: { type: 'widgets', default: null },
+      holder: { type: 'widgets', default: null, widgetType: 'holder' },
       collection: { type: 'collection', default: 'DEFAULT' },
       variable: { type: 'string', default: 'COUNT' }
     },
@@ -96,7 +101,7 @@ const routineOperationMetadata = {
     template: v=>v('faceCycle') == 'random' ? '{func} {count} widgets from {holder,collection} a {faceCycle} face' : '{func} {count} widgets from {holder,collection}; cycle {faceCycle} by {face}',
     parameters: {
       count: { type: 'number', default: 'all', special: [ 'all' ] },
-      holder: { type: 'widgets', default: null, display: { 'null': '?' } },
+      holder: { type: 'widgets', default: null, display: { 'null': '?' }, widgetType: 'holder' },
       collection: { type: 'collection', default: 'DEFAULT' },
       face: { type: 'number', default: null, special: [ null ], display: { 'null': 'next' } },
       faceCycle: { type: 'enum', values: [ 'forward', 'backward', 'random' ], default: 'forward' }
@@ -145,7 +150,7 @@ const routineOperationMetadata = {
   LABEL: {
     template: v=>v('label') != null ? '{func}: {mode} {value} to {label}' : '{func}: {mode} {value} to labels in {collection}',
     parameters: {
-      label: { type: 'widgets', default: null },
+      label: { type: 'widgets', default: null, widgetType: 'label' },
       collection: { type: 'collection', default: 'DEFAULT' },
       value: { type: 'string', default: 0 },
       mode: { type: 'enum', values: [ 'set', 'inc', 'dec', 'append' ], default: 'set' }
@@ -156,9 +161,9 @@ const routineOperationMetadata = {
     parameters: {
       fillTo: { type: 'number', default: null },
       count: { type: 'number', default: operation=>operation.from ? 1 : 'all', special: [ 'all' ] },
-      from: { type: 'widgets', default: null, display: { 'null': '?' } },
+      from: { type: 'widgets', default: null, display: { 'null': '?' }, widgetType: 'holder' },
       collection: { type: 'collection', default: 'DEFAULT' },
-      to: { type: 'widgets', default: null, display: { 'null': '?' } },
+      to: { type: 'widgets', default: null, display: { 'null': '?' }, widgetType: 'holder' },
       face: { type: 'number', default: null, special: [ null ], display: { 'null': 'unchanged' } }
     },
     ignored: v=>v('fillTo') != null ? { count: 'ignored because "fill up to" is set' } : {}
@@ -167,7 +172,7 @@ const routineOperationMetadata = {
     template: '{func} {count} widgets from {from} to ({x}, {y})[; flip to face {face}]',
     parameters: {
       count: { type: 'number', default: 1, special: [ 'all' ] },
-      from: { type: 'widgets', default: null, display: { 'null': '?' } },
+      from: { type: 'widgets', default: null, display: { 'null': '?' }, widgetType: 'holder' },
       x: { type: 'number', default: 0 },
       y: { type: 'number', default: 0 },
       face: { type: 'number', default: null, special: [ null ], display: { 'null': 'unchanged' } },
@@ -178,7 +183,7 @@ const routineOperationMetadata = {
   RECALL: {
     template: '{func} cards that belong to {holder}[; include cards in hands {owned}][, only cards in holders {inHolder}][, excluding {excludeCollection}]',
     parameters: {
-      holder: { type: 'widgets', default: null, display: { 'null': '?' } },
+      holder: { type: 'widgets', default: null, display: { 'null': '?' }, widgetType: 'holder' },
       owned: { type: 'enum', values: [ true, false ], default: true },
       inHolder: { type: 'enum', values: [ true, false ], default: true },
       excludeCollection: { type: 'collection', default: null },
@@ -195,7 +200,7 @@ const routineOperationMetadata = {
     template: v=>v('mode') == 'set' ? '{func} {count} widgets in {holder,collection}; {mode} to {angle} degrees' : '{func} {count} widgets in {holder,collection}; {mode} {angle} degrees',
     parameters: {
       count: { type: 'number', default: 1, special: [ 'all' ] },
-      holder: { type: 'widgets', default: null },
+      holder: { type: 'widgets', default: null, widgetType: 'holder' },
       collection: { type: 'collection', default: 'DEFAULT' },
       angle: { type: 'number', default: 90, special: [ 45, 60, 90, 135, 180 ] },
       mode: { type: 'enum', values: [ 'set', 'add' ], default: 'add' }
@@ -205,7 +210,7 @@ const routineOperationMetadata = {
     template: '{func}: get {property} in {seats}[; for round {round}][; use as {mode}][ with multiplier {value}]',
     parameters: {
       property: { type: 'string', default: 'score' },
-      seats: { type: 'widgets', default: null, display: { 'null': 'every seat' } },
+      seats: { type: 'widgets', default: null, display: { 'null': 'every seat' }, widgetType: 'seat' },
       round: { type: 'number', default: null, special: [ null ], display: { 'null': 'new round' } },
       mode: { type: 'enum', values: [ 'set', 'inc', 'dec' ], default: 'set' },
       value: { type: 'number', default: null, special: [ null ] }
@@ -247,7 +252,7 @@ const routineOperationMetadata = {
       return '{func} {holder,collection}'; // true random
     },
     parameters: {
-      holder: { type: 'widgets', default: null, display: { 'null': '?' } },
+      holder: { type: 'widgets', default: null, display: { 'null': '?' }, widgetType: 'holder' },
       collection: { type: 'collection', default: 'DEFAULT' },
       mode: { type: 'enum', values: [ 'true random', 'overhand', 'riffle', 'reverse', 'seeded' ], default: 'true random' },
       modeValue: { type: 'number', default: 1 }
@@ -256,7 +261,7 @@ const routineOperationMetadata = {
   SORT: {
     template: '{func} {holder,collection} by {key}[; reverse {reverse}]',
     parameters: {
-      holder: { type: 'widgets', default: null },
+      holder: { type: 'widgets', default: null, widgetType: 'holder' },
       collection: { type: 'collection', default: 'DEFAULT' },
       key: { type: 'json', default: 'value' },
       reverse: { type: 'enum', values: [ true, false ], default: false },
@@ -268,7 +273,7 @@ const routineOperationMetadata = {
   SWAPHANDS: {
     template: '{func} hands among players in {source}[, interval {interval}][, direction {direction}]',
     parameters: {
-      source: { type: 'collection', default: 'all', display: { 'all': 'all seats' } },
+      source: { type: 'collection', default: 'all', display: { 'all': 'all seats' }, widgetType: 'seat' },
       interval: { type: 'number', default: 1 },
       direction: { type: 'enum', values: [ 'forward', 'backward', 'random' ], default: 'forward' }
     }
@@ -284,8 +289,8 @@ const routineOperationMetadata = {
       return `{func}: {mode} ${target}`; // pause/start/toggle/reset ignore the value
     },
     parameters: {
-      timer: { type: 'widgets', default: null },
-      collection: { type: 'collection', default: 'DEFAULT' },
+      timer: { type: 'widgets', default: null, widgetType: 'timer' },
+      collection: { type: 'collection', default: 'DEFAULT', widgetType: 'timer' },
       mode: { type: 'enum', values: [ 'pause', 'start', 'toggle', 'set', 'dec', 'inc', 'reset' ], default: 'toggle' },
       value: { type: 'number', default: 0, special: [ 'start', 'end' ], textHint: 'name of a timer property to read the time from' },
       seconds: { type: 'number', default: 0 }
@@ -309,9 +314,9 @@ const routineOperationMetadata = {
       return '{func} {turnCycle} by {turn}'; // forward / backward
     },
     parameters: {
-      turn: { type: 'number', default: 1, special: [ 'first', 'last' ], textHint: 'id of a seat (used with turnCycle seat)' },
+      turn: { type: 'number', default: 1, special: [ 'first', 'last' ], textHint: 'id of a seat (used with turnCycle seat)', widgetType: 'seat' },
       turnCycle: { type: 'enum', values: [ 'forward', 'backward', 'random', 'position', 'seat' ], default: 'forward' },
-      source: { type: 'collection', default: 'all', display: { 'all': 'all seats' } },
+      source: { type: 'collection', default: 'all', display: { 'all': 'all seats' }, widgetType: 'seat' },
       collection: { type: 'collection', default: 'TURN' }
     },
     definesCollection: 'collection'
@@ -870,15 +875,19 @@ class RoutineOperationEditor {
 
   createPopup(parameterNames) {
     const spec = this.parameterSpec(parameterNames[parameterNames.length-1]);
+    // a chip can stand for alternative parameters ({holder,collection}), so the
+    // type preset of any of them applies to the picker the chip opens
+    const typedSpec = parameterNames.map(name=>this.parameterSpec(name)).find(s=>s && s.widgetType);
+    const pickerOptions = { widgetType: typedSpec && typedSpec.widgetType };
     if(parameterNames[0] == 'func')
       return new RoutineOperationPopup();
     if(parameterNames.length > 1 && spec && spec.type == 'collection')
-      return new RoutineHoldersOrCollectionSourcePopup();
+      return new RoutineHoldersOrCollectionSourcePopup(pickerOptions);
     switch(spec && spec.type) {
-      case 'number':     return new RoutineNumberPopup({ specialValues: spec.special, textHint: spec.textHint });
+      case 'number':     return new RoutineNumberPopup({ specialValues: spec.special, textHint: spec.textHint, widgetType: pickerOptions.widgetType });
       case 'enum':       return new RoutineEnumPopup({ values: spec.values });
-      case 'widgets':    return new RoutineWidgetIDPopup();
-      case 'collection': return new RoutineHoldersOrCollectionSourcePopup();
+      case 'widgets':    return new RoutineWidgetIDPopup(pickerOptions);
+      case 'collection': return new RoutineHoldersOrCollectionSourcePopup(pickerOptions);
       case 'json':       return new RoutineJSONPopup();
       case 'color':      return new RoutineColorPopup();
       case 'icon':       return new RoutineIconPopup();

--- a/client/js/editor/controls/widgetselection.js
+++ b/client/js/editor/controls/widgetselection.js
@@ -1,96 +1,289 @@
-class WidgetSelection {
-  constructor(widgets, callback, resolveWidget=null) {
-    this.widgets = widgets;
-    this.callback = callback;
-    this.resolveWidget = resolveWidget; // maps a picked widget to the one that was meant (e.g. card to its holder)
-    this.domElement = document.createElement('div');
-    this.widgetRows = {};
+// The widget picker the whole editor shares: a searchable list of widget ids
+// with a type filter, plus a mode that picks widgets by clicking them in the
+// room. The properties sidebar uses it for the parent and seat inputs, the
+// routine editor for widget, holder and collection parameters.
+let activeWidgetPicker = null;
+
+function startWidgetPicker(targetWidgetID, onPick, options = {}) {
+  activeWidgetPicker = {
+    targetWidgetID,
+    onPick,
+    pickerKey: options.pickerKey || null,
+    filter: typeof options.filter === 'function' ? options.filter : null,
+    resolve: typeof options.resolve === 'function' ? options.resolve : null,
+    multiple: !!options.multiple
+  };
+
+  $('body').classList.add('editorWidgetPicking');
+}
+
+function stopWidgetPicker() {
+  activeWidgetPicker = null;
+  $('body').classList.remove('editorWidgetPicking');
+}
+
+function getWidgetPicker(targetWidgetID = null, pickerKey = null) {
+  if(!activeWidgetPicker)
+    return null;
+
+  if(targetWidgetID !== null && activeWidgetPicker.targetWidgetID != targetWidgetID)
+    return null;
+
+  if(pickerKey !== null && activeWidgetPicker.pickerKey !== pickerKey)
+    return null;
+
+  return activeWidgetPicker;
+}
+
+function isWidgetPickerActive(targetWidgetID = null, pickerKey = null) {
+  return !!getWidgetPicker(targetWidgetID, pickerKey);
+}
+
+// A click in the room hits the top-most widget, which is often not the one the
+// picker is looking for - a holder is covered by the cards lying on it. The
+// picker resolves such a click to the widget underneath it that fits.
+function resolvePickedWidget(clickedWidget, picker) {
+  const pickedWidget = picker.resolve ? picker.resolve(clickedWidget) : clickedWidget;
+  if(!pickedWidget)
+    return null;
+  return !picker.filter || picker.filter(pickedWidget) ? pickedWidget : null;
+}
+
+// the picker restores the selection it started from after every pick, which must
+// not be mistaken for the player picking that widget
+let restoringWidgetPickerSelection = false;
+
+function handleWidgetPickerSelection(newSelection) {
+  if(restoringWidgetPickerSelection)
+    return true;
+
+  const picker = getWidgetPicker();
+  if(!picker)
+    return false;
+
+  const targetWidget = widgets.get(picker.targetWidgetID);
+
+  if(!targetWidget) {
+    stopWidgetPicker();
+    return false;
   }
 
-  resolveAll(widgets) {
-    if(!this.resolveWidget)
-      return widgets;
-    const resolved = [];
-    for(const widget of widgets.map(this.resolveWidget))
-      if(widget && resolved.indexOf(widget) == -1)
-        resolved.push(widget);
-    return resolved;
-  }
-
-  addWidgetEntry(widget) {
-    const row = document.createElement('tr');
-    for(const text of [ widget.id, widget.get('type') ]) {
-      const cell = document.createElement('td');
-      cell.textContent = text; // widget ids and types come from untrusted room state
-      row.appendChild(cell);
+  const restoreSelection = _=>{
+    if(newSelection.length == 1 && newSelection[0].id == targetWidget.id)
+      return;
+    restoringWidgetPickerSelection = true;
+    try {
+      setSelection([ targetWidget ]);
+    } finally {
+      restoringWidgetPickerSelection = false;
     }
-    const actionCell = document.createElement('td');
-    button(actionCell, 'Remove', _=>this.removeWidget(widget));
-    row.appendChild(actionCell);
-    row.dataset.widgetId = widget.id;
-    this.widgetRows[widget.id] = row;
-    $('table', this.domElement).appendChild(row);
+  };
+
+  const resolved = [];
+  for(const clickedWidget of newSelection) {
+    // the target widget is selected again after every pick, so a click on it
+    // cannot be told apart from that - it is only pickable from the id list
+    if(!clickedWidget || clickedWidget.id == targetWidget.id)
+      continue;
+    const pickedWidget = resolvePickedWidget(clickedWidget, picker);
+    if(!pickedWidget || pickedWidget.id == targetWidget.id)
+      continue;
+    if(resolved.indexOf(pickedWidget) == -1)
+      resolved.push(pickedWidget);
   }
 
-  removeWidget(widget) {
-    this.widgetRows[widget.id].remove();
-    delete this.widgetRows[widget.id];
-    this.widgets = this.widgets.filter(w=>w.id !== widget.id);
+  // an ambiguous selection of several widgets only counts when the picker
+  // collects more than one anyway
+  const pickedWidgets = picker.multiple || resolved.length == 1 ? resolved : [];
+
+  if(pickedWidgets.length) {
+    // a picker that collects several widgets stays active for the next click
+    if(!picker.multiple)
+      stopWidgetPicker();
+    picker.onPick(targetWidget, pickedWidgets);
   }
 
-  render() {
-    const selectionDiv = div(this.domElement, 'selection', `
-        <table>
-          <tr>
-            <th>Widget</th>
-            <th>Type</th>
-            <th>Action</th>
-          </tr>
-        </table>
-        <div class=start>
-          <button>Add Widgets</button>
-          <button>Start Fresh</button>
-          <button>Use These Widgets</button>
-        </div>
-        <div class=end style=display:none>
-          <p>Select widgets in the room. A plain click replaces the selection; shift-click adds to it. Then click Select to apply the selection.</p>
-          <button>Select</button>
-        </div>
-    `);
-    for(const widget of this.widgets) {
-      this.addWidgetEntry(widget);
-    }
-    $('.start button:nth-child(1)', selectionDiv).addEventListener('click', _=>{
-      startCustomSelection(this.widgets, customSelection=>this.updateWidgets(this.resolveAll(customSelection)));
-      $('.start', selectionDiv).style.display = 'none';
-      $('.end', selectionDiv).style.display = 'block';
-    });
-    $('.start button:nth-child(2)', selectionDiv).addEventListener('click', _=>{
-      // empty the current picks now so "Select" with no room picks applies nothing
-      this.updateWidgets([]);
-      startCustomSelection([], customSelection=>this.updateWidgets(this.resolveAll(customSelection)));
-      $('.start', selectionDiv).style.display = 'none';
-      $('.end', selectionDiv).style.display = 'block';
-    });
-    $('.start button:nth-child(3)', selectionDiv).addEventListener('click', _=>{
-      this.callback(this.widgets);
-    });
-    $('.end button', selectionDiv).addEventListener('click', _=>{
-      endCustomSelection();
-      $('.start', selectionDiv).style.display = 'block';
-      $('.end', selectionDiv).style.display = 'none';
-    });
+  restoreSelection();
+  return true;
+}
+
+// Inline popout (styled like the icon/image pickers) to select widgets by
+// searching their ID, filtered by type, or by clicking them in the room.
+// options:
+//   pickerKey      - key for the in-room widget picker
+//   typeFilter     - presets the type filter (e.g. 'seat' for seat inputs)
+//   multiple       - toggle entries in a list of IDs instead of picking one
+//   getSelectedIDs - returns the currently selected widget IDs
+//   apply          - called with the picked ID (single) or array of IDs (multiple)
+//   onClear        - when given, adds a button that removes the value
+//   clearLabel     - label of that button
+//   excludeIDs     - returns additional widget IDs to hide from the list
+//   allowSelf      - offer the widget the popout belongs to as well
+//   resolveCovering - without a type filter, resolve a clicked card or pile to
+//                    the widget it lies on instead of picking it
+//   inline         - always show the list instead of hiding it behind an arrow
+function renderWidgetSelectPopout(wrap, widget, options = {}) {
+  let expandButton = null;
+  if(!options.inline) {
+    expandButton = document.createElement('button');
+    expandButton.className = 'propertyExpandButton';
+    expandButton.setAttribute('icon', 'expand_more');
+    expandButton.title = 'Select a widget';
+    wrap.appendChild(expandButton);
   }
 
-  updateWidgets(widgets) {
-    for(const widget of this.widgets)
-      if(!widgets.includes(widget))
-        this.removeWidget(widget);
-    for(const widget of widgets) {
-      if(!this.widgetRows[widget.id]) {
-        this.addWidgetEntry(widget);
-        this.widgets.push(widget);
+  const popout = div(wrap, 'propertyPicker widgetSelectPopout');
+  if(!options.inline)
+    popout.style.display = 'none';
+
+  const selectedIDs = _=>options.getSelectedIDs ? options.getSelectedIDs() : [];
+  const excludedIDs = _=>(options.allowSelf ? [] : [ widget.id ]).concat(options.excludeIDs ? options.excludeIDs() : []);
+
+  let typeFilter = options.typeFilter || '';
+  let searchTerm = '';
+  let refreshEntries = _=>{}; // updates the list in place, keeping search focus
+
+  const matchesTypeFilter = w=>!typeFilter || (w.get('type') || 'basic') == typeFilter;
+  // what a click in the room should resolve to: the type filter when there is
+  // one, otherwise (with resolveCovering) the widget below a card or pile,
+  // because those cover whatever they lie on
+  const isPickTarget = w=>typeFilter ? matchesTypeFilter(w) : !options.resolveCovering || [ 'card', 'pile' ].indexOf(w.get('type')) == -1;
+
+  const renderPopout = _=>{
+    popout.innerHTML = '';
+
+    if(options.title)
+      div(popout, 'propertyPickerSectionTitle', html(options.title));
+
+    const buttonBar = div(popout, 'propertyPickerSection');
+    const pickButton = document.createElement('button');
+    pickButton.setAttribute('icon', 'colorize');
+    pickButton.title = `Click this button and then the ${options.multiple ? 'widgets' : 'widget'} on the table. The type filter applies here as well, so with the type set to holder a click on a card selects the holder it lies on.`;
+    buttonBar.appendChild(pickButton);
+
+    const updatePickButton = _=>{
+      const isSelecting = isWidgetPickerActive(widget.id, options.pickerKey);
+      pickButton.textContent = isSelecting ? `click ${options.multiple ? 'widgets' : 'a widget'}...` : 'Pick in the room';
+      pickButton.classList.toggle('selected', isSelecting);
+    };
+    updatePickButton();
+
+    pickButton.onclick = _=>{
+      if(isWidgetPickerActive(widget.id, options.pickerKey)) {
+        stopWidgetPicker();
+      } else {
+        startWidgetPicker(widget.id, (targetWidget, pickedWidgets)=>{
+          if(options.multiple)
+            options.apply([...new Set(selectedIDs().concat(pickedWidgets.map(w=>w.id)))]);
+          else
+            options.apply(pickedWidgets[0].id);
+          refreshEntries();
+          updatePickButton();
+        }, {
+          pickerKey: options.pickerKey,
+          multiple: !!options.multiple,
+          filter: pickedWidget=>excludedIDs().indexOf(pickedWidget.id) == -1 && matchesTypeFilter(pickedWidget),
+          resolve: pickedWidget=>{
+            let resolved = pickedWidget;
+            const visited = new Set(); // a broken parent chain must not loop forever
+            while(resolved && !isPickTarget(resolved) && widgets.has(resolved.get('parent')) && !visited.has(resolved.id)) {
+              visited.add(resolved.id);
+              resolved = widgets.get(resolved.get('parent'));
+            }
+            return resolved;
+          }
+        });
       }
+      updatePickButton();
+    };
+
+    if(options.onClear) {
+      const clearButton = document.createElement('button');
+      clearButton.setAttribute('icon', 'link_off');
+      clearButton.textContent = options.clearLabel || 'Clear';
+      clearButton.onclick = _=>{
+        options.onClear();
+        refreshEntries();
+      };
+      buttonBar.appendChild(clearButton);
     }
-  }
+
+    const searchSection = div(popout, 'propertyPickerSection');
+    div(searchSection, 'propertyPickerSectionTitle', 'Search widgets');
+
+    const typeNames = typeof editorTypeNames != 'undefined' ? editorTypeNames : {};
+    const typeSelect = document.createElement('select');
+    typeSelect.innerHTML = '<option value="">any type</option>' + Object.keys(typeNames).map(type=>`<option value="${type}">${typeNames[type]}</option>`).join('');
+    typeSelect.value = typeFilter;
+    searchSection.appendChild(typeSelect);
+
+    const search = document.createElement('input');
+    search.placeholder = 'Search by ID...';
+    search.value = searchTerm;
+    searchSection.appendChild(search);
+
+    const list = div(searchSection, 'widgetPickerList');
+
+    const showEntries = _=>{
+      list.innerHTML = '';
+      const term = searchTerm.trim().toLowerCase();
+      const current = selectedIDs();
+      const excluded = excludedIDs();
+      const matches = [...widgets.values()]
+        .filter(w=>excluded.indexOf(w.id) == -1)
+        .filter(w=>matchesTypeFilter(w))
+        .filter(w=>!term || w.id.toLowerCase().includes(term))
+        // picked widgets come first so they stay visible (and removable) when
+        // the list is cut off below
+        .sort((a, b)=>(current.indexOf(b.id) != -1) - (current.indexOf(a.id) != -1) || a.id.localeCompare(b.id));
+      for(const match of matches.slice(0, 50)) {
+        const entry = div(list, 'widgetPickerEntry', `<span>${html(match.id)}</span><span class=widgetPickerType>${html(match.get('type') || 'basic')}</span>`);
+        entry.classList.toggle('selected', current.indexOf(match.id) != -1);
+        entry.onclick = _=>{
+          if(options.multiple) {
+            const now = selectedIDs();
+            options.apply(now.indexOf(match.id) == -1 ? now.concat(match.id) : now.filter(id=>id != match.id));
+            entry.classList.toggle('selected');
+          } else {
+            options.apply(match.id);
+            toggle(false);
+          }
+        };
+      }
+      if(!matches.length)
+        div(list, 'propertyPickerEmpty', 'No matching widgets.');
+      else if(matches.length > 50)
+        div(list, 'propertyPickerEmpty', `${matches.length - 50} more - refine the search.`);
+    };
+
+    refreshEntries = showEntries;
+    typeSelect.onchange = _=>{ typeFilter = typeSelect.value; showEntries(); };
+    search.oninput = _=>{ searchTerm = search.value; showEntries(); };
+    showEntries();
+  };
+
+  const toggle = open=>{
+    if(options.inline)
+      return;
+    popout.style.display = open ? '' : 'none';
+    expandButton.classList.toggle('open', open);
+    if(open)
+      renderPopout();
+    else if(isWidgetPickerActive(widget.id, options.pickerKey))
+      stopWidgetPicker();
+  };
+
+  if(options.inline)
+    renderPopout();
+  else
+    expandButton.onclick = _=>toggle(popout.style.display == 'none');
+
+  return {
+    expandButton,
+    popout,
+    refresh: _=>{
+      if(popout.style.display != 'none' && !popout.contains(document.activeElement))
+        renderPopout();
+    }
+  };
 }

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -764,6 +764,7 @@ class PropertiesModule extends SidebarModule {
 
     for(const widget of newSelection) {
       this.inputUpdaters[widget.id] = {};
+      this.otherPropertiesHeader = null;
 
       switch(widget.get('type')) {
         case 'button':     this.renderForButton(widget);     break;
@@ -784,8 +785,8 @@ class PropertiesModule extends SidebarModule {
           break;
       }
 
-      // every widget can have routines, so the section is always the last one -
-      // piles are the exception because they are temporary and not editable
+      // every widget can have routines, so the section is always there - piles are
+      // the exception because they are temporary and not editable
       if(widget.get('type') != 'pile')
         this.renderEvents(widget);
     }
@@ -3661,6 +3662,8 @@ class PropertiesModule extends SidebarModule {
     if(!remaining.length)
       return;
     this.addSubHeader('Other properties');
+    // where the Automations section goes: in front of the raw property list
+    this.otherPropertiesHeader = this.moduleDOM.lastChild;
     this.renderGenericProperties(widget, exclude);
   }
 
@@ -4860,15 +4863,19 @@ class PropertiesModule extends SidebarModule {
   }
 
   renderEvents(widget) {
-    this.addSubHeader('Automations');
+    const section = document.createElement('div');
+    this.addSubHeader('Automations', section);
     const eventsEditor = new EventsEditor(widget, (property, value)=>this.inputValueUpdated(widget, property, value));
-    // a delta listener instead of per-property listeners so event handlers added
+    // a delta listener instead of per-property listeners so routines added
     // by other players (properties that did not exist on selection) show up too
     this.addDeltaListener(deltaS=>{
       if(deltaS[widget.id] && Object.keys(deltaS[widget.id]).some(p=>p.match(/Routine$/) || [ 'onEnter', 'onLeave', 'resetProperties' ].indexOf(p) != -1))
         eventsEditor.onPropertyChange();
     });
-    this.moduleDOM.append(eventsEditor.domElement);
+    section.append(eventsEditor.domElement);
+    // the curated sections come first, then the routines, then the raw list of
+    // whatever properties are left (which the type editor may not render at all)
+    this.moduleDOM.insertBefore(section, this.otherPropertiesHeader);
   }
 
   renderGenericProperties(widget, exclude) {
@@ -4876,9 +4883,9 @@ class PropertiesModule extends SidebarModule {
       if([ 'id', 'type', 'parent' ].concat(exclude).indexOf(property) != -1)
         continue;
       if(property.match(/Routine$/) && Array.isArray(widget.state[property]))
-        continue; // edited in the Automations section below
+        continue; // edited in the Automations section above
       if(property == 'resetProperties' || (widget.get('type') == 'holder' && [ 'onEnter', 'onLeave' ].indexOf(property) != -1))
-        continue; // edited in the Automations section below
+        continue; // edited in the Automations section above
 
       const input = this.addInput(property, widget.state[property], v=>this.inputValueUpdated(widget, property, v))
       if(!this.inputUpdaters[widget.id][property])

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -481,131 +481,7 @@ const editorTypeSections = {
 class PropertiesModule extends SidebarModule {
   constructor() {
     super('tune', 'Edit Widgets', 'Edit widget properties.');
-    this.widgetPicker = null;
     this.collapsibleStates = {};
-  }
-
-  startWidgetPicker(targetWidgetID, onPick, options = {}) {
-    const pendingWidgetIDs = Array.isArray(options.pendingWidgetIDs) ?
-      [...new Set(options.pendingWidgetIDs.filter(v => typeof v === 'string' && v.trim() !== ''))] : [];
-
-    this.widgetPicker = {
-      targetWidgetID,
-      onPick,
-      pickerKey: options.pickerKey || null,
-      filter: typeof options.filter === 'function' ? options.filter : null,
-      allowMultiple: !!options.allowMultiple,
-      toggleSelection: options.toggleSelection !== false,
-      pendingWidgetIDs,
-      onPendingChanged: typeof options.onPendingChanged === 'function' ? options.onPendingChanged : null
-    };
-
-    if(this.widgetPicker.onPendingChanged)
-      this.widgetPicker.onPendingChanged([ ...this.widgetPicker.pendingWidgetIDs ]);
-
-    $('body').classList.add('editorWidgetPicking');
-  }
-
-  stopWidgetPicker() {
-    this.widgetPicker = null;
-    $('body').classList.remove('editorWidgetPicking');
-  }
-
-  getWidgetPicker(targetWidgetID = null, pickerKey = null) {
-    if(!this.widgetPicker)
-      return null;
-
-    if(targetWidgetID !== null && this.widgetPicker.targetWidgetID != targetWidgetID)
-      return null;
-
-    if(pickerKey !== null && this.widgetPicker.pickerKey !== pickerKey)
-      return null;
-
-    return this.widgetPicker;
-  }
-
-  isWidgetPickerActive(targetWidgetID = null, pickerKey = null) {
-    return !!this.getWidgetPicker(targetWidgetID, pickerKey);
-  }
-
-  confirmWidgetPicker() {
-    const picker = this.getWidgetPicker();
-    if(!picker || !picker.allowMultiple)
-      return false;
-
-    const targetWidget = widgets.get(picker.targetWidgetID);
-    if(!targetWidget) {
-      this.stopWidgetPicker();
-      return false;
-    }
-
-    const pickedWidgets = picker.pendingWidgetIDs
-      .map(widgetID => widgets.get(widgetID))
-      .filter(pickedWidget => pickedWidget && pickedWidget.id != targetWidget.id);
-
-    this.stopWidgetPicker();
-    picker.onPick(targetWidget, pickedWidgets);
-    setSelection([ targetWidget ]);
-    return true;
-  }
-
-  handleWidgetPickerSelection(newSelection) {
-    const picker = this.getWidgetPicker();
-    if(!picker)
-      return false;
-
-    const targetWidget = widgets.get(picker.targetWidgetID);
-
-    if(!targetWidget) {
-      this.stopWidgetPicker();
-      return false;
-    }
-
-    const keepTargetSelection = () => {
-      if(newSelection.length != 1 || newSelection[0].id != targetWidget.id)
-        setSelection([ targetWidget ]);
-    };
-
-    const pickedWidgets = newSelection.filter(pickedWidget => {
-      if(!pickedWidget || pickedWidget.id == targetWidget.id)
-        return false;
-      return !picker.filter || picker.filter(pickedWidget);
-    });
-
-    if(picker.allowMultiple) {
-      if(pickedWidgets.length) {
-        if(pickedWidgets.length == 1) {
-          const pickedWidgetID = pickedWidgets[0].id;
-          const existingIndex = picker.pendingWidgetIDs.indexOf(pickedWidgetID);
-          if(existingIndex == -1)
-            picker.pendingWidgetIDs.push(pickedWidgetID);
-          else if(picker.toggleSelection)
-            picker.pendingWidgetIDs.splice(existingIndex, 1);
-        } else {
-          for(const pickedWidget of pickedWidgets)
-            if(picker.pendingWidgetIDs.indexOf(pickedWidget.id) == -1)
-              picker.pendingWidgetIDs.push(pickedWidget.id);
-        }
-
-        if(picker.onPendingChanged)
-          picker.onPendingChanged([ ...picker.pendingWidgetIDs ]);
-      }
-
-      keepTargetSelection();
-      return true;
-    }
-
-    const pickedWidget = pickedWidgets.length == 1 ? pickedWidgets[0] : null;
-
-    if(pickedWidget && pickedWidget.id != targetWidget.id) {
-      this.stopWidgetPicker();
-      picker.onPick(targetWidget, pickedWidget);
-      setSelection([ targetWidget ]);
-      return true;
-    }
-
-    keepTargetSelection();
-    return true;
   }
 
   addInput(labelText, value, onValueChanged, target, type='auto') {
@@ -743,6 +619,11 @@ class PropertiesModule extends SidebarModule {
     widget.set(property, typeof value === 'undefined' ? null : value);
   }
 
+  onClose() {
+    // this module drives the widget picker, so a pick cannot outlive it
+    stopWidgetPicker();
+  }
+
   onDeltaReceivedWhileActive(delta) {
     for(const widgetID in delta.s)
       if(delta.s[widgetID] && this.inputUpdaters[widgetID])
@@ -755,7 +636,7 @@ class PropertiesModule extends SidebarModule {
   }
 
   onSelectionChangedWhileActive(newSelection) {
-    if(this.handleWidgetPickerSelection(newSelection))
+    if(handleWidgetPickerSelection(newSelection))
       return;
 
     this.moduleDOM.innerHTML = '';
@@ -2372,146 +2253,6 @@ class PropertiesModule extends SidebarModule {
     });
   }
 
-  // Inline popout (styled like the icon/image pickers) to select widgets by
-  // searching their ID, filtered by type, or by clicking them in the room.
-  // options:
-  //   pickerKey      - key for the in-room widget picker
-  //   typeFilter     - presets the type filter (e.g. 'seat' for seat inputs)
-  //   multiple       - toggle entries in a list of IDs instead of picking one
-  //   getSelectedIDs - returns the currently selected widget IDs
-  //   apply          - called with the picked ID (single) or array of IDs (multiple)
-  //   onClear        - when given, adds a button that removes the value
-  //   clearLabel     - label of that button
-  //   excludeIDs     - returns additional widget IDs to hide from the list
-  renderWidgetSelectPopout(wrap, widget, options = {}) {
-    const expandButton = document.createElement('button');
-    expandButton.className = 'propertyExpandButton';
-    expandButton.setAttribute('icon', 'expand_more');
-    expandButton.title = 'Select a widget';
-    wrap.appendChild(expandButton);
-
-    const popout = div(wrap, 'propertyPicker widgetSelectPopout');
-    popout.style.display = 'none';
-
-    const selectedIDs = _=>options.getSelectedIDs ? options.getSelectedIDs() : [];
-    const excludedIDs = _=>[ widget.id ].concat(options.excludeIDs ? options.excludeIDs() : []);
-
-    let typeFilter = options.typeFilter || '';
-    let searchTerm = '';
-
-    const renderPopout = _=>{
-      popout.innerHTML = '';
-
-      if(options.title)
-        div(popout, 'propertyPickerSectionTitle', html(options.title));
-
-      const buttonBar = div(popout, 'propertyPickerSection');
-      const pickButton = document.createElement('button');
-      pickButton.setAttribute('icon', 'colorize');
-      pickButton.title = 'Click this button and then the widget on the table';
-      buttonBar.appendChild(pickButton);
-
-      const updatePickButton = _=>{
-        const isSelecting = this.isWidgetPickerActive(widget.id, options.pickerKey);
-        pickButton.textContent = isSelecting ? 'click a widget...' : 'Pick in the room';
-        pickButton.classList.toggle('selected', isSelecting);
-      };
-      updatePickButton();
-
-      pickButton.onclick = _=>{
-        if(this.isWidgetPickerActive(widget.id, options.pickerKey)) {
-          this.stopWidgetPicker();
-        } else {
-          this.startWidgetPicker(widget.id, (targetWidget, pickedWidget)=>{
-            if(options.multiple)
-              options.apply([...new Set(selectedIDs().concat(pickedWidget.id))]);
-            else
-              options.apply(pickedWidget.id);
-          }, {
-            pickerKey: options.pickerKey,
-            filter: pickedWidget=>excludedIDs().indexOf(pickedWidget.id) == -1 && (!typeFilter || (pickedWidget.get('type') || 'basic') == typeFilter)
-          });
-        }
-        updatePickButton();
-      };
-
-      if(options.onClear) {
-        const clearButton = document.createElement('button');
-        clearButton.setAttribute('icon', 'link_off');
-        clearButton.textContent = options.clearLabel || 'Clear';
-        clearButton.onclick = _=>options.onClear();
-        buttonBar.appendChild(clearButton);
-      }
-
-      const searchSection = div(popout, 'propertyPickerSection');
-      div(searchSection, 'propertyPickerSectionTitle', 'Search widgets');
-
-      const typeSelect = document.createElement('select');
-      typeSelect.innerHTML = '<option value="">any type</option>' + Object.keys(editorTypeNames).map(type=>`<option value="${type}">${editorTypeNames[type]}</option>`).join('');
-      typeSelect.value = typeFilter;
-      searchSection.appendChild(typeSelect);
-
-      const search = document.createElement('input');
-      search.placeholder = 'Search by ID...';
-      search.value = searchTerm;
-      searchSection.appendChild(search);
-
-      const list = div(searchSection, 'widgetPickerList');
-
-      const showEntries = _=>{
-        list.innerHTML = '';
-        const term = searchTerm.trim().toLowerCase();
-        const current = selectedIDs();
-        const matches = [...widgets.values()]
-          .filter(w=>excludedIDs().indexOf(w.id) == -1)
-          .filter(w=>!typeFilter || (w.get('type') || 'basic') == typeFilter)
-          .filter(w=>!term || w.id.toLowerCase().includes(term))
-          .sort((a, b)=>a.id.localeCompare(b.id));
-        for(const match of matches.slice(0, 50)) {
-          const entry = div(list, 'widgetPickerEntry', `<span>${html(match.id)}</span><span class=widgetPickerType>${html(match.get('type') || 'basic')}</span>`);
-          entry.classList.toggle('selected', current.indexOf(match.id) != -1);
-          entry.onclick = _=>{
-            if(options.multiple) {
-              const now = selectedIDs();
-              options.apply(now.indexOf(match.id) == -1 ? now.concat(match.id) : now.filter(id=>id != match.id));
-              entry.classList.toggle('selected');
-            } else {
-              options.apply(match.id);
-              toggle(false);
-            }
-          };
-        }
-        if(!matches.length)
-          div(list, 'propertyPickerEmpty', 'No matching widgets.');
-        else if(matches.length > 50)
-          div(list, 'propertyPickerEmpty', `${matches.length - 50} more - refine the search.`);
-      };
-
-      typeSelect.onchange = _=>{ typeFilter = typeSelect.value; showEntries(); };
-      search.oninput = _=>{ searchTerm = search.value; showEntries(); };
-      showEntries();
-    };
-
-    const toggle = open=>{
-      popout.style.display = open ? '' : 'none';
-      expandButton.classList.toggle('open', open);
-      if(open)
-        renderPopout();
-      else if(this.isWidgetPickerActive(widget.id, options.pickerKey))
-        this.stopWidgetPicker();
-    };
-    expandButton.onclick = _=>toggle(popout.style.display == 'none');
-
-    return {
-      expandButton,
-      popout,
-      refresh: _=>{
-        if(popout.style.display != 'none' && !popout.contains(document.activeElement))
-          renderPopout();
-      }
-    };
-  }
-
   // Sets the parent while preserving the widget's position on the table.
   // Returns an error message or null on success.
   async setWidgetParent(widget, parentID) {
@@ -2578,7 +2319,7 @@ class PropertiesModule extends SidebarModule {
       lockParentButton.classList.toggle('selected', isParentLocked);
     };
 
-    const popoutControls = this.renderWidgetSelectPopout(wrap, widget, {
+    const popoutControls = renderWidgetSelectPopout(wrap, widget, {
       title: 'Choose a parent widget',
       pickerKey: 'parent',
       getSelectedIDs: () => widget.get('parent') ? [ widget.get('parent') ] : [],
@@ -2637,7 +2378,7 @@ class PropertiesModule extends SidebarModule {
 
     if(options.enablePicker) {
       // widget selection popout with the type filter preset to seats
-      popoutControls = this.renderWidgetSelectPopout(wrap, widget, {
+      popoutControls = renderWidgetSelectPopout(wrap, widget, {
         title: 'Choose seats',
         pickerKey,
         typeFilter: 'seat',
@@ -2715,7 +2456,7 @@ class PropertiesModule extends SidebarModule {
     wrap.appendChild(input);
 
     const pickerKey = 'onlyVisibleForSeat';
-    const popoutControls = this.renderWidgetSelectPopout(wrap, widget, {
+    const popoutControls = renderWidgetSelectPopout(wrap, widget, {
       title: 'Choose which seats can see this widget',
       pickerKey,
       typeFilter: 'seat',
@@ -3261,7 +3002,7 @@ class PropertiesModule extends SidebarModule {
     label.textContent = '+ Add widget';
     wrap.appendChild(label);
 
-    const popoutControls = this.renderWidgetSelectPopout(wrap, widget, {
+    const popoutControls = renderWidgetSelectPopout(wrap, widget, {
       title: 'Choose a widget to inherit properties from',
       pickerKey: 'inheritFrom',
       apply: pickedWidgetID => {
@@ -4265,7 +4006,7 @@ class PropertiesModule extends SidebarModule {
     input.onchange = () => this.inputValueUpdated(widget, 'hand', input.value.trim() || null);
     wrap.appendChild(input);
 
-    const popoutControls = this.renderWidgetSelectPopout(wrap, widget, {
+    const popoutControls = renderWidgetSelectPopout(wrap, widget, {
       title: 'Choose the holder used as this seat\'s hand',
       pickerKey: 'hand',
       typeFilter: 'holder',

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -783,6 +783,11 @@ class PropertiesModule extends SidebarModule {
           this.renderForBasic(widget);
           break;
       }
+
+      // every widget can have routines, so the section is always the last one -
+      // piles are the exception because they are temporary and not editable
+      if(widget.get('type') != 'pile')
+        this.renderEvents(widget);
     }
 
     if(!newSelection.length)
@@ -3931,18 +3936,6 @@ class PropertiesModule extends SidebarModule {
     this.renderBasicSection(widget);
     this.renderBasicContentSection(widget);
     this.renderAppearanceSection(widget);
-    this.addSubHeader('Behavior');
-    div(this.moduleDOM, '', `
-      <p>What the button does when clicked is defined by its <b>clickRoutine</b> which you can edit in the JSON editor.</p>
-      <div class=buttonBar>
-        <button icon=data_object>Open in JSON editor</button>
-      </div>
-    `);
-    $('[icon=data_object]', this.moduleDOM).onclick = _=>{
-      const jsonModuleButton = $('#editorSidebar button[icon=data_object]');
-      if(jsonModuleButton)
-        jsonModuleButton.click();
-    };
     this.renderOtherPropertiesSection(widget);
   }
 
@@ -4893,7 +4886,6 @@ class PropertiesModule extends SidebarModule {
 
       this.inputUpdaters[widget.id][property].push(input.setValue);
     }
-    this.renderEvents(widget);
   }
 
     renderObscureProperties(widget, specs) {

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -127,6 +127,7 @@ export default async function minifyHTML() {
     'client/js/editor/dragbuttons/resize.js',
     'client/js/editor/sidebarModule.js',
     'client/js/editor/propertyInputs.js',
+    'client/js/editor/controls/widgetselection.js',
     'client/js/editor/sidebar/properties.js',
     'client/js/editor/sidebar/undo.js',
     'client/js/editor/sidebar/json.js',
@@ -137,7 +138,6 @@ export default async function minifyHTML() {
 
     'client/js/editor/controls/routine.js',
     'client/js/editor/controls/popup.js',
-    'client/js/editor/controls/widgetselection.js',
     'client/js/editor/controls/events.js',
 
     'client/js/editmode.js',

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -107,7 +107,7 @@ describe('operation rendering', () => {
     expect(dom.querySelector('[data-parameter="face"]')).toBeNull(); // face at its default stays hidden
     const toggle = dom.querySelector('.routine-editor-view-toggle');
     expect(toggle).not.toBeNull();
-    expect(dom.firstChild).toBe(toggle); // the arrow sits at the start of the operation
+    expect(dom.querySelector('.routine-editor-operation-body').firstChild).toBe(toggle); // the arrow sits at the start of the operation
     toggle.dispatchEvent(new Event('click'));
     expect(editor.domElement.classList.contains('list-view')).toBe(true);
     const rows = editor.domElement.querySelectorAll('.routine-editor-parameter-row');
@@ -124,7 +124,7 @@ describe('operation rendering', () => {
     const toggle = dom.querySelector('.routine-editor-view-toggle');
     expect(toggle).not.toBeNull();
     toggle.dispatchEvent(new Event('click'));
-    const names = [...editor.domElement.querySelectorAll(':scope > .routine-editor-parameter-row .routine-editor-parameter-name')].map(e => e.textContent);
+    const names = [...editor.domElement.querySelectorAll(':scope > .routine-editor-operation-header > .routine-editor-operation-body > .routine-editor-parameter-row .routine-editor-parameter-name')].map(e => e.textContent);
     expect(names).toEqual([ 'condition', 'operand1', 'relation', 'operand2' ]);
     expect(editor.domElement.querySelector('.routine-editor')).not.toBeNull(); // nested routines stay visible
   });
@@ -305,8 +305,7 @@ describe('routine editor state handling', () => {
     const editor = new RoutineEditor({ state: {} }, routine);
     let notified = null;
     editor.registerChangeListener(v => notified = v);
-    editor.dragIndices = [ 0 ]; // grab FLIP
-    editor.performDrag(2, true); // drop after DELETE
+    editor.performDrag(2, true, { editor, indices: [ 0 ] }); // grab FLIP, drop after DELETE
     expect(notified.map(o => o.func)).toEqual([ 'SHUFFLE', 'DELETE', 'FLIP' ]);
     expect(editor.routine).toBe(routine); // the array reference is preserved
   });
@@ -316,8 +315,7 @@ describe('routine editor state handling', () => {
     const editor = new RoutineEditor({ state: {} }, routine);
     let notified = null;
     editor.registerChangeListener(v => notified = v);
-    editor.dragIndices = [ 0, 2 ]; // FLIP and DELETE
-    editor.performDrag(3, true); // drop after ROTATE
+    editor.performDrag(3, true, { editor, indices: [ 0, 2 ] }); // FLIP and DELETE, dropped after ROTATE
     expect(notified.map(o => o.func)).toEqual([ 'SHUFFLE', 'ROTATE', 'FLIP', 'DELETE' ]);
   });
 
@@ -326,8 +324,7 @@ describe('routine editor state handling', () => {
     const editor = new RoutineEditor({ state: {} }, routine);
     let notified = null;
     editor.registerChangeListener(v => notified = v);
-    editor.dragIndices = [ 0 ];
-    editor.performDrag(0, false);
+    editor.performDrag(0, false, { editor, indices: [ 0 ] });
     expect(notified).toBeNull();
   });
 
@@ -336,9 +333,38 @@ describe('routine editor state handling', () => {
     const editor = new RoutineEditor({ state: {} }, routine);
     let notified = null;
     editor.registerChangeListener(v => notified = v);
-    editor.dragIndices = [ 2 ]; // FLIP
-    editor.performDrag(0, false); // before the first comment
+    editor.performDrag(0, false, { editor, indices: [ 2 ] }); // FLIP before the first comment
     expect(notified).toEqual([ { func: 'FLIP' }, '// one', '// one' ]);
+  });
+
+  test('dragging an operation into an IF block moves it inside the block', () => {
+    const routine = [ { func: 'FLIP' }, { func: 'IF', operand1: 1, thenRoutine: [] } ];
+    const editor = new RoutineEditor({ state: {} }, routine);
+    let notified = null;
+    editor.registerChangeListener(v => notified = v);
+    const block = editor.operations[1].subroutineEditors.thenRoutine;
+    block.performDrag(-1, true, { editor, indices: [ 0 ] }); // drop into the empty block
+    expect(notified).toEqual([ { func: 'IF', operand1: 1, thenRoutine: [ { func: 'FLIP' } ] } ]);
+    expect(editor.routine).toBe(routine); // the array reference is preserved
+  });
+
+  test('dragging an operation out of a FOREACH block moves it into the parent routine', () => {
+    const routine = [ { func: 'FOREACH', loopRoutine: [ { func: 'FLIP' } ] }, { func: 'SHUFFLE' } ];
+    const editor = new RoutineEditor({ state: {} }, routine);
+    let notified = null;
+    editor.registerChangeListener(v => notified = v);
+    const block = editor.operations[0].subroutineEditors.loopRoutine;
+    editor.performDrag(1, true, { editor: block, indices: [ 0 ] }); // drop after SHUFFLE
+    expect(notified).toEqual([ { func: 'FOREACH', loopRoutine: [] }, { func: 'SHUFFLE' }, { func: 'FLIP' } ]);
+  });
+
+  test('a block nested inside the dragged operation refuses the drop', () => {
+    const routine = [ { func: 'IF', operand1: 1, thenRoutine: [] }, { func: 'FLIP' } ];
+    const editor = new RoutineEditor({ state: {} }, routine);
+    const block = editor.operations[0].subroutineEditors.thenRoutine;
+    editor.beginDrag(editor.directChildCards()[0].querySelector('.routine-editor-drag-handle'));
+    expect(block.acceptsActiveDrag()).toBe(false); // the IF cannot go into its own block
+    expect(editor.acceptsActiveDrag()).toBe(true);
   });
 
   test('Ctrl-clicking a card toggles it in and out of the selection', () => {

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -22,6 +22,7 @@ beforeAll(() => {
   window.endCustomSelection = () => {};
   window.widgets = new Map();
   window.setSelection = () => {};
+  window.editorTypeNames = { basic: 'Widget', button: 'Button', canvas: 'Canvas', card: 'Card', holder: 'Holder', label: 'Label', seat: 'Seat', timer: 'Timer' };
 
   const editorDiv = document.createElement('div');
   editorDiv.id = 'editor';
@@ -647,8 +648,10 @@ describe('number popups with text values', () => {
 describe('the shared widget picker', () => {
   function room(...definitions) {
     widgets.clear();
-    for(const [ id, type, parent ] of definitions)
-      widgets.set(id, { id, get: p => ({ type, parent: parent || null })[p] });
+    for(const [ id, type, parent ] of definitions) {
+      const state = { id, type, parent: parent || null };
+      widgets.set(id, { id, state, get: p => state[p] });
+    }
     return id => widgets.get(id);
   }
 
@@ -767,6 +770,142 @@ describe('the shared widget picker', () => {
     entries[1].onclick();
     [...popup.domElement.querySelectorAll('button')].find(b => b.textContent == 'Use these widgets').dispatchEvent(new Event('click'));
     expect(value).toEqual({ from: [ 'h1', 'h2' ] });
+    popup.hide();
+  });
+});
+
+describe('widget type presets', () => {
+  function room(...definitions) {
+    widgets.clear();
+    for(const [ id, type ] of definitions) {
+      const state = { id, type, parent: 'theTable' };
+      widgets.set(id, { id, state, get: p => state[p] });
+    }
+  }
+
+  // opens the popup a chip opens, the way the routine editor does
+  function showPopup(operation, parameterNames) {
+    const editor = editorForOperation(operation);
+    editor.setOperationDetails(widgets.get('target'), operation, [], []);
+    const popup = editor.createPopup(parameterNames);
+    const source = document.createElement('span');
+    document.getElementById('editor').append(source);
+    popup.setSource(source);
+    popup.setOperationDetails(operation, parameterNames, widgets.get('target'), [], []);
+    popup.show();
+    return popup;
+  }
+
+  const pickedTypes = popup => [...popup.domElement.querySelectorAll('.widgetPickerEntry')].map(e => e.querySelector('.widgetPickerType').textContent);
+
+  afterEach(() => {
+    stopWidgetPicker();
+    widgets.clear();
+  });
+
+  test('parameters that name one kind of widget preset that type', () => {
+    const presets = {};
+    for(const func in routineOperationMetadata)
+      for(const parameter in routineOperationMetadata[func].parameters)
+        if(routineOperationMetadata[func].parameters[parameter].widgetType)
+          presets[`${func}.${parameter}`] = routineOperationMetadata[func].parameters[parameter].widgetType;
+    expect(presets).toEqual({
+      'CANVAS.collection': 'canvas',
+      'COUNT.holder': 'holder',
+      'FLIP.holder': 'holder',
+      'LABEL.label': 'label',
+      'MOVE.from': 'holder', 'MOVE.to': 'holder',
+      'MOVEXY.from': 'holder',
+      'RECALL.holder': 'holder',
+      'ROTATE.holder': 'holder',
+      'SCORE.seats': 'seat',
+      'SHUFFLE.holder': 'holder',
+      'SORT.holder': 'holder',
+      'SWAPHANDS.source': 'seat',
+      'TIMER.timer': 'timer', 'TIMER.collection': 'timer',
+      'TURN.turn': 'seat', 'TURN.source': 'seat'
+    });
+  });
+
+  test('the preset filters the picker list and can be changed to any type', () => {
+    room([ 'target', 'button' ], [ 'h1', 'holder' ], [ 'l1', 'label' ]);
+    const popup = showPopup({ func: 'SHUFFLE' }, [ 'holder', 'collection' ]); // the {holder,collection} chip
+    expect(pickedTypes(popup)).toEqual([ 'holder' ]);
+    const typeSelect = popup.domElement.querySelector('select');
+    expect(typeSelect.value).toBe('holder');
+    typeSelect.value = '';
+    typeSelect.onchange();
+    expect(pickedTypes(popup).sort()).toEqual([ 'button', 'holder', 'label' ]);
+    popup.hide();
+  });
+
+  test('collection-only and widget-only parameters get their preset as well', () => {
+    room([ 'target', 'button' ], [ 'l1', 'label' ], [ 't1', 'timer' ]);
+    const timer = showPopup({ func: 'TIMER' }, [ 'collection' ]); // no timer set: the chip is the collection
+    expect(pickedTypes(timer)).toEqual([ 'timer' ]);
+    timer.hide();
+    const label = showPopup({ func: 'LABEL' }, [ 'label' ]);
+    expect(pickedTypes(label)).toEqual([ 'label' ]);
+    label.hide();
+  });
+
+  test('TURN offers the seats for its turn parameter', () => {
+    room([ 'target', 'button' ], [ 's1', 'seat' ], [ 'h1', 'holder' ]);
+    const popup = showPopup({ func: 'TURN', turnCycle: 'seat' }, [ 'turn' ]);
+    expect(popup).toBeInstanceOf(RoutineNumberPopup);
+    expect(pickedTypes(popup)).toEqual([ 'seat' ]);
+    let value = null;
+    popup.registerChangeListener(v => value = v);
+    popup.domElement.querySelector('.widgetPickerEntry').onclick();
+    expect(value).toEqual({ turn: 's1' });
+    popup.hide();
+  });
+});
+
+describe('variables in widget parameters', () => {
+  function showWidgetPopup(operation, parameterNames) {
+    widgets.clear();
+    const source = document.createElement('span');
+    document.getElementById('editor').append(source);
+    const editor = editorForOperation(operation);
+    const widget = { id: 'button1', state: { id: 'button1', parent: 'holder1' }, get: p => widget.state[p] };
+    editor.setOperationDetails(widget, operation, [ 'myHolder' ], []);
+    const popup = editor.createPopup(parameterNames);
+    popup.setSource(source);
+    popup.setOperationDetails(operation, parameterNames, widget, [ 'myHolder' ], []);
+    popup.show();
+    return popup;
+  }
+
+  const buttonNamed = (popup, text) => [...popup.domElement.querySelectorAll('button')].find(b => b.textContent == text);
+
+  test('a widget parameter offers variables and widget properties', () => {
+    const popup = showWidgetPopup({ func: 'MOVE', from: [ 'h1' ] }, [ 'to' ]);
+    let value = null;
+    popup.registerChangeListener(v => value = v);
+    expect(buttonNamed(popup, 'myHolder')).toBeDefined();
+    buttonNamed(popup, 'parent').dispatchEvent(new Event('click'));
+    expect(value).toEqual({ to: '${PROPERTY parent}' });
+    popup.hide();
+  });
+
+  test('a variable used for a holder goes to the holder parameter, not the collection', () => {
+    const popup = showWidgetPopup({ func: 'SHUFFLE' }, [ 'holder', 'collection' ]);
+    let value = null;
+    popup.registerChangeListener(v => value = v);
+    buttonNamed(popup, 'parent').dispatchEvent(new Event('click'));
+    expect(value.holder).toBe('${PROPERTY parent}');
+    expect('collection' in value).toBe(true);
+    expect(value.collection).toBeUndefined();
+    popup.hide();
+  });
+
+  test('a collection name still goes to the collection parameter', () => {
+    const popup = showWidgetPopup({ func: 'SHUFFLE' }, [ 'holder', 'collection' ]);
+    let value = null;
+    popup.registerChangeListener(v => value = v);
+    popup.setNewCollectionValue('DEFAULT');
+    expect(value).toEqual({ holder: undefined, collection: 'DEFAULT' });
     popup.hide();
   });
 });

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -16,9 +16,12 @@ beforeAll(() => {
     if (parent) parent.append(d);
     return d;
   };
+  window.html = string => String(string).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
   window.customSelectionCallback = null;
   window.startCustomSelection = () => {};
   window.endCustomSelection = () => {};
+  window.widgets = new Map();
+  window.setSelection = () => {};
 
   const editorDiv = document.createElement('div');
   editorDiv.id = 'editor';
@@ -36,8 +39,10 @@ beforeAll(() => {
     'VarStringRoutineOperationEditor', 'CommentRoutineOperationEditor', 'UnknownRoutineOperationEditor',
     'editorForOperation', 'routineOperationExamples', 'routineOperationMetadata', 'simpleRoutineOperationExamples',
     'RoutineHoldersOrCollectionSourcePopup', 'RoutineForeachSourcePopup', 'newRoutineValues', 'escapeHTML',
-    'EventsEditor', 'InfoPopup', 'WidgetSelection', 'RoutineStringPopup', 'RoutineNumberPopup',
-    'RoutineColorPopup', 'RoutineIconPopup', 'RoutineJSONPopup'
+    'EventsEditor', 'InfoPopup', 'RoutineStringPopup', 'RoutineNumberPopup',
+    'RoutineColorPopup', 'RoutineIconPopup', 'RoutineJSONPopup', 'RoutineWidgetIDPopup',
+    'renderWidgetSelectPopout', 'startWidgetPicker', 'stopWidgetPicker', 'isWidgetPickerActive',
+    'handleWidgetPickerSelection'
   ];
   // eval in test scope so the plain-script class declarations see the jsdom globals
   eval(code + '\n' + exposed.map(x => `globalThis['${x}'] = ${x};`).join('\n'));
@@ -639,29 +644,130 @@ describe('number popups with text values', () => {
   });
 });
 
-describe('widget picker resolution', () => {
-  test('picked widgets run through the resolver and are deduplicated', () => {
-    const holder = { id: 'h1', get: p => ({ type: 'holder', parent: null })[p] };
-    const cardA = { id: 'c1', get: p => ({ type: 'card', parent: 'h1' })[p] };
-    const cardB = { id: 'c2', get: p => ({ type: 'card', parent: 'h1' })[p] };
-    const selection = new WidgetSelection([], () => {}, w => w.get('type') == 'card' ? holder : w);
-    expect(selection.resolveAll([ cardA, cardB, holder ])).toEqual([ holder ]);
+describe('the shared widget picker', () => {
+  function room(...definitions) {
+    widgets.clear();
+    for(const [ id, type, parent ] of definitions)
+      widgets.set(id, { id, get: p => ({ type, parent: parent || null })[p] });
+    return id => widgets.get(id);
+  }
+
+  // renders the popout the properties sidebar and the routine editor share and
+  // starts its in-room pick mode
+  function pickInRoom(options) {
+    const wrap = document.createElement('div');
+    document.getElementById('editor').append(wrap);
+    const controls = renderWidgetSelectPopout(wrap, widgets.get('target'), Object.assign({ inline: true }, options));
+    controls.popout.querySelector('button[icon=colorize]').onclick();
+    return controls;
+  }
+
+  afterEach(() => {
+    stopWidgetPicker();
+    widgets.clear();
   });
 
-  test('without a resolver the picked widgets pass through unchanged', () => {
-    const widgetsPicked = [ { id: 'a' }, { id: 'b' } ];
-    const selection = new WidgetSelection([], () => {});
-    expect(selection.resolveAll(widgetsPicked)).toBe(widgetsPicked);
+  test('the type filter also applies to picking in the room', () => {
+    const get = room([ 'target', 'button' ], [ 'h1', 'holder' ], [ 'c1', 'card', 'h1' ]);
+    let picked = null;
+    pickInRoom({ typeFilter: 'holder', apply: id => picked = id });
+    // the card covers the holder, so a click on it means the holder underneath
+    handleWidgetPickerSelection([ get('c1') ]);
+    expect(picked).toBe('h1');
   });
 
-  test('"Start Fresh" empties the current selection right away', () => {
-    const widget = { id: 'w1', get: p => ({ type: 'holder' })[p] };
-    const selection = new WidgetSelection([ widget ], () => {});
-    selection.render();
-    expect(selection.widgets).toHaveLength(1);
-    selection.domElement.querySelector('.start button:nth-child(2)').dispatchEvent(new Event('click'));
-    expect(selection.widgets).toHaveLength(0);
-    expect(selection.domElement.querySelectorAll('table tr[data-widget-id]')).toHaveLength(0);
+  test('a click that resolves to nothing matching is ignored', () => {
+    const get = room([ 'target', 'button' ], [ 'l1', 'label' ]);
+    let picked = null;
+    pickInRoom({ typeFilter: 'holder', apply: id => picked = id });
+    handleWidgetPickerSelection([ get('l1') ]);
+    expect(picked).toBeNull();
+    expect(isWidgetPickerActive()).toBe(true); // still waiting for a matching click
+  });
+
+  test('without a type filter only resolveCovering pickers look past cards and piles', () => {
+    const get = room([ 'target', 'button' ], [ 'h1', 'holder' ], [ 'p1', 'pile', 'h1' ], [ 'c1', 'card', 'p1' ], [ 'c2', 'card' ]);
+    let picked = null;
+    pickInRoom({ apply: id => picked = id });
+    handleWidgetPickerSelection([ get('c1') ]); // the plain picker takes what was clicked
+    expect(picked).toBe('c1');
+
+    stopWidgetPicker();
+    pickInRoom({ resolveCovering: true, apply: id => picked = id });
+    handleWidgetPickerSelection([ get('c1') ]);
+    expect(picked).toBe('h1');
+
+    stopWidgetPicker();
+    pickInRoom({ resolveCovering: true, apply: id => picked = id });
+    handleWidgetPickerSelection([ get('c2') ]); // a card on the table stays itself
+    expect(picked).toBe('c2');
+  });
+
+  test('a broken parent chain does not send the resolver in circles', () => {
+    const get = room([ 'target', 'button' ], [ 'c1', 'card', 'c2' ], [ 'c2', 'card', 'c1' ]);
+    let picked = null;
+    pickInRoom({ typeFilter: 'holder', apply: id => picked = id });
+    handleWidgetPickerSelection([ get('c1') ]);
+    expect(picked).toBeNull();
+  });
+
+  test('picking several widgets keeps the pick mode running and collects them', () => {
+    const get = room([ 'target', 'button' ], [ 'h1', 'holder' ], [ 'h2', 'holder' ], [ 'c1', 'card', 'h2' ]);
+    let picked = [];
+    pickInRoom({ multiple: true, resolveCovering: true, getSelectedIDs: () => picked, apply: ids => picked = ids });
+    handleWidgetPickerSelection([ get('h1') ]);
+    expect(isWidgetPickerActive()).toBe(true);
+    handleWidgetPickerSelection([ get('c1') ]);
+    expect(picked).toEqual([ 'h1', 'h2' ]);
+  });
+
+  test('the widget the picker belongs to is only listed when allowed, never picked in the room', () => {
+    room([ 'target', 'holder' ], [ 'h1', 'holder' ]);
+    let picked = null;
+    const ids = controls => [...controls.popout.querySelectorAll('.widgetPickerEntry')].map(e => e.textContent.replace('holder', ''));
+
+    expect(ids(pickInRoom({ apply: id => picked = id }))).toEqual([ 'h1' ]);
+    stopWidgetPicker();
+    expect(ids(pickInRoom({ allowSelf: true, apply: id => picked = id }))).toEqual([ 'h1', 'target' ]);
+
+    // the target is selected again after every pick, so clicking it in the room
+    // cannot be told apart from that restore
+    handleWidgetPickerSelection([ widgets.get('target') ]);
+    expect(picked).toBeNull();
+  });
+
+  test('a collection name is not mistaken for a widget id', () => {
+    room([ 'target', 'holder' ], [ 'h1', 'holder' ]);
+    const source = document.createElement('span');
+    document.getElementById('editor').append(source);
+    const popup = new RoutineHoldersOrCollectionSourcePopup();
+    popup.setSource(source);
+    popup.setOperationDetails({ func: 'SELECT', collection: 'myCards' }, [ 'collection' ], widgets.get('target'), [], []);
+    let value = null;
+    popup.registerChangeListener(v => value = v);
+    popup.show();
+    expect([...popup.domElement.querySelectorAll('.widgetPickerEntry.selected')]).toHaveLength(0);
+    popup.hide();
+  });
+
+  test('the routine popup uses the shared picker and applies the selection', () => {
+    room([ 'target', 'holder' ], [ 'h1', 'holder' ], [ 'h2', 'holder' ]);
+    const source = document.createElement('span');
+    document.getElementById('editor').append(source);
+    const popup = new RoutineWidgetIDPopup();
+    popup.setSource(source);
+    popup.setOperationDetails({ func: 'MOVE', from: [ 'h1' ] }, [ 'from' ], widgets.get('target'), [], []);
+    let value = null;
+    popup.registerChangeListener(v => value = v);
+    popup.show();
+
+    const entries = [...popup.domElement.querySelectorAll('.widgetPickerEntry')];
+    expect(entries.map(e => e.textContent.replace('holder', ''))).toEqual([ 'h1', 'h2', 'target' ]);
+    expect(entries[0].classList.contains('selected')).toBe(true); // seeded with the current value
+    entries[1].onclick();
+    [...popup.domElement.querySelectorAll('button')].find(b => b.textContent == 'Use these widgets').dispatchEvent(new Event('click'));
+    expect(value).toEqual({ from: [ 'h1', 'h2' ] });
+    popup.hide();
   });
 });
 

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -348,6 +348,29 @@ describe('routine editor state handling', () => {
     expect(editor.routine).toBe(routine); // the array reference is preserved
   });
 
+  test('dragging into a block the operation does not have yet attaches the block', () => {
+    // a freshly added IF/FOREACH has no thenRoutine/loopRoutine key at all
+    for (const [ operation, property ] of [ [ { func: 'IF', operand1: 1 }, 'thenRoutine' ], [ { func: 'FOREACH' }, 'loopRoutine' ] ]) {
+      const editor = new RoutineEditor({ state: {} }, [ { func: 'FLIP' }, operation ]);
+      let notified = null;
+      editor.registerChangeListener(v => notified = v);
+      const block = editor.operations[1].subroutineEditors[property];
+      block.performDrag(-1, true, { editor, indices: [ 0 ] });
+      expect(notified).toHaveLength(1);
+      expect(notified[0][property]).toEqual([ { func: 'FLIP' } ]);
+    }
+  });
+
+  test('dragging into an ELSE block moves the operation there', () => {
+    const routine = [ { func: 'FLIP' }, { func: 'IF', operand1: 1, thenRoutine: [], elseRoutine: [] } ];
+    const editor = new RoutineEditor({ state: {} }, routine);
+    let notified = null;
+    editor.registerChangeListener(v => notified = v);
+    const block = editor.operations[1].subroutineEditors.elseRoutine;
+    block.performDrag(-1, true, { editor, indices: [ 0 ] });
+    expect(notified).toEqual([ { func: 'IF', operand1: 1, thenRoutine: [], elseRoutine: [ { func: 'FLIP' } ] } ]);
+  });
+
   test('dragging an operation out of a FOREACH block moves it into the parent routine', () => {
     const routine = [ { func: 'FOREACH', loopRoutine: [ { func: 'FLIP' } ] }, { func: 'SHUFFLE' } ];
     const editor = new RoutineEditor({ state: {} }, routine);


### PR DESCRIPTION
Follow-up to the Discord feedback on #3034 (the routine editor on the expanded widget editor). Based on that branch, so the diff is only the follow-up work.

> The Ctrl+click multi select for drag and drop should also be supported on mobile. Use long press to select.
>
> Currently it's not possible to drag a function into If or Foreach
>
> O mobile the arrow, drag and delete buttons overlap with the inputs
>
> Remove the behavior section
>
> Automation section should always be visible to all widgets.
> Rename Events to Routines.
> The add Routines button should always be available

(Source: [Discord message from rapha195](https://discord.com/channels/770758631146782780/1527815541925085307/1530858547150065664))

## What changed

**Touch support for selecting and dragging.** A **long press** (500 ms) on an operation card toggles it in and out of the multi-selection — the touch equivalent of Ctrl+click — and the press that selects no longer opens the parameter popup underneath. Browsers do not turn a touch into a native HTML5 drag, so the drag handle now also follows the finger with pointer events and drops where it is released. Ctrl+click on a chip selects the card now instead of opening that chip's popup.

**Dragging into and out of IF/FOREACH blocks.** The drag is tracked in one module-level state instead of per routine level, and the drop target is resolved from the point under the pointer against whichever routine level owns it. So an operation can be dragged into a block (including an empty one, which highlights as a whole), back out into the parent routine, or into a sibling block. A block nested inside a dragged operation refuses the drop, because that would detach the routine from the widget. Cross-level moves re-render from the outermost editor, since the level the operation left no longer owns it.

**The move/delete icons no longer cover the summary.** They used to be absolutely positioned in the card's top right corner with a fixed 60px of reserved padding, while a card with the block arrows needs about twice that — so they sat on top of the text. They are now laid out next to the summary, which simply gets less room, and they wrap instead of overlapping. On coarse pointers they are bigger and further apart.

**The Automations section is always there.** It used to be rendered at the end of the generic "Other properties" list, which is skipped when a widget has no properties left to show — so widgets whose properties are all covered by curated inputs had no Automations section and no way to add a routine at all. It is now rendered for every widget as the last section (except piles, which are temporary and say so). "Events" is called **Routines** throughout: the group header, the *Add Routine* button and the popup.

**Removed the button's Behavior section**, which only said the clickRoutine has to be edited in the JSON editor and offered a button to jump there — the routine editor right below it now does that job. I read "remove the behavior section" as this one; the per-type Behavior groups that hold real inputs (dice roll times, holder drop options, scoreboard scores) are untouched. Happy to remove more if that was meant.

## Before / after

The overlap on a narrow screen, same routine before and after:

| before | after |
| --- | --- |
| ![before](https://agent.virtualtabletop.io/reports/pr/1527815541925085307/routine-editor-before.png) | ![after](https://agent.virtualtabletop.io/reports/pr/1527815541925085307/routine-editor-after.png) |

## Testing

- `npm test` — 85 pass, including new jest tests for dragging into an IF block, out of a FOREACH block, and a block refusing to receive an operation it lives inside.
- `tests/testcafe/editor.js` passes locally. (`tests/testcafe/functions.js` "Compute" fails on this branch with and without these changes, so it is not from here.)
- Drove the editor in Chromium: dragged an operation into an empty FOREACH block and out of an IF block with the mouse, long-pressed to select and dragged with synthetic touch events, and checked every widget type shows the Automations section with its add button.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3053/pr-test (or any other room on that server)