### PR TITLE
Perfect Draw!: update to the author's styled HTML player decks

### DIFF
--- a/library/games/Perfect Draw_/0.json
+++ b/library/games/Perfect Draw_/0.json
@@ -287,7 +287,11 @@
                 "position": "absolute",
                 "left": "12px",
                 "top": "76px",
-                "width": "76px"
+                "width": "76px",
+                "height": "41px",
+                "line-height": "7px",
+                "overflow": "hidden",
+                "overflow-wrap": "break-word"
               },
               ".footer": {
                 "font-size": "6px",
@@ -919,7 +923,11 @@
                 "position": "absolute",
                 "left": "12px",
                 "top": "76px",
-                "width": "76px"
+                "width": "76px",
+                "height": "41px",
+                "line-height": "7px",
+                "overflow": "hidden",
+                "overflow-wrap": "break-word"
               },
               ".footer": {
                 "font-size": "6px",
@@ -2297,7 +2305,11 @@
                 "position": "absolute",
                 "left": "12px",
                 "top": "76px",
-                "width": "76px"
+                "width": "76px",
+                "height": "41px",
+                "line-height": "7px",
+                "overflow": "hidden",
+                "overflow-wrap": "break-word"
               },
               ".footer": {
                 "font-size": "6px",
@@ -2504,7 +2516,11 @@
                 "position": "absolute",
                 "left": "12px",
                 "top": "76px",
-                "width": "76px"
+                "width": "76px",
+                "height": "41px",
+                "line-height": "7px",
+                "overflow": "hidden",
+                "overflow-wrap": "break-word"
               },
               ".footer": {
                 "font-size": "6px",

--- a/library/games/Perfect Draw_/0.json
+++ b/library/games/Perfect Draw_/0.json
@@ -10,7 +10,7 @@
       "mode": "vs",
       "time": "120",
       "attribution": "<div>Game name, design, text, and graphics by Nora Jean Haynes, Iris Cassandra Saintclaire, and Thunderderder. Published by Double Summon Games: https://doublesummon.itch.io/perfect-draw-ttrpg and https://www.fiverr.com/thunderderder. Approved for use on Virtualtabletop.io with permission from the rights holders.</div><div>\n</div><div>Additional graphics from https://game-icons.net/ available as listed on the About overlay.</div><div>\n</div><div>Urbanist Font by Corey Hu, available under SIL Open Font License, Version 1.1.</div><div><br></div><div>Room Layout by Littlemitten and released to the Public Domain under CC0.</div>",
-      "lastUpdate": 1775692826812,
+      "lastUpdate": 1785221852470,
       "skill": "",
       "description": "\"Perfect Draw! is a tabletop role-playing game based on the Powered By The Apocalypse framework that combines Trading Card Games with collaborative storytelling - allowing you to tell stories similar to card game anime like Yu-Gi-Oh!, Duel Masters, and CardFight! Vanguard\"",
       "similarImage": "",
@@ -185,63 +185,124 @@
     "y": 36,
     "cardTypes": {
       "card1": {
-        "face": "/assets/1185280421_37356",
-        "offsetX": 0,
-        "offsetY": 0,
-        "deckWidth": 1,
-        "deckHeight": 1
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
       },
       "card2": {
-        "face": "/assets/1185280421_37356",
-        "offsetX": 0,
-        "offsetY": 0,
-        "deckWidth": 1,
-        "deckHeight": 1
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
       },
       "card3": {
-        "face": "/assets/1185280421_37356",
-        "offsetX": 0,
-        "offsetY": 0,
-        "deckWidth": 1,
-        "deckHeight": 1
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
       },
       "card4": {
-        "face": "/assets/1185280421_37356",
-        "offsetX": 0,
-        "offsetY": 0,
-        "deckWidth": 1,
-        "deckHeight": 1
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
+      },
+      "card5": {
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
+      },
+      "card6": {
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
+      },
+      "card7": {
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
+      },
+      "card8": {
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
       }
     },
     "faceTemplates": [
       {
+        "border": false,
+        "radius": false,
         "objects": [
           {
             "type": "image",
-            "css": {
-              "background-size": "calc(var(--width) * var(--deckWidth) * 1px) calc(var(--height) * var(--deckHeight) * 1px)",
-              "background-position": "calc(var(--width) * var(--offsetX) * -1px) calc(var(--height) * var(--offsetY) * -1px)"
-            },
-            "dynamicProperties": {
-              "value": "back",
-              "width": "width",
-              "height": "height"
-            }
+            "x": 0,
+            "y": 0,
+            "width": 100,
+            "height": 140,
+            "color": "transparent",
+            "value": "/assets/-1569446033_3396"
           }
         ]
       },
       {
+        "border": false,
+        "radius": false,
         "objects": [
           {
             "type": "image",
+            "x": 0,
+            "y": 0,
+            "width": 100,
+            "height": 140,
+            "color": "transparent",
+            "value": "/assets/1185280421_37356"
+          },
+          {
+            "type": "html",
+            "x": 0,
+            "y": 0,
+            "value": "<div class=name>${PROPERTY cardName}</div><img src=${PROPERTY cardImage} class=image><div class=text>${PROPERTY cardText}</div><div class=footer>${PROPERTY cardFooter}</div>",
+            "width": 100,
+            "height": 140,
             "css": {
-              "background-size": "calc(var(--width) * var(--deckWidth) * 1px) calc(var(--height) * var(--deckHeight) * 1px)",
-              "background-position": "calc(var(--width) * var(--offsetX) * -1px) calc(var(--height) * var(--offsetY) * -1px)"
-            },
-            "dynamicProperties": {
-              "value": "face",
-              "width": "width",
-              "height": "height"
+              "body": {
+                "font-family": "Urbanist",
+                "text-align": "left",
+                "color": "#2F3433",
+                "font-size": "6px"
+              },
+              ".name": {
+                "font-family": "Urbanist-bold",
+                "position": "absolute",
+                "left": "12px",
+                "top": "4px",
+                "width": "76px"
+              },
+              ".text": {
+                "position": "absolute",
+                "left": "12px",
+                "top": "76px",
+                "width": "76px"
+              },
+              ".footer": {
+                "font-size": "6px",
+                "position": "absolute",
+                "left": "12px",
+                "top": "125px",
+                "width": "76px"
+              },
+              ".image": {
+                "position": "absolute",
+                "left": "8px",
+                "top": "16px",
+                "max-width": "84px",
+                "max-height": "55px"
+              }
             }
           }
         ]
@@ -249,18 +310,9 @@
     ],
     "z": 353,
     "cardDefaults": {
-      "width": 100,
       "height": 140,
-      "enlarge": 4,
-      "css": {
-        "--offsetX": "${PROPERTY offsetX}",
-        "--offsetY": "${PROPERTY offsetY}",
-        "--deckWidth": "${PROPERTY deckWidth}",
-        "--deckHeight": "${PROPERTY deckHeight}",
-        "--width": "${PROPERTY width}",
-        "--height": "${PROPERTY height}"
-      },
-      "back": "/assets/-1569446033_3396"
+      "width": 100,
+      "enlarge": 4
     },
     "parent": "xi12b"
   },
@@ -2143,63 +2195,124 @@
     "y": 36,
     "cardTypes": {
       "card1": {
-        "face": "/assets/1185280421_37356",
-        "offsetX": 0,
-        "offsetY": 0,
-        "deckWidth": 1,
-        "deckHeight": 1
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
       },
       "card2": {
-        "face": "/assets/1185280421_37356",
-        "offsetX": 0,
-        "offsetY": 0,
-        "deckWidth": 1,
-        "deckHeight": 1
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
       },
       "card3": {
-        "face": "/assets/1185280421_37356",
-        "offsetX": 0,
-        "offsetY": 0,
-        "deckWidth": 1,
-        "deckHeight": 1
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
       },
       "card4": {
-        "face": "/assets/1185280421_37356",
-        "offsetX": 0,
-        "offsetY": 0,
-        "deckWidth": 1,
-        "deckHeight": 1
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
+      },
+      "card5": {
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
+      },
+      "card6": {
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
+      },
+      "card7": {
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
+      },
+      "card8": {
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
       }
     },
     "faceTemplates": [
       {
+        "border": false,
+        "radius": false,
         "objects": [
           {
             "type": "image",
-            "css": {
-              "background-size": "calc(var(--width) * var(--deckWidth) * 1px) calc(var(--height) * var(--deckHeight) * 1px)",
-              "background-position": "calc(var(--width) * var(--offsetX) * -1px) calc(var(--height) * var(--offsetY) * -1px)"
-            },
-            "dynamicProperties": {
-              "value": "back",
-              "width": "width",
-              "height": "height"
-            }
+            "x": 0,
+            "y": 0,
+            "width": 100,
+            "height": 140,
+            "color": "transparent",
+            "value": "/assets/-1569446033_3396"
           }
         ]
       },
       {
+        "border": false,
+        "radius": false,
         "objects": [
           {
             "type": "image",
+            "x": 0,
+            "y": 0,
+            "width": 100,
+            "height": 140,
+            "color": "transparent",
+            "value": "/assets/1185280421_37356"
+          },
+          {
+            "type": "html",
+            "x": 0,
+            "y": 0,
+            "value": "<div class=name>${PROPERTY cardName}</div><img src=${PROPERTY cardImage} class=image><div class=text>${PROPERTY cardText}</div><div class=footer>${PROPERTY cardFooter}</div>",
+            "width": 100,
+            "height": 140,
             "css": {
-              "background-size": "calc(var(--width) * var(--deckWidth) * 1px) calc(var(--height) * var(--deckHeight) * 1px)",
-              "background-position": "calc(var(--width) * var(--offsetX) * -1px) calc(var(--height) * var(--offsetY) * -1px)"
-            },
-            "dynamicProperties": {
-              "value": "face",
-              "width": "width",
-              "height": "height"
+              "body": {
+                "font-family": "Urbanist",
+                "text-align": "left",
+                "color": "#2F3433",
+                "font-size": "6px"
+              },
+              ".name": {
+                "font-family": "Urbanist-bold",
+                "position": "absolute",
+                "left": "12px",
+                "top": "4px",
+                "width": "76px"
+              },
+              ".text": {
+                "position": "absolute",
+                "left": "12px",
+                "top": "76px",
+                "width": "76px"
+              },
+              ".footer": {
+                "font-size": "6px",
+                "position": "absolute",
+                "left": "12px",
+                "top": "125px",
+                "width": "76px"
+              },
+              ".image": {
+                "position": "absolute",
+                "left": "8px",
+                "top": "16px",
+                "max-width": "84px",
+                "max-height": "55px"
+              }
             }
           }
         ]
@@ -2207,18 +2320,9 @@
     ],
     "z": 353,
     "cardDefaults": {
-      "width": 100,
       "height": 140,
-      "enlarge": 4,
-      "css": {
-        "--offsetX": "${PROPERTY offsetX}",
-        "--offsetY": "${PROPERTY offsetY}",
-        "--deckWidth": "${PROPERTY deckWidth}",
-        "--deckHeight": "${PROPERTY deckHeight}",
-        "--width": "${PROPERTY width}",
-        "--height": "${PROPERTY height}"
-      },
-      "back": "/assets/-1569446033_3396"
+      "width": 100,
+      "enlarge": 4
     },
     "parent": "xi13b"
   },
@@ -2298,63 +2402,124 @@
     "y": 36,
     "cardTypes": {
       "card1": {
-        "face": "/assets/1185280421_37356",
-        "offsetX": 0,
-        "offsetY": 0,
-        "deckWidth": 1,
-        "deckHeight": 1
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
       },
       "card2": {
-        "face": "/assets/1185280421_37356",
-        "offsetX": 0,
-        "offsetY": 0,
-        "deckWidth": 1,
-        "deckHeight": 1
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
       },
       "card3": {
-        "face": "/assets/1185280421_37356",
-        "offsetX": 0,
-        "offsetY": 0,
-        "deckWidth": 1,
-        "deckHeight": 1
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
       },
       "card4": {
-        "face": "/assets/1185280421_37356",
-        "offsetX": 0,
-        "offsetY": 0,
-        "deckWidth": 1,
-        "deckHeight": 1
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
+      },
+      "card5": {
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
+      },
+      "card6": {
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
+      },
+      "card7": {
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
+      },
+      "card8": {
+        "cardName": "Card Name",
+        "cardText": "Card Text",
+        "cardFooter": "{Strength} Type",
+        "cardImage": "/i/game-icons.net/lorc/wyvern.svg"
       }
     },
     "faceTemplates": [
       {
+        "border": false,
+        "radius": false,
         "objects": [
           {
             "type": "image",
-            "css": {
-              "background-size": "calc(var(--width) * var(--deckWidth) * 1px) calc(var(--height) * var(--deckHeight) * 1px)",
-              "background-position": "calc(var(--width) * var(--offsetX) * -1px) calc(var(--height) * var(--offsetY) * -1px)"
-            },
-            "dynamicProperties": {
-              "value": "back",
-              "width": "width",
-              "height": "height"
-            }
+            "x": 0,
+            "y": 0,
+            "width": 100,
+            "height": 140,
+            "color": "transparent",
+            "value": "/assets/-1569446033_3396"
           }
         ]
       },
       {
+        "border": false,
+        "radius": false,
         "objects": [
           {
             "type": "image",
+            "x": 0,
+            "y": 0,
+            "width": 100,
+            "height": 140,
+            "color": "transparent",
+            "value": "/assets/1185280421_37356"
+          },
+          {
+            "type": "html",
+            "x": 0,
+            "y": 0,
+            "value": "<div class=name>${PROPERTY cardName}</div><img src=${PROPERTY cardImage} class=image><div class=text>${PROPERTY cardText}</div><div class=footer>${PROPERTY cardFooter}</div>",
+            "width": 100,
+            "height": 140,
             "css": {
-              "background-size": "calc(var(--width) * var(--deckWidth) * 1px) calc(var(--height) * var(--deckHeight) * 1px)",
-              "background-position": "calc(var(--width) * var(--offsetX) * -1px) calc(var(--height) * var(--offsetY) * -1px)"
-            },
-            "dynamicProperties": {
-              "value": "face",
-              "width": "width",
-              "height": "height"
+              "body": {
+                "font-family": "Urbanist",
+                "text-align": "left",
+                "color": "#2F3433",
+                "font-size": "6px"
+              },
+              ".name": {
+                "font-family": "Urbanist-bold",
+                "position": "absolute",
+                "left": "12px",
+                "top": "4px",
+                "width": "76px"
+              },
+              ".text": {
+                "position": "absolute",
+                "left": "12px",
+                "top": "76px",
+                "width": "76px"
+              },
+              ".footer": {
+                "font-size": "6px",
+                "position": "absolute",
+                "left": "12px",
+                "top": "125px",
+                "width": "76px"
+              },
+              ".image": {
+                "position": "absolute",
+                "left": "8px",
+                "top": "16px",
+                "max-width": "84px",
+                "max-height": "55px"
+              }
             }
           }
         ]
@@ -2362,18 +2527,9 @@
     ],
     "z": 353,
     "cardDefaults": {
-      "width": 100,
       "height": 140,
-      "enlarge": 4,
-      "css": {
-        "--offsetX": "${PROPERTY offsetX}",
-        "--offsetY": "${PROPERTY offsetY}",
-        "--deckWidth": "${PROPERTY deckWidth}",
-        "--deckHeight": "${PROPERTY deckHeight}",
-        "--width": "${PROPERTY width}",
-        "--height": "${PROPERTY height}"
-      },
-      "back": "/assets/-1569446033_3396"
+      "width": 100,
+      "enlarge": 4
     },
     "parent": "xi15b"
   },


### PR DESCRIPTION
## What

Public-library update for the existing game **Perfect Draw!** (`library/games/Perfect Draw_/`).

The game's authors sent a new `.vtt` export, forwarded by **rapha195**. It replaces the three default player decks with the game's **styled HTML cards**: instead of a plain spritesheet image, each card face is now built from a background, an icon and `${PROPERTY …}` text fields (`cardName`, `cardText`, `cardFooter`, `cardImage`), styled with the game's Urbanist font. That makes the starter cards directly fillable/editable by players rather than fixed artwork, and the decks grew from 4 to 8 card types.

Only `library/games/Perfect Draw_/0.json` changes — every asset in `assets/` is byte-identical to what is already in the repo and all 14 of them are still referenced, so nothing was added or removed there.

## Metadata

The uploaded export was based on an **older revision of the library metadata**, so its `_meta.info` was *not* taken over. The `_meta.info` currently on `main` is kept verbatim — the cleaned-up attribution with the rights-holder permission note, `bgg` pointing at the itch.io page, `year: "2024"`, and the tidied description / `similarDesigner` / `helpText`. The only metadata field changed is `lastUpdate`, bumped because the game content itself changed.

Two cosmetic export artifacts were normalised back to what `main` had, because they are new validator errors and have no effect on the game: `epl1` gained a `"parent": null`, and the three `xi9bD` cards gained `"x": null, "y": null` instead of `0`.

## Verification

- `node validator/validate_gamefile_node.js "library/games/Perfect Draw_/0.json"` reports exactly the same single pre-existing note as `main` (`_meta.info.bgg` is the itch.io URL, not a BGG one) — no new findings.
- `npm test` passes.
- Loaded the game from the library on a local server: the styled faces render correctly and are usable — flipping a deck's top card shows the HTML face, and it can be dragged onto a Battlefield.

Card close-up and full table after flipping/dragging:

![styled card close-up](https://agent.virtualtabletop.io/reports/pr/1531555337956757530/perfect-draw-card-closeup.png)

![game table](https://agent.virtualtabletop.io/reports/pr/1531555337956757530/perfect-draw-styled-cards.png)

Credit to **rapha195** for submitting the updated file on the authors' behalf.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3061/pr-test (or any other room on that server)