### PR TITLE
Offer the four line widgets in the Widgets sidebar

### DIFF
--- a/assets/icons/divider.svg
+++ b/assets/icons/divider.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <rect x="4" y="11" width="16" height="2" fill="currentColor"/>
+  <rect width="24" height="24" fill="none"/>
+</svg>

--- a/assets/icons/line.svg
+++ b/assets/icons/line.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
   <g fill="currentColor">
     <rect x="4" y="11" width="16" height="2"/>
-    <circle cx="4" cy="12" r="3"/>
-    <circle cx="20" cy="12" r="3"/>
+    <circle cx="4" cy="12" r="2.5"/>
+    <circle cx="20" cy="12" r="2.5"/>
   </g>
   <rect width="24" height="24" fill="none"/>
 </svg>

--- a/assets/icons/line.svg
+++ b/assets/icons/line.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <g fill="currentColor">
+    <rect x="4" y="11" width="16" height="2"/>
+    <circle cx="4" cy="12" r="3"/>
+    <circle cx="20" cy="12" r="3"/>
+  </g>
+  <rect width="24" height="24" fill="none"/>
+</svg>

--- a/assets/icons/ring.svg
+++ b/assets/icons/ring.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="8" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor">
+    <circle cx="12" cy="4" r="2"/>
+    <circle cx="20" cy="12" r="2"/>
+    <circle cx="12" cy="20" r="2"/>
+    <circle cx="4" cy="12" r="2"/>
+  </g>
+  <rect width="24" height="24" fill="none"/>
+</svg>

--- a/assets/icons/ring.svg
+++ b/assets/icons/ring.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-  <circle cx="12" cy="12" r="8" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <circle cx="12" cy="12" r="7" fill="none" stroke="currentColor" stroke-width="2"/>
   <g fill="currentColor">
-    <circle cx="12" cy="4" r="2"/>
-    <circle cx="20" cy="12" r="2"/>
-    <circle cx="12" cy="20" r="2"/>
-    <circle cx="4" cy="12" r="2"/>
+    <circle cx="12" cy="5" r="2.5"/>
+    <circle cx="19" cy="12" r="2.5"/>
+    <circle cx="12" cy="19" r="2.5"/>
+    <circle cx="5" cy="12" r="2.5"/>
   </g>
   <rect width="24" height="24" fill="none"/>
 </svg>

