### PR TITLE
Routine editor: preset the widget type per parameter and allow ${PROPERTY} in widget inputs

### DIFF
--- a/client/js/editor/controls/popup.js
+++ b/client/js/editor/controls/popup.js
@@ -216,6 +216,8 @@ const predefinedCollectionDescriptions = {
   thisButton: 'the widget that contains the routine (not necessarily a button)'
 };
 
+const routineWidgetPickerKey = 'routineWidgets';
+
 class RoutinePopup extends Popup {
   constructor(source) {
     super(source);
@@ -224,6 +226,10 @@ class RoutinePopup extends Popup {
   hide() {
     if(openRoutinePopup === this)
       openRoutinePopup = null;
+    // a popup that offers the widget picker starts in-room picks, so end them
+    // when it goes away; other popups (e.g. info popups) must not interfere
+    if(isWidgetPickerActive(null, routineWidgetPickerKey))
+      stopWidgetPicker();
     super.hide();
   }
 
@@ -232,6 +238,13 @@ class RoutinePopup extends Popup {
   }
 
   onClick(e) {
+  }
+
+  onOutsideClick(e) {
+    // clicking widgets in the room is how the widget picker works
+    if(isWidgetPickerActive(null, routineWidgetPickerKey))
+      return;
+    super.onOutsideClick(e);
   }
 
   setNewCollectionValue(value) {
@@ -440,6 +453,23 @@ class RoutineNumberPopup extends RoutinePopup {
       valueContent.append(text);
     }
 
+    // a few number parameters name a widget instead (TURN turn takes a seat id),
+    // so offer the picker for those as well
+    if(this.options.widgetType) {
+      const [ widgetTitle, widgetContent ] = this.addAccordionSection('Widgets');
+      infoButton(widgetTitle, 'Use the id of a widget instead of a number: search it by id or pick it in the room.');
+      // the properties module's picker CSS is scoped to .editorModule
+      const host = div(widgetContent, 'editorModule');
+      renderWidgetSelectPopout(host, this.widget, {
+        pickerKey: routineWidgetPickerKey,
+        inline: true,
+        allowSelf: true,
+        typeFilter: this.options.widgetType,
+        getSelectedIDs: _=>typeof currentValue == 'string' ? [ currentValue ] : [],
+        apply: widgetID=>this.setNewValue(widgetID)
+      });
+    }
+
     super.show(true, false);
   }
 }
@@ -459,27 +489,11 @@ class RoutineEnumPopup extends RoutinePopup {
   }
 }
 
-const routineWidgetPickerKey = 'routineWidgets';
-
 class RoutineWidgetIDPopup extends RoutinePopup {
-  constructor() {
+  constructor(options={}) {
     super();
+    this.options = options;
     this.workingIDs = [];
-  }
-
-  hide() {
-    // this popup starts in-room picks, so end them when it goes away; other
-    // popups (e.g. info popups) must not interfere with a running pick
-    if(isWidgetPickerActive(null, routineWidgetPickerKey))
-      stopWidgetPicker();
-    super.hide();
-  }
-
-  onOutsideClick(e) {
-    // clicking widgets in the room is how this popup's picker works
-    if(isWidgetPickerActive(null, routineWidgetPickerKey))
-      return;
-    super.onOutsideClick(e);
   }
 
   show(showCollections=false) {
@@ -506,19 +520,22 @@ class RoutineWidgetIDPopup extends RoutinePopup {
       multiple: true,
       allowSelf: true, // a routine regularly acts on the widget it belongs to
       resolveCovering: true, // holders are usually covered by their cards
+      typeFilter: this.options.widgetType, // preset from the parameter, changeable in the picker
       getSelectedIDs: _=>this.workingIDs,
       apply: widgetIDs=>this.workingIDs = widgetIDs,
       onClear: _=>this.workingIDs = [],
       clearLabel: 'Select none'
     });
     button(content, 'Use these widgets', _=>this.setNewValue([ ...this.workingIDs ]));
-    super.show(false, showCollections);
+    // a widget parameter takes a widget id, which a variable or widget property
+    // can provide as well - e.g. ${PROPERTY parent} for the holder a button sits on
+    super.show(true, showCollections);
   }
 }
 
 class RoutineHoldersOrCollectionSourcePopup extends RoutineWidgetIDPopup {
-  constructor() {
-    super();
+  constructor(options={}) {
+    super(options);
   }
 
   setNewCollectionValue(value) {
@@ -535,8 +552,9 @@ class RoutineHoldersOrCollectionSourcePopup extends RoutineWidgetIDPopup {
 
   setNewValue(value) {
     // widget ids arrive as an array and belong to the first (holder-like) parameter;
+    // a variable or widget property resolves to a widget id, so it goes there too;
     // collection names are strings and belong to the second parameter if there is one
-    if(Array.isArray(value)) {
+    if(Array.isArray(value) || typeof value == 'string' && value.match(/\$\{[^}]+\}/)) {
       const holderParameter = this.parameterNames[0];
       const collectionParameter = this.parameterNames[1];
       // clear the sibling collection (mirror of setNewCollectionValue) so a leftover

--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -13,6 +13,11 @@
 // Parameter types decide which popup opens: number, enum (with values),
 // string, json, widgets (pick widgets in the room), collection (pick widgets
 // or a collection name).
+//
+// widgetType presets the picker's type filter for parameters that almost always
+// name a widget of one type (SHUFFLE holder is a holder, TIMER timer a timer).
+// It is only the initial value of the filter dropdown - the type can be changed
+// to any other one (or to "any type") in the picker.
 const routineOperationMetadata = {
   AUDIO: {
     template: '{func}: play {source} at volume {maxVolume}[ to {player}][; {count} time(s)]',
@@ -42,7 +47,7 @@ const routineOperationMetadata = {
     template: '{func}: {mode} on {collection}[ using value {value}][ and color {color}]',
     parameters: {
       mode: { type: 'enum', values: [ 'set', 'inc', 'dec', 'change', 'reset', 'setPixel' ], default: 'reset' },
-      collection: { type: 'collection', default: 'DEFAULT' },
+      collection: { type: 'collection', default: 'DEFAULT', widgetType: 'canvas' },
       value: { type: 'number', default: 1 },
       color: { type: 'color', default: '#1F5CA6' },
       x: { type: 'number', default: 0 },
@@ -74,7 +79,7 @@ const routineOperationMetadata = {
     template: '{func} widgets[ owned by {owner}] in {holder,collection} and store as {variable}',
     parameters: {
       owner: { type: 'string', default: null, display: { 'null': 'anyone' } },
-      holder: { type: 'widgets', default: null },
+      holder: { type: 'widgets', default: null, widgetType: 'holder' },
       collection: { type: 'collection', default: 'DEFAULT' },
       variable: { type: 'string', default: 'COUNT' }
     },
@@ -96,7 +101,7 @@ const routineOperationMetadata = {
     template: v=>v('faceCycle') == 'random' ? '{func} {count} widgets from {holder,collection} a {faceCycle} face' : '{func} {count} widgets from {holder,collection}; cycle {faceCycle} by {face}',
     parameters: {
       count: { type: 'number', default: 'all', special: [ 'all' ] },
-      holder: { type: 'widgets', default: null, display: { 'null': '?' } },
+      holder: { type: 'widgets', default: null, display: { 'null': '?' }, widgetType: 'holder' },
       collection: { type: 'collection', default: 'DEFAULT' },
       face: { type: 'number', default: null, special: [ null ], display: { 'null': 'next' } },
       faceCycle: { type: 'enum', values: [ 'forward', 'backward', 'random' ], default: 'forward' }
@@ -145,7 +150,7 @@ const routineOperationMetadata = {
   LABEL: {
     template: v=>v('label') != null ? '{func}: {mode} {value} to {label}' : '{func}: {mode} {value} to labels in {collection}',
     parameters: {
-      label: { type: 'widgets', default: null },
+      label: { type: 'widgets', default: null, widgetType: 'label' },
       collection: { type: 'collection', default: 'DEFAULT' },
       value: { type: 'string', default: 0 },
       mode: { type: 'enum', values: [ 'set', 'inc', 'dec', 'append' ], default: 'set' }
@@ -156,9 +161,9 @@ const routineOperationMetadata = {
     parameters: {
       fillTo: { type: 'number', default: null },
       count: { type: 'number', default: operation=>operation.from ? 1 : 'all', special: [ 'all' ] },
-      from: { type: 'widgets', default: null, display: { 'null': '?' } },
+      from: { type: 'widgets', default: null, display: { 'null': '?' }, widgetType: 'holder' },
       collection: { type: 'collection', default: 'DEFAULT' },
-      to: { type: 'widgets', default: null, display: { 'null': '?' } },
+      to: { type: 'widgets', default: null, display: { 'null': '?' }, widgetType: 'holder' },
       face: { type: 'number', default: null, special: [ null ], display: { 'null': 'unchanged' } }
     },
     ignored: v=>v('fillTo') != null ? { count: 'ignored because "fill up to" is set' } : {}
@@ -167,7 +172,7 @@ const routineOperationMetadata = {
     template: '{func} {count} widgets from {from} to ({x}, {y})[; flip to face {face}]',
     parameters: {
       count: { type: 'number', default: 1, special: [ 'all' ] },
-      from: { type: 'widgets', default: null, display: { 'null': '?' } },
+      from: { type: 'widgets', default: null, display: { 'null': '?' }, widgetType: 'holder' },
       x: { type: 'number', default: 0 },
       y: { type: 'number', default: 0 },
       face: { type: 'number', default: null, special: [ null ], display: { 'null': 'unchanged' } },
@@ -178,7 +183,7 @@ const routineOperationMetadata = {
   RECALL: {
     template: '{func} cards that belong to {holder}[; include cards in hands {owned}][, only cards in holders {inHolder}][, excluding {excludeCollection}]',
     parameters: {
-      holder: { type: 'widgets', default: null, display: { 'null': '?' } },
+      holder: { type: 'widgets', default: null, display: { 'null': '?' }, widgetType: 'holder' },
       owned: { type: 'enum', values: [ true, false ], default: true },
       inHolder: { type: 'enum', values: [ true, false ], default: true },
       excludeCollection: { type: 'collection', default: null },
@@ -195,7 +200,7 @@ const routineOperationMetadata = {
     template: v=>v('mode') == 'set' ? '{func} {count} widgets in {holder,collection}; {mode} to {angle} degrees' : '{func} {count} widgets in {holder,collection}; {mode} {angle} degrees',
     parameters: {
       count: { type: 'number', default: 1, special: [ 'all' ] },
-      holder: { type: 'widgets', default: null },
+      holder: { type: 'widgets', default: null, widgetType: 'holder' },
       collection: { type: 'collection', default: 'DEFAULT' },
       angle: { type: 'number', default: 90, special: [ 45, 60, 90, 135, 180 ] },
       mode: { type: 'enum', values: [ 'set', 'add' ], default: 'add' }
@@ -205,7 +210,7 @@ const routineOperationMetadata = {
     template: '{func}: get {property} in {seats}[; for round {round}][; use as {mode}][ with multiplier {value}]',
     parameters: {
       property: { type: 'string', default: 'score' },
-      seats: { type: 'widgets', default: null, display: { 'null': 'every seat' } },
+      seats: { type: 'widgets', default: null, display: { 'null': 'every seat' }, widgetType: 'seat' },
       round: { type: 'number', default: null, special: [ null ], display: { 'null': 'new round' } },
       mode: { type: 'enum', values: [ 'set', 'inc', 'dec' ], default: 'set' },
       value: { type: 'number', default: null, special: [ null ] }
@@ -247,7 +252,7 @@ const routineOperationMetadata = {
       return '{func} {holder,collection}'; // true random
     },
     parameters: {
-      holder: { type: 'widgets', default: null, display: { 'null': '?' } },
+      holder: { type: 'widgets', default: null, display: { 'null': '?' }, widgetType: 'holder' },
       collection: { type: 'collection', default: 'DEFAULT' },
       mode: { type: 'enum', values: [ 'true random', 'overhand', 'riffle', 'reverse', 'seeded' ], default: 'true random' },
       modeValue: { type: 'number', default: 1 }
@@ -256,7 +261,7 @@ const routineOperationMetadata = {
   SORT: {
     template: '{func} {holder,collection} by {key}[; reverse {reverse}]',
     parameters: {
-      holder: { type: 'widgets', default: null },
+      holder: { type: 'widgets', default: null, widgetType: 'holder' },
       collection: { type: 'collection', default: 'DEFAULT' },
       key: { type: 'json', default: 'value' },
       reverse: { type: 'enum', values: [ true, false ], default: false },
@@ -268,7 +273,7 @@ const routineOperationMetadata = {
   SWAPHANDS: {
     template: '{func} hands among players in {source}[, interval {interval}][, direction {direction}]',
     parameters: {
-      source: { type: 'collection', default: 'all', display: { 'all': 'all seats' } },
+      source: { type: 'collection', default: 'all', display: { 'all': 'all seats' }, widgetType: 'seat' },
       interval: { type: 'number', default: 1 },
       direction: { type: 'enum', values: [ 'forward', 'backward', 'random' ], default: 'forward' }
     }
@@ -284,8 +289,8 @@ const routineOperationMetadata = {
       return `{func}: {mode} ${target}`; // pause/start/toggle/reset ignore the value
     },
     parameters: {
-      timer: { type: 'widgets', default: null },
-      collection: { type: 'collection', default: 'DEFAULT' },
+      timer: { type: 'widgets', default: null, widgetType: 'timer' },
+      collection: { type: 'collection', default: 'DEFAULT', widgetType: 'timer' },
       mode: { type: 'enum', values: [ 'pause', 'start', 'toggle', 'set', 'dec', 'inc', 'reset' ], default: 'toggle' },
       value: { type: 'number', default: 0, special: [ 'start', 'end' ], textHint: 'name of a timer property to read the time from' },
       seconds: { type: 'number', default: 0 }
@@ -309,9 +314,9 @@ const routineOperationMetadata = {
       return '{func} {turnCycle} by {turn}'; // forward / backward
     },
     parameters: {
-      turn: { type: 'number', default: 1, special: [ 'first', 'last' ], textHint: 'id of a seat (used with turnCycle seat)' },
+      turn: { type: 'number', default: 1, special: [ 'first', 'last' ], textHint: 'id of a seat (used with turnCycle seat)', widgetType: 'seat' },
       turnCycle: { type: 'enum', values: [ 'forward', 'backward', 'random', 'position', 'seat' ], default: 'forward' },
-      source: { type: 'collection', default: 'all', display: { 'all': 'all seats' } },
+      source: { type: 'collection', default: 'all', display: { 'all': 'all seats' }, widgetType: 'seat' },
       collection: { type: 'collection', default: 'TURN' }
     },
     definesCollection: 'collection'
@@ -870,15 +875,19 @@ class RoutineOperationEditor {
 
   createPopup(parameterNames) {
     const spec = this.parameterSpec(parameterNames[parameterNames.length-1]);
+    // a chip can stand for alternative parameters ({holder,collection}), so the
+    // type preset of any of them applies to the picker the chip opens
+    const typedSpec = parameterNames.map(name=>this.parameterSpec(name)).find(s=>s && s.widgetType);
+    const pickerOptions = { widgetType: typedSpec && typedSpec.widgetType };
     if(parameterNames[0] == 'func')
       return new RoutineOperationPopup();
     if(parameterNames.length > 1 && spec && spec.type == 'collection')
-      return new RoutineHoldersOrCollectionSourcePopup();
+      return new RoutineHoldersOrCollectionSourcePopup(pickerOptions);
     switch(spec && spec.type) {
-      case 'number':     return new RoutineNumberPopup({ specialValues: spec.special, textHint: spec.textHint });
+      case 'number':     return new RoutineNumberPopup({ specialValues: spec.special, textHint: spec.textHint, widgetType: pickerOptions.widgetType });
       case 'enum':       return new RoutineEnumPopup({ values: spec.values });
-      case 'widgets':    return new RoutineWidgetIDPopup();
-      case 'collection': return new RoutineHoldersOrCollectionSourcePopup();
+      case 'widgets':    return new RoutineWidgetIDPopup(pickerOptions);
+      case 'collection': return new RoutineHoldersOrCollectionSourcePopup(pickerOptions);
       case 'json':       return new RoutineJSONPopup();
       case 'color':      return new RoutineColorPopup();
       case 'icon':       return new RoutineIconPopup();

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -22,6 +22,7 @@ beforeAll(() => {
   window.endCustomSelection = () => {};
   window.widgets = new Map();
   window.setSelection = () => {};
+  window.editorTypeNames = { basic: 'Widget', button: 'Button', canvas: 'Canvas', card: 'Card', holder: 'Holder', label: 'Label', seat: 'Seat', timer: 'Timer' };
 
   const editorDiv = document.createElement('div');
   editorDiv.id = 'editor';
@@ -647,8 +648,10 @@ describe('number popups with text values', () => {
 describe('the shared widget picker', () => {
   function room(...definitions) {
     widgets.clear();
-    for(const [ id, type, parent ] of definitions)
-      widgets.set(id, { id, get: p => ({ type, parent: parent || null })[p] });
+    for(const [ id, type, parent ] of definitions) {
+      const state = { id, type, parent: parent || null };
+      widgets.set(id, { id, state, get: p => state[p] });
+    }
     return id => widgets.get(id);
   }
 
@@ -767,6 +770,142 @@ describe('the shared widget picker', () => {
     entries[1].onclick();
     [...popup.domElement.querySelectorAll('button')].find(b => b.textContent == 'Use these widgets').dispatchEvent(new Event('click'));
     expect(value).toEqual({ from: [ 'h1', 'h2' ] });
+    popup.hide();
+  });
+});
+
+describe('widget type presets', () => {
+  function room(...definitions) {
+    widgets.clear();
+    for(const [ id, type ] of definitions) {
+      const state = { id, type, parent: 'theTable' };
+      widgets.set(id, { id, state, get: p => state[p] });
+    }
+  }
+
+  // opens the popup a chip opens, the way the routine editor does
+  function showPopup(operation, parameterNames) {
+    const editor = editorForOperation(operation);
+    editor.setOperationDetails(widgets.get('target'), operation, [], []);
+    const popup = editor.createPopup(parameterNames);
+    const source = document.createElement('span');
+    document.getElementById('editor').append(source);
+    popup.setSource(source);
+    popup.setOperationDetails(operation, parameterNames, widgets.get('target'), [], []);
+    popup.show();
+    return popup;
+  }
+
+  const pickedTypes = popup => [...popup.domElement.querySelectorAll('.widgetPickerEntry')].map(e => e.querySelector('.widgetPickerType').textContent);
+
+  afterEach(() => {
+    stopWidgetPicker();
+    widgets.clear();
+  });
+
+  test('parameters that name one kind of widget preset that type', () => {
+    const presets = {};
+    for(const func in routineOperationMetadata)
+      for(const parameter in routineOperationMetadata[func].parameters)
+        if(routineOperationMetadata[func].parameters[parameter].widgetType)
+          presets[`${func}.${parameter}`] = routineOperationMetadata[func].parameters[parameter].widgetType;
+    expect(presets).toEqual({
+      'CANVAS.collection': 'canvas',
+      'COUNT.holder': 'holder',
+      'FLIP.holder': 'holder',
+      'LABEL.label': 'label',
+      'MOVE.from': 'holder', 'MOVE.to': 'holder',
+      'MOVEXY.from': 'holder',
+      'RECALL.holder': 'holder',
+      'ROTATE.holder': 'holder',
+      'SCORE.seats': 'seat',
+      'SHUFFLE.holder': 'holder',
+      'SORT.holder': 'holder',
+      'SWAPHANDS.source': 'seat',
+      'TIMER.timer': 'timer', 'TIMER.collection': 'timer',
+      'TURN.turn': 'seat', 'TURN.source': 'seat'
+    });
+  });
+
+  test('the preset filters the picker list and can be changed to any type', () => {
+    room([ 'target', 'button' ], [ 'h1', 'holder' ], [ 'l1', 'label' ]);
+    const popup = showPopup({ func: 'SHUFFLE' }, [ 'holder', 'collection' ]); // the {holder,collection} chip
+    expect(pickedTypes(popup)).toEqual([ 'holder' ]);
+    const typeSelect = popup.domElement.querySelector('select');
+    expect(typeSelect.value).toBe('holder');
+    typeSelect.value = '';
+    typeSelect.onchange();
+    expect(pickedTypes(popup).sort()).toEqual([ 'button', 'holder', 'label' ]);
+    popup.hide();
+  });
+
+  test('collection-only and widget-only parameters get their preset as well', () => {
+    room([ 'target', 'button' ], [ 'l1', 'label' ], [ 't1', 'timer' ]);
+    const timer = showPopup({ func: 'TIMER' }, [ 'collection' ]); // no timer set: the chip is the collection
+    expect(pickedTypes(timer)).toEqual([ 'timer' ]);
+    timer.hide();
+    const label = showPopup({ func: 'LABEL' }, [ 'label' ]);
+    expect(pickedTypes(label)).toEqual([ 'label' ]);
+    label.hide();
+  });
+
+  test('TURN offers the seats for its turn parameter', () => {
+    room([ 'target', 'button' ], [ 's1', 'seat' ], [ 'h1', 'holder' ]);
+    const popup = showPopup({ func: 'TURN', turnCycle: 'seat' }, [ 'turn' ]);
+    expect(popup).toBeInstanceOf(RoutineNumberPopup);
+    expect(pickedTypes(popup)).toEqual([ 'seat' ]);
+    let value = null;
+    popup.registerChangeListener(v => value = v);
+    popup.domElement.querySelector('.widgetPickerEntry').onclick();
+    expect(value).toEqual({ turn: 's1' });
+    popup.hide();
+  });
+});
+
+describe('variables in widget parameters', () => {
+  function showWidgetPopup(operation, parameterNames) {
+    widgets.clear();
+    const source = document.createElement('span');
+    document.getElementById('editor').append(source);
+    const editor = editorForOperation(operation);
+    const widget = { id: 'button1', state: { id: 'button1', parent: 'holder1' }, get: p => widget.state[p] };
+    editor.setOperationDetails(widget, operation, [ 'myHolder' ], []);
+    const popup = editor.createPopup(parameterNames);
+    popup.setSource(source);
+    popup.setOperationDetails(operation, parameterNames, widget, [ 'myHolder' ], []);
+    popup.show();
+    return popup;
+  }
+
+  const buttonNamed = (popup, text) => [...popup.domElement.querySelectorAll('button')].find(b => b.textContent == text);
+
+  test('a widget parameter offers variables and widget properties', () => {
+    const popup = showWidgetPopup({ func: 'MOVE', from: [ 'h1' ] }, [ 'to' ]);
+    let value = null;
+    popup.registerChangeListener(v => value = v);
+    expect(buttonNamed(popup, 'myHolder')).toBeDefined();
+    buttonNamed(popup, 'parent').dispatchEvent(new Event('click'));
+    expect(value).toEqual({ to: '${PROPERTY parent}' });
+    popup.hide();
+  });
+
+  test('a variable used for a holder goes to the holder parameter, not the collection', () => {
+    const popup = showWidgetPopup({ func: 'SHUFFLE' }, [ 'holder', 'collection' ]);
+    let value = null;
+    popup.registerChangeListener(v => value = v);
+    buttonNamed(popup, 'parent').dispatchEvent(new Event('click'));
+    expect(value.holder).toBe('${PROPERTY parent}');
+    expect('collection' in value).toBe(true);
+    expect(value.collection).toBeUndefined();
+    popup.hide();
+  });
+
+  test('a collection name still goes to the collection parameter', () => {
+    const popup = showWidgetPopup({ func: 'SHUFFLE' }, [ 'holder', 'collection' ]);
+    let value = null;
+    popup.registerChangeListener(v => value = v);
+    popup.setNewCollectionValue('DEFAULT');
+    expect(value).toEqual({ holder: undefined, collection: 'DEFAULT' });
     popup.hide();
   });
 });


### PR DESCRIPTION
Follow-up to #3053 (based on that branch), acting on feedback from rapha195 on Discord:

> Use these preset for the listed inputs of functions. Nothing complicated with additional conditions. It's just a preset and user can change it anyway.
>
>
> - `TIMER` → `timer` / `collection`: type timer.
> - `CANVAS` → `collection` (+ deprecated `canvas`): type canvas.
> - `SCORE` → `seats`: type seats.
> - `TURN` → `source`, and `turn`: type seats.
> - `SWAPHANDS` → `source`: type seats
> - `RECALL` → `holder`: type holder
> - `LABEL` → `label`: type label
> - `FLIP`, `SHUFFLE`, `SORT`, `ROTATE`, `COUNT` → `holder`: type holder
> - `MOVE` → `from` / `to`: type holder,
> - `MOVEXY` → `from`: type holder
>
> Additionally I noticed that some inputs didn't have the option to use a ${PROPERTY xx}
> For example I wanted to use ${PROPERTY parent} to shuffle a holder that was the parent of a button

([source](https://discord.com/channels/770758631146782780/1527815541925085307/1530979680419709088))

## Type presets

The parameters listed above get a `widgetType` in the routine editor's operation metadata, which becomes the initial value of the picker's type filter. Opening SHUFFLE's holder chip now lists only holders instead of every widget in the room, and - because #3053 made the filter apply to picking in the room as well - a click on a card there selects the holder it lies on.

![the holder picker preset to Holder](https://agent.virtualtabletop.io/reports/pr/1527815541925085307/holder-picker-preset.png)

It really is just a preset: the dropdown still offers every type and "any type", and nothing depends on the operation's other parameters.

The deprecated `canvas` parameter of CANVAS has no chip in the routine editor (the editor only shows `collection`), so only `collection` got the preset.

## ${PROPERTY xx} in widget parameters

The widget/holder/collection popups only showed the picker and the collections, so a widget could not be named indirectly. They now offer the same Variables / Predefined Variables / Widget Properties sections as the other parameters, so `${PROPERTY parent}` shuffles the holder a button sits on:

![SHUFFLE ${PROPERTY parent}](https://agent.virtualtabletop.io/reports/pr/1527815541925085307/shuffle-property-parent.png)

Such a value goes to the holder-style parameter (it resolves to a widget id) and clears the sibling `collection`, mirroring what picking widgets already did. Collection names picked from the Collections section still go to `collection`.

TURN's `turn` is a number parameter that also accepts a seat id, so it gets a picker section of its own, preset to seats.

## Testing

- `npx jest` - green, with new cases for the preset list, the filtered picker, the `${PROPERTY parent}` routing and the TURN seat picker (79 tests in the routine editor suite).
- Manually in the browser: opened the routine editor for a button with SHUFFLE/TIMER/TURN, checked each picker opens preset to holder/timer/seat, and applied `${PROPERTY parent}` to SHUFFLE - the saved routine is `{"func":"SHUFFLE","holder":"${PROPERTY parent}"}`.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3056/pr-test (or any other room on that server)
