### PR TITLE
Show whether a routine is still running in the debug log

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -574,6 +574,20 @@ body.jsonEdit #toolbar {
   margin-top: 20px;
 }
 
+#jeLog > .jeLogRunning {
+  font-weight: bold;
+}
+
+#jeLog > .jeLogRunning .jeLogTime {
+  animation: jeLogRunning 1s infinite alternate;
+}
+
+@keyframes jeLogRunning {
+  to {
+    opacity: 0.3;
+  }
+}
+
 .jeLogSkipped { color: var(--textDimColor1); }
 .jeLogSummary { color: var(--textHighlightColor4); }
 .jeLogResult  { color: var(--textHighlightColor2); }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3044,9 +3044,49 @@ let jeRoutineResult = '';
 let jeLoggingHTML = '';
 let jeLoggingDepth = 0;
 let jeHTMLStack = [];
+let jeLoggingRunningInterval = null;
+let jeLoggingStartTime = 0;
+
+// Substituted with the total runtime once the routine returns - the placeholder of an earlier
+// routine is always replaced already, so replacing the first occurrence hits the current one.
+const jeLoggingTimePlaceholder = '<!--routine runtime-->';
 
 function jeLoggingJSON(obj) {
   return html(JSON.stringify(obj, null, '  ').split('\n').slice(1, -1).join('\n'));
+}
+
+// The finished log is only rendered once the routine returns. Until then, show which routine is
+// running and for how long so that a slow or hanging routine doesn't look like nothing happened.
+function jeLoggingShowRunning(widget, property) {
+  jeLoggingHideRunning();
+  const log = $('#jeLog');
+  if(!log)
+    return;
+
+  const startTime = +new Date();
+  const entry = document.createElement('div');
+  entry.className = 'jeLog jeLogRunning';
+  entry.innerHTML = `
+    <span class="jeLogWidget">${html(widget.get('id'))}</span>
+    <span class="jeLogProperty">${typeof property == 'string' ? html(property) : '--custom--'}</span>
+    <span class="jeLogTime">running…</span>
+  `;
+  log.appendChild(entry);
+
+  const time = $('.jeLogTime', entry);
+  jeLoggingRunningInterval = setInterval(function() {
+    if(!time.isConnected)
+      jeLoggingHideRunning();
+    else
+      time.textContent = `running… ${((+new Date() - startTime)/1000).toFixed(1)}s`;
+  }, 100);
+}
+
+function jeLoggingHideRunning() {
+  if(jeLoggingRunningInterval) {
+    clearInterval(jeLoggingRunningInterval);
+    jeLoggingRunningInterval = null;
+  }
 }
 
 export function jeLoggingRoutineStart(widget, property, initialVariables, initialCollections, byReference) {
@@ -3054,15 +3094,22 @@ export function jeLoggingRoutineStart(widget, property, initialVariables, initia
     if(jeRoutineResetOnNextLog) {
       jeLoggingHTML = '';
       jeRoutineResetOnNextLog = false;
+      if(!jeLoggingDepth && $('#jeLog'))
+        $('#jeLog').innerHTML = '';
     }
     jeLoggingHTML += `
       <div class="jeLog">
         <div class="jeExpander ${jeLoggingDepth ? '' : 'jeExpander-down'}">
           <span class="jeLogWidget">${widget.get('id')}</span>
           <span class="jeLogProperty">${typeof property == 'string' ? property : '--custom--'}</span>
+          <span class="jeLogTime">${jeLoggingDepth ? '' : jeLoggingTimePlaceholder}</span>
         </div>
         <div class="jeLogNested ${jeLoggingDepth ? '' : 'active'}">
     `;
+  }
+  if(!jeLoggingDepth) {
+    jeLoggingStartTime = +new Date();
+    jeLoggingShowRunning(widget, property);
   }
   ++jeLoggingDepth;
 }
@@ -3071,6 +3118,8 @@ export function jeLoggingRoutineEnd(variables, collections) {
   if( jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine'].indexOf( jeHTMLStack[0][3] ) == -1 ) jeLoggingHTML += '</div></div>';
   --jeLoggingDepth;
   if(!jeLoggingDepth) {
+    jeLoggingHideRunning();
+    jeLoggingHTML = jeLoggingHTML.replace(jeLoggingTimePlaceholder, `(${+new Date() - jeLoggingStartTime}ms)`);
     $('#jeLog').innerHTML = jeLoggingHTML + '</div></div>';
 
     // Make it so clicking on the arrows expands the subtree


### PR DESCRIPTION
## The problem

Reported on Discord:

> I don't get this last message. Did it run? Is it stuck?
>
> — rapha195, [Discord](https://discord.com/channels/770758631146782780/1530556507635056771/1530864186190598317)

The routine log in the editor's **Debug** pane is only painted once the top-level routine has
returned (`jeLoggingRoutineEnd` writes `#jeLog` when the nesting depth is back to 0). Everything
before that just accumulates in a string.

So while a routine is waiting — `DELAY`, `INPUT`, `UPLOAD`, a long `FOREACH` — the pane keeps
showing the log of the **previous** interaction, unchanged. You click a button, nothing in the
debug pane changes, and the "last message" you are looking at is from the click before. There is
no way to tell whether your click ran at all, whether it is still running, or whether it hung.

## The change

* When "Clear after each interaction" is on, `#jeLog` is now emptied as soon as the new routine
  **starts** instead of when it finishes — no more stale log from the previous click.
* While a routine runs, a live entry is shown: `slowButton clickRoutine running… 2.5s`, with a
  ticking counter (gently pulsing) so a hanging routine is visibly hanging. It is replaced by the
  real log as soon as the routine returns.
* The finished routine header now also shows its total runtime, e.g.
  `slowButton clickRoutine (6002ms)`, next to the per-operation times that were already there.

Editor-only: no widget properties, routine operations or room state are touched.

## Before / after

A button with a 6 s `DELAY`, clicked right after another button:

| | 2.5 s into the routine |
|---|---|
| before | ![before](https://agent.virtualtabletop.io/reports/pr/1530556507635056771/before-during.png) |
| after | ![after](https://agent.virtualtabletop.io/reports/pr/1530556507635056771/after-during.png) |

Before, the pane shows `fastButton clickRoutine / SCORE …` — the *previous* click's log. After, it
shows `slowButton clickRoutine running… 2.5s`.
[Finished state after the change](https://agent.virtualtabletop.io/reports/pr/1530556507635056771/after-finished.png).

## Verification

* `npm test` — 44 passed
* `npx testcafe chromium:headless tests/testcafe/editor.js` — 4 passed
* Manually driven in a real browser (screenshots above), including nested `CALL` routines, the
  "Clear after each interaction" checkbox off (each run keeps its own runtime) and pressing
  *Clear* while a routine is still running.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3054/pr-test (or any other room on that server)