--- a/assets/widgets.json
+++ b/assets/widgets.json
@@ -3400,7 +3400,8 @@
       "preview": "symbol:format_h1"
     },
     {
-      "name": "Line",
+      "name": "Line (with stops)",
+      "description": "A straight line with a drop spot at each end - drop a piece onto a stop and it snaps to it. Move, curve or rotate the line and the stops follow.",
       "id": "line",
       "widgets": [
         {
@@ -3461,6 +3462,7 @@
     },
     {
       "name": "Divider",
+      "description": "A plain line without stops - the horizontal or vertical rule to separate areas of the table. Rotate it, curve it or restyle it however you like.",
       "id": "divider",
       "widgets": [
         {
@@ -3481,10 +3483,11 @@
           "lineWidth": 4
         }
       ],
-      "preview": "i/icons/remove.svg"
+      "preview": "i/icons/divider.svg"
     },
     {
       "name": "Circle",
+      "description": "A plain circle outline without stops - resize it into an oval or restyle it like any other line.",
       "id": "circle",
       "widgets": [
         {
@@ -3509,7 +3512,8 @@
       "preview": "i/icons/circle_hollow.svg"
     },
     {
-      "name": "Ring",
+      "name": "Ring (with stops)",
+      "description": "A circle with four drop spots spaced around it - drop a piece onto a stop and it snaps to it. Add or move stops to build a round track.",
       "id": "ring",
       "widgets": [
         {
@@ -4638,8 +4642,8 @@
       "widgets": [
         "heading",
         "label",
-        "line",
         "divider",
+        "line",
         "circle",
         "ring"
       ],

--- a/assets/widgets.json
+++ b/assets/widgets.json
@@ -3400,42 +3400,202 @@
       "preview": "symbol:format_h1"
     },
     {
-      "name": "Horizontal Rule",
-      "id": "horizontalRule",
+      "name": "Line",
+      "id": "line",
       "widgets": [
         {
-          "id": "horizontalRule",
-          "x": 1300,
-          "y": 325,
-          "width": 200,
-          "height": 0,
-          "borderRadius": "3px",
-          "z": 26,
-          "css": {
-            "border": "3px solid #666"
-          }
+          "type": "line",
+          "id": "line",
+          "x": 1310,
+          "y": 420,
+          "width": 220,
+          "height": 40,
+          "lineStart": {
+            "x": 10,
+            "y": 20
+          },
+          "lineEnd": {
+            "x": 210,
+            "y": 20
+          },
+          "stops": [
+            {
+              "widget": "lineS0",
+              "position": 0
+            },
+            {
+              "widget": "lineS1",
+              "position": 1
+            }
+          ]
+        },
+        {
+          "type": "holder",
+          "id": "lineS0",
+          "parent": "line",
+          "fixedParent": true,
+          "movableInEdit": false,
+          "x": -10,
+          "y": 0,
+          "width": 40,
+          "height": 40,
+          "borderRadius": 20,
+          "dropTarget": {
+            "type": null
+          },
+          "dropOffsetX": 2,
+          "dropOffsetY": 2
+        },
+        {
+          "type": "holder",
+          "id": "lineS1",
+          "parent": "line",
+          "fixedParent": true,
+          "movableInEdit": false,
+          "inheritFrom": "lineS0",
+          "x": 190,
+          "y": 0
         }
       ],
-      "preview": "i/icons/width.svg"
+      "preview": "i/icons/line.svg"
     },
     {
-      "name": "Vertical Rule",
-      "id": "verticalRule",
+      "name": "Divider",
+      "id": "divider",
       "widgets": [
         {
-          "id": "verticalRule",
-          "x": 1535,
-          "y": 190,
-          "width": 0,
-          "height": 200,
-          "borderRadius": "3px",
-          "z": 27,
-          "css": {
-            "border": "3px solid #666"
-          }
+          "type": "line",
+          "id": "divider",
+          "x": 1290,
+          "y": 315,
+          "width": 220,
+          "height": 20,
+          "lineStart": {
+            "x": 10,
+            "y": 10
+          },
+          "lineEnd": {
+            "x": 210,
+            "y": 10
+          },
+          "lineWidth": 4
         }
       ],
-      "preview": "i/icons/height.svg"
+      "preview": "i/icons/remove.svg"
+    },
+    {
+      "name": "Circle",
+      "id": "circle",
+      "widgets": [
+        {
+          "type": "line",
+          "id": "circle",
+          "x": 1300,
+          "y": 500,
+          "width": 100,
+          "height": 100,
+          "lineShape": "ellipse",
+          "lineStart": {
+            "x": 10,
+            "y": 10
+          },
+          "lineEnd": {
+            "x": 90,
+            "y": 90
+          },
+          "lineWidth": 4
+        }
+      ],
+      "preview": "i/icons/circle_hollow.svg"
+    },
+    {
+      "name": "Ring",
+      "id": "ring",
+      "widgets": [
+        {
+          "type": "line",
+          "id": "ring",
+          "x": 1420,
+          "y": 495,
+          "width": 130,
+          "height": 130,
+          "lineShape": "ellipse",
+          "lineStart": {
+            "x": 15,
+            "y": 15
+          },
+          "lineEnd": {
+            "x": 115,
+            "y": 115
+          },
+          "stops": [
+            {
+              "widget": "ringS0",
+              "position": 0
+            },
+            {
+              "widget": "ringS1",
+              "position": 0.25
+            },
+            {
+              "widget": "ringS2",
+              "position": 0.5
+            },
+            {
+              "widget": "ringS3",
+              "position": 0.75
+            }
+          ]
+        },
+        {
+          "type": "holder",
+          "id": "ringS0",
+          "parent": "ring",
+          "fixedParent": true,
+          "movableInEdit": false,
+          "x": 45,
+          "y": -5,
+          "width": 40,
+          "height": 40,
+          "borderRadius": 20,
+          "dropTarget": {
+            "type": null
+          },
+          "dropOffsetX": 2,
+          "dropOffsetY": 2
+        },
+        {
+          "type": "holder",
+          "id": "ringS1",
+          "parent": "ring",
+          "fixedParent": true,
+          "movableInEdit": false,
+          "inheritFrom": "ringS0",
+          "x": 95,
+          "y": 45
+        },
+        {
+          "type": "holder",
+          "id": "ringS2",
+          "parent": "ring",
+          "fixedParent": true,
+          "movableInEdit": false,
+          "inheritFrom": "ringS0",
+          "x": 45,
+          "y": 95
+        },
+        {
+          "type": "holder",
+          "id": "ringS3",
+          "parent": "ring",
+          "fixedParent": true,
+          "movableInEdit": false,
+          "inheritFrom": "ringS0",
+          "x": -5,
+          "y": 45
+        }
+      ],
+      "preview": "i/icons/ring.svg"
     },
     {
       "name": "Basic Widget",
@@ -4478,8 +4638,10 @@
       "widgets": [
         "heading",
         "label",
-        "horizontalRule",
-        "verticalRule"
+        "line",
+        "divider",
+        "circle",
+        "ring"
       ],
       "collapsed": true
     },

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -287,7 +287,9 @@ function generateLineStop(id, lineID, index, x, y) {
 }
 
 // every line offered in the add widget overlay is drawn in the VTT blue the
-// line widget defaults to, so none of them has to spell out a lineColor
+// line widget defaults to, so none of them has to spell out a lineColor.
+// The same four lines are also in assets/widgets.json so that they show up in
+// the Widgets sidebar - keep both copies in sync when changing one of them.
 function generateLineWidgets(id, x, y) {
   const line = {
     type: 'line',

--- a/client/js/editor/sidebar/widgets.js
+++ b/client/js/editor/sidebar/widgets.js
@@ -109,6 +109,14 @@ async function getSavedWidgets(source) {
   return { widgets: [], groups: [] };
 }
 
+// Entries can explain themselves in plain language through an optional
+// description. In grid view the name is all that is shown, so the tooltip is
+// the only place that can tell apart e.g. a line with stops from a plain one.
+function tooltipAttribute(state) {
+  const tooltip = [ state.name || state.id, state.description ].filter(t=>t).join('\n');
+  return ` title="${html(tooltip)}"`;
+}
+
 // Render preview markup from a URL or a Material Symbol reference like "symbol:heading"
 function renderSavedWidgetPreviewHTML(preview) {
   if (!preview) return '';
@@ -490,6 +498,9 @@ class WidgetsModule extends SidebarModule {
         if (!filter) return true;
         const nameMatch = (widgetData.name || widgetData.id || '').toLowerCase().includes(lowerCaseFilter);
         if (nameMatch) return true;
+        // the description doubles as the entry's tooltip, so searching it also
+        // finds a widget by what it does instead of just by its name
+        if ((widgetData.description || '').toLowerCase().includes(lowerCaseFilter)) return true;
         if (widgetData.widgets && Array.isArray(widgetData.widgets)) {
           return widgetData.widgets.some(subWidget =>
             (subWidget.type || 'basic').toLowerCase().includes(lowerCaseFilter)
@@ -1365,7 +1376,7 @@ class WidgetsModule extends SidebarModule {
     const widgetTypes = getWidgetTypesString(state);
     const hasAddToRoomRoutine = state.widgets.some(w => w.editorAddToRoomRoutine);
     return `
-          <li data-id="${state.id}" data-source="${source}" draggable="${isEditing}" style="display: flex; align-items: center; margin-bottom: 5px;">
+          <li data-id="${state.id}" data-source="${source}" draggable="${isEditing}"${tooltipAttribute(state)} style="display: flex; align-items: center; margin-bottom: 5px;">
               <span class="drag-handle"></span>
               <div class="widget-preview">
                 ${this.renderPreviewHTML(state.preview)}
@@ -1388,7 +1399,7 @@ class WidgetsModule extends SidebarModule {
 
   renderGridWidget(state, source, isEditing) {
     return `
-      <div class="widget-grid-item" data-id="${state.id}" data-source="${source}" draggable="true">
+      <div class="widget-grid-item" data-id="${state.id}" data-source="${source}" draggable="true"${tooltipAttribute(state)}>
         <div class="widget-preview">
           ${this.renderPreviewHTML(state.preview)}
           <button icon="add" class="sidebarButton add-to-room-grid"><span>Add widget to room</span></button>

--- a/client/js/editor/sidebar/widgets.js
+++ b/client/js/editor/sidebar/widgets.js
@@ -50,6 +50,35 @@ function deepReplace(obj, idMap) {
   }
 }
 
+// Prepares one widget state of a saved widget for the drag image. Every id
+// reference is remapped to the temporary preview ids the same way
+// placeSavedWidgetFromBuffer does for the real placement, so references like
+// inheritFrom or a line's stops point at the preview copies instead of at the
+// library ids (or at an unrelated room widget that happens to use one of them).
+// Returns null for a card whose deck is not part of the preview.
+function remapPreviewState(state, tempId, idMap, minX, minY) {
+  if (state.deck && !idMap.has(state.deck)) {
+    return null;
+  }
+
+  const tempState = JSON.parse(JSON.stringify(state));
+  tempState.id = tempId;
+  deepReplace(tempState, Object.fromEntries(idMap));
+
+  // roots of the buffer are placed side by side in the drag image instead of
+  // keeping the coordinates they had in the library
+  if (!hasPreviewParent(state, idMap)) {
+    tempState.x = (state.x || 0) - minX;
+    tempState.y = (state.y || 0) - minY;
+  }
+
+  return tempState;
+}
+
+function hasPreviewParent(state, idMap) {
+  return !!state.parent && idMap.has(state.parent);
+}
+
 // The saved widget library, shared by the Widgets sidebar and by anything else
 // that offers to place one of them (e.g. adding a stop to a line).
 async function getSavedWidgets(source) {
@@ -866,25 +895,14 @@ class WidgetsModule extends SidebarModule {
               const previewWidget = tempWidgetInstances.get(tempId);
               widgets.set(tempId, previewWidget);
 
-              const tempState = JSON.parse(JSON.stringify(s));
-              tempState.id = tempId;
-
-              const parentId = tempState.parent ? idMap.get(tempState.parent) : null;
-              if (parentId) {
-                tempState.parent = parentId;
-              } else {
-                tempState.x = (s.x || 0) - minX;
-                tempState.y = (s.y || 0) - minY;
-              }
-              if (tempState.deck) {
-                if(!idMap.has(tempState.deck))
-                  continue;
-                tempState.deck = idMap.get(tempState.deck);
+              const tempState = remapPreviewState(s, tempId, idMap, minX, minY);
+              if (!tempState) {
+                continue;
               }
 
               previewWidget.applyInitialDelta(tempState);
 
-              if (!parentId) {
+              if (!hasPreviewParent(s, idMap)) {
                 scaleWrapper.appendChild(previewWidget.domElement);
               }
             }
@@ -1115,24 +1133,14 @@ class WidgetsModule extends SidebarModule {
             const previewWidget = tempWidgetInstances.get(tempId);
             widgets.set(tempId, previewWidget);
 
-            const tempState = JSON.parse(JSON.stringify(s));
-            tempState.id = tempId;
-            const parentId = tempState.parent ? idMap.get(tempState.parent) : null;
-            if (parentId) {
-              tempState.parent = parentId;
-            } else {
-              tempState.x = (s.x || 0) - minX;
-              tempState.y = (s.y || 0) - minY;
-            }
-            if (tempState.deck) {
-              if(!idMap.has(tempState.deck))
-                continue;
-              tempState.deck = idMap.get(tempState.deck);
+            const tempState = remapPreviewState(s, tempId, idMap, minX, minY);
+            if (!tempState) {
+              continue;
             }
 
             previewWidget.applyInitialDelta(tempState);
 
-            if (!parentId) {
+            if (!hasPreviewParent(s, idMap)) {
               scaleWrapper.appendChild(previewWidget.domElement);
             }
           }


### PR DESCRIPTION
## What

The Widgets tab in the right sidebar still offered the two old basic-widget rules under **Decorative** ("Horizontal Rule" and "Vertical Rule"). Since #3021 added the `line` widget type, the add widget overlay offers four line-based decorations instead — but the sidebar never learned about them.

This replaces the two rules with those four widgets, using the exact same JSON the add widget overlay generates:

| Widget | What it is |
| --- | --- |
| **Divider** | a plain line, the drop-in replacement for the old rules (it can be rotated, curved and restyled, so it covers both the horizontal and the vertical case) |
| **Line (with stops)** | the same line with a stop holder at each end |
| **Circle** | a closed line in its `ellipse` shape, without stops |
| **Ring (with stops)** | a closed line with four stops spread all the way round |

Each pair is ordered plain-first, and the two entries that carry stops say so in their name, following the convention the neighbouring group already uses (*Hex (flat)*, *Die (image)*) — without it, *Line*/*Divider* and *Circle*/*Ring* read as synonyms and the only thing telling them apart was the grey `line, holder` type line.

All four also carry a new optional `description`, which the sidebar shows as a tooltip in both list and grid view (in grid view the name is all there is) and which the filter now searches, so the retired vocabulary still finds the replacement: typing `rule`, `horizontal` or `vertical` returns **Divider**.

Three 24×24 icons (`line.svg`, `ring.svg`, `divider.svg`) are added for the previews so the four read as one family — same bar length and stop radius, one stroke weight, and the ring inset far enough that its stops stay clear of the grid view's add button. Circle reuses the existing `circle_hollow.svg`.

These are the first library entries that use `inheritFrom` and a line's `stops`, which exposed a gap in the sidebar's **drag image**: the `dragstart` preview builders only remapped `parent` and `deck`, so every other id reference kept the library id and the widget fell back to its default size — dragging **Line** showed one round stop plus a 111×168 card holder, **Ring** one stop plus three. The dropped result was always correct, only the drag image was wrong. Both builders (grid view and list view) now run the preview states through the same `deepReplace` the placement path uses.

## Why

Anything the add widget overlay offers should also be reachable from the Widgets sidebar — that is where the widgets can be dragged into the room and dropped onto an existing line. Leaving the rules there also pointed people at the old basic-widget-with-a-border trick instead of the real line widget.

## Testing

- `npm test` passes (86 tests), `tests/testcafe/editor.js` passes (5 tests).
- Verified in a browser: the Decorative group now lists Heading, Label, Divider, Line (with stops), Circle and Ring (with stops), and adding each of the four places a correctly-shaped line in the room with its stops attached (`stops`/`parent`/`inheritFrom` are remapped correctly by the sidebar's id remapper).
- Tooltips are present on every entry in both views; filtering for `rule`, `horizontal` and `vertical` returns Divider, `oval` returns Circle, `stops` returns all four.
- Measured the grid view add button against the ring artwork: the button covers viewBox x ≥ 15.6 / y ≤ 8.4, the ring's top stop spans x 9.5–14.5 and its right stop y 9.5–14.5, so both stay visible (also at 500×800).
- Drag image: dispatched `dragstart` on the sidebar entries and inspected the preview container. `lineS1` went from 111×168 / radius 8px to 40×40 / radius 20px, Ring shows four 40×40 circles, and a deck-based entry (*Stacks of Chips*) still previews its cards with the deck's cardType in both grid and list view.

![Decorative group in grid view](https://agent.virtualtabletop.io/reports/pr/1531506069518418021/decorative-grid-after.png)
![Decorative group in list view, with all four widgets added to the room](https://agent.virtualtabletop.io/reports/pr/1531506069518418021/decorative-list-and-room-after.png)


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3060/pr-test (or any other room on that server)
