### PR TITLE
Rebuild the All Aboard map with line widgets

### DIFF
--- a/client/js/widgets/line.js
+++ b/client/js/widgets/line.js
@@ -298,40 +298,37 @@ export class Line extends Widget {
   // A stop outside the line is placed through global coordinates, which read the
   // CSS transforms of the frames it converts between. Inside a batch those show
   // the state of the previous event, so after normalizeGeometry moved the box -
-  // which is what positionAttachedWidgets runs on - every stop would land off
-  // the path by exactly that move. Same reason applyConnections flushes. Only a
-  // transform change can make them stale, so a re-space - which rewrites nothing
-  // but the stops and their own x/y - costs one flush instead of one per pass.
-  flushStaleTransforms() {
-    if(!this.hasExternalStops())
-      return;
-    const transforms = this.stopFrameTransforms();
-    if(transforms == this.flushedTransforms)
-      return;
-    flushDelta();
-    this.flushedTransforms = transforms;
+  // which is what positionAttachedWidgets runs on - the stop would land off the
+  // path by exactly that move. Same reason applyConnections flushes. Asking the
+  // DOM whether it still matches the state - rather than remembering what was
+  // flushed before - also covers a frame that was flushed by something else in
+  // the batch and changed again since, and still costs no flush at all for a
+  // re-space, which rewrites nothing but the stops and their own x/y.
+  flushStaleTransforms(stop) {
+    if(this.stopFrames(stop).some(frame=>frame.domElement.style.transform != frame.cssTransform()))
+      flushDelta();
   }
 
   // stopCoordInParentFrame converts through two chains of DOM transforms: this
-  // line up to the room, and the same for the parent each external stop is
-  // placed in. Either going stale inside a batch displaces the stop, so both
-  // sides go into the snapshot flushStaleTransforms compares against.
-  stopFrameTransforms() {
-    const frames = [ this, ...this.attachedWidgets().map(stop=>widgets.get(stop.get('parent'))) ];
-    const seen = new Set();
-    const chain = [];
-    for(const frame of frames)
-      for(let w = frame; w && !seen.has(w.id); w = widgets.get(w.get('parent'))) {
-        seen.add(w.id);
-        chain.push(w.id, ...w.cssTransformProperties().map(property=>w.get(property)));
-      }
-    return chain.join();
+  // line up to the room, and the same for the parent the stop is placed in.
+  // Either going stale inside a batch displaces the stop. A stop that is a child
+  // of the line is never converted, so it reads no transform at all.
+  stopFrames(stop) {
+    if(stop.get('parent') == this.id)
+      return [];
+    const frames = [];
+    for(const start of [ this, widgets.get(stop.get('parent')) ])
+      for(let w = start; w && !frames.includes(w); w = widgets.get(w.get('parent')))
+        frames.push(w);
+    return frames;
   }
 
   async positionAttachedWidgets() {
-    this.flushStaleTransforms();
     for(const entry of this.stopList()) {
       const stop = widgets.get(entry.widget);
+      // per stop, because the x/y this loop writes are themselves unflushed and
+      // one stop can be (inside) the frame another stop is placed in
+      this.flushStaleTransforms(stop);
       const p = this.stopCoordInParentFrame(stop, this.pointAtPosition(entry.position));
       await stop.set('x', Math.round(p.x - stop.get('width')/2));
       await stop.set('y', Math.round(p.y - stop.get('height')/2));

--- a/client/js/widgets/line.js
+++ b/client/js/widgets/line.js
@@ -295,14 +295,28 @@ export class Line extends Widget {
     }
   }
 
+  // A stop outside the line is placed through global coordinates, which read the
+  // CSS transforms of this line and its parents. Inside a batch those still show
+  // the state of the previous event, so after normalizeGeometry moved the box -
+  // which is what positionAttachedWidgets runs on - every stop would land off
+  // the path by exactly that move. Same reason applyConnections flushes. Only a
+  // transform change can make them stale, so a re-space - which rewrites nothing
+  // but the stops and their own x/y - costs one flush instead of one per pass.
+  flushStaleTransforms() {
+    if(!this.hasExternalStops())
+      return;
+    const chain = [];
+    for(let w = this; w; w = widgets.get(w.get('parent')))
+      chain.push(w.id, ...w.cssTransformProperties().map(property=>w.get(property)));
+    const transforms = chain.join();
+    if(transforms == this.flushedTransforms)
+      return;
+    flushDelta();
+    this.flushedTransforms = transforms;
+  }
+
   async positionAttachedWidgets() {
-    // A stop outside the line is placed through global coordinates, which read
-    // this line's CSS transform. Inside a batch that still shows the state of
-    // the previous event, so after normalizeGeometry moved the box - which is
-    // what the layout below runs on - every stop would land off the path by
-    // exactly that move. Same reason applyConnections flushes.
-    if(this.hasExternalStops())
-      flushDelta();
+    this.flushStaleTransforms();
     for(const entry of this.stopList()) {
       const stop = widgets.get(entry.widget);
       const p = this.stopCoordInParentFrame(stop, this.pointAtPosition(entry.position));

--- a/client/js/widgets/line.js
+++ b/client/js/widgets/line.js
@@ -296,7 +296,7 @@ export class Line extends Widget {
   }
 
   // A stop outside the line is placed through global coordinates, which read the
-  // CSS transforms of this line and its parents. Inside a batch those still show
+  // CSS transforms of the frames it converts between. Inside a batch those show
   // the state of the previous event, so after normalizeGeometry moved the box -
   // which is what positionAttachedWidgets runs on - every stop would land off
   // the path by exactly that move. Same reason applyConnections flushes. Only a
@@ -305,14 +305,27 @@ export class Line extends Widget {
   flushStaleTransforms() {
     if(!this.hasExternalStops())
       return;
-    const chain = [];
-    for(let w = this; w; w = widgets.get(w.get('parent')))
-      chain.push(w.id, ...w.cssTransformProperties().map(property=>w.get(property)));
-    const transforms = chain.join();
+    const transforms = this.stopFrameTransforms();
     if(transforms == this.flushedTransforms)
       return;
     flushDelta();
     this.flushedTransforms = transforms;
+  }
+
+  // stopCoordInParentFrame converts through two chains of DOM transforms: this
+  // line up to the room, and the same for the parent each external stop is
+  // placed in. Either going stale inside a batch displaces the stop, so both
+  // sides go into the snapshot flushStaleTransforms compares against.
+  stopFrameTransforms() {
+    const frames = [ this, ...this.attachedWidgets().map(stop=>widgets.get(stop.get('parent'))) ];
+    const seen = new Set();
+    const chain = [];
+    for(const frame of frames)
+      for(let w = frame; w && !seen.has(w.id); w = widgets.get(w.get('parent'))) {
+        seen.add(w.id);
+        chain.push(w.id, ...w.cssTransformProperties().map(property=>w.get(property)));
+      }
+    return chain.join();
   }
 
   async positionAttachedWidgets() {

--- a/client/js/widgets/line.js
+++ b/client/js/widgets/line.js
@@ -296,6 +296,13 @@ export class Line extends Widget {
   }
 
   async positionAttachedWidgets() {
+    // A stop outside the line is placed through global coordinates, which read
+    // this line's CSS transform. Inside a batch that still shows the state of
+    // the previous event, so after normalizeGeometry moved the box - which is
+    // what the layout below runs on - every stop would land off the path by
+    // exactly that move. Same reason applyConnections flushes.
+    if(this.hasExternalStops())
+      flushDelta();
     for(const entry of this.stopList()) {
       const stop = widgets.get(entry.widget);
       const p = this.stopCoordInParentFrame(stop, this.pointAtPosition(entry.position));

--- a/library/games/All Aboard/0.json
+++ b/library/games/All Aboard/0.json
@@ -1922,8 +1922,8 @@
   "h3": {
     "type": "holder",
     "id": "h3",
-    "x": 781,
-    "y": 90,
+    "x": 782,
+    "y": 91,
     "inheritFrom": "Holder Template",
     "route": 3,
     "rotation": -158,
@@ -1932,11 +1932,11 @@
   "h4": {
     "type": "holder",
     "id": "h4",
-    "x": 1001,
+    "x": 1004,
     "y": 165,
     "inheritFrom": "Holder Template",
     "route": 4,
-    "rotation": 14.46,
+    "rotation": 15.84,
     "parent": "Board"
   },
   "h5": {
@@ -1953,11 +1953,11 @@
   "h6": {
     "type": "holder",
     "id": "h6",
-    "x": 1234,
-    "y": 140,
+    "x": 1235,
+    "y": 141,
     "inheritFrom": "Holder Template",
     "route": 6,
-    "rotation": -130.39,
+    "rotation": -130.09,
     "parent": "Board"
   },
   "h7": {
@@ -1967,7 +1967,7 @@
     "y": 120,
     "inheritFrom": "Holder Template",
     "route": 7,
-    "rotation": -139.64,
+    "rotation": -139.82,
     "parent": "Board"
   },
   "h8": {
@@ -2005,30 +2005,30 @@
   "h11": {
     "type": "holder",
     "id": "h11",
-    "x": 1132,
+    "x": 1133,
     "y": 271,
     "inheritFrom": "Holder Template",
     "route": 11,
     "color": "#9EEFE5",
-    "rotation": 160.1,
+    "rotation": 159.78,
     "parent": "Board"
   },
   "h12": {
     "type": "holder",
     "id": "h12",
-    "x": 1092,
+    "x": 1090,
     "y": 304,
     "inheritFrom": "Holder Template",
     "route": 12,
     "color": "#058C42",
-    "rotation": 164.33,
+    "rotation": 164.43,
     "parent": "Board"
   },
   "h13": {
     "type": "holder",
     "id": "h13",
     "x": 1048,
-    "y": 268,
+    "y": 269,
     "inheritFrom": "Holder Template",
     "route": 13,
     "rotation": -93.75,
@@ -2059,29 +2059,29 @@
   "h16": {
     "type": "holder",
     "id": "h16",
-    "x": 865,
-    "y": 154,
+    "x": 871,
+    "y": 152,
     "inheritFrom": "Holder Template",
     "route": 16,
-    "rotation": -14.95,
+    "rotation": -14.61,
     "parent": "Board"
   },
   "h17": {
     "type": "holder",
     "id": "h17",
-    "x": 553,
-    "y": 48,
+    "x": 567,
+    "y": 40,
     "inheritFrom": "Holder Template",
     "route": 17,
     "color": "#648DE5",
-    "rotation": -30.78,
+    "rotation": -28.8,
     "parent": "Board"
   },
   "h18": {
     "type": "holder",
     "id": "h18",
-    "x": 659,
-    "y": 96,
+    "x": 658,
+    "y": 94,
     "inheritFrom": "Holder Template",
     "route": 18,
     "color": "#A300A0",
@@ -2155,7 +2155,7 @@
   "h25": {
     "type": "holder",
     "id": "h25",
-    "x": 132,
+    "x": 131,
     "y": 42,
     "inheritFrom": "Holder Template",
     "route": 25,
@@ -2178,18 +2178,18 @@
   "h27": {
     "type": "holder",
     "id": "h27",
-    "x": 423,
-    "y": 339,
+    "x": 424,
+    "y": 342,
     "inheritFrom": "Holder Template",
     "route": 27,
     "color": "#058C42",
-    "rotation": -105.82,
+    "rotation": -105.92,
     "parent": "Board"
   },
   "h28": {
     "type": "holder",
     "id": "h28",
-    "x": 584,
+    "x": 587,
     "y": 189,
     "inheritFrom": "Holder Template",
     "route": 28,
@@ -2247,8 +2247,8 @@
   "h33": {
     "type": "holder",
     "id": "h33",
-    "x": 397,
-    "y": 352,
+    "x": 401,
+    "y": 353,
     "inheritFrom": "Holder Template",
     "route": 33,
     "color": "#A30000",
@@ -2259,7 +2259,7 @@
   "h34": {
     "type": "holder",
     "id": "h34",
-    "x": 878,
+    "x": 879,
     "y": 480,
     "inheritFrom": "Holder Template",
     "route": 34,
@@ -2270,32 +2270,32 @@
   "h35": {
     "type": "holder",
     "id": "h35",
-    "x": 801,
-    "y": 638,
+    "x": 802,
+    "y": 639,
     "inheritFrom": "Holder Template",
     "route": 35,
     "color": "#058C42",
-    "rotation": 71.7,
+    "rotation": 71.77,
     "parent": "Board"
   },
   "h36": {
     "type": "holder",
     "id": "h36",
     "x": 638,
-    "y": 525,
+    "y": 524,
     "inheritFrom": "Holder Template",
     "route": 36,
-    "rotation": -100.24,
+    "rotation": -100.12,
     "parent": "Board"
   },
   "h37": {
     "type": "holder",
     "id": "h37",
     "x": 619,
-    "y": 530,
+    "y": 529,
     "inheritFrom": "Holder Template",
     "route": 37,
-    "rotation": -100.4,
+    "rotation": -100.19,
     "parent": "Board"
   },
   "h38": {
@@ -2321,8 +2321,8 @@
   "h40": {
     "type": "holder",
     "id": "h40",
-    "x": 669,
-    "y": 418,
+    "x": 670,
+    "y": 417,
     "inheritFrom": "Holder Template",
     "route": 40,
     "rotation": 115.74,
@@ -2331,8 +2331,8 @@
   "h41": {
     "type": "holder",
     "id": "h41",
-    "x": 652,
-    "y": 409,
+    "x": 653,
+    "y": 408,
     "inheritFrom": "Holder Template",
     "route": 41,
     "rotation": 115.74,
@@ -2341,45 +2341,45 @@
   "h42": {
     "type": "holder",
     "id": "h42",
-    "x": 627,
+    "x": 636,
     "y": 389,
     "inheritFrom": "Holder Template",
     "route": 42,
     "color": "#FF7700",
     "parent": "Board",
-    "rotation": -1.37
+    "rotation": -1.32
   },
   "h43": {
     "type": "holder",
     "id": "h43",
-    "x": 580,
-    "y": 372,
+    "x": 583,
+    "y": 371,
     "inheritFrom": "Holder Template",
     "route": 43,
     "color": "#A300A0",
     "parent": "Board",
-    "rotation": -1.03
+    "rotation": -1.1
   },
   "h44": {
     "type": "holder",
     "id": "h44",
-    "x": 567,
+    "x": 569,
     "y": 324,
     "inheritFrom": "Holder Template",
     "route": 44,
     "color": "#EF233C",
-    "rotation": -11.54,
+    "rotation": -11.26,
     "parent": "Board"
   },
   "h45": {
     "type": "holder",
     "id": "h45",
-    "x": 1099,
-    "y": 735,
+    "x": 1101,
+    "y": 742,
     "inheritFrom": "Holder Template",
     "route": 45,
     "color": "#EF233C",
-    "rotation": 77.34,
+    "rotation": 81.1,
     "parent": "Board"
   },
   "h46": {
@@ -2396,22 +2396,22 @@
   "h47": {
     "type": "holder",
     "id": "h47",
-    "x": 1066,
-    "y": 748,
+    "x": 1071,
+    "y": 753,
     "inheritFrom": "Holder Template",
     "route": 47,
     "color": "#A30000",
-    "rotation": -134.98,
+    "rotation": -134.69,
     "parent": "Board"
   },
   "h48": {
     "type": "holder",
     "id": "h48",
-    "x": 776,
+    "x": 777,
     "y": 681,
     "inheritFrom": "Holder Template",
     "route": 48,
-    "rotation": -5.95,
+    "rotation": -6.2,
     "parent": "Board"
   },
   "h49": {
@@ -2439,19 +2439,19 @@
   "h51": {
     "type": "holder",
     "id": "h51",
-    "x": 543,
+    "x": 549,
     "y": 615,
     "inheritFrom": "Holder Template",
     "route": 51,
     "color": "#A30000",
     "z": 234,
     "parent": "Board",
-    "rotation": -179.91
+    "rotation": 179.81
   },
   "h52": {
     "type": "holder",
     "id": "h52",
-    "x": 557,
+    "x": 558,
     "y": 680,
     "inheritFrom": "Holder Template",
     "route": 52,
@@ -2474,8 +2474,8 @@
   "h54": {
     "type": "holder",
     "id": "h54",
-    "x": 353,
-    "y": 596,
+    "x": 354,
+    "y": 597,
     "inheritFrom": "Holder Template",
     "route": 54,
     "rotation": -149.21,
@@ -2485,12 +2485,12 @@
   "h55": {
     "type": "holder",
     "id": "h55",
-    "x": 248,
+    "x": 249,
     "y": 598,
     "inheritFrom": "Holder Template",
     "route": 55,
     "color": "#A300A0",
-    "rotation": -162.53,
+    "rotation": -162.63,
     "z": 219,
     "parent": "Board"
   },
@@ -2521,7 +2521,7 @@
     "type": "holder",
     "id": "h58",
     "x": 413,
-    "y": 460,
+    "y": 461,
     "inheritFrom": "Holder Template",
     "route": 58,
     "rotation": 105.05,
@@ -2543,7 +2543,7 @@
   "h60": {
     "type": "holder",
     "id": "h60",
-    "x": 184,
+    "x": 185,
     "y": 336,
     "inheritFrom": "Holder Template",
     "route": 60,
@@ -2555,8 +2555,8 @@
   "h61": {
     "type": "holder",
     "id": "h61",
-    "x": 152,
-    "y": 471,
+    "x": 153,
+    "y": 470,
     "inheritFrom": "Holder Template",
     "route": 61,
     "rotation": 146.82,
@@ -2578,8 +2578,8 @@
   "h63": {
     "type": "holder",
     "id": "h63",
-    "x": 390,
-    "y": 369,
+    "x": 394,
+    "y": 370,
     "inheritFrom": "Holder Template",
     "route": 63,
     "color": "#F7F052",
@@ -2622,21 +2622,21 @@
   "h67": {
     "type": "holder",
     "id": "h67",
-    "x": 1036,
-    "y": 482,
+    "x": 1037,
+    "y": 481,
     "inheritFrom": "Holder Template",
     "route": 67,
-    "rotation": -32.48,
+    "rotation": -32.71,
     "parent": "Board"
   },
   "h68": {
     "type": "holder",
     "id": "h68",
-    "x": 1006,
-    "y": 521,
+    "x": 1005,
+    "y": 522,
     "inheritFrom": "Holder Template",
     "route": 68,
-    "rotation": -30.19,
+    "rotation": -30.31,
     "parent": "Board"
   },
   "h69": {
@@ -2667,14 +2667,14 @@
     "inheritFrom": "Holder Template",
     "route": 71,
     "color": "#A30000",
-    "rotation": 28.8,
+    "rotation": 28.82,
     "z": 43,
     "parent": "Board"
   },
   "h72": {
     "type": "holder",
     "id": "h72",
-    "x": 711,
+    "x": 713,
     "y": 507,
     "inheritFrom": "Holder Template",
     "route": 72,
@@ -2684,50 +2684,50 @@
   "h73": {
     "type": "holder",
     "id": "h73",
-    "x": 672,
-    "y": 269,
+    "x": 671,
+    "y": 270,
     "inheritFrom": "Holder Template",
     "route": 73,
-    "rotation": 126.65,
+    "rotation": 126.25,
     "parent": "Board"
   },
   "h74": {
     "type": "holder",
     "id": "h74",
     "x": 687,
-    "y": 280,
+    "y": 281,
     "inheritFrom": "Holder Template",
     "route": 74,
-    "rotation": 126.55,
+    "rotation": 126.33,
     "parent": "Board"
   },
   "h75": {
     "type": "holder",
     "id": "h75",
-    "x": 850,
-    "y": 283,
+    "x": 851,
+    "y": 284,
     "inheritFrom": "Holder Template",
     "route": 75,
     "color": "#A30000",
-    "rotation": -140.02,
+    "rotation": -139.48,
     "parent": "Board",
     "z": 226
   },
   "h76": {
     "type": "holder",
     "id": "h76",
-    "x": 840,
+    "x": 842,
     "y": 301,
     "inheritFrom": "Holder Template",
     "route": 76,
     "color": "#648DE5",
-    "rotation": -168.81,
+    "rotation": -168.45,
     "parent": "Board"
   },
   "h77": {
     "type": "holder",
     "id": "h77",
-    "x": 1011,
+    "x": 1013,
     "y": 316,
     "inheritFrom": "Holder Template",
     "route": 77,
@@ -2738,7 +2738,7 @@
   "h78": {
     "type": "holder",
     "id": "h78",
-    "x": 1010,
+    "x": 1012,
     "y": 297,
     "inheritFrom": "Holder Template",
     "route": 78,
@@ -2754,7 +2754,7 @@
     "inheritFrom": "Holder Template",
     "route": 79,
     "color": "#FF7700",
-    "rotation": 88.61,
+    "rotation": 88.4,
     "parent": "Board"
   },
   "h80": {
@@ -2765,14 +2765,14 @@
     "inheritFrom": "Holder Template",
     "route": 80,
     "color": "#A300A0",
-    "rotation": 88.04,
+    "rotation": 87.91,
     "parent": "Board"
   },
   "h81": {
     "type": "holder",
     "id": "h81",
-    "x": 1129,
-    "y": 358,
+    "x": 1132,
+    "y": 360,
     "inheritFrom": "Holder Template",
     "route": 81,
     "rotation": 33.8,
@@ -2781,8 +2781,8 @@
   "h82": {
     "type": "holder",
     "id": "h82",
-    "x": 1095,
-    "y": 433,
+    "x": 1094,
+    "y": 434,
     "inheritFrom": "Holder Template",
     "route": 82,
     "rotation": -40.21,
@@ -2791,8 +2791,8 @@
   "h83": {
     "type": "holder",
     "id": "h83",
-    "x": 1107,
-    "y": 448,
+    "x": 1106,
+    "y": 449,
     "inheritFrom": "Holder Template",
     "route": 83,
     "rotation": -40.21,
@@ -2802,7 +2802,7 @@
     "type": "holder",
     "id": "h84",
     "x": 398,
-    "y": 533,
+    "y": 532,
     "inheritFrom": "Holder Template",
     "route": 84,
     "rotation": -81.4,
@@ -2813,12 +2813,12 @@
     "type": "holder",
     "id": "h85",
     "x": 975,
-    "y": 412,
+    "y": 413,
     "inheritFrom": "Holder Template",
     "route": 85,
     "color": "#F7F052",
     "parent": "Board",
-    "rotation": -40.68
+    "rotation": -40.58
   },
   "h86": {
     "type": "holder",
@@ -2834,8 +2834,8 @@
   "h87": {
     "type": "holder",
     "id": "h87",
-    "x": 826,
-    "y": 381,
+    "x": 825,
+    "y": 382,
     "inheritFrom": "Holder Template",
     "route": 87,
     "color": "#9EEFE5",
@@ -2845,8 +2845,8 @@
   "h88": {
     "type": "holder",
     "id": "h88",
-    "x": 812,
-    "y": 368,
+    "x": 811,
+    "y": 369,
     "inheritFrom": "Holder Template",
     "route": 88,
     "color": "#058C42",
@@ -2899,8 +2899,8 @@
   "h93": {
     "type": "holder",
     "id": "h93",
-    "x": 874,
-    "y": 449,
+    "x": 877,
+    "y": 450,
     "inheritFrom": "Holder Template",
     "route": 93,
     "rotation": -150.82,
@@ -2921,12 +2921,12 @@
   "h95": {
     "type": "holder",
     "id": "h95",
-    "x": 548,
-    "y": 535,
+    "x": 550,
+    "y": 534,
     "inheritFrom": "Holder Template",
     "route": 95,
     "color": "#F7F052",
-    "rotation": -26.13,
+    "rotation": -26.29,
     "z": 72,
     "parent": "Board"
   },
@@ -2938,18 +2938,18 @@
     "inheritFrom": "Holder Template",
     "route": 96,
     "color": "#A30000",
-    "rotation": 129.89,
+    "rotation": 129.73,
     "parent": "Board"
   },
   "h97": {
     "type": "holder",
     "id": "h97",
-    "x": 562,
-    "y": 260,
+    "x": 570,
+    "y": 265,
     "inheritFrom": "Holder Template",
     "route": 97,
     "color": "#A30000",
-    "rotation": 27.97,
+    "rotation": 27.7,
     "parent": "Board"
   },
   "h98": {
@@ -2967,8 +2967,8 @@
   "h99": {
     "type": "holder",
     "id": "h99",
-    "x": 1057,
-    "y": 362,
+    "x": 1056,
+    "y": 355,
     "inheritFrom": "Holder Template",
     "route": 99,
     "rotation": 82.57,
@@ -2977,20 +2977,20 @@
   "h100": {
     "type": "holder",
     "id": "h100",
-    "x": 723,
-    "y": 548,
+    "x": 725,
+    "y": 545,
     "inheritFrom": "Holder Template",
     "route": 100,
-    "rotation": -46.44,
+    "rotation": -46.82,
     "parent": "Board"
   },
   "h101": {
     "inheritFrom": "h29",
     "id": "h101",
     "type": "holder",
-    "x": -12,
-    "y": 320,
-    "rotation": 81.92,
+    "x": -11,
+    "y": 328,
+    "rotation": 80.44,
     "parent": "Board",
     "z": 228
   },
@@ -2999,8 +2999,8 @@
     "id": "h102",
     "type": "holder",
     "x": -15,
-    "y": 273,
-    "rotation": 90.17,
+    "y": 277,
+    "rotation": 89.36,
     "parent": "Board",
     "z": 227
   },
@@ -3008,9 +3008,9 @@
     "inheritFrom": "h29",
     "id": "h103",
     "type": "holder",
-    "x": -1,
-    "y": 179,
-    "rotation": 107.05,
+    "x": 0,
+    "y": 176,
+    "rotation": 107.55,
     "parent": "Board",
     "z": 225
   },
@@ -3018,9 +3018,9 @@
     "inheritFrom": "h29",
     "id": "h104",
     "type": "holder",
-    "x": 16,
-    "y": 135,
-    "rotation": 114.79,
+    "x": 19,
+    "y": 128,
+    "rotation": 116.13,
     "parent": "Board",
     "z": 224
   },
@@ -3029,35 +3029,35 @@
     "id": "h105",
     "type": "holder",
     "x": 4,
-    "y": 276,
-    "rotation": 90.14,
+    "y": 280,
+    "rotation": 89.65,
     "parent": "Board"
   },
   "h106": {
     "inheritFrom": "h30",
     "id": "h106",
     "type": "holder",
-    "x": 7,
-    "y": 323,
-    "rotation": 82.23,
+    "x": 8,
+    "y": 331,
+    "rotation": 80.93,
     "parent": "Board"
   },
   "h107": {
     "inheritFrom": "h30",
     "id": "h107",
     "type": "holder",
-    "x": 18,
-    "y": 182,
-    "rotation": 107.05,
+    "x": 19,
+    "y": 179,
+    "rotation": 107.67,
     "parent": "Board"
   },
   "h108": {
     "inheritFrom": "h30",
     "id": "h108",
     "type": "holder",
-    "x": 35,
-    "y": 138,
-    "rotation": 114.82,
+    "x": 38,
+    "y": 131,
+    "rotation": 116.19,
     "parent": "Board"
   },
   "h109": {
@@ -3082,8 +3082,8 @@
     "inheritFrom": "h40",
     "id": "h111",
     "type": "holder",
-    "x": 649,
-    "y": 461,
+    "x": 648,
+    "y": 462,
     "parent": "Board",
     "rotation": 115.74
   },
@@ -3091,8 +3091,8 @@
     "inheritFrom": "h41",
     "id": "h112",
     "type": "holder",
-    "x": 632,
-    "y": 452,
+    "x": 631,
+    "y": 453,
     "parent": "Board",
     "rotation": 115.74
   },
@@ -3100,7 +3100,7 @@
     "inheritFrom": "h72",
     "id": "h113",
     "type": "holder",
-    "x": 665,
+    "x": 663,
     "y": 498,
     "parent": "Board",
     "rotation": -170.25
@@ -3118,35 +3118,35 @@
     "inheritFrom": "h100",
     "id": "h115",
     "type": "holder",
-    "x": 688,
-    "y": 580,
+    "x": 686,
+    "y": 582,
     "parent": "Board",
-    "rotation": -40.25
+    "rotation": -39.92
   },
   "h116": {
     "inheritFrom": "h37",
     "id": "h116",
     "type": "holder",
-    "x": 630,
+    "x": 631,
     "y": 576,
     "parent": "Board",
-    "rotation": -108.49
+    "rotation": -108.6
   },
   "h117": {
     "inheritFrom": "h36",
     "id": "h117",
     "type": "holder",
     "x": 649,
-    "y": 571,
+    "y": 572,
     "parent": "Board",
-    "rotation": -107.62
+    "rotation": -107.81
   },
   "h118": {
     "inheritFrom": "h88",
     "id": "h118",
     "type": "holder",
-    "x": 843,
-    "y": 332,
+    "x": 844,
+    "y": 331,
     "parent": "Board",
     "rotation": 131.75
   },
@@ -3154,8 +3154,8 @@
     "inheritFrom": "h87",
     "id": "h119",
     "type": "holder",
-    "x": 858,
-    "y": 345,
+    "x": 859,
+    "y": 344,
     "parent": "Board",
     "rotation": 132.09
   },
@@ -3163,7 +3163,7 @@
     "inheritFrom": "h76",
     "id": "h120",
     "type": "holder",
-    "x": 793,
+    "x": 794,
     "y": 295,
     "parent": "Board",
     "rotation": -176.34
@@ -3174,27 +3174,27 @@
     "type": "holder",
     "x": 745,
     "y": 295,
-    "rotation": 176.48,
+    "rotation": 176.17,
     "parent": "Board"
   },
   "h122": {
     "inheritFrom": "h76",
     "id": "h122",
     "type": "holder",
-    "x": 698,
+    "x": 696,
     "y": 301,
-    "rotation": 170.22,
+    "rotation": 169.96,
     "parent": "Board"
   },
   "h123": {
     "inheritFrom": "h75",
     "id": "h123",
     "type": "holder",
-    "x": 770,
-    "y": 231,
+    "x": 768,
+    "y": 230,
     "parent": "Board",
     "z": 224,
-    "rotation": -149.58
+    "rotation": -149.53
   },
   "h124": {
     "inheritFrom": "h75",
@@ -3210,28 +3210,28 @@
     "inheritFrom": "h74",
     "id": "h125",
     "type": "holder",
-    "x": 719,
+    "x": 720,
     "y": 244,
     "parent": "Board",
-    "rotation": 133.42
+    "rotation": 133.38
   },
   "h126": {
     "inheritFrom": "h73",
     "id": "h126",
     "type": "holder",
-    "x": 703,
-    "y": 233,
+    "x": 704,
+    "y": 232,
     "parent": "Board",
-    "rotation": 133.91
+    "rotation": 133.89
   },
   "h127": {
     "inheritFrom": "h48",
     "id": "h127",
     "type": "holder",
-    "x": 729,
+    "x": 728,
     "y": 679,
     "parent": "Board",
-    "rotation": 12.75,
+    "rotation": 13.38,
     "z": 230
   },
   "h128": {
@@ -3247,55 +3247,55 @@
     "inheritFrom": "h35",
     "id": "h129",
     "type": "holder",
-    "x": 768,
-    "y": 549,
+    "x": 767,
+    "y": 547,
     "parent": "Board",
-    "rotation": 66.82
+    "rotation": 66.71
   },
   "h130": {
     "inheritFrom": "h47",
     "id": "h130",
     "type": "holder",
-    "x": 994,
+    "x": 995,
     "y": 687,
-    "rotation": -147.83,
+    "rotation": -147.32,
     "parent": "Board"
   },
   "h131": {
     "inheritFrom": "h47",
     "id": "h131",
     "type": "holder",
-    "x": 951,
+    "x": 950,
     "y": 666,
-    "rotation": -162.23,
+    "rotation": -163.23,
     "parent": "Board"
   },
   "h132": {
     "inheritFrom": "h47",
     "id": "h132",
     "type": "holder",
-    "x": 904,
+    "x": 900,
     "y": 659,
-    "rotation": -178.39,
+    "rotation": 179.69,
     "parent": "Board"
   },
   "h133": {
     "inheritFrom": "h47",
     "id": "h133",
     "type": "holder",
-    "x": 857,
-    "y": 663,
-    "rotation": 169.37,
+    "x": 850,
+    "y": 664,
+    "rotation": 167.88,
     "parent": "Board"
   },
   "h134": {
     "inheritFrom": "h47",
     "id": "h134",
     "type": "holder",
-    "x": 1032,
-    "y": 715,
+    "x": 1035,
+    "y": 718,
     "parent": "Board",
-    "rotation": -138.89
+    "rotation": -138.3
   },
   "h135": {
     "inheritFrom": "h34",
@@ -3319,8 +3319,8 @@
     "inheritFrom": "h93",
     "id": "h137",
     "type": "holder",
-    "x": 832,
-    "y": 425,
+    "x": 829,
+    "y": 424,
     "parent": "Board",
     "rotation": -150.82
   },
@@ -3328,37 +3328,37 @@
     "inheritFrom": "h89",
     "id": "h138",
     "type": "holder",
-    "x": 834,
-    "y": 392,
+    "x": 829,
+    "y": 393,
     "parent": "Board",
-    "rotation": 162.65
+    "rotation": 163.05
   },
   "h139": {
     "inheritFrom": "h89",
     "id": "h139",
     "type": "holder",
-    "x": 879,
+    "x": 877,
     "y": 377,
     "parent": "Board",
-    "rotation": 159.75
+    "rotation": 159.89
   },
   "h140": {
     "inheritFrom": "h89",
     "id": "h140",
     "type": "holder",
-    "x": 967,
-    "y": 341,
+    "x": 969,
+    "y": 340,
     "parent": "Board",
-    "rotation": 156.79
+    "rotation": 156.76
   },
   "h141": {
     "inheritFrom": "h89",
     "id": "h141",
     "type": "holder",
-    "x": 1011,
-    "y": 322,
+    "x": 1015,
+    "y": 320,
     "parent": "Board",
-    "rotation": 156.79
+    "rotation": 156.86
   },
   "h142": {
     "inheritFrom": "h77",
@@ -3373,7 +3373,7 @@
     "inheritFrom": "h77",
     "id": "h143",
     "type": "holder",
-    "x": 916,
+    "x": 914,
     "y": 318,
     "parent": "Board",
     "rotation": -1.66
@@ -3391,7 +3391,7 @@
     "inheritFrom": "h78",
     "id": "h145",
     "type": "holder",
-    "x": 915,
+    "x": 913,
     "y": 299,
     "parent": "Board",
     "rotation": -1.66
@@ -3454,8 +3454,8 @@
     "inheritFrom": "h46",
     "id": "h152",
     "type": "holder",
-    "x": 1056,
-    "y": 700,
+    "x": 1057,
+    "y": 703,
     "parent": "Board",
     "rotation": 62.42
   },
@@ -3463,8 +3463,8 @@
     "inheritFrom": "h46",
     "id": "h153",
     "type": "holder",
-    "x": 1078,
-    "y": 742,
+    "x": 1081,
+    "y": 747,
     "parent": "Board",
     "rotation": 62.42
   },
@@ -3472,8 +3472,8 @@
     "inheritFrom": "h46",
     "id": "h154",
     "type": "holder",
-    "x": 1012,
-    "y": 616,
+    "x": 1011,
+    "y": 613,
     "parent": "Board",
     "rotation": 62.42
   },
@@ -3481,8 +3481,8 @@
     "inheritFrom": "h46",
     "id": "h155",
     "type": "holder",
-    "x": 990,
-    "y": 574,
+    "x": 987,
+    "y": 569,
     "parent": "Board",
     "rotation": 62.42
   },
@@ -3499,18 +3499,18 @@
     "inheritFrom": "h45",
     "id": "h157",
     "type": "holder",
-    "x": 1061,
-    "y": 601,
-    "rotation": 105.15,
+    "x": 1063,
+    "y": 595,
+    "rotation": 110.41,
     "parent": "Board"
   },
   "h158": {
     "inheritFrom": "h45",
     "id": "h158",
     "type": "holder",
-    "x": 1063,
-    "y": 648,
-    "rotation": 71.89,
+    "x": 1062,
+    "y": 646,
+    "rotation": 72.9,
     "parent": "Board",
     "z": 235
   },
@@ -3518,9 +3518,9 @@
     "inheritFrom": "h45",
     "id": "h159",
     "type": "holder",
-    "x": 1082,
-    "y": 691,
-    "rotation": 63.46,
+    "x": 1083,
+    "y": 693,
+    "rotation": 63.62,
     "parent": "Board"
   },
   "Waggon Pieces": {
@@ -3616,28 +3616,28 @@
     "inheritFrom": "h85",
     "id": "h160",
     "type": "holder",
-    "x": 1010,
-    "y": 380,
+    "x": 1011,
+    "y": 379,
     "parent": "Board",
-    "rotation": -46.92
+    "rotation": -47.08
   },
   "h161": {
     "inheritFrom": "h85",
     "id": "h161",
     "type": "holder",
-    "x": 1038,
-    "y": 341,
-    "rotation": -62.51,
+    "x": 1039,
+    "y": 340,
+    "rotation": -63.43,
     "parent": "Board"
   },
   "h162": {
     "inheritFrom": "h85",
     "id": "h162",
     "type": "holder",
-    "x": 940,
-    "y": 443,
+    "x": 938,
+    "y": 445,
     "parent": "Board",
-    "rotation": -42.42
+    "rotation": -42.7
   },
   "h163": {
     "inheritFrom": "h86",
@@ -3661,19 +3661,19 @@
     "inheritFrom": "h67",
     "id": "h165",
     "type": "holder",
-    "x": 995,
+    "x": 994,
     "y": 506,
     "parent": "Board",
-    "rotation": -30.53
+    "rotation": -30.56
   },
   "h166": {
     "inheritFrom": "h68",
     "id": "h166",
     "type": "holder",
-    "x": 1047,
+    "x": 1048,
     "y": 497,
     "parent": "Board",
-    "rotation": -32.92
+    "rotation": -33.22
   },
   "h167": {
     "inheritFrom": "h66",
@@ -3688,8 +3688,8 @@
     "inheritFrom": "h82",
     "id": "h168",
     "type": "holder",
-    "x": 1132,
-    "y": 402,
+    "x": 1133,
+    "y": 401,
     "parent": "Board",
     "rotation": -40.21
   },
@@ -3697,8 +3697,8 @@
     "inheritFrom": "h83",
     "id": "h169",
     "type": "holder",
-    "x": 1144,
-    "y": 417,
+    "x": 1145,
+    "y": 416,
     "parent": "Board",
     "rotation": -40.21
   },
@@ -3706,8 +3706,8 @@
     "inheritFrom": "h99",
     "id": "h170",
     "type": "holder",
-    "x": 1064,
-    "y": 410,
+    "x": 1065,
+    "y": 417,
     "parent": "Board",
     "rotation": 82.57
   },
@@ -3715,8 +3715,8 @@
     "inheritFrom": "h81",
     "id": "h171",
     "type": "holder",
-    "x": 1089,
-    "y": 332,
+    "x": 1086,
+    "y": 330,
     "parent": "Board",
     "rotation": 33.8
   },
@@ -3724,19 +3724,19 @@
     "inheritFrom": "h11",
     "id": "h172",
     "type": "holder",
-    "x": 1086,
-    "y": 285,
+    "x": 1085,
+    "y": 286,
     "parent": "Board",
-    "rotation": 164.64
+    "rotation": 164.73
   },
   "h173": {
     "inheritFrom": "h12",
     "id": "h173",
     "type": "holder",
-    "x": 1137,
-    "y": 290,
+    "x": 1139,
+    "y": 289,
     "parent": "Board",
-    "rotation": 160.61
+    "rotation": 160.47
   },
   "h174": {
     "inheritFrom": "h79",
@@ -3754,7 +3754,7 @@
     "x": 1183,
     "y": 349,
     "parent": "Board",
-    "rotation": 96.42
+    "rotation": 96.61
   },
   "h176": {
     "inheritFrom": "h8",
@@ -3763,7 +3763,7 @@
     "x": 1224,
     "y": 201,
     "parent": "Board",
-    "rotation": 129.31
+    "rotation": 129.23
   },
   "h177": {
     "inheritFrom": "h96",
@@ -3778,8 +3778,8 @@
     "inheritFrom": "h9",
     "id": "h178",
     "type": "holder",
-    "x": 1170,
-    "y": 226,
+    "x": 1171,
+    "y": 228,
     "parent": "Board",
     "rotation": 87.7
   },
@@ -3787,8 +3787,8 @@
     "inheritFrom": "h9",
     "id": "h179",
     "type": "holder",
-    "x": 1167,
-    "y": 131,
+    "x": 1166,
+    "y": 129,
     "parent": "Board",
     "rotation": 87.7
   },
@@ -3796,7 +3796,7 @@
     "inheritFrom": "h6",
     "id": "h180",
     "type": "holder",
-    "x": 1201,
+    "x": 1200,
     "y": 107,
     "parent": "Board",
     "rotation": -140.15
@@ -3806,7 +3806,7 @@
     "id": "h181",
     "type": "holder",
     "x": 1221,
-    "y": 153,
+    "y": 154,
     "parent": "Board",
     "rotation": -130.23
   },
@@ -3815,7 +3815,7 @@
     "id": "h182",
     "type": "holder",
     "x": 1044,
-    "y": 221,
+    "y": 220,
     "parent": "Board",
     "rotation": -93.75
   },
@@ -3850,7 +3850,7 @@
     "inheritFrom": "h14",
     "id": "h186",
     "type": "holder",
-    "x": 976,
+    "x": 977,
     "y": 233,
     "rotation": -24.6,
     "parent": "Board"
@@ -3913,10 +3913,10 @@
     "inheritFrom": "h4",
     "id": "h193",
     "type": "holder",
-    "x": 954,
-    "y": 156,
+    "x": 950,
+    "y": 155,
     "parent": "Board",
-    "rotation": 10.25
+    "rotation": 10.89
   },
   "h194": {
     "inheritFrom": "h16",
@@ -3931,53 +3931,53 @@
     "inheritFrom": "h16",
     "id": "h195",
     "type": "holder",
-    "x": 776,
-    "y": 186,
+    "x": 771,
+    "y": 189,
     "parent": "Board",
-    "rotation": -27.11
+    "rotation": -28.24
   },
   "h196": {
     "inheritFrom": "h5",
     "id": "h196",
     "type": "holder",
-    "x": 986,
-    "y": 90,
-    "rotation": 155.07,
+    "x": 983,
+    "y": 92,
+    "rotation": 154.16,
     "parent": "Board"
   },
   "h197": {
     "inheritFrom": "h5",
     "id": "h197",
     "type": "holder",
-    "x": 945,
-    "y": 114,
-    "rotation": 145.28,
+    "x": 939,
+    "y": 118,
+    "rotation": 143.87,
     "parent": "Board"
   },
   "h198": {
     "inheritFrom": "h5",
     "id": "h198",
     "type": "holder",
-    "x": 1077,
+    "x": 1080,
     "y": 68,
-    "rotation": 179.09,
+    "rotation": -179.65,
     "parent": "Board"
   },
   "h199": {
     "inheritFrom": "h5",
     "id": "h199",
     "type": "holder",
-    "x": 1124,
-    "y": 74,
-    "rotation": -164.38,
+    "x": 1130,
+    "y": 75,
+    "rotation": -162.32,
     "parent": "Board"
   },
   "h200": {
     "inheritFrom": "h18",
     "id": "h200",
     "type": "holder",
-    "x": 632,
-    "y": 57,
+    "x": 630,
+    "y": 52,
     "parent": "Board",
     "z": 224,
     "rotation": -124.17
@@ -3986,8 +3986,8 @@
     "inheritFrom": "h18",
     "id": "h201",
     "type": "holder",
-    "x": 686,
-    "y": 135,
+    "x": 687,
+    "y": 137,
     "parent": "Board",
     "z": 226,
     "rotation": -124.17
@@ -3996,8 +3996,8 @@
     "inheritFrom": "h18",
     "id": "h202",
     "type": "holder",
-    "x": 713,
-    "y": 174,
+    "x": 715,
+    "y": 179,
     "parent": "Board",
     "z": 227,
     "rotation": -124.17
@@ -4006,8 +4006,8 @@
     "inheritFrom": "h3",
     "id": "h203",
     "type": "holder",
-    "x": 737,
-    "y": 73,
+    "x": 736,
+    "y": 72,
     "parent": "Board",
     "rotation": -158
   },
@@ -4015,8 +4015,8 @@
     "inheritFrom": "h3",
     "id": "h204",
     "type": "holder",
-    "x": 825,
-    "y": 108,
+    "x": 829,
+    "y": 110,
     "parent": "Board",
     "rotation": -158
   },
@@ -4024,8 +4024,8 @@
     "inheritFrom": "h3",
     "id": "h205",
     "type": "holder",
-    "x": 869,
-    "y": 126,
+    "x": 875,
+    "y": 128,
     "parent": "Board",
     "rotation": -158
   },
@@ -4033,8 +4033,8 @@
     "inheritFrom": "h3",
     "id": "h206",
     "type": "holder",
-    "x": 693,
-    "y": 55,
+    "x": 689,
+    "y": 53,
     "parent": "Board",
     "rotation": -158
   },
@@ -4042,8 +4042,8 @@
     "inheritFrom": "h3",
     "id": "h207",
     "type": "holder",
-    "x": 649,
-    "y": 37,
+    "x": 643,
+    "y": 35,
     "parent": "Board",
     "rotation": -158
   },
@@ -4111,35 +4111,35 @@
     "inheritFrom": "h17",
     "id": "h208",
     "type": "holder",
-    "x": 513,
-    "y": 74,
+    "x": 517,
+    "y": 71,
     "parent": "Board",
-    "rotation": -34.74
+    "rotation": -34.43
   },
   "h209": {
     "inheritFrom": "h17",
     "id": "h209",
     "type": "holder",
-    "x": 474,
-    "y": 101,
+    "x": 470,
+    "y": 104,
     "parent": "Board",
-    "rotation": -35.86
+    "rotation": -35.81
   },
   "h210": {
     "inheritFrom": "h17",
     "id": "h210",
     "type": "holder",
-    "x": 436,
-    "y": 129,
+    "x": 422,
+    "y": 137,
     "parent": "Board",
-    "rotation": -34.11
+    "rotation": -32.87
   },
   "h211": {
     "inheritFrom": "h28",
     "id": "h211",
     "type": "holder",
-    "x": 631,
-    "y": 195,
+    "x": 641,
+    "y": 197,
     "parent": "Board",
     "rotation": -171.96
   },
@@ -4147,8 +4147,8 @@
     "inheritFrom": "h28",
     "id": "h212",
     "type": "holder",
-    "x": 678,
-    "y": 202,
+    "x": 695,
+    "y": 205,
     "parent": "Board",
     "rotation": -171.96
   },
@@ -4156,7 +4156,7 @@
     "inheritFrom": "h28",
     "id": "h213",
     "type": "holder",
-    "x": 536,
+    "x": 533,
     "y": 182,
     "z": 81,
     "parent": "Board",
@@ -4166,8 +4166,8 @@
     "inheritFrom": "h28",
     "id": "h214",
     "type": "holder",
-    "x": 489,
-    "y": 176,
+    "x": 479,
+    "y": 174,
     "z": 79,
     "parent": "Board",
     "rotation": -171.96
@@ -4176,8 +4176,8 @@
     "inheritFrom": "h28",
     "id": "h215",
     "type": "holder",
-    "x": 442,
-    "y": 169,
+    "x": 425,
+    "y": 166,
     "parent": "Board",
     "rotation": -171.96
   },
@@ -4185,10 +4185,10 @@
     "inheritFrom": "h97",
     "id": "h216",
     "type": "holder",
-    "x": 604,
-    "y": 282,
+    "x": 621,
+    "y": 290,
     "parent": "Board",
-    "rotation": 26.35
+    "rotation": 25.58
   },
   "h217": {
     "inheritFrom": "h97",
@@ -4203,145 +4203,145 @@
     "inheritFrom": "h97",
     "id": "h218",
     "type": "holder",
-    "x": 479,
-    "y": 214,
+    "x": 471,
+    "y": 210,
     "parent": "Board",
-    "rotation": 29.56
+    "rotation": 29.59
   },
   "h219": {
     "inheritFrom": "h97",
     "id": "h219",
     "type": "holder",
-    "x": 438,
-    "y": 191,
+    "x": 422,
+    "y": 182,
     "parent": "Board",
-    "rotation": 29.48
+    "rotation": 29.32
   },
   "h220": {
     "inheritFrom": "h27",
     "id": "h220",
     "type": "holder",
-    "x": 411,
-    "y": 293,
+    "x": 412,
+    "y": 294,
     "parent": "Board",
-    "rotation": -103.84
+    "rotation": -103.92
   },
   "h221": {
     "inheritFrom": "h27",
     "id": "h221",
     "type": "holder",
     "x": 400,
-    "y": 247,
+    "y": 246,
     "parent": "Board",
-    "rotation": -102.38
+    "rotation": -102.36
   },
   "h222": {
     "inheritFrom": "h27",
     "id": "h222",
     "type": "holder",
-    "x": 391,
-    "y": 200,
+    "x": 390,
+    "y": 197,
     "parent": "Board",
-    "rotation": -101.37
+    "rotation": -101.3
   },
   "h223": {
     "inheritFrom": "h44",
     "id": "h223",
     "type": "holder",
-    "x": 613,
-    "y": 316,
-    "rotation": -9.06,
+    "x": 621,
+    "y": 315,
+    "rotation": -8.93,
     "parent": "Board"
   },
   "h224": {
     "inheritFrom": "h44",
     "id": "h224",
     "type": "holder",
-    "x": 521,
-    "y": 336,
+    "x": 518,
+    "y": 337,
     "parent": "Board",
-    "rotation": -16.81
+    "rotation": -17.36
   },
   "h225": {
     "inheritFrom": "h44",
     "id": "h225",
     "type": "holder",
-    "x": 476,
-    "y": 353,
-    "rotation": -25.33,
+    "x": 469,
+    "y": 356,
+    "rotation": -27.32,
     "parent": "Board"
   },
   "h226": {
     "inheritFrom": "h43",
     "id": "h226",
     "type": "holder",
-    "x": 628,
+    "x": 637,
     "y": 370,
     "parent": "Board",
-    "rotation": -1.36
+    "rotation": -1.31
   },
   "h227": {
     "inheritFrom": "h43",
     "id": "h227",
     "type": "holder",
-    "x": 533,
+    "x": 530,
     "y": 372,
     "parent": "Board",
-    "rotation": 0.18
+    "rotation": 0.29
   },
   "h228": {
     "inheritFrom": "h43",
     "id": "h228",
     "type": "holder",
-    "x": 485,
+    "x": 476,
     "y": 371,
     "parent": "Board",
-    "rotation": 2.4
+    "rotation": 2.95
   },
   "h229": {
     "inheritFrom": "h42",
     "id": "h229",
     "type": "holder",
-    "x": 579,
-    "y": 391,
+    "x": 582,
+    "y": 390,
     "parent": "Board",
-    "rotation": -1.03
+    "rotation": -1.07
   },
   "h230": {
     "inheritFrom": "h42",
     "id": "h230",
     "type": "holder",
-    "x": 532,
+    "x": 529,
     "y": 391,
     "z": 38,
     "parent": "Board",
-    "rotation": 0.22
+    "rotation": 0.36
   },
   "h231": {
     "inheritFrom": "h42",
     "id": "h231",
     "type": "holder",
-    "x": 484,
+    "x": 475,
     "y": 390,
     "z": 37,
     "parent": "Board",
-    "rotation": 2.38
+    "rotation": 2.93
   },
   "h232": {
     "inheritFrom": "h71",
     "id": "h232",
     "type": "holder",
-    "x": 591,
-    "y": 470,
+    "x": 593,
+    "y": 472,
     "z": 42,
     "parent": "Board",
-    "rotation": 30.91
+    "rotation": 31.07
   },
   "h233": {
     "inheritFrom": "h71",
     "id": "h233",
     "type": "holder",
-    "x": 508,
+    "x": 507,
     "y": 424,
     "z": 41,
     "parent": "Board",
@@ -4351,38 +4351,38 @@
     "inheritFrom": "h71",
     "id": "h234",
     "type": "holder",
-    "x": 467,
-    "y": 400,
+    "x": 465,
+    "y": 398,
     "z": 39,
     "parent": "Board",
-    "rotation": 32.55
+    "rotation": 32.78
   },
   "h235": {
     "inheritFrom": "h98",
     "id": "h235",
     "type": "holder",
-    "x": 561,
+    "x": 575,
     "y": 497,
     "z": 45,
     "parent": "Board",
-    "rotation": 177.53
+    "rotation": 176.49
   },
   "h236": {
     "inheritFrom": "h98",
     "id": "h236",
     "type": "holder",
-    "x": 466,
+    "x": 452,
     "y": 497,
     "z": 47,
     "parent": "Board",
-    "rotation": -178.8
+    "rotation": -178.81
   },
   "h237": {
     "inheritFrom": "h58",
     "id": "h237",
     "type": "holder",
     "x": 425,
-    "y": 414,
+    "y": 413,
     "z": 48,
     "parent": "Board",
     "rotation": 105.05
@@ -4391,67 +4391,67 @@
     "inheritFrom": "h52",
     "id": "h238",
     "type": "holder",
-    "x": 465,
-    "y": 659,
+    "x": 461,
+    "y": 658,
     "z": 57,
-    "rotation": 20.47,
+    "rotation": 21.01,
     "parent": "Board"
   },
   "h239": {
     "inheritFrom": "h52",
     "id": "h239",
     "type": "holder",
-    "x": 422,
-    "y": 639,
+    "x": 416,
+    "y": 636,
     "z": 56,
-    "rotation": 28.96,
+    "rotation": 30.08,
     "parent": "Board"
   },
   "h240": {
     "inheritFrom": "h52",
     "id": "h240",
     "type": "holder",
-    "x": 605,
-    "y": 682,
+    "x": 608,
+    "y": 681,
     "z": 61,
-    "rotation": -2.26,
+    "rotation": -2.82,
     "parent": "Board"
   },
   "h241": {
     "inheritFrom": "h52",
     "id": "h241",
     "type": "holder",
-    "x": 652,
-    "y": 676,
+    "x": 658,
+    "y": 675,
     "z": 59,
-    "rotation": -11.13,
+    "rotation": -12.4,
     "parent": "Board"
   },
   "h242": {
     "inheritFrom": "h52",
     "id": "h242",
     "type": "holder",
-    "x": 510,
-    "y": 673,
+    "x": 509,
+    "y": 672,
     "z": 58,
-    "rotation": 13.08,
+    "rotation": 13.09,
     "parent": "Board"
   },
   "h243": {
     "inheritFrom": "h51",
     "id": "h243",
     "type": "holder",
-    "x": 590,
-    "y": 614,
+    "x": 607,
+    "y": 613,
     "z": 233,
     "parent": "Board",
-    "rotation": 177.16
+    "rotation": 175.75
   },
   "h244": {
     "inheritFrom": "h51",
     "id": "h244",
     "type": "holder",
-    "x": 495,
+    "x": 490,
     "y": 614,
     "z": 66,
     "parent": "Board",
@@ -4461,11 +4461,11 @@
     "inheritFrom": "h51",
     "id": "h245",
     "type": "holder",
-    "x": 448,
+    "x": 431,
     "y": 614,
     "z": 67,
     "parent": "Board",
-    "rotation": -179.79
+    "rotation": 179.49
   },
   "h246": {
     "inheritFrom": "h95",
@@ -4481,38 +4481,38 @@
     "inheritFrom": "h95",
     "id": "h247",
     "type": "holder",
-    "x": 462,
-    "y": 575,
+    "x": 461,
+    "y": 576,
     "z": 70,
     "parent": "Board",
-    "rotation": -24.93
+    "rotation": -25.02
   },
   "h248": {
     "inheritFrom": "h95",
     "id": "h248",
     "type": "holder",
-    "x": 420,
-    "y": 596,
+    "x": 417,
+    "y": 597,
     "z": 69,
     "parent": "Board",
-    "rotation": -27.75
+    "rotation": -27.97
   },
   "h249": {
     "inheritFrom": "h95",
     "id": "h249",
     "type": "holder",
-    "x": 590,
-    "y": 513,
+    "x": 593,
+    "y": 511,
     "z": 73,
     "parent": "Board",
-    "rotation": -30.17
+    "rotation": -30.46
   },
   "h250": {
     "inheritFrom": "h84",
     "id": "h250",
     "type": "holder",
     "x": 390,
-    "y": 579,
+    "y": 580,
     "z": 77,
     "parent": "Board",
     "rotation": -81.4
@@ -4561,7 +4561,7 @@
     "inheritFrom": "h2",
     "id": "h255",
     "type": "holder",
-    "x": 520,
+    "x": 523,
     "y": 8,
     "z": 228,
     "parent": "Board",
@@ -4571,7 +4571,7 @@
     "inheritFrom": "h2",
     "id": "h256",
     "type": "holder",
-    "x": 568,
+    "x": 572,
     "y": 15,
     "z": 229,
     "parent": "Board",
@@ -4581,7 +4581,7 @@
     "inheritFrom": "h2",
     "id": "h257",
     "type": "holder",
-    "x": 380,
+    "x": 377,
     "y": -13,
     "z": 102,
     "parent": "Board",
@@ -4591,7 +4591,7 @@
     "inheritFrom": "h2",
     "id": "h258",
     "type": "holder",
-    "x": 332,
+    "x": 328,
     "y": -20,
     "z": 94,
     "parent": "Board",
@@ -4601,7 +4601,7 @@
     "inheritFrom": "h1",
     "id": "h259",
     "type": "holder",
-    "x": 148,
+    "x": 141,
     "y": -27,
     "z": 105,
     "parent": "Board",
@@ -4611,7 +4611,7 @@
     "inheritFrom": "h1",
     "id": "h260",
     "type": "holder",
-    "x": 243,
+    "x": 250,
     "y": -26,
     "z": 107,
     "parent": "Board",
@@ -4631,7 +4631,7 @@
     "inheritFrom": "h20",
     "id": "h262",
     "type": "holder",
-    "x": 349,
+    "x": 350,
     "y": 149,
     "z": 111,
     "parent": "Board",
@@ -4655,7 +4655,7 @@
     "y": 77,
     "z": 115,
     "parent": "Board",
-    "rotation": -157.4
+    "rotation": -157.42
   },
   "h265": {
     "inheritFrom": "h20",
@@ -4671,8 +4671,8 @@
     "inheritFrom": "h26",
     "id": "h266",
     "type": "holder",
-    "x": 294,
-    "y": 271,
+    "x": 291,
+    "y": 276,
     "z": 119,
     "parent": "Board",
     "rotation": 128.75
@@ -4681,8 +4681,8 @@
     "inheritFrom": "h26",
     "id": "h267",
     "type": "holder",
-    "x": 354,
-    "y": 197,
+    "x": 357,
+    "y": 192,
     "z": 118,
     "parent": "Board",
     "rotation": 128.75
@@ -4701,7 +4701,7 @@
     "inheritFrom": "h25",
     "id": "h269",
     "type": "holder",
-    "x": 224,
+    "x": 225,
     "y": 22,
     "z": 133,
     "rotation": 158.52,
@@ -4781,8 +4781,8 @@
     "inheritFrom": "h33",
     "id": "h277",
     "type": "holder",
-    "x": 309,
-    "y": 315,
+    "x": 305,
+    "y": 314,
     "z": 145,
     "parent": "Board",
     "rotation": -157.62
@@ -4801,8 +4801,8 @@
     "inheritFrom": "h63",
     "id": "h279",
     "type": "holder",
-    "x": 302,
-    "y": 332,
+    "x": 298,
+    "y": 331,
     "z": 148,
     "parent": "Board",
     "rotation": -157.62
@@ -4811,7 +4811,7 @@
     "inheritFrom": "h59",
     "id": "h280",
     "type": "holder",
-    "x": 226,
+    "x": 227,
     "y": 306,
     "z": 152,
     "parent": "Board",
@@ -4841,7 +4841,7 @@
     "inheritFrom": "h59",
     "id": "h283",
     "type": "holder",
-    "x": 41,
+    "x": 40,
     "y": 349,
     "z": 162,
     "parent": "Board",
@@ -4851,7 +4851,7 @@
     "inheritFrom": "h60",
     "id": "h284",
     "type": "holder",
-    "x": 231,
+    "x": 232,
     "y": 325,
     "z": 157,
     "parent": "Board",
@@ -4871,7 +4871,7 @@
     "inheritFrom": "h60",
     "id": "h286",
     "type": "holder",
-    "x": 92,
+    "x": 91,
     "y": 357,
     "z": 163,
     "parent": "Board",
@@ -4881,7 +4881,7 @@
     "inheritFrom": "h60",
     "id": "h287",
     "type": "holder",
-    "x": 45,
+    "x": 44,
     "y": 368,
     "z": 164,
     "parent": "Board",
@@ -4891,28 +4891,28 @@
     "inheritFrom": "h62",
     "id": "h288",
     "type": "holder",
-    "x": 261,
-    "y": 346,
+    "x": 262,
+    "y": 344,
     "z": 171,
-    "rotation": -79.18,
+    "rotation": -79.75,
     "parent": "Board"
   },
   "h289": {
     "inheritFrom": "h62",
     "id": "h289",
     "type": "holder",
-    "x": 215,
-    "y": 426,
+    "x": 213,
+    "y": 428,
     "z": 169,
-    "rotation": -41.51,
+    "rotation": -40.99,
     "parent": "Board"
   },
   "h290": {
     "inheritFrom": "h61",
     "id": "h290",
     "type": "holder",
-    "x": 112,
-    "y": 496,
+    "x": 111,
+    "y": 497,
     "z": 172,
     "parent": "Board",
     "rotation": 146.82
@@ -4931,8 +4931,8 @@
     "inheritFrom": "h54",
     "id": "h292",
     "type": "holder",
-    "x": 271,
-    "y": 548,
+    "x": 270,
+    "y": 547,
     "z": 174,
     "parent": "Board",
     "rotation": -149.21
@@ -5012,7 +5012,7 @@
     "id": "h300",
     "type": "holder",
     "x": 25,
-    "y": 398,
+    "y": 397,
     "z": 196,
     "parent": "Board",
     "rotation": -112.01
@@ -5061,8 +5061,8 @@
     "inheritFrom": "h55",
     "id": "h305",
     "type": "holder",
-    "x": 203,
-    "y": 582,
+    "x": 202,
+    "y": 581,
     "z": 223,
     "rotation": -157.89,
     "parent": "Board"
@@ -5071,40 +5071,40 @@
     "inheritFrom": "h55",
     "id": "h306",
     "type": "holder",
-    "x": 160,
-    "y": 563,
+    "x": 156,
+    "y": 561,
     "z": 222,
-    "rotation": -153.97,
+    "rotation": -153.71,
     "parent": "Board"
   },
   "h307": {
     "inheritFrom": "h55",
     "id": "h307",
     "type": "holder",
-    "x": 294,
-    "y": 610,
+    "x": 298,
+    "y": 611,
     "z": 218,
-    "rotation": -168.31,
+    "rotation": -168.78,
     "parent": "Board"
   },
   "h308": {
     "inheritFrom": "h55",
     "id": "h308",
     "type": "holder",
-    "x": 118,
-    "y": 541,
+    "x": 112,
+    "y": 537,
     "z": 210,
-    "rotation": -150.43,
+    "rotation": -149.93,
     "parent": "Board"
   },
   "h309": {
     "inheritFrom": "h55",
     "id": "h309",
     "type": "holder",
-    "x": 341,
+    "x": 347,
     "y": 617,
     "z": 217,
-    "rotation": -176.44,
+    "rotation": -177.72,
     "parent": "Board"
   },
   "Player 1 - Seat": {
@@ -10598,7 +10598,7 @@
     "stops": [
       {
         "widget": "h260",
-        "position": 0.2539
+        "position": 0.2176
       },
       {
         "widget": "h1",
@@ -10606,7 +10606,7 @@
       },
       {
         "widget": "h259",
-        "position": 0.7461
+        "position": 0.7824
       }
     ]
   },
@@ -10640,27 +10640,27 @@
     "stops": [
       {
         "widget": "h258",
-        "position": 0.1281
+        "position": 0.1149
       },
       {
         "widget": "h257",
-        "position": 0.2769
+        "position": 0.2689
       },
       {
         "widget": "h254",
-        "position": 0.4256
+        "position": 0.423
       },
       {
         "widget": "h2",
-        "position": 0.5744
+        "position": 0.577
       },
       {
         "widget": "h255",
-        "position": 0.7231
+        "position": 0.7311
       },
       {
         "widget": "h256",
-        "position": 0.8719
+        "position": 0.8851
       }
     ]
   },
@@ -10694,27 +10694,27 @@
     "stops": [
       {
         "widget": "h205",
-        "position": 0.1354
+        "position": 0.1154
       },
       {
         "widget": "h204",
-        "position": 0.2812
+        "position": 0.2693
       },
       {
         "widget": "h3",
-        "position": 0.4271
+        "position": 0.4231
       },
       {
         "widget": "h203",
-        "position": 0.5729
+        "position": 0.5769
       },
       {
         "widget": "h206",
-        "position": 0.7188
+        "position": 0.7307
       },
       {
         "widget": "h207",
-        "position": 0.8646
+        "position": 0.8846
       }
     ]
   },
@@ -10748,11 +10748,11 @@
     "stops": [
       {
         "widget": "h193",
-        "position": 0.3296
+        "position": 0.3034
       },
       {
         "widget": "h4",
-        "position": 0.6704
+        "position": 0.6966
       }
     ],
     "controlStart": {
@@ -10794,11 +10794,11 @@
     "stops": [
       {
         "widget": "h199",
-        "position": 0.1601
+        "position": 0.1369
       },
       {
         "widget": "h198",
-        "position": 0.3301
+        "position": 0.3184
       },
       {
         "widget": "h5",
@@ -10806,11 +10806,11 @@
       },
       {
         "widget": "h196",
-        "position": 0.6699
+        "position": 0.6816
       },
       {
         "widget": "h197",
-        "position": 0.8399
+        "position": 0.8631
       }
     ],
     "controlStart": {
@@ -10852,11 +10852,11 @@
     "stops": [
       {
         "widget": "h181",
-        "position": 0.3039
+        "position": 0.2989
       },
       {
         "widget": "h7",
-        "position": 0.6961
+        "position": 0.7011
       }
     ],
     "controlStart": {
@@ -10898,11 +10898,11 @@
     "stops": [
       {
         "widget": "h6",
-        "position": 0.3052
+        "position": 0.2992
       },
       {
         "widget": "h180",
-        "position": 0.6948
+        "position": 0.7008
       }
     ],
     "controlStart": {
@@ -10944,11 +10944,11 @@
     "stops": [
       {
         "widget": "h96",
-        "position": 0.2987
+        "position": 0.298
       },
       {
         "widget": "h177",
-        "position": 0.7013
+        "position": 0.702
       }
     ],
     "controlStart": {
@@ -10990,11 +10990,11 @@
     "stops": [
       {
         "widget": "h176",
-        "position": 0.2988
+        "position": 0.298
       },
       {
         "widget": "h8",
-        "position": 0.7012
+        "position": 0.702
       }
     ],
     "controlStart": {
@@ -11036,7 +11036,7 @@
     "stops": [
       {
         "widget": "h179",
-        "position": 0.2272
+        "position": 0.2141
       },
       {
         "widget": "h9",
@@ -11044,7 +11044,7 @@
       },
       {
         "widget": "h178",
-        "position": 0.7728
+        "position": 0.7859
       }
     ]
   },
@@ -11128,11 +11128,11 @@
     "stops": [
       {
         "widget": "h173",
-        "position": 0.3166
+        "position": 0.3012
       },
       {
         "widget": "h12",
-        "position": 0.6834
+        "position": 0.6988
       }
     ],
     "controlStart": {
@@ -11174,11 +11174,11 @@
     "stops": [
       {
         "widget": "h11",
-        "position": 0.3154
+        "position": 0.3009
       },
       {
         "widget": "h172",
-        "position": 0.6846
+        "position": 0.6991
       }
     ],
     "controlStart": {
@@ -11220,11 +11220,11 @@
     "stops": [
       {
         "widget": "h13",
-        "position": 0.3057
+        "position": 0.2993
       },
       {
         "widget": "h182",
-        "position": 0.6943
+        "position": 0.7007
       }
     ]
   },
@@ -11258,19 +11258,19 @@
     "stops": [
       {
         "widget": "h187",
-        "position": 0.1665
+        "position": 0.1649
       },
       {
         "widget": "h185",
-        "position": 0.3888
+        "position": 0.3883
       },
       {
         "widget": "h186",
-        "position": 0.6112
+        "position": 0.6117
       },
       {
         "widget": "h14",
-        "position": 0.8335
+        "position": 0.8351
       }
     ],
     "controlStart": {
@@ -11366,7 +11366,7 @@
     "stops": [
       {
         "widget": "h195",
-        "position": 0.2465
+        "position": 0.2166
       },
       {
         "widget": "h194",
@@ -11374,7 +11374,7 @@
       },
       {
         "widget": "h16",
-        "position": 0.7535
+        "position": 0.7834
       }
     ],
     "controlStart": {
@@ -11416,19 +11416,19 @@
     "stops": [
       {
         "widget": "h210",
-        "position": 0.2317
+        "position": 0.1718
       },
       {
         "widget": "h209",
-        "position": 0.4106
+        "position": 0.3906
       },
       {
         "widget": "h208",
-        "position": 0.5894
+        "position": 0.6094
       },
       {
         "widget": "h17",
-        "position": 0.7683
+        "position": 0.8282
       }
     ],
     "controlStart": {
@@ -11470,19 +11470,19 @@
     "stops": [
       {
         "widget": "h202",
-        "position": 0.1898
+        "position": 0.1673
       },
       {
         "widget": "h201",
-        "position": 0.3966
+        "position": 0.3891
       },
       {
         "widget": "h18",
-        "position": 0.6034
+        "position": 0.6109
       },
       {
         "widget": "h200",
-        "position": 0.8102
+        "position": 0.8327
       }
     ]
   },
@@ -11562,27 +11562,27 @@
     "stops": [
       {
         "widget": "h262",
-        "position": 0.1156
+        "position": 0.114
       },
       {
         "widget": "h261",
-        "position": 0.2693
+        "position": 0.2684
       },
       {
         "widget": "h20",
-        "position": 0.4231
+        "position": 0.4228
       },
       {
         "widget": "h263",
-        "position": 0.5769
+        "position": 0.5772
       },
       {
         "widget": "h264",
-        "position": 0.7307
+        "position": 0.7316
       },
       {
         "widget": "h265",
-        "position": 0.8844
+        "position": 0.886
       }
     ],
     "controlStart": {
@@ -11760,19 +11760,19 @@
     "stops": [
       {
         "widget": "h270",
-        "position": 0.1682
+        "position": 0.1651
       },
       {
         "widget": "h269",
-        "position": 0.3894
+        "position": 0.3884
       },
       {
         "widget": "h268",
-        "position": 0.6106
+        "position": 0.6116
       },
       {
         "widget": "h25",
-        "position": 0.8318
+        "position": 0.8349
       }
     ],
     "controlStart": {
@@ -11814,7 +11814,7 @@
     "stops": [
       {
         "widget": "h267",
-        "position": 0.248
+        "position": 0.2168
       },
       {
         "widget": "h26",
@@ -11822,7 +11822,7 @@
       },
       {
         "widget": "h266",
-        "position": 0.752
+        "position": 0.7832
       }
     ]
   },
@@ -11856,19 +11856,19 @@
     "stops": [
       {
         "widget": "h27",
-        "position": 0.1809
+        "position": 0.1664
       },
       {
         "widget": "h220",
-        "position": 0.3936
+        "position": 0.3888
       },
       {
         "widget": "h221",
-        "position": 0.6064
+        "position": 0.6112
       },
       {
         "widget": "h222",
-        "position": 0.8191
+        "position": 0.8336
       }
     ],
     "controlStart": {
@@ -11910,27 +11910,27 @@
     "stops": [
       {
         "widget": "h212",
-        "position": 0.1678
+        "position": 0.1179
       },
       {
         "widget": "h211",
-        "position": 0.3007
+        "position": 0.2707
       },
       {
         "widget": "h28",
-        "position": 0.4336
+        "position": 0.4236
       },
       {
         "widget": "h213",
-        "position": 0.5664
+        "position": 0.5764
       },
       {
         "widget": "h214",
-        "position": 0.6993
+        "position": 0.7293
       },
       {
         "widget": "h215",
-        "position": 0.8322
+        "position": 0.8821
       }
     ]
   },
@@ -11964,11 +11964,11 @@
     "stops": [
       {
         "widget": "h108",
-        "position": 0.1637
+        "position": 0.1372
       },
       {
         "widget": "h107",
-        "position": 0.3318
+        "position": 0.3186
       },
       {
         "widget": "h30",
@@ -11976,11 +11976,11 @@
       },
       {
         "widget": "h105",
-        "position": 0.6682
+        "position": 0.6814
       },
       {
         "widget": "h106",
-        "position": 0.8363
+        "position": 0.8628
       }
     ],
     "controlStart": {
@@ -12022,11 +12022,11 @@
     "stops": [
       {
         "widget": "h104",
-        "position": 0.1637
+        "position": 0.1372
       },
       {
         "widget": "h103",
-        "position": 0.3319
+        "position": 0.3186
       },
       {
         "widget": "h29",
@@ -12034,11 +12034,11 @@
       },
       {
         "widget": "h102",
-        "position": 0.6681
+        "position": 0.6814
       },
       {
         "widget": "h101",
-        "position": 0.8363
+        "position": 0.8628
       }
     ],
     "controlStart": {
@@ -12080,7 +12080,7 @@
     "stops": [
       {
         "widget": "h31",
-        "position": 0.217
+        "position": 0.2128
       },
       {
         "widget": "h301",
@@ -12088,7 +12088,7 @@
       },
       {
         "widget": "h302",
-        "position": 0.783
+        "position": 0.7872
       }
     ],
     "controlStart": {
@@ -12130,7 +12130,7 @@
     "stops": [
       {
         "widget": "h32",
-        "position": 0.2172
+        "position": 0.2128
       },
       {
         "widget": "h299",
@@ -12138,7 +12138,7 @@
       },
       {
         "widget": "h300",
-        "position": 0.7828
+        "position": 0.7872
       }
     ],
     "controlStart": {
@@ -12180,7 +12180,7 @@
     "stops": [
       {
         "widget": "h63",
-        "position": 0.2416
+        "position": 0.216
       },
       {
         "widget": "h278",
@@ -12188,7 +12188,7 @@
       },
       {
         "widget": "h279",
-        "position": 0.7584
+        "position": 0.784
       }
     ]
   },
@@ -12222,7 +12222,7 @@
     "stops": [
       {
         "widget": "h33",
-        "position": 0.2416
+        "position": 0.216
       },
       {
         "widget": "h276",
@@ -12230,7 +12230,7 @@
       },
       {
         "widget": "h277",
-        "position": 0.7584
+        "position": 0.784
       }
     ]
   },
@@ -12264,7 +12264,7 @@
     "stops": [
       {
         "widget": "h136",
-        "position": 0.2153
+        "position": 0.2125
       },
       {
         "widget": "h135",
@@ -12272,7 +12272,7 @@
       },
       {
         "widget": "h34",
-        "position": 0.7847
+        "position": 0.7875
       }
     ],
     "controlStart": {
@@ -12314,7 +12314,7 @@
     "stops": [
       {
         "widget": "h129",
-        "position": 0.2244
+        "position": 0.2137
       },
       {
         "widget": "h128",
@@ -12322,7 +12322,7 @@
       },
       {
         "widget": "h35",
-        "position": 0.7756
+        "position": 0.7863
       }
     ],
     "controlStart": {
@@ -12364,11 +12364,11 @@
     "stops": [
       {
         "widget": "h116",
-        "position": 0.3029
+        "position": 0.2987
       },
       {
         "widget": "h37",
-        "position": 0.6971
+        "position": 0.7013
       }
     ],
     "controlStart": {
@@ -12410,11 +12410,11 @@
     "stops": [
       {
         "widget": "h117",
-        "position": 0.3039
+        "position": 0.2989
       },
       {
         "widget": "h36",
-        "position": 0.6961
+        "position": 0.7011
       }
     ],
     "controlStart": {
@@ -12524,11 +12524,11 @@
     "stops": [
       {
         "widget": "h40",
-        "position": 0.309
+        "position": 0.2998
       },
       {
         "widget": "h111",
-        "position": 0.691
+        "position": 0.7002
       }
     ]
   },
@@ -12562,11 +12562,11 @@
     "stops": [
       {
         "widget": "h41",
-        "position": 0.309
+        "position": 0.2998
       },
       {
         "widget": "h112",
-        "position": 0.691
+        "position": 0.7002
       }
     ]
   },
@@ -12600,19 +12600,19 @@
     "stops": [
       {
         "widget": "h228",
-        "position": 0.207
+        "position": 0.1692
       },
       {
         "widget": "h227",
-        "position": 0.4023
+        "position": 0.3897
       },
       {
         "widget": "h43",
-        "position": 0.5977
+        "position": 0.6103
       },
       {
         "widget": "h226",
-        "position": 0.793
+        "position": 0.8308
       }
     ],
     "controlStart": {
@@ -12654,19 +12654,19 @@
     "stops": [
       {
         "widget": "h231",
-        "position": 0.207
+        "position": 0.1692
       },
       {
         "widget": "h230",
-        "position": 0.4023
+        "position": 0.3897
       },
       {
         "widget": "h229",
-        "position": 0.5977
+        "position": 0.6103
       },
       {
         "widget": "h42",
-        "position": 0.793
+        "position": 0.8308
       }
     ],
     "controlStart": {
@@ -12708,19 +12708,19 @@
     "stops": [
       {
         "widget": "h225",
-        "position": 0.2017
+        "position": 0.1686
       },
       {
         "widget": "h224",
-        "position": 0.4006
+        "position": 0.3895
       },
       {
         "widget": "h44",
-        "position": 0.5994
+        "position": 0.6105
       },
       {
         "widget": "h223",
-        "position": 0.7983
+        "position": 0.8314
       }
     ],
     "controlStart": {
@@ -12762,19 +12762,19 @@
     "stops": [
       {
         "widget": "h157",
-        "position": 0.1956
+        "position": 0.168
       },
       {
         "widget": "h158",
-        "position": 0.3985
+        "position": 0.3893
       },
       {
         "widget": "h159",
-        "position": 0.6015
+        "position": 0.6107
       },
       {
         "widget": "h45",
-        "position": 0.8044
+        "position": 0.832
       }
     ],
     "controlStart": {
@@ -12816,11 +12816,11 @@
     "stops": [
       {
         "widget": "h155",
-        "position": 0.1563
+        "position": 0.1365
       },
       {
         "widget": "h154",
-        "position": 0.3282
+        "position": 0.3183
       },
       {
         "widget": "h46",
@@ -12828,11 +12828,11 @@
       },
       {
         "widget": "h152",
-        "position": 0.6718
+        "position": 0.6817
       },
       {
         "widget": "h153",
-        "position": 0.8437
+        "position": 0.8635
       }
     ]
   },
@@ -12866,27 +12866,27 @@
     "stops": [
       {
         "widget": "h47",
-        "position": 0.1388
+        "position": 0.1157
       },
       {
         "widget": "h134",
-        "position": 0.2833
+        "position": 0.2694
       },
       {
         "widget": "h130",
-        "position": 0.4278
+        "position": 0.4231
       },
       {
         "widget": "h131",
-        "position": 0.5722
+        "position": 0.5769
       },
       {
         "widget": "h132",
-        "position": 0.7167
+        "position": 0.7306
       },
       {
         "widget": "h133",
-        "position": 0.8612
+        "position": 0.8843
       }
     ],
     "controlStart": {
@@ -12928,11 +12928,11 @@
     "stops": [
       {
         "widget": "h127",
-        "position": 0.3072
+        "position": 0.2995
       },
       {
         "widget": "h48",
-        "position": 0.6928
+        "position": 0.7005
       }
     ],
     "controlStart": {
@@ -13058,19 +13058,19 @@
     "stops": [
       {
         "widget": "h243",
-        "position": 0.2346
+        "position": 0.1721
       },
       {
         "widget": "h51",
-        "position": 0.4115
+        "position": 0.3907
       },
       {
         "widget": "h244",
-        "position": 0.5885
+        "position": 0.6093
       },
       {
         "widget": "h245",
-        "position": 0.7654
+        "position": 0.8279
       }
     ],
     "controlStart": {
@@ -13112,27 +13112,27 @@
     "stops": [
       {
         "widget": "h239",
-        "position": 0.1347
+        "position": 0.1154
       },
       {
         "widget": "h238",
-        "position": 0.2808
+        "position": 0.2692
       },
       {
         "widget": "h242",
-        "position": 0.4269
+        "position": 0.4231
       },
       {
         "widget": "h52",
-        "position": 0.5731
+        "position": 0.5769
       },
       {
         "widget": "h240",
-        "position": 0.7192
+        "position": 0.7308
       },
       {
         "widget": "h241",
-        "position": 0.8653
+        "position": 0.8846
       }
     ],
     "controlStart": {
@@ -13174,7 +13174,7 @@
     "stops": [
       {
         "widget": "h294",
-        "position": 0.2157
+        "position": 0.2126
       },
       {
         "widget": "h293",
@@ -13182,7 +13182,7 @@
       },
       {
         "widget": "h53",
-        "position": 0.7843
+        "position": 0.7874
       }
     ]
   },
@@ -13216,7 +13216,7 @@
     "stops": [
       {
         "widget": "h54",
-        "position": 0.2205
+        "position": 0.2132
       },
       {
         "widget": "h291",
@@ -13224,7 +13224,7 @@
       },
       {
         "widget": "h292",
-        "position": 0.7795
+        "position": 0.7868
       }
     ]
   },
@@ -13258,27 +13258,27 @@
     "stops": [
       {
         "widget": "h309",
-        "position": 0.1358
+        "position": 0.1155
       },
       {
         "widget": "h307",
-        "position": 0.2815
+        "position": 0.2693
       },
       {
         "widget": "h55",
-        "position": 0.4272
+        "position": 0.4231
       },
       {
         "widget": "h305",
-        "position": 0.5728
+        "position": 0.5769
       },
       {
         "widget": "h306",
-        "position": 0.7185
+        "position": 0.7307
       },
       {
         "widget": "h308",
-        "position": 0.8642
+        "position": 0.8845
       }
     ],
     "controlStart": {
@@ -13420,11 +13420,11 @@
     "stops": [
       {
         "widget": "h237",
-        "position": 0.3073
+        "position": 0.2995
       },
       {
         "widget": "h58",
-        "position": 0.6927
+        "position": 0.7005
       }
     ]
   },
@@ -13458,11 +13458,11 @@
     "stops": [
       {
         "widget": "h284",
-        "position": 0.1414
+        "position": 0.1352
       },
       {
         "widget": "h60",
-        "position": 0.3207
+        "position": 0.3176
       },
       {
         "widget": "h285",
@@ -13470,11 +13470,11 @@
       },
       {
         "widget": "h286",
-        "position": 0.6793
+        "position": 0.6824
       },
       {
         "widget": "h287",
-        "position": 0.8586
+        "position": 0.8648
       }
     ]
   },
@@ -13508,11 +13508,11 @@
     "stops": [
       {
         "widget": "h280",
-        "position": 0.14
+        "position": 0.1351
       },
       {
         "widget": "h59",
-        "position": 0.32
+        "position": 0.3175
       },
       {
         "widget": "h281",
@@ -13520,11 +13520,11 @@
       },
       {
         "widget": "h282",
-        "position": 0.68
+        "position": 0.6825
       },
       {
         "widget": "h283",
-        "position": 0.86
+        "position": 0.8649
       }
     ]
   },
@@ -13558,11 +13558,11 @@
     "stops": [
       {
         "widget": "h61",
-        "position": 0.3089
+        "position": 0.2998
       },
       {
         "widget": "h290",
-        "position": 0.6911
+        "position": 0.7002
       }
     ]
   },
@@ -13596,7 +13596,7 @@
     "stops": [
       {
         "widget": "h289",
-        "position": 0.2238
+        "position": 0.2137
       },
       {
         "widget": "h62",
@@ -13604,7 +13604,7 @@
       },
       {
         "widget": "h288",
-        "position": 0.7762
+        "position": 0.7863
       }
     ],
     "controlStart": {
@@ -13800,11 +13800,11 @@
     "stops": [
       {
         "widget": "h165",
-        "position": 0.3077
+        "position": 0.2996
       },
       {
         "widget": "h67",
-        "position": 0.6923
+        "position": 0.7004
       }
     ],
     "controlStart": {
@@ -13846,11 +13846,11 @@
     "stops": [
       {
         "widget": "h68",
-        "position": 0.3066
+        "position": 0.2994
       },
       {
         "widget": "h166",
-        "position": 0.6934
+        "position": 0.7006
       }
     ],
     "controlStart": {
@@ -13964,19 +13964,19 @@
     "stops": [
       {
         "widget": "h234",
-        "position": 0.1774
+        "position": 0.166
       },
       {
         "widget": "h233",
-        "position": 0.3925
+        "position": 0.3887
       },
       {
         "widget": "h71",
-        "position": 0.6075
+        "position": 0.6113
       },
       {
         "widget": "h232",
-        "position": 0.8226
+        "position": 0.834
       }
     ],
     "controlStart": {
@@ -14018,11 +14018,11 @@
     "stops": [
       {
         "widget": "h72",
-        "position": 0.3171
+        "position": 0.3013
       },
       {
         "widget": "h113",
-        "position": 0.6829
+        "position": 0.6987
       }
     ]
   },
@@ -14056,11 +14056,11 @@
     "stops": [
       {
         "widget": "h125",
-        "position": 0.3088
+        "position": 0.2998
       },
       {
         "widget": "h74",
-        "position": 0.6912
+        "position": 0.7002
       }
     ],
     "controlStart": {
@@ -14102,11 +14102,11 @@
     "stops": [
       {
         "widget": "h126",
-        "position": 0.3098
+        "position": 0.3
       },
       {
         "widget": "h73",
-        "position": 0.6902
+        "position": 0.7
       }
     ],
     "controlStart": {
@@ -14148,7 +14148,7 @@
     "stops": [
       {
         "widget": "h75",
-        "position": 0.2253
+        "position": 0.2139
       },
       {
         "widget": "h124",
@@ -14156,7 +14156,7 @@
       },
       {
         "widget": "h123",
-        "position": 0.7747
+        "position": 0.7861
       }
     ],
     "controlStart": {
@@ -14198,19 +14198,19 @@
     "stops": [
       {
         "widget": "h76",
-        "position": 0.1745
+        "position": 0.1657
       },
       {
         "widget": "h120",
-        "position": 0.3915
+        "position": 0.3886
       },
       {
         "widget": "h121",
-        "position": 0.6085
+        "position": 0.6114
       },
       {
         "widget": "h122",
-        "position": 0.8255
+        "position": 0.8343
       }
     ],
     "controlStart": {
@@ -14252,7 +14252,7 @@
     "stops": [
       {
         "widget": "h145",
-        "position": 0.2255
+        "position": 0.2139
       },
       {
         "widget": "h144",
@@ -14260,7 +14260,7 @@
       },
       {
         "widget": "h78",
-        "position": 0.7745
+        "position": 0.7861
       }
     ]
   },
@@ -14294,7 +14294,7 @@
     "stops": [
       {
         "widget": "h143",
-        "position": 0.2255
+        "position": 0.2139
       },
       {
         "widget": "h142",
@@ -14302,7 +14302,7 @@
       },
       {
         "widget": "h77",
-        "position": 0.7745
+        "position": 0.7861
       }
     ]
   },
@@ -14336,11 +14336,11 @@
     "stops": [
       {
         "widget": "h80",
-        "position": 0.3017
+        "position": 0.2985
       },
       {
         "widget": "h175",
-        "position": 0.6983
+        "position": 0.7015
       }
     ],
     "controlStart": {
@@ -14382,11 +14382,11 @@
     "stops": [
       {
         "widget": "h79",
-        "position": 0.3014
+        "position": 0.2985
       },
       {
         "widget": "h174",
-        "position": 0.6986
+        "position": 0.7015
       }
     ],
     "controlStart": {
@@ -14428,11 +14428,11 @@
     "stops": [
       {
         "widget": "h171",
-        "position": 0.3328
+        "position": 0.304
       },
       {
         "widget": "h81",
-        "position": 0.6672
+        "position": 0.696
       }
     ]
   },
@@ -14466,11 +14466,11 @@
     "stops": [
       {
         "widget": "h82",
-        "position": 0.313
+        "position": 0.3005
       },
       {
         "widget": "h168",
-        "position": 0.687
+        "position": 0.6995
       }
     ]
   },
@@ -14504,11 +14504,11 @@
     "stops": [
       {
         "widget": "h83",
-        "position": 0.313
+        "position": 0.3005
       },
       {
         "widget": "h169",
-        "position": 0.687
+        "position": 0.6995
       }
     ]
   },
@@ -14542,11 +14542,11 @@
     "stops": [
       {
         "widget": "h250",
-        "position": 0.3027
+        "position": 0.2987
       },
       {
         "widget": "h84",
-        "position": 0.6973
+        "position": 0.7013
       }
     ]
   },
@@ -14580,19 +14580,19 @@
     "stops": [
       {
         "widget": "h162",
-        "position": 0.1741
+        "position": 0.1657
       },
       {
         "widget": "h85",
-        "position": 0.3914
+        "position": 0.3886
       },
       {
         "widget": "h160",
-        "position": 0.6086
+        "position": 0.6114
       },
       {
         "widget": "h161",
-        "position": 0.8259
+        "position": 0.8343
       }
     ],
     "controlStart": {
@@ -14684,11 +14684,11 @@
     "stops": [
       {
         "widget": "h119",
-        "position": 0.3105
+        "position": 0.3001
       },
       {
         "widget": "h87",
-        "position": 0.6895
+        "position": 0.6999
       }
     ]
   },
@@ -14722,11 +14722,11 @@
     "stops": [
       {
         "widget": "h118",
-        "position": 0.3095
+        "position": 0.2999
       },
       {
         "widget": "h88",
-        "position": 0.6905
+        "position": 0.7001
       }
     ]
   },
@@ -14760,11 +14760,11 @@
     "stops": [
       {
         "widget": "h141",
-        "position": 0.155
+        "position": 0.1364
       },
       {
         "widget": "h140",
-        "position": 0.3275
+        "position": 0.3182
       },
       {
         "widget": "h89",
@@ -14772,11 +14772,11 @@
       },
       {
         "widget": "h139",
-        "position": 0.6725
+        "position": 0.6818
       },
       {
         "widget": "h138",
-        "position": 0.845
+        "position": 0.8636
       }
     ],
     "controlStart": {
@@ -14818,11 +14818,11 @@
     "stops": [
       {
         "widget": "h110",
-        "position": 0.2995
+        "position": 0.2982
       },
       {
         "widget": "h91",
-        "position": 0.7005
+        "position": 0.7018
       }
     ]
   },
@@ -14932,11 +14932,11 @@
     "stops": [
       {
         "widget": "h93",
-        "position": 0.3272
+        "position": 0.303
       },
       {
         "widget": "h137",
-        "position": 0.6728
+        "position": 0.697
       }
     ]
   },
@@ -15024,11 +15024,11 @@
     "stops": [
       {
         "widget": "h248",
-        "position": 0.1476
+        "position": 0.1358
       },
       {
         "widget": "h247",
-        "position": 0.3238
+        "position": 0.3179
       },
       {
         "widget": "h246",
@@ -15036,11 +15036,11 @@
       },
       {
         "widget": "h95",
-        "position": 0.6762
+        "position": 0.6821
       },
       {
         "widget": "h249",
-        "position": 0.8524
+        "position": 0.8642
       }
     ],
     "controlStart": {
@@ -15082,11 +15082,11 @@
     "stops": [
       {
         "widget": "h219",
-        "position": 0.1985
+        "position": 0.1402
       },
       {
         "widget": "h218",
-        "position": 0.3492
+        "position": 0.3201
       },
       {
         "widget": "h217",
@@ -15094,11 +15094,11 @@
       },
       {
         "widget": "h97",
-        "position": 0.6508
+        "position": 0.6799
       },
       {
         "widget": "h216",
-        "position": 0.8015
+        "position": 0.8598
       }
     ],
     "controlStart": {
@@ -15140,7 +15140,7 @@
     "stops": [
       {
         "widget": "h235",
-        "position": 0.2854
+        "position": 0.2218
       },
       {
         "widget": "h98",
@@ -15148,7 +15148,7 @@
       },
       {
         "widget": "h236",
-        "position": 0.7146
+        "position": 0.7782
       }
     ],
     "controlStart": {
@@ -15190,11 +15190,11 @@
     "stops": [
       {
         "widget": "h99",
-        "position": 0.3537
+        "position": 0.3077
       },
       {
         "widget": "h170",
-        "position": 0.6463
+        "position": 0.6923
       }
     ]
   },
@@ -15228,11 +15228,11 @@
     "stops": [
       {
         "widget": "h115",
-        "position": 0.3267
+        "position": 0.3029
       },
       {
         "widget": "h100",
-        "position": 0.6733
+        "position": 0.6971
       }
     ],
     "controlStart": {

--- a/library/games/All Aboard/0.json
+++ b/library/games/All Aboard/0.json
@@ -1230,7 +1230,7 @@
           {
             "type": "image",
             "x": 0,
-            "y": 0,
+            "y": 4,
             "color": "invalid",
             "value": "image",
             "width": 20,
@@ -1382,7 +1382,7 @@
     "id": "7ivc",
     "parent": "Board",
     "x": 1004.5,
-    "y": 542.5
+    "y": 538.5
   },
   "5dd4": {
     "deck": "Cities",
@@ -1391,7 +1391,7 @@
     "id": "5dd4",
     "parent": "Board",
     "x": 1284,
-    "y": 184.5
+    "y": 180.5
   },
   "k9i7": {
     "deck": "Cities",
@@ -1400,7 +1400,7 @@
     "id": "k9i7",
     "parent": "Board",
     "x": 327,
-    "y": -18.5,
+    "y": -22.5,
     "z": 14
   },
   "z59b": {
@@ -1410,7 +1410,7 @@
     "id": "z59b",
     "parent": "Board",
     "x": 1117.5,
-    "y": 568.5
+    "y": 564.5
   },
   "v2um": {
     "deck": "Cities",
@@ -1419,7 +1419,7 @@
     "id": "v2um",
     "parent": "Board",
     "x": 911.5,
-    "y": 317.5
+    "y": 313.5
   },
   "4v1g": {
     "deck": "Cities",
@@ -1428,7 +1428,7 @@
     "id": "4v1g",
     "parent": "Board",
     "x": 688,
-    "y": 615,
+    "y": 611,
     "z": 156
   },
   "qcv9": {
@@ -1438,7 +1438,7 @@
     "id": "qcv9",
     "parent": "Board",
     "x": 469.5,
-    "y": 384.5
+    "y": 380.5
   },
   "cmjv": {
     "deck": "Cities",
@@ -1447,7 +1447,7 @@
     "id": "cmjv",
     "parent": "Board",
     "x": 771.5,
-    "y": 217.5
+    "y": 213.5
   },
   "lttw": {
     "deck": "Cities",
@@ -1456,7 +1456,7 @@
     "id": "lttw",
     "parent": "Board",
     "x": 420,
-    "y": 622.5,
+    "y": 618.5,
     "z": 1
   },
   "uwi8": {
@@ -1466,7 +1466,7 @@
     "id": "uwi8",
     "parent": "Board",
     "x": 417.5,
-    "y": 167.5
+    "y": 163.5
   },
   "gidn": {
     "deck": "Cities",
@@ -1475,7 +1475,7 @@
     "id": "gidn",
     "parent": "Board",
     "x": 729,
-    "y": 672,
+    "y": 668,
     "z": 155
   },
   "r6t9": {
@@ -1485,7 +1485,7 @@
     "id": "r6t9",
     "parent": "Board",
     "x": 712.5,
-    "y": 386.5
+    "y": 382.5
   },
   "waqo": {
     "deck": "Cities",
@@ -1494,7 +1494,7 @@
     "id": "waqo",
     "parent": "Board",
     "x": 218.5,
-    "y": 456.5
+    "y": 452.5
   },
   "8nof": {
     "deck": "Cities",
@@ -1503,7 +1503,7 @@
     "id": "8nof",
     "parent": "Board",
     "x": 787,
-    "y": 520.5
+    "y": 516.5
   },
   "0nfa": {
     "deck": "Cities",
@@ -1512,7 +1512,7 @@
     "id": "0nfa",
     "parent": "Board",
     "x": 115,
-    "y": 524.5,
+    "y": 520.5,
     "z": 16
   },
   "gnye": {
@@ -1522,7 +1522,7 @@
     "id": "gnye",
     "parent": "Board",
     "x": 1132.5,
-    "y": 787.5
+    "y": 783.5
   },
   "x85g": {
     "deck": "Cities",
@@ -1531,7 +1531,7 @@
     "id": "x85g",
     "parent": "Board",
     "x": 1199.5,
-    "y": 98.5
+    "y": 94.5
   },
   "918y": {
     "deck": "Cities",
@@ -1540,7 +1540,7 @@
     "id": "918y",
     "parent": "Board",
     "x": 947.5,
-    "y": 477.5
+    "y": 473.5
   },
   "hetp": {
     "deck": "Cities",
@@ -1549,7 +1549,7 @@
     "id": "hetp",
     "parent": "Board",
     "x": 847.5,
-    "y": 681.5
+    "y": 677.5
   },
   "w8lu": {
     "deck": "Cities",
@@ -1558,7 +1558,7 @@
     "id": "w8lu",
     "parent": "Board",
     "x": 1207,
-    "y": 272.5
+    "y": 268.5
   },
   "g1f4": {
     "deck": "Cities",
@@ -1567,7 +1567,7 @@
     "id": "g1f4",
     "parent": "Board",
     "x": 658.5,
-    "y": 498.5
+    "y": 494.5
   },
   "zr1n": {
     "deck": "Cities",
@@ -1576,7 +1576,7 @@
     "id": "zr1n",
     "parent": "Board",
     "x": 696,
-    "y": 315.5
+    "y": 311.5
   },
   "f381": {
     "deck": "Cities",
@@ -1585,7 +1585,7 @@
     "id": "f381",
     "parent": "Board",
     "x": 274,
-    "y": 535.5,
+    "y": 531.5,
     "z": 15
   },
   "ek3p": {
@@ -1595,7 +1595,7 @@
     "id": "ek3p",
     "parent": "Board",
     "x": 1084.5,
-    "y": 312.5
+    "y": 308.5
   },
   "86gn": {
     "deck": "Cities",
@@ -1604,7 +1604,7 @@
     "id": "86gn",
     "parent": "Board",
     "x": 82.5,
-    "y": 103.5
+    "y": 99.5
   },
   "jji3": {
     "deck": "Cities",
@@ -1613,7 +1613,7 @@
     "id": "jji3",
     "parent": "Board",
     "x": 1106,
-    "y": 473.5,
+    "y": 469.5,
     "z": 17
   },
   "5k17": {
@@ -1623,7 +1623,7 @@
     "id": "5k17",
     "parent": "Board",
     "x": 828,
-    "y": 410.5
+    "y": 406.5
   },
   "59cj": {
     "deck": "Cities",
@@ -1632,7 +1632,7 @@
     "id": "59cj",
     "parent": "Board",
     "x": 299.5,
-    "y": 314.5
+    "y": 310.5
   },
   "nrzv": {
     "deck": "Cities",
@@ -1641,7 +1641,7 @@
     "id": "nrzv",
     "parent": "Board",
     "x": 42,
-    "y": 374.5
+    "y": 370.5
   },
   "wyka": {
     "deck": "Cities",
@@ -1650,7 +1650,7 @@
     "id": "wyka",
     "parent": "Board",
     "x": 437.5,
-    "y": 503.5
+    "y": 499.5
   },
   "rj57": {
     "deck": "Cities",
@@ -1658,7 +1658,7 @@
     "cardType": "Seattle",
     "id": "rj57",
     "parent": "Board",
-    "y": 53.5,
+    "y": 49.5,
     "x": 131
   },
   "8ocd": {
@@ -1667,7 +1667,7 @@
     "cardType": "Toronto",
     "id": "8ocd",
     "parent": "Board",
-    "y": 190.5,
+    "y": 186.5,
     "x": 1077
   },
   "821m": {
@@ -1677,7 +1677,7 @@
     "id": "821m",
     "parent": "Board",
     "x": 134,
-    "y": -20.5
+    "y": -24.5
   },
   "29mv": {
     "deck": "Cities",
@@ -1686,7 +1686,7 @@
     "id": "29mv",
     "parent": "Board",
     "x": 1203,
-    "y": 391.5
+    "y": 387.5
   },
   "pv47": {
     "deck": "Cities",
@@ -1695,7 +1695,7 @@
     "id": "pv47",
     "parent": "Board",
     "x": 642.5,
-    "y": 27.5
+    "y": 23.5
   },
   "Waggons Draw": {
     "type": "holder",
@@ -1736,7 +1736,7 @@
     "cardType": "Sault St. Marie",
     "id": "m0o7",
     "x": 945,
-    "y": 149.5,
+    "y": 145.5,
     "parent": "Board"
   },
   "Holder Template": {
@@ -1899,192 +1899,193 @@
   "h1": {
     "type": "holder",
     "id": "h1",
-    "x": 193,
-    "y": -27,
+    "x": 196,
+    "y": -26,
     "inheritFrom": "Holder Template",
     "route": 1,
     "z": 106,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -179.41
   },
   "h2": {
     "type": "holder",
     "id": "h2",
-    "x": 473,
-    "y": -1,
+    "x": 474,
+    "y": 1,
     "inheritFrom": "Holder Template",
     "route": 2,
     "color": "#9EEFE5",
-    "rotation": 7,
+    "rotation": 8.28,
     "z": 227,
     "parent": "Board"
   },
   "h3": {
     "type": "holder",
     "id": "h3",
-    "x": 783,
-    "y": 88,
+    "x": 781,
+    "y": 90,
     "inheritFrom": "Holder Template",
     "route": 3,
-    "rotation": 22,
+    "rotation": -158,
     "parent": "Board"
   },
   "h4": {
     "type": "holder",
     "id": "h4",
-    "x": 999,
-    "y": 164,
+    "x": 1001,
+    "y": 165,
     "inheritFrom": "Holder Template",
     "route": 4,
-    "rotation": 10,
+    "rotation": 14.46,
     "parent": "Board"
   },
   "h5": {
     "type": "holder",
     "id": "h5",
-    "x": 1023,
-    "y": 76,
+    "x": 1030,
+    "y": 74,
     "inheritFrom": "Holder Template",
     "route": 5,
     "color": "#A300A0",
-    "rotation": 165,
+    "rotation": 165.6,
     "parent": "Board"
   },
   "h6": {
     "type": "holder",
     "id": "h6",
-    "x": 1235,
-    "y": 142,
+    "x": 1234,
+    "y": 140,
     "inheritFrom": "Holder Template",
     "route": 6,
-    "rotation": 45,
+    "rotation": -130.39,
     "parent": "Board"
   },
   "h7": {
     "type": "holder",
     "id": "h7",
-    "x": 1190,
-    "y": 122,
+    "x": 1187,
+    "y": 120,
     "inheritFrom": "Holder Template",
     "route": 7,
-    "rotation": 45,
+    "rotation": -139.64,
     "parent": "Board"
   },
   "h8": {
     "type": "holder",
     "id": "h8",
     "x": 1190,
-    "y": 235,
+    "y": 234,
     "inheritFrom": "Holder Template",
     "route": 8,
     "color": "#F7F052",
-    "rotation": 135,
+    "rotation": 138.14,
     "parent": "Board"
   },
   "h9": {
     "type": "holder",
     "id": "h9",
-    "x": 1167,
-    "y": 180,
+    "x": 1169,
+    "y": 179,
     "inheritFrom": "Holder Template",
     "route": 9,
     "color": "#648DE5",
-    "rotation": 87,
+    "rotation": 87.7,
     "parent": "Board"
   },
   "h10": {
     "type": "holder",
     "id": "h10",
-    "x": 1089,
+    "x": 1090,
     "y": 119,
     "inheritFrom": "Holder Template",
     "route": 10,
-    "rotation": 140,
+    "rotation": 140.49,
     "parent": "Board"
   },
   "h11": {
     "type": "holder",
     "id": "h11",
-    "x": 1131,
-    "y": 272,
+    "x": 1132,
+    "y": 271,
     "inheritFrom": "Holder Template",
     "route": 11,
     "color": "#9EEFE5",
-    "rotation": 165,
+    "rotation": 160.1,
     "parent": "Board"
   },
   "h12": {
     "type": "holder",
     "id": "h12",
-    "x": 1091,
-    "y": 305,
+    "x": 1092,
+    "y": 304,
     "inheritFrom": "Holder Template",
     "route": 12,
     "color": "#058C42",
-    "rotation": 165,
+    "rotation": 164.33,
     "parent": "Board"
   },
   "h13": {
     "type": "holder",
     "id": "h13",
-    "x": 1047,
+    "x": 1048,
     "y": 268,
     "inheritFrom": "Holder Template",
     "route": 13,
-    "rotation": 88,
+    "rotation": -93.75,
     "parent": "Board"
   },
   "h14": {
     "type": "holder",
     "id": "h14",
-    "x": 1015,
-    "y": 210,
+    "x": 1018,
+    "y": 209,
     "inheritFrom": "Holder Template",
     "route": 14,
     "color": "#9EEFE5",
-    "rotation": 140,
+    "rotation": -37.43,
     "parent": "Board"
   },
   "h15": {
     "type": "holder",
     "id": "h15",
-    "x": 1008,
-    "y": 186,
+    "x": 1007,
+    "y": 187,
     "inheritFrom": "Holder Template",
     "route": 15,
     "color": "#EF233C",
-    "rotation": 175,
+    "rotation": -5.06,
     "parent": "Board"
   },
   "h16": {
     "type": "holder",
     "id": "h16",
-    "x": 874,
-    "y": 150,
+    "x": 865,
+    "y": 154,
     "inheritFrom": "Holder Template",
     "route": 16,
-    "rotation": 160,
+    "rotation": -14.95,
     "parent": "Board"
   },
   "h17": {
     "type": "holder",
     "id": "h17",
-    "x": 559,
-    "y": 44,
+    "x": 553,
+    "y": 48,
     "inheritFrom": "Holder Template",
     "route": 17,
     "color": "#648DE5",
-    "rotation": 145,
+    "rotation": -30.78,
     "parent": "Board"
   },
   "h18": {
     "type": "holder",
     "id": "h18",
-    "x": 655,
-    "y": 95,
+    "x": 659,
+    "y": 96,
     "inheritFrom": "Holder Template",
     "route": 18,
     "color": "#A300A0",
-    "rotation": 57,
+    "rotation": -124.17,
     "parent": "Board",
     "z": 225
   },
@@ -2092,84 +2093,85 @@
     "type": "holder",
     "id": "h19",
     "x": 348,
-    "y": 87,
+    "y": 88,
     "inheritFrom": "Holder Template",
     "route": 19,
-    "rotation": 64,
+    "rotation": 63.93,
     "z": 92,
     "parent": "Board"
   },
   "h20": {
     "type": "holder",
     "id": "h20",
-    "x": 258,
-    "y": 112,
+    "x": 261,
+    "y": 114,
     "inheritFrom": "Holder Template",
     "route": 20,
     "color": "#F7F052",
-    "rotation": 22,
+    "rotation": -157.27,
     "z": 113,
     "parent": "Board"
   },
   "h21": {
     "type": "holder",
     "id": "h21",
-    "x": 64,
-    "y": 64,
+    "x": 65,
+    "y": 65,
     "inheritFrom": "Holder Template",
     "route": 21,
-    "rotation": 130,
+    "rotation": -46.17,
     "parent": "Board"
   },
   "h22": {
     "type": "holder",
     "id": "h22",
-    "x": 78,
-    "y": 77,
+    "x": 79,
+    "y": 78,
     "inheritFrom": "Holder Template",
     "route": 22,
-    "rotation": 130,
+    "rotation": -45.58,
     "parent": "Board"
   },
   "h23": {
     "type": "holder",
     "id": "h23",
     "x": 89,
-    "y": 8,
+    "y": 9,
     "inheritFrom": "Holder Template",
     "route": 23,
-    "rotation": 90,
+    "rotation": -87.68,
     "parent": "Board"
   },
   "h24": {
     "type": "holder",
     "id": "h24",
-    "x": 108,
-    "y": 8,
+    "x": 107,
+    "y": 10,
     "inheritFrom": "Holder Template",
     "route": 24,
-    "rotation": 90,
+    "rotation": -87.68,
     "parent": "Board"
   },
   "h25": {
     "type": "holder",
     "id": "h25",
-    "x": 135,
-    "y": 40,
+    "x": 132,
+    "y": 42,
     "inheritFrom": "Holder Template",
     "route": 25,
     "z": 131,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 173.23
   },
   "h26": {
     "type": "holder",
     "id": "h26",
-    "x": 322,
-    "y": 233,
+    "x": 324,
+    "y": 234,
     "inheritFrom": "Holder Template",
     "route": 26,
     "color": "#EF233C",
-    "rotation": 130,
+    "rotation": 128.75,
     "z": 120,
     "parent": "Board"
   },
@@ -2181,29 +2183,29 @@
     "inheritFrom": "Holder Template",
     "route": 27,
     "color": "#058C42",
-    "rotation": 78,
+    "rotation": -105.82,
     "parent": "Board"
   },
   "h28": {
     "type": "holder",
     "id": "h28",
-    "x": 583,
-    "y": 190,
+    "x": 584,
+    "y": 189,
     "inheritFrom": "Holder Template",
     "route": 28,
     "color": "#FF7700",
-    "rotation": 7,
+    "rotation": -171.96,
     "parent": "Board"
   },
   "h29": {
     "type": "holder",
     "id": "h29",
-    "x": -13,
+    "x": -12,
     "y": 226,
     "inheritFrom": "Holder Template",
     "route": 29,
     "color": "#058C42",
-    "rotation": 100,
+    "rotation": 98.7,
     "parent": "Board",
     "z": 226
   },
@@ -2215,403 +2217,406 @@
     "inheritFrom": "Holder Template",
     "route": 30,
     "color": "#EF233C",
-    "rotation": 100,
+    "rotation": 98.62,
     "parent": "Board"
   },
   "h31": {
     "type": "holder",
     "id": "h31",
-    "x": 52,
-    "y": 483,
+    "x": 56,
+    "y": 489,
     "inheritFrom": "Holder Template",
     "route": 31,
     "color": "#F7F052",
-    "rotation": 60,
+    "rotation": -119.35,
     "z": 201,
     "parent": "Board"
   },
   "h32": {
     "type": "holder",
     "id": "h32",
-    "x": 69,
-    "y": 476,
+    "x": 73,
+    "y": 480,
     "inheritFrom": "Holder Template",
     "route": 32,
     "color": "#EF233C",
-    "rotation": 60,
+    "rotation": -120.14,
     "z": 198,
     "parent": "Board"
   },
   "h33": {
     "type": "holder",
     "id": "h33",
-    "x": 395,
-    "y": 351,
+    "x": 397,
+    "y": 352,
     "inheritFrom": "Holder Template",
     "route": 33,
     "color": "#A30000",
-    "rotation": 22,
+    "rotation": -157.62,
     "z": 147,
     "parent": "Board"
   },
   "h34": {
     "type": "holder",
     "id": "h34",
-    "x": 879,
+    "x": 878,
     "y": 480,
     "inheritFrom": "Holder Template",
     "route": 34,
     "color": "#9EEFE5",
-    "rotation": 165,
+    "rotation": -16.78,
     "parent": "Board"
   },
   "h35": {
     "type": "holder",
     "id": "h35",
     "x": 801,
-    "y": 636,
+    "y": 638,
     "inheritFrom": "Holder Template",
     "route": 35,
     "color": "#058C42",
-    "rotation": 70,
+    "rotation": 71.7,
     "parent": "Board"
   },
   "h36": {
     "type": "holder",
     "id": "h36",
     "x": 638,
-    "y": 527,
+    "y": 525,
     "inheritFrom": "Holder Template",
     "route": 36,
-    "rotation": 75,
+    "rotation": -100.24,
     "parent": "Board"
   },
   "h37": {
     "type": "holder",
     "id": "h37",
     "x": 619,
-    "y": 532,
+    "y": 530,
     "inheritFrom": "Holder Template",
     "route": 37,
-    "rotation": 75,
+    "rotation": -100.4,
     "parent": "Board"
   },
   "h38": {
     "type": "holder",
     "id": "h38",
-    "x": 680,
-    "y": 343,
+    "x": 679,
+    "y": 341,
     "inheritFrom": "Holder Template",
     "route": 38,
-    "rotation": 75,
+    "rotation": -103.47,
     "parent": "Board"
   },
   "h39": {
     "type": "holder",
     "id": "h39",
-    "x": 661,
+    "x": 660,
     "y": 346,
     "inheritFrom": "Holder Template",
     "route": 39,
-    "rotation": 75,
+    "rotation": -102.7,
     "parent": "Board"
   },
   "h40": {
     "type": "holder",
     "id": "h40",
     "x": 669,
-    "y": 416,
+    "y": 418,
     "inheritFrom": "Holder Template",
     "route": 40,
-    "rotation": 115,
+    "rotation": 115.74,
     "parent": "Board"
   },
   "h41": {
     "type": "holder",
     "id": "h41",
     "x": 652,
-    "y": 407,
+    "y": 409,
     "inheritFrom": "Holder Template",
     "route": 41,
-    "rotation": 115,
+    "rotation": 115.74,
     "parent": "Board"
   },
   "h42": {
     "type": "holder",
     "id": "h42",
-    "x": 622,
-    "y": 391,
+    "x": 627,
+    "y": 389,
     "inheritFrom": "Holder Template",
     "route": 42,
     "color": "#FF7700",
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -1.37
   },
   "h43": {
     "type": "holder",
     "id": "h43",
-    "x": 575,
-    "y": 371,
+    "x": 580,
+    "y": 372,
     "inheritFrom": "Holder Template",
     "route": 43,
     "color": "#A300A0",
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -1.03
   },
   "h44": {
     "type": "holder",
     "id": "h44",
-    "x": 571,
-    "y": 323,
+    "x": 567,
+    "y": 324,
     "inheritFrom": "Holder Template",
     "route": 44,
     "color": "#EF233C",
-    "rotation": 165,
+    "rotation": -11.54,
     "parent": "Board"
   },
   "h45": {
     "type": "holder",
     "id": "h45",
     "x": 1099,
-    "y": 727,
+    "y": 735,
     "inheritFrom": "Holder Template",
     "route": 45,
     "color": "#EF233C",
-    "rotation": 70,
+    "rotation": 77.34,
     "parent": "Board"
   },
   "h46": {
     "type": "holder",
     "id": "h46",
-    "x": 1033,
-    "y": 654,
+    "x": 1034,
+    "y": 658,
     "inheritFrom": "Holder Template",
     "route": 46,
     "color": "#648DE5",
-    "rotation": 60,
+    "rotation": 62.42,
     "parent": "Board"
   },
   "h47": {
     "type": "holder",
     "id": "h47",
-    "x": 1060,
-    "y": 752,
+    "x": 1066,
+    "y": 748,
     "inheritFrom": "Holder Template",
     "route": 47,
     "color": "#A30000",
-    "rotation": 50,
+    "rotation": -134.98,
     "parent": "Board"
   },
   "h48": {
     "type": "holder",
     "id": "h48",
-    "x": 777,
+    "x": 776,
     "y": 681,
     "inheritFrom": "Holder Template",
     "route": 48,
-    "rotation": -10,
+    "rotation": -5.95,
     "parent": "Board"
   },
   "h49": {
     "type": "holder",
     "id": "h49",
     "x": 677,
-    "y": 632,
+    "y": 633,
     "inheritFrom": "Holder Template",
     "route": 49,
-    "rotation": 55,
+    "rotation": 54.19,
     "parent": "Board",
     "z": 231
   },
   "h50": {
     "type": "holder",
     "id": "h50",
-    "x": 661,
-    "y": 643,
+    "x": 662,
+    "y": 644,
     "inheritFrom": "Holder Template",
     "route": 50,
-    "rotation": 55,
+    "rotation": 53.98,
     "parent": "Board",
     "z": 232
   },
   "h51": {
     "type": "holder",
     "id": "h51",
-    "x": 552,
+    "x": 543,
     "y": 615,
     "inheritFrom": "Holder Template",
     "route": 51,
     "color": "#A30000",
     "z": 234,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -179.91
   },
   "h52": {
     "type": "holder",
     "id": "h52",
-    "x": 563,
+    "x": 557,
     "y": 680,
     "inheritFrom": "Holder Template",
     "route": 52,
     "color": "#058C42",
-    "rotation": 6,
+    "rotation": 5.3,
     "z": 60,
     "parent": "Board"
   },
   "h53": {
     "type": "holder",
     "id": "h53",
-    "x": 367,
+    "x": 368,
     "y": 503,
     "inheritFrom": "Holder Template",
     "route": 53,
-    "rotation": 170,
+    "rotation": -11.04,
     "z": 180,
     "parent": "Board"
   },
   "h54": {
     "type": "holder",
     "id": "h54",
-    "x": 351,
-    "y": 598,
+    "x": 353,
+    "y": 596,
     "inheritFrom": "Holder Template",
     "route": 54,
-    "rotation": 30,
+    "rotation": -149.21,
     "z": 176,
     "parent": "Board"
   },
   "h55": {
     "type": "holder",
     "id": "h55",
-    "x": 253,
-    "y": 597,
+    "x": 248,
+    "y": 598,
     "inheritFrom": "Holder Template",
     "route": 55,
     "color": "#A300A0",
-    "rotation": 17,
+    "rotation": -162.53,
     "z": 219,
     "parent": "Board"
   },
   "h56": {
     "type": "holder",
     "id": "h56",
-    "x": 206,
-    "y": 527,
+    "x": 205,
+    "y": 526,
     "inheritFrom": "Holder Template",
     "route": 56,
     "z": 206,
-    "rotation": 4,
+    "rotation": 3.96,
     "parent": "Board"
   },
   "h57": {
     "type": "holder",
     "id": "h57",
-    "x": 321,
+    "x": 322,
     "y": 433,
     "inheritFrom": "Holder Template",
     "route": 57,
     "color": "#9EEFE5",
-    "rotation": 140,
+    "rotation": 141.08,
     "z": 193,
     "parent": "Board"
   },
   "h58": {
     "type": "holder",
     "id": "h58",
-    "x": 412,
-    "y": 458,
+    "x": 413,
+    "y": 460,
     "inheritFrom": "Holder Template",
     "route": 58,
-    "rotation": 105,
+    "rotation": 105.05,
     "z": 49,
     "parent": "Board"
   },
   "h59": {
     "type": "holder",
     "id": "h59",
-    "x": 173,
-    "y": 318,
+    "x": 180,
+    "y": 317,
     "inheritFrom": "Holder Template",
     "route": 59,
     "color": "#FF7700",
     "z": 153,
-    "rotation": 168,
+    "rotation": 166.86,
     "parent": "Board"
   },
   "h60": {
     "type": "holder",
     "id": "h60",
-    "x": 177,
-    "y": 335,
+    "x": 184,
+    "y": 336,
     "inheritFrom": "Holder Template",
     "route": 60,
     "color": "#9EEFE5",
-    "rotation": 168,
+    "rotation": 166.91,
     "z": 159,
     "parent": "Board"
   },
   "h61": {
     "type": "holder",
     "id": "h61",
-    "x": 154,
-    "y": 469,
+    "x": 152,
+    "y": 471,
     "inheritFrom": "Holder Template",
     "route": 61,
-    "rotation": 145,
+    "rotation": 146.82,
     "z": 173,
     "parent": "Board"
   },
   "h62": {
     "type": "holder",
     "id": "h62",
-    "x": 248,
-    "y": 389,
+    "x": 245,
+    "y": 390,
     "inheritFrom": "Holder Template",
     "route": 62,
     "color": "#FF7700",
-    "rotation": 116,
+    "rotation": -59.79,
     "z": 170,
     "parent": "Board"
   },
   "h63": {
     "type": "holder",
     "id": "h63",
-    "x": 387,
-    "y": 367,
+    "x": 390,
+    "y": 369,
     "inheritFrom": "Holder Template",
     "route": 63,
     "color": "#F7F052",
-    "rotation": 22,
+    "rotation": -157.62,
     "z": 150,
     "parent": "Board"
   },
   "h64": {
     "type": "holder",
     "id": "h64",
-    "x": 912,
+    "x": 910,
     "y": 590,
     "inheritFrom": "Holder Template",
     "route": 64,
     "color": "#FF7700",
-    "rotation": 140,
+    "rotation": 140.37,
     "parent": "Board"
   },
   "h65": {
     "type": "holder",
     "id": "h65",
-    "x": 899,
+    "x": 897,
     "y": 576,
     "inheritFrom": "Holder Template",
     "route": 65,
     "color": "#F7F052",
-    "rotation": 140,
+    "rotation": 140.48,
     "parent": "Board"
   },
   "h66": {
     "type": "holder",
     "id": "h66",
     "x": 1101,
-    "y": 531,
+    "y": 534,
     "inheritFrom": "Holder Template",
     "route": 66,
-    "rotation": 120,
+    "rotation": -76.85,
     "parent": "Board"
   },
   "h67": {
@@ -2621,7 +2626,7 @@
     "y": 482,
     "inheritFrom": "Holder Template",
     "route": 67,
-    "rotation": 150,
+    "rotation": -32.48,
     "parent": "Board"
   },
   "h68": {
@@ -2631,80 +2636,80 @@
     "y": 521,
     "inheritFrom": "Holder Template",
     "route": 68,
-    "rotation": 150,
+    "rotation": -30.19,
     "parent": "Board"
   },
   "h69": {
     "type": "holder",
     "id": "h69",
-    "x": 1047,
-    "y": 555,
+    "x": 1049,
+    "y": 554,
     "inheritFrom": "Holder Template",
     "route": 69,
-    "rotation": 15,
+    "rotation": 12.96,
     "parent": "Board"
   },
   "h70": {
     "type": "holder",
     "id": "h70",
-    "x": 941,
-    "y": 502,
+    "x": 942,
+    "y": 503,
     "inheritFrom": "Holder Template",
     "route": 70,
-    "rotation": 50,
+    "rotation": -131.25,
     "parent": "Board"
   },
   "h71": {
     "type": "holder",
     "id": "h71",
-    "x": 549,
-    "y": 446,
+    "x": 550,
+    "y": 447,
     "inheritFrom": "Holder Template",
     "route": 71,
     "color": "#A30000",
-    "rotation": 30,
+    "rotation": 28.8,
     "z": 43,
     "parent": "Board"
   },
   "h72": {
     "type": "holder",
     "id": "h72",
-    "x": 714,
+    "x": 711,
     "y": 507,
     "inheritFrom": "Holder Template",
     "route": 72,
-    "rotation": 10,
+    "rotation": -170.25,
     "parent": "Board"
   },
   "h73": {
     "type": "holder",
     "id": "h73",
-    "x": 674,
-    "y": 267,
+    "x": 672,
+    "y": 269,
     "inheritFrom": "Holder Template",
     "route": 73,
-    "rotation": 130,
+    "rotation": 126.65,
     "parent": "Board"
   },
   "h74": {
     "type": "holder",
     "id": "h74",
     "x": 687,
-    "y": 279,
+    "y": 280,
     "inheritFrom": "Holder Template",
     "route": 74,
-    "rotation": 130,
+    "rotation": 126.55,
     "parent": "Board"
   },
   "h75": {
     "type": "holder",
     "id": "h75",
-    "x": 847,
-    "y": 280,
+    "x": 850,
+    "y": 283,
     "inheritFrom": "Holder Template",
     "route": 75,
     "color": "#A30000",
-    "rotation": 32,
+    "rotation": -140.02,
     "parent": "Board",
     "z": 226
   },
@@ -2712,150 +2717,151 @@
     "type": "holder",
     "id": "h76",
     "x": 840,
-    "y": 302,
+    "y": 301,
     "inheritFrom": "Holder Template",
     "route": 76,
     "color": "#648DE5",
-    "rotation": 10,
+    "rotation": -168.81,
     "parent": "Board"
   },
   "h77": {
     "type": "holder",
     "id": "h77",
-    "x": 1002,
-    "y": 315,
+    "x": 1011,
+    "y": 316,
     "inheritFrom": "Holder Template",
     "route": 77,
     "color": "#A300A0",
-    "rotation": 178,
+    "rotation": -1.66,
     "parent": "Board"
   },
   "h78": {
     "type": "holder",
     "id": "h78",
-    "x": 1004,
-    "y": 299,
+    "x": 1010,
+    "y": 297,
     "inheritFrom": "Holder Template",
     "route": 78,
     "color": "#FF7700",
-    "rotation": 178,
+    "rotation": -1.66,
     "parent": "Board"
   },
   "h79": {
     "type": "holder",
     "id": "h79",
     "x": 1166,
-    "y": 301,
+    "y": 300,
     "inheritFrom": "Holder Template",
     "route": 79,
     "color": "#FF7700",
-    "rotation": 92,
+    "rotation": 88.61,
     "parent": "Board"
   },
   "h80": {
     "type": "holder",
     "id": "h80",
     "x": 1185,
-    "y": 303,
+    "y": 301,
     "inheritFrom": "Holder Template",
     "route": 80,
     "color": "#A300A0",
-    "rotation": 92,
+    "rotation": 88.04,
     "parent": "Board"
   },
   "h81": {
     "type": "holder",
     "id": "h81",
-    "x": 1128,
-    "y": 357,
+    "x": 1129,
+    "y": 358,
     "inheritFrom": "Holder Template",
     "route": 81,
-    "rotation": 30,
+    "rotation": 33.8,
     "parent": "Board"
   },
   "h82": {
     "type": "holder",
     "id": "h82",
     "x": 1095,
-    "y": 434,
+    "y": 433,
     "inheritFrom": "Holder Template",
     "route": 82,
-    "rotation": 140,
+    "rotation": -40.21,
     "parent": "Board"
   },
   "h83": {
     "type": "holder",
     "id": "h83",
-    "x": 1109,
-    "y": 449,
+    "x": 1107,
+    "y": 448,
     "inheritFrom": "Holder Template",
     "route": 83,
-    "rotation": 140,
+    "rotation": -40.21,
     "parent": "Board"
   },
   "h84": {
     "type": "holder",
     "id": "h84",
-    "x": 396,
-    "y": 531,
+    "x": 398,
+    "y": 533,
     "inheritFrom": "Holder Template",
     "route": 84,
-    "rotation": 100,
+    "rotation": -81.4,
     "z": 76,
     "parent": "Board"
   },
   "h85": {
     "type": "holder",
     "id": "h85",
-    "x": 978,
-    "y": 411,
+    "x": 975,
+    "y": 412,
     "inheritFrom": "Holder Template",
     "route": 85,
     "color": "#F7F052",
     "parent": "Board",
-    "rotation": 140
+    "rotation": -40.68
   },
   "h86": {
     "type": "holder",
     "id": "h86",
-    "x": 993,
-    "y": 451,
+    "x": 992,
+    "y": 453,
     "inheritFrom": "Holder Template",
     "route": 86,
     "color": "#A300A0",
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -2.18
   },
   "h87": {
     "type": "holder",
     "id": "h87",
     "x": 826,
-    "y": 382,
+    "y": 381,
     "inheritFrom": "Holder Template",
     "route": 87,
     "color": "#9EEFE5",
-    "rotation": 130,
+    "rotation": 132.09,
     "parent": "Board"
   },
   "h88": {
     "type": "holder",
     "id": "h88",
-    "x": 811,
-    "y": 370,
+    "x": 812,
+    "y": 368,
     "inheritFrom": "Holder Template",
     "route": 88,
     "color": "#058C42",
-    "rotation": 130,
+    "rotation": 131.75,
     "parent": "Board"
   },
   "h89": {
     "type": "holder",
     "id": "h89",
-    "x": 928,
-    "y": 356,
+    "x": 923,
+    "y": 359,
     "inheritFrom": "Holder Template",
     "route": 89,
     "color": "#058C42",
-    "rotation": 160,
+    "rotation": 157.72,
     "parent": "Board"
   },
   "h90": {
@@ -2866,38 +2872,38 @@
     "inheritFrom": "Holder Template",
     "route": 90,
     "color": "#EF233C",
-    "rotation": 10,
+    "rotation": 11.79,
     "parent": "Board"
   },
   "h91": {
     "type": "holder",
     "id": "h91",
     "x": 760,
-    "y": 385,
+    "y": 386,
     "inheritFrom": "Holder Template",
     "route": 91,
     "color": "#648DE5",
-    "rotation": 10,
+    "rotation": 11.69,
     "parent": "Board"
   },
   "h92": {
     "type": "holder",
     "id": "h92",
     "x": 781,
-    "y": 434,
+    "y": 436,
     "inheritFrom": "Holder Template",
     "route": 92,
-    "rotation": 108,
+    "rotation": -69.56,
     "parent": "Board"
   },
   "h93": {
     "type": "holder",
     "id": "h93",
-    "x": 869,
-    "y": 446.5,
+    "x": 874,
+    "y": 449,
     "inheritFrom": "Holder Template",
     "route": 93,
-    "rotation": 30,
+    "rotation": -150.82,
     "parent": "Board"
   },
   "h94": {
@@ -2908,82 +2914,83 @@
     "inheritFrom": "Holder Template",
     "route": 94,
     "color": "#648DE5",
-    "rotation": 43,
+    "rotation": 44.2,
     "z": 142,
     "parent": "Board"
   },
   "h95": {
     "type": "holder",
     "id": "h95",
-    "x": 543,
-    "y": 537,
+    "x": 548,
+    "y": 535,
     "inheritFrom": "Holder Template",
     "route": 95,
     "color": "#F7F052",
-    "rotation": 155,
+    "rotation": -26.13,
     "z": 72,
     "parent": "Board"
   },
   "h96": {
     "type": "holder",
     "id": "h96",
-    "x": 1236,
-    "y": 215,
+    "x": 1238,
+    "y": 214,
     "inheritFrom": "Holder Template",
     "route": 96,
     "color": "#A30000",
-    "rotation": 135,
+    "rotation": 129.89,
     "parent": "Board"
   },
   "h97": {
     "type": "holder",
     "id": "h97",
-    "x": 571,
-    "y": 264,
+    "x": 562,
+    "y": 260,
     "inheritFrom": "Holder Template",
     "route": 97,
     "color": "#A30000",
-    "rotation": 27,
+    "rotation": 27.97,
     "parent": "Board"
   },
   "h98": {
     "type": "holder",
     "id": "h98",
-    "x": 525,
-    "y": 497,
+    "x": 514,
+    "y": 498,
     "inheritFrom": "Holder Template",
     "route": 98,
     "color": "#648DE5",
     "z": 46,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -179.84
   },
   "h99": {
     "type": "holder",
     "id": "h99",
     "x": 1057,
-    "y": 365,
+    "y": 362,
     "inheritFrom": "Holder Template",
     "route": 99,
-    "rotation": 83,
+    "rotation": 82.57,
     "parent": "Board"
   },
   "h100": {
     "type": "holder",
     "id": "h100",
-    "x": 726,
-    "y": 544,
+    "x": 723,
+    "y": 548,
     "inheritFrom": "Holder Template",
     "route": 100,
-    "rotation": 135,
+    "rotation": -46.44,
     "parent": "Board"
   },
   "h101": {
     "inheritFrom": "h29",
     "id": "h101",
     "type": "holder",
-    "x": -11,
-    "y": 328,
-    "rotation": 80,
+    "x": -12,
+    "y": 320,
+    "rotation": 81.92,
     "parent": "Board",
     "z": 228
   },
@@ -2991,9 +2998,9 @@
     "inheritFrom": "h29",
     "id": "h102",
     "type": "holder",
-    "x": -16,
-    "y": 277,
-    "rotation": 90,
+    "x": -15,
+    "y": 273,
+    "rotation": 90.17,
     "parent": "Board",
     "z": 227
   },
@@ -3001,9 +3008,9 @@
     "inheritFrom": "h29",
     "id": "h103",
     "type": "holder",
-    "x": 0,
-    "y": 174,
-    "rotation": 110,
+    "x": -1,
+    "y": 179,
+    "rotation": 107.05,
     "parent": "Board",
     "z": 225
   },
@@ -3011,9 +3018,9 @@
     "inheritFrom": "h29",
     "id": "h104",
     "type": "holder",
-    "x": 20,
-    "y": 127,
-    "rotation": 120,
+    "x": 16,
+    "y": 135,
+    "rotation": 114.79,
     "parent": "Board",
     "z": 224
   },
@@ -3021,36 +3028,36 @@
     "inheritFrom": "h30",
     "id": "h105",
     "type": "holder",
-    "x": 5,
-    "y": 278,
-    "rotation": 90,
+    "x": 4,
+    "y": 276,
+    "rotation": 90.14,
     "parent": "Board"
   },
   "h106": {
     "inheritFrom": "h30",
     "id": "h106",
     "type": "holder",
-    "x": 9,
-    "y": 324,
-    "rotation": 80,
+    "x": 7,
+    "y": 323,
+    "rotation": 82.23,
     "parent": "Board"
   },
   "h107": {
     "inheritFrom": "h30",
     "id": "h107",
     "type": "holder",
-    "x": 19,
-    "y": 180,
-    "rotation": 110,
+    "x": 18,
+    "y": 182,
+    "rotation": 107.05,
     "parent": "Board"
   },
   "h108": {
     "inheritFrom": "h30",
     "id": "h108",
     "type": "holder",
-    "x": 38,
-    "y": 136,
-    "rotation": 120,
+    "x": 35,
+    "y": 138,
+    "rotation": 114.82,
     "parent": "Board"
   },
   "h109": {
@@ -3058,8 +3065,9 @@
     "id": "h109",
     "type": "holder",
     "x": 710,
-    "y": 397,
-    "parent": "Board"
+    "y": 396,
+    "parent": "Board",
+    "rotation": 11.79
   },
   "h110": {
     "inheritFrom": "h91",
@@ -3067,403 +3075,442 @@
     "type": "holder",
     "x": 714,
     "y": 377,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 11.69
   },
   "h111": {
     "inheritFrom": "h40",
     "id": "h111",
     "type": "holder",
-    "x": 648,
-    "y": 459,
-    "parent": "Board"
+    "x": 649,
+    "y": 461,
+    "parent": "Board",
+    "rotation": 115.74
   },
   "h112": {
     "inheritFrom": "h41",
     "id": "h112",
     "type": "holder",
-    "x": 631,
-    "y": 451,
-    "parent": "Board"
+    "x": 632,
+    "y": 452,
+    "parent": "Board",
+    "rotation": 115.74
   },
   "h113": {
     "inheritFrom": "h72",
     "id": "h113",
     "type": "holder",
-    "x": 667,
-    "y": 499,
-    "parent": "Board"
+    "x": 665,
+    "y": 498,
+    "parent": "Board",
+    "rotation": -170.25
   },
   "h114": {
     "inheritFrom": "h92",
     "id": "h114",
     "type": "holder",
-    "x": 766,
-    "y": 478,
-    "parent": "Board"
+    "x": 764,
+    "y": 481,
+    "parent": "Board",
+    "rotation": -69.56
   },
   "h115": {
     "inheritFrom": "h100",
     "id": "h115",
     "type": "holder",
-    "x": 687,
-    "y": 581,
-    "parent": "Board"
+    "x": 688,
+    "y": 580,
+    "parent": "Board",
+    "rotation": -40.25
   },
   "h116": {
     "inheritFrom": "h37",
     "id": "h116",
     "type": "holder",
-    "x": 631,
-    "y": 578,
-    "parent": "Board"
+    "x": 630,
+    "y": 576,
+    "parent": "Board",
+    "rotation": -108.49
   },
   "h117": {
     "inheritFrom": "h36",
     "id": "h117",
     "type": "holder",
-    "x": 650,
-    "y": 573,
-    "parent": "Board"
+    "x": 649,
+    "y": 571,
+    "parent": "Board",
+    "rotation": -107.62
   },
   "h118": {
     "inheritFrom": "h88",
     "id": "h118",
     "type": "holder",
-    "x": 842,
-    "y": 334,
-    "parent": "Board"
+    "x": 843,
+    "y": 332,
+    "parent": "Board",
+    "rotation": 131.75
   },
   "h119": {
     "inheritFrom": "h87",
     "id": "h119",
     "type": "holder",
-    "x": 857,
-    "y": 346,
-    "parent": "Board"
+    "x": 858,
+    "y": 345,
+    "parent": "Board",
+    "rotation": 132.09
   },
   "h120": {
     "inheritFrom": "h76",
     "id": "h120",
     "type": "holder",
-    "x": 795,
-    "y": 294,
+    "x": 793,
+    "y": 295,
     "parent": "Board",
-    "rotation": 5
+    "rotation": -176.34
   },
   "h121": {
     "inheritFrom": "h76",
     "id": "h121",
     "type": "holder",
-    "x": 749,
-    "y": 294,
-    "rotation": 175,
+    "x": 745,
+    "y": 295,
+    "rotation": 176.48,
     "parent": "Board"
   },
   "h122": {
     "inheritFrom": "h76",
     "id": "h122",
     "type": "holder",
-    "x": 702,
+    "x": 698,
     "y": 301,
-    "rotation": 175,
+    "rotation": 170.22,
     "parent": "Board"
   },
   "h123": {
     "inheritFrom": "h75",
     "id": "h123",
     "type": "holder",
-    "x": 767,
-    "y": 228,
+    "x": 770,
+    "y": 231,
     "parent": "Board",
-    "z": 224
+    "z": 224,
+    "rotation": -149.58
   },
   "h124": {
     "inheritFrom": "h75",
     "id": "h124",
     "type": "holder",
-    "x": 807,
-    "y": 254,
+    "x": 811,
+    "y": 255,
     "parent": "Board",
-    "z": 225
+    "z": 225,
+    "rotation": -147.67
   },
   "h125": {
     "inheritFrom": "h74",
     "id": "h125",
     "type": "holder",
-    "x": 720,
-    "y": 243,
-    "parent": "Board"
+    "x": 719,
+    "y": 244,
+    "parent": "Board",
+    "rotation": 133.42
   },
   "h126": {
     "inheritFrom": "h73",
     "id": "h126",
     "type": "holder",
-    "x": 705,
-    "y": 231,
-    "parent": "Board"
+    "x": 703,
+    "y": 233,
+    "parent": "Board",
+    "rotation": 133.91
   },
   "h127": {
     "inheritFrom": "h48",
     "id": "h127",
     "type": "holder",
-    "x": 728,
+    "x": 729,
     "y": 679,
     "parent": "Board",
-    "rotation": 15,
+    "rotation": 12.75,
     "z": 230
   },
   "h128": {
     "inheritFrom": "h35",
     "id": "h128",
     "type": "holder",
-    "x": 785,
-    "y": 592,
-    "parent": "Board"
+    "x": 786,
+    "y": 593,
+    "parent": "Board",
+    "rotation": 69.55
   },
   "h129": {
     "inheritFrom": "h35",
     "id": "h129",
     "type": "holder",
     "x": 768,
-    "y": 548,
-    "parent": "Board"
+    "y": 549,
+    "parent": "Board",
+    "rotation": 66.82
   },
   "h130": {
     "inheritFrom": "h47",
     "id": "h130",
     "type": "holder",
-    "x": 988,
-    "y": 678,
-    "rotation": 20,
+    "x": 994,
+    "y": 687,
+    "rotation": -147.83,
     "parent": "Board"
   },
   "h131": {
     "inheritFrom": "h47",
     "id": "h131",
     "type": "holder",
-    "x": 944,
-    "y": 664,
-    "rotation": 10,
+    "x": 951,
+    "y": 666,
+    "rotation": -162.23,
     "parent": "Board"
   },
   "h132": {
     "inheritFrom": "h47",
     "id": "h132",
     "type": "holder",
-    "x": 896,
-    "y": 660,
-    "rotation": 0,
+    "x": 904,
+    "y": 659,
+    "rotation": -178.39,
     "parent": "Board"
   },
   "h133": {
     "inheritFrom": "h47",
     "id": "h133",
     "type": "holder",
-    "x": 849,
-    "y": 666,
-    "rotation": 170,
+    "x": 857,
+    "y": 663,
+    "rotation": 169.37,
     "parent": "Board"
   },
   "h134": {
     "inheritFrom": "h47",
     "id": "h134",
     "type": "holder",
-    "x": 1029,
-    "y": 710,
-    "parent": "Board"
+    "x": 1032,
+    "y": 715,
+    "parent": "Board",
+    "rotation": -138.89
   },
   "h135": {
     "inheritFrom": "h34",
     "id": "h135",
     "type": "holder",
-    "x": 835,
-    "y": 493,
-    "parent": "Board"
+    "x": 833,
+    "y": 494,
+    "parent": "Board",
+    "rotation": -17.25
   },
   "h136": {
     "inheritFrom": "h34",
     "id": "h136",
     "type": "holder",
-    "x": 792,
-    "y": 506,
-    "parent": "Board"
+    "x": 787,
+    "y": 507,
+    "parent": "Board",
+    "rotation": -13.23
   },
   "h137": {
     "inheritFrom": "h93",
     "id": "h137",
     "type": "holder",
-    "x": 828,
-    "y": 422,
-    "parent": "Board"
+    "x": 832,
+    "y": 425,
+    "parent": "Board",
+    "rotation": -150.82
   },
   "h138": {
     "inheritFrom": "h89",
     "id": "h138",
     "type": "holder",
-    "x": 840,
+    "x": 834,
     "y": 392,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 162.65
   },
   "h139": {
     "inheritFrom": "h89",
     "id": "h139",
     "type": "holder",
-    "x": 884,
-    "y": 374,
-    "parent": "Board"
+    "x": 879,
+    "y": 377,
+    "parent": "Board",
+    "rotation": 159.75
   },
   "h140": {
     "inheritFrom": "h89",
     "id": "h140",
     "type": "holder",
-    "x": 972,
-    "y": 339,
-    "parent": "Board"
+    "x": 967,
+    "y": 341,
+    "parent": "Board",
+    "rotation": 156.79
   },
   "h141": {
     "inheritFrom": "h89",
     "id": "h141",
     "type": "holder",
-    "x": 1016,
-    "y": 321,
-    "parent": "Board"
+    "x": 1011,
+    "y": 322,
+    "parent": "Board",
+    "rotation": 156.79
   },
   "h142": {
     "inheritFrom": "h77",
     "id": "h142",
     "type": "holder",
-    "x": 957,
+    "x": 964,
     "y": 317,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -1.66
   },
   "h143": {
     "inheritFrom": "h77",
     "id": "h143",
     "type": "holder",
-    "x": 911,
-    "y": 319,
-    "parent": "Board"
+    "x": 916,
+    "y": 318,
+    "parent": "Board",
+    "rotation": -1.66
   },
   "h144": {
     "inheritFrom": "h78",
     "id": "h144",
     "type": "holder",
-    "x": 958,
+    "x": 963,
     "y": 298,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -1.66
   },
   "h145": {
     "inheritFrom": "h78",
     "id": "h145",
     "type": "holder",
-    "x": 912,
-    "y": 300,
-    "parent": "Board"
+    "x": 915,
+    "y": 299,
+    "parent": "Board",
+    "rotation": -1.66
   },
   "h146": {
     "inheritFrom": "h65",
     "id": "h146",
     "type": "holder",
-    "x": 933,
-    "y": 546,
-    "parent": "Board"
+    "x": 935,
+    "y": 547,
+    "parent": "Board",
+    "rotation": 144.06
   },
   "h147": {
     "inheritFrom": "h65",
     "id": "h147",
     "type": "holder",
-    "x": 865,
+    "x": 862,
     "y": 607,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 136.72
   },
   "h148": {
     "inheritFrom": "h65",
     "id": "h148",
     "type": "holder",
-    "x": 831,
-    "y": 637,
-    "parent": "Board"
+    "x": 829,
+    "y": 641,
+    "parent": "Board",
+    "rotation": 132.79
   },
   "h149": {
     "inheritFrom": "h64",
     "id": "h149",
     "type": "holder",
-    "x": 946,
-    "y": 560,
-    "parent": "Board"
+    "x": 947,
+    "y": 562,
+    "parent": "Board",
+    "rotation": 144.55
   },
   "h150": {
     "inheritFrom": "h64",
     "id": "h150",
     "type": "holder",
-    "x": 877,
-    "y": 620,
-    "parent": "Board"
+    "x": 875,
+    "y": 622,
+    "parent": "Board",
+    "rotation": 136.36
   },
   "h151": {
     "inheritFrom": "h64",
     "id": "h151",
     "type": "holder",
-    "x": 843,
-    "y": 650,
-    "parent": "Board"
+    "x": 842,
+    "y": 655,
+    "parent": "Board",
+    "rotation": 132.5
   },
   "h152": {
     "inheritFrom": "h46",
     "id": "h152",
     "type": "holder",
     "x": 1056,
-    "y": 696,
-    "parent": "Board"
+    "y": 700,
+    "parent": "Board",
+    "rotation": 62.42
   },
   "h153": {
     "inheritFrom": "h46",
     "id": "h153",
     "type": "holder",
-    "x": 1079,
-    "y": 739,
-    "parent": "Board"
+    "x": 1078,
+    "y": 742,
+    "parent": "Board",
+    "rotation": 62.42
   },
   "h154": {
     "inheritFrom": "h46",
     "id": "h154",
     "type": "holder",
-    "x": 1010,
-    "y": 612,
-    "parent": "Board"
+    "x": 1012,
+    "y": 616,
+    "parent": "Board",
+    "rotation": 62.42
   },
   "h155": {
     "inheritFrom": "h46",
     "id": "h155",
     "type": "holder",
-    "x": 987,
-    "y": 569,
-    "parent": "Board"
+    "x": 990,
+    "y": 574,
+    "parent": "Board",
+    "rotation": 62.42
   },
   "h156": {
     "inheritFrom": "h69",
     "id": "h156",
     "type": "holder",
-    "x": 1002,
-    "y": 544,
-    "parent": "Board"
+    "x": 1004,
+    "y": 543,
+    "parent": "Board",
+    "rotation": 12.96
   },
   "h157": {
     "inheritFrom": "h45",
     "id": "h157",
     "type": "holder",
-    "x": 1066,
-    "y": 592,
-    "rotation": 120,
+    "x": 1061,
+    "y": 601,
+    "rotation": 105.15,
     "parent": "Board"
   },
   "h158": {
     "inheritFrom": "h45",
     "id": "h158",
     "type": "holder",
-    "x": 1059,
-    "y": 638,
-    "rotation": 80,
+    "x": 1063,
+    "y": 648,
+    "rotation": 71.89,
     "parent": "Board",
     "z": 235
   },
@@ -3471,9 +3518,9 @@
     "inheritFrom": "h45",
     "id": "h159",
     "type": "holder",
-    "x": 1076,
-    "y": 683,
-    "rotation": 60,
+    "x": 1082,
+    "y": 691,
+    "rotation": 63.46,
     "parent": "Board"
   },
   "Waggon Pieces": {
@@ -3569,18 +3616,18 @@
     "inheritFrom": "h85",
     "id": "h160",
     "type": "holder",
-    "x": 1013,
-    "y": 376,
+    "x": 1010,
+    "y": 380,
     "parent": "Board",
-    "rotation": 130
+    "rotation": -46.92
   },
   "h161": {
     "inheritFrom": "h85",
     "id": "h161",
     "type": "holder",
-    "x": 1040,
-    "y": 337,
-    "rotation": 125,
+    "x": 1038,
+    "y": 341,
+    "rotation": -62.51,
     "parent": "Board"
   },
   "h162": {
@@ -3588,25 +3635,26 @@
     "id": "h162",
     "type": "holder",
     "x": 940,
-    "y": 442,
-    "parent": "Board"
+    "y": 443,
+    "parent": "Board",
+    "rotation": -42.42
   },
   "h163": {
     "inheritFrom": "h86",
     "id": "h163",
     "type": "holder",
     "x": 1038,
-    "y": 458,
-    "rotation": 20,
+    "y": 457,
+    "rotation": 12.24,
     "parent": "Board"
   },
   "h164": {
     "inheritFrom": "h86",
     "id": "h164",
     "type": "holder",
-    "x": 949,
+    "x": 946,
     "y": 460,
-    "rotation": 160,
+    "rotation": -14.95,
     "parent": "Board"
   },
   "h165": {
@@ -3615,72 +3663,80 @@
     "type": "holder",
     "x": 995,
     "y": 506,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -30.53
   },
   "h166": {
     "inheritFrom": "h68",
     "id": "h166",
     "type": "holder",
-    "x": 1046,
-    "y": 498,
-    "parent": "Board"
+    "x": 1047,
+    "y": 497,
+    "parent": "Board",
+    "rotation": -32.92
   },
   "h167": {
     "inheritFrom": "h66",
     "id": "h167",
     "type": "holder",
-    "x": 1095,
-    "y": 491,
-    "rotation": 40,
+    "x": 1094,
+    "y": 490,
+    "rotation": -117.97,
     "parent": "Board"
   },
   "h168": {
     "inheritFrom": "h82",
     "id": "h168",
     "type": "holder",
-    "x": 1133,
-    "y": 400,
-    "parent": "Board"
+    "x": 1132,
+    "y": 402,
+    "parent": "Board",
+    "rotation": -40.21
   },
   "h169": {
     "inheritFrom": "h83",
     "id": "h169",
     "type": "holder",
-    "x": 1147,
+    "x": 1144,
     "y": 417,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -40.21
   },
   "h170": {
     "inheritFrom": "h99",
     "id": "h170",
     "type": "holder",
     "x": 1064,
-    "y": 416,
-    "parent": "Board"
+    "y": 410,
+    "parent": "Board",
+    "rotation": 82.57
   },
   "h171": {
     "inheritFrom": "h81",
     "id": "h171",
     "type": "holder",
-    "x": 1087,
-    "y": 333,
-    "parent": "Board"
+    "x": 1089,
+    "y": 332,
+    "parent": "Board",
+    "rotation": 33.8
   },
   "h172": {
     "inheritFrom": "h11",
     "id": "h172",
     "type": "holder",
-    "x": 1085,
+    "x": 1086,
     "y": 285,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 164.64
   },
   "h173": {
     "inheritFrom": "h12",
     "id": "h173",
     "type": "holder",
-    "x": 1135,
+    "x": 1137,
     "y": 290,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 160.61
   },
   "h174": {
     "inheritFrom": "h79",
@@ -3688,7 +3744,8 @@
     "type": "holder",
     "x": 1164,
     "y": 348,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 95.88
   },
   "h175": {
     "inheritFrom": "h80",
@@ -3696,274 +3753,299 @@
     "type": "holder",
     "x": 1183,
     "y": 349,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 96.42
   },
   "h176": {
     "inheritFrom": "h8",
     "id": "h176",
     "type": "holder",
-    "x": 1223,
-    "y": 203,
-    "parent": "Board"
+    "x": 1224,
+    "y": 201,
+    "parent": "Board",
+    "rotation": 129.31
   },
   "h177": {
     "inheritFrom": "h96",
     "id": "h177",
     "type": "holder",
-    "x": 1203,
+    "x": 1204,
     "y": 247,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 138.06
   },
   "h178": {
     "inheritFrom": "h9",
     "id": "h178",
     "type": "holder",
-    "x": 1169,
-    "y": 227,
-    "parent": "Board"
+    "x": 1170,
+    "y": 226,
+    "parent": "Board",
+    "rotation": 87.7
   },
   "h179": {
     "inheritFrom": "h9",
     "id": "h179",
     "type": "holder",
-    "x": 1164,
-    "y": 133,
-    "parent": "Board"
+    "x": 1167,
+    "y": 131,
+    "parent": "Board",
+    "rotation": 87.7
   },
   "h180": {
     "inheritFrom": "h6",
     "id": "h180",
     "type": "holder",
     "x": 1201,
-    "y": 108,
-    "parent": "Board"
+    "y": 107,
+    "parent": "Board",
+    "rotation": -140.15
   },
   "h181": {
     "inheritFrom": "h7",
     "id": "h181",
     "type": "holder",
-    "x": 1223,
-    "y": 155,
-    "parent": "Board"
+    "x": 1221,
+    "y": 153,
+    "parent": "Board",
+    "rotation": -130.23
   },
   "h182": {
     "inheritFrom": "h13",
     "id": "h182",
     "type": "holder",
-    "x": 1045,
+    "x": 1044,
     "y": 221,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -93.75
   },
   "h183": {
     "inheritFrom": "h10",
     "id": "h183",
     "type": "holder",
-    "x": 1129,
-    "y": 97,
-    "rotation": 160,
+    "x": 1131,
+    "y": 96,
+    "rotation": 162.63,
     "parent": "Board"
   },
   "h184": {
     "inheritFrom": "h10",
     "id": "h184",
     "type": "holder",
-    "x": 1060,
-    "y": 153,
-    "rotation": 120,
+    "x": 1059,
+    "y": 154,
+    "rotation": 124.76,
     "parent": "Board"
   },
   "h185": {
     "inheritFrom": "h14",
     "id": "h185",
     "type": "holder",
-    "x": 932,
-    "y": 253,
-    "rotation": 150,
+    "x": 933,
+    "y": 252,
+    "rotation": -27.23,
     "parent": "Board"
   },
   "h186": {
     "inheritFrom": "h14",
     "id": "h186",
     "type": "holder",
-    "x": 975,
-    "y": 234,
-    "rotation": 160,
+    "x": 976,
+    "y": 233,
+    "rotation": -24.6,
     "parent": "Board"
   },
   "h187": {
     "inheritFrom": "h14",
     "id": "h187",
     "type": "holder",
-    "x": 894,
+    "x": 895,
     "y": 280,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -47.54
   },
   "h188": {
     "inheritFrom": "h15",
     "id": "h188",
     "type": "holder",
-    "x": 961,
-    "y": 190,
-    "parent": "Board"
+    "x": 960,
+    "y": 191,
+    "parent": "Board",
+    "rotation": -5.06
   },
   "h189": {
     "inheritFrom": "h15",
     "id": "h189",
     "type": "holder",
-    "x": 916,
-    "y": 194,
-    "parent": "Board"
+    "x": 913,
+    "y": 195,
+    "parent": "Board",
+    "rotation": -5.06
   },
   "h190": {
     "inheritFrom": "h15",
     "id": "h190",
     "type": "holder",
-    "x": 869,
-    "y": 198,
-    "parent": "Board"
+    "x": 866,
+    "y": 199,
+    "parent": "Board",
+    "rotation": -5.06
   },
   "h191": {
     "inheritFrom": "h15",
     "id": "h191",
     "type": "holder",
-    "x": 822,
-    "y": 200,
-    "parent": "Board"
+    "x": 819,
+    "y": 203,
+    "parent": "Board",
+    "rotation": -5.06
   },
   "h192": {
     "inheritFrom": "h15",
     "id": "h192",
     "type": "holder",
-    "x": 774,
-    "y": 204,
-    "parent": "Board"
+    "x": 772,
+    "y": 207,
+    "parent": "Board",
+    "rotation": -5.06
   },
   "h193": {
     "inheritFrom": "h4",
     "id": "h193",
     "type": "holder",
-    "x": 951,
-    "y": 155,
-    "parent": "Board"
+    "x": 954,
+    "y": 156,
+    "parent": "Board",
+    "rotation": 10.25
   },
   "h194": {
     "inheritFrom": "h16",
     "id": "h194",
     "type": "holder",
-    "x": 829,
-    "y": 165,
-    "parent": "Board"
+    "x": 820,
+    "y": 167,
+    "parent": "Board",
+    "rotation": -19.43
   },
   "h195": {
     "inheritFrom": "h16",
     "id": "h195",
     "type": "holder",
-    "x": 784,
-    "y": 181,
-    "parent": "Board"
+    "x": 776,
+    "y": 186,
+    "parent": "Board",
+    "rotation": -27.11
   },
   "h196": {
     "inheritFrom": "h5",
     "id": "h196",
     "type": "holder",
-    "x": 980,
-    "y": 94,
-    "rotation": 155,
+    "x": 986,
+    "y": 90,
+    "rotation": 155.07,
     "parent": "Board"
   },
   "h197": {
     "inheritFrom": "h5",
     "id": "h197",
     "type": "holder",
-    "x": 937,
-    "y": 118,
-    "rotation": 150,
+    "x": 945,
+    "y": 114,
+    "rotation": 145.28,
     "parent": "Board"
   },
   "h198": {
     "inheritFrom": "h5",
     "id": "h198",
     "type": "holder",
-    "x": 1074,
+    "x": 1077,
     "y": 68,
-    "rotation": 0,
+    "rotation": 179.09,
     "parent": "Board"
   },
   "h199": {
     "inheritFrom": "h5",
     "id": "h199",
     "type": "holder",
-    "x": 1123,
-    "y": 73,
-    "rotation": 10,
+    "x": 1124,
+    "y": 74,
+    "rotation": -164.38,
     "parent": "Board"
   },
   "h200": {
     "inheritFrom": "h18",
     "id": "h200",
     "type": "holder",
-    "x": 627,
-    "y": 54,
+    "x": 632,
+    "y": 57,
     "parent": "Board",
-    "z": 224
+    "z": 224,
+    "rotation": -124.17
   },
   "h201": {
     "inheritFrom": "h18",
     "id": "h201",
     "type": "holder",
-    "x": 684,
-    "y": 137,
+    "x": 686,
+    "y": 135,
     "parent": "Board",
-    "z": 226
+    "z": 226,
+    "rotation": -124.17
   },
   "h202": {
     "inheritFrom": "h18",
     "id": "h202",
     "type": "holder",
-    "x": 712,
-    "y": 178,
+    "x": 713,
+    "y": 174,
     "parent": "Board",
-    "z": 227
+    "z": 227,
+    "rotation": -124.17
   },
   "h203": {
     "inheritFrom": "h3",
     "id": "h203",
     "type": "holder",
-    "x": 738,
-    "y": 70,
-    "parent": "Board"
+    "x": 737,
+    "y": 73,
+    "parent": "Board",
+    "rotation": -158
   },
   "h204": {
     "inheritFrom": "h3",
     "id": "h204",
     "type": "holder",
-    "x": 829,
-    "y": 107,
-    "parent": "Board"
+    "x": 825,
+    "y": 108,
+    "parent": "Board",
+    "rotation": -158
   },
   "h205": {
     "inheritFrom": "h3",
     "id": "h205",
     "type": "holder",
-    "x": 875,
-    "y": 125,
-    "parent": "Board"
+    "x": 869,
+    "y": 126,
+    "parent": "Board",
+    "rotation": -158
   },
   "h206": {
     "inheritFrom": "h3",
     "id": "h206",
     "type": "holder",
-    "x": 692,
-    "y": 51,
-    "parent": "Board"
+    "x": 693,
+    "y": 55,
+    "parent": "Board",
+    "rotation": -158
   },
   "h207": {
     "inheritFrom": "h3",
     "id": "h207",
     "type": "holder",
-    "x": 646,
-    "y": 33,
-    "parent": "Board"
+    "x": 649,
+    "y": 37,
+    "parent": "Board",
+    "rotation": -158
   },
   "d32iD": {
     "id": "d32iD",
@@ -4029,99 +4111,111 @@
     "inheritFrom": "h17",
     "id": "h208",
     "type": "holder",
-    "x": 514,
-    "y": 72,
-    "parent": "Board"
+    "x": 513,
+    "y": 74,
+    "parent": "Board",
+    "rotation": -34.74
   },
   "h209": {
     "inheritFrom": "h17",
     "id": "h209",
     "type": "holder",
-    "x": 470,
-    "y": 105,
-    "parent": "Board"
+    "x": 474,
+    "y": 101,
+    "parent": "Board",
+    "rotation": -35.86
   },
   "h210": {
     "inheritFrom": "h17",
     "id": "h210",
     "type": "holder",
-    "x": 424,
-    "y": 135,
-    "parent": "Board"
+    "x": 436,
+    "y": 129,
+    "parent": "Board",
+    "rotation": -34.11
   },
   "h211": {
     "inheritFrom": "h28",
     "id": "h211",
     "type": "holder",
-    "x": 636,
-    "y": 197,
-    "parent": "Board"
+    "x": 631,
+    "y": 195,
+    "parent": "Board",
+    "rotation": -171.96
   },
   "h212": {
     "inheritFrom": "h28",
     "id": "h212",
     "type": "holder",
-    "x": 688,
-    "y": 204,
-    "parent": "Board"
+    "x": 678,
+    "y": 202,
+    "parent": "Board",
+    "rotation": -171.96
   },
   "h213": {
     "inheritFrom": "h28",
     "id": "h213",
     "type": "holder",
-    "x": 531,
+    "x": 536,
     "y": 182,
     "z": 81,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -171.96
   },
   "h214": {
     "inheritFrom": "h28",
     "id": "h214",
     "type": "holder",
-    "x": 478,
-    "y": 175,
+    "x": 489,
+    "y": 176,
     "z": 79,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -171.96
   },
   "h215": {
     "inheritFrom": "h28",
     "id": "h215",
     "type": "holder",
-    "x": 426,
-    "y": 168,
-    "parent": "Board"
+    "x": 442,
+    "y": 169,
+    "parent": "Board",
+    "rotation": -171.96
   },
   "h216": {
     "inheritFrom": "h97",
     "id": "h216",
     "type": "holder",
-    "x": 622,
-    "y": 291,
-    "parent": "Board"
+    "x": 604,
+    "y": 282,
+    "parent": "Board",
+    "rotation": 26.35
   },
   "h217": {
     "inheritFrom": "h97",
     "id": "h217",
     "type": "holder",
-    "x": 524,
-    "y": 240,
-    "parent": "Board"
+    "x": 520,
+    "y": 238,
+    "parent": "Board",
+    "rotation": 29.04
   },
   "h218": {
     "inheritFrom": "h97",
     "id": "h218",
     "type": "holder",
-    "x": 478,
+    "x": 479,
     "y": 214,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 29.56
   },
   "h219": {
     "inheritFrom": "h97",
     "id": "h219",
     "type": "holder",
-    "x": 434,
-    "y": 188,
-    "parent": "Board"
+    "x": 438,
+    "y": 191,
+    "parent": "Board",
+    "rotation": 29.48
   },
   "h220": {
     "inheritFrom": "h27",
@@ -4129,212 +4223,229 @@
     "type": "holder",
     "x": 411,
     "y": 293,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -103.84
   },
   "h221": {
     "inheritFrom": "h27",
     "id": "h221",
     "type": "holder",
-    "x": 401,
+    "x": 400,
     "y": 247,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -102.38
   },
   "h222": {
     "inheritFrom": "h27",
     "id": "h222",
     "type": "holder",
-    "x": 390,
+    "x": 391,
     "y": 200,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -101.37
   },
   "h223": {
     "inheritFrom": "h44",
     "id": "h223",
     "type": "holder",
-    "x": 620,
-    "y": 315,
-    "rotation": 0,
+    "x": 613,
+    "y": 316,
+    "rotation": -9.06,
     "parent": "Board"
   },
   "h224": {
     "inheritFrom": "h44",
     "id": "h224",
     "type": "holder",
-    "x": 520,
-    "y": 337,
-    "parent": "Board"
+    "x": 521,
+    "y": 336,
+    "parent": "Board",
+    "rotation": -16.81
   },
   "h225": {
     "inheritFrom": "h44",
     "id": "h225",
     "type": "holder",
-    "x": 469,
-    "y": 355,
-    "rotation": 150,
+    "x": 476,
+    "y": 353,
+    "rotation": -25.33,
     "parent": "Board"
   },
   "h226": {
     "inheritFrom": "h43",
     "id": "h226",
     "type": "holder",
-    "x": 626,
-    "y": 371,
-    "parent": "Board"
+    "x": 628,
+    "y": 370,
+    "parent": "Board",
+    "rotation": -1.36
   },
   "h227": {
     "inheritFrom": "h43",
     "id": "h227",
     "type": "holder",
-    "x": 524,
-    "y": 371,
-    "parent": "Board"
+    "x": 533,
+    "y": 372,
+    "parent": "Board",
+    "rotation": 0.18
   },
   "h228": {
     "inheritFrom": "h43",
     "id": "h228",
     "type": "holder",
-    "x": 473,
+    "x": 485,
     "y": 371,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 2.4
   },
   "h229": {
     "inheritFrom": "h42",
     "id": "h229",
     "type": "holder",
-    "x": 572,
+    "x": 579,
     "y": 391,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -1.03
   },
   "h230": {
     "inheritFrom": "h42",
     "id": "h230",
     "type": "holder",
-    "x": 522,
+    "x": 532,
     "y": 391,
     "z": 38,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 0.22
   },
   "h231": {
     "inheritFrom": "h42",
     "id": "h231",
     "type": "holder",
-    "x": 472,
-    "y": 391,
+    "x": 484,
+    "y": 390,
     "z": 37,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 2.38
   },
   "h232": {
     "inheritFrom": "h71",
     "id": "h232",
     "type": "holder",
-    "x": 593,
-    "y": 472,
+    "x": 591,
+    "y": 470,
     "z": 42,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 30.91
   },
   "h233": {
     "inheritFrom": "h71",
     "id": "h233",
     "type": "holder",
     "x": 508,
-    "y": 423,
+    "y": 424,
     "z": 41,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 29.31
   },
   "h234": {
     "inheritFrom": "h71",
     "id": "h234",
     "type": "holder",
-    "x": 468,
-    "y": 401,
+    "x": 467,
+    "y": 400,
     "z": 39,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 32.55
   },
   "h235": {
     "inheritFrom": "h98",
     "id": "h235",
     "type": "holder",
-    "x": 582,
+    "x": 561,
     "y": 497,
     "z": 45,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 177.53
   },
   "h236": {
     "inheritFrom": "h98",
     "id": "h236",
     "type": "holder",
-    "x": 458,
-    "y": 498,
+    "x": 466,
+    "y": 497,
     "z": 47,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -178.8
   },
   "h237": {
     "inheritFrom": "h58",
     "id": "h237",
     "type": "holder",
-    "x": 423,
-    "y": 412,
+    "x": 425,
+    "y": 414,
     "z": 48,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 105.05
   },
   "h238": {
     "inheritFrom": "h52",
     "id": "h238",
     "type": "holder",
-    "x": 466,
+    "x": 465,
     "y": 659,
     "z": 57,
-    "rotation": 18,
+    "rotation": 20.47,
     "parent": "Board"
   },
   "h239": {
     "inheritFrom": "h52",
     "id": "h239",
     "type": "holder",
-    "x": 416,
-    "y": 637,
+    "x": 422,
+    "y": 639,
     "z": 56,
-    "rotation": 26,
+    "rotation": 28.96,
     "parent": "Board"
   },
   "h240": {
     "inheritFrom": "h52",
     "id": "h240",
     "type": "holder",
-    "x": 611,
-    "y": 681,
+    "x": 605,
+    "y": 682,
     "z": 61,
-    "rotation": -2,
+    "rotation": -2.26,
     "parent": "Board"
   },
   "h241": {
     "inheritFrom": "h52",
     "id": "h241",
     "type": "holder",
-    "x": 659,
+    "x": 652,
     "y": 676,
     "z": 59,
-    "rotation": -10,
+    "rotation": -11.13,
     "parent": "Board"
   },
   "h242": {
     "inheritFrom": "h52",
     "id": "h242",
     "type": "holder",
-    "x": 515,
+    "x": 510,
     "y": 673,
     "z": 58,
-    "rotation": 10,
+    "rotation": 13.08,
     "parent": "Board"
   },
   "h243": {
     "inheritFrom": "h51",
     "id": "h243",
     "type": "holder",
-    "x": 609,
-    "y": 613,
+    "x": 590,
+    "y": 614,
     "z": 233,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 177.16
   },
   "h244": {
     "inheritFrom": "h51",
@@ -4343,178 +4454,198 @@
     "x": 495,
     "y": 614,
     "z": 66,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -178.93
   },
   "h245": {
     "inheritFrom": "h51",
     "id": "h245",
     "type": "holder",
-    "x": 438,
+    "x": 448,
     "y": 614,
     "z": 67,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -179.79
   },
   "h246": {
     "inheritFrom": "h95",
     "id": "h246",
     "type": "holder",
-    "x": 501,
-    "y": 557,
+    "x": 505,
+    "y": 555,
     "z": 74,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -24.45
   },
   "h247": {
     "inheritFrom": "h95",
     "id": "h247",
     "type": "holder",
-    "x": 460,
-    "y": 576,
+    "x": 462,
+    "y": 575,
     "z": 70,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -24.93
   },
   "h248": {
     "inheritFrom": "h95",
     "id": "h248",
     "type": "holder",
-    "x": 419,
+    "x": 420,
     "y": 596,
     "z": 69,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -27.75
   },
   "h249": {
     "inheritFrom": "h95",
     "id": "h249",
     "type": "holder",
-    "x": 584,
-    "y": 517,
+    "x": 590,
+    "y": 513,
     "z": 73,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -30.17
   },
   "h250": {
     "inheritFrom": "h84",
     "id": "h250",
     "type": "holder",
-    "x": 388,
-    "y": 577,
+    "x": 390,
+    "y": 579,
     "z": 77,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -81.4
   },
   "h251": {
     "inheritFrom": "h19",
     "id": "h251",
     "type": "holder",
     "x": 368,
-    "y": 128,
+    "y": 130,
     "z": 93,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 63.93
   },
   "h252": {
     "inheritFrom": "h19",
     "id": "h252",
     "type": "holder",
-    "x": 328,
-    "y": 45,
+    "x": 327,
+    "y": 47,
     "z": 91,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 63.93
   },
   "h253": {
     "inheritFrom": "h19",
     "id": "h253",
     "type": "holder",
-    "x": 308,
-    "y": 4,
+    "x": 307,
+    "y": 5,
     "z": 89,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 63.93
   },
   "h254": {
     "inheritFrom": "h2",
     "id": "h254",
     "type": "holder",
-    "x": 425,
-    "y": -7,
+    "x": 426,
+    "y": -6,
     "z": 226,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 8.28
   },
   "h255": {
     "inheritFrom": "h2",
     "id": "h255",
     "type": "holder",
     "x": 520,
-    "y": 6,
+    "y": 8,
     "z": 228,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 8.28
   },
   "h256": {
     "inheritFrom": "h2",
     "id": "h256",
     "type": "holder",
-    "x": 567,
-    "y": 13,
+    "x": 568,
+    "y": 15,
     "z": 229,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 8.28
   },
   "h257": {
     "inheritFrom": "h2",
     "id": "h257",
     "type": "holder",
-    "x": 378,
-    "y": -14,
+    "x": 380,
+    "y": -13,
     "z": 102,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 8.28
   },
   "h258": {
     "inheritFrom": "h2",
     "id": "h258",
     "type": "holder",
-    "x": 331,
-    "y": -21,
+    "x": 332,
+    "y": -20,
     "z": 94,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 8.28
   },
   "h259": {
     "inheritFrom": "h1",
     "id": "h259",
     "type": "holder",
-    "x": 142,
+    "x": 148,
     "y": -27,
     "z": 105,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -179.41
   },
   "h260": {
     "inheritFrom": "h1",
     "id": "h260",
     "type": "holder",
-    "x": 244,
-    "y": -27,
+    "x": 243,
+    "y": -26,
     "z": 107,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -179.41
   },
   "h261": {
     "inheritFrom": "h20",
     "id": "h261",
     "type": "holder",
-    "x": 301,
-    "y": 130,
+    "x": 305,
+    "y": 132,
     "z": 117,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -158.36
   },
   "h262": {
     "inheritFrom": "h20",
     "id": "h262",
     "type": "holder",
-    "x": 344,
-    "y": 148,
+    "x": 349,
+    "y": 149,
     "z": 111,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -160.1
   },
   "h263": {
     "inheritFrom": "h20",
     "id": "h263",
     "type": "holder",
-    "x": 216,
+    "x": 217,
     "y": 95,
     "z": 114,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -156.98
   },
   "h264": {
     "inheritFrom": "h20",
@@ -4523,291 +4654,317 @@
     "x": 173,
     "y": 77,
     "z": 115,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -157.4
   },
   "h265": {
     "inheritFrom": "h20",
     "id": "h265",
     "type": "holder",
-    "x": 130,
+    "x": 129,
     "y": 59,
     "z": 116,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -158.59
   },
   "h266": {
     "inheritFrom": "h26",
     "id": "h266",
     "type": "holder",
-    "x": 290,
+    "x": 294,
     "y": 271,
     "z": 119,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 128.75
   },
   "h267": {
     "inheritFrom": "h26",
     "id": "h267",
     "type": "holder",
-    "x": 353,
-    "y": 195,
+    "x": 354,
+    "y": 197,
     "z": 118,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 128.75
   },
   "h268": {
     "inheritFrom": "h25",
     "id": "h268",
     "type": "holder",
-    "x": 183,
-    "y": 36,
+    "x": 179,
+    "y": 35,
     "z": 132,
-    "rotation": 170,
+    "rotation": 169.02,
     "parent": "Board"
   },
   "h269": {
     "inheritFrom": "h25",
     "id": "h269",
     "type": "holder",
-    "x": 228,
-    "y": 21,
+    "x": 224,
+    "y": 22,
     "z": 133,
-    "rotation": 155,
+    "rotation": 158.52,
     "parent": "Board"
   },
   "h270": {
     "inheritFrom": "h25",
     "id": "h270",
     "type": "holder",
-    "x": 268,
-    "y": -4,
+    "x": 266,
+    "y": -1,
     "z": 128,
-    "rotation": 140,
+    "rotation": 142.5,
     "parent": "Board"
   },
   "h271": {
     "inheritFrom": "h94",
     "id": "h271",
     "type": "holder",
-    "x": 206,
+    "x": 207,
     "y": 251,
     "z": 141,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 44.2
   },
   "h272": {
     "inheritFrom": "h94",
     "id": "h272",
     "type": "holder",
-    "x": 239,
+    "x": 240,
     "y": 284,
     "z": 137,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 44.2
   },
   "h273": {
     "inheritFrom": "h94",
     "id": "h273",
     "type": "holder",
     "x": 140,
-    "y": 184,
+    "y": 186,
     "z": 143,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 44.2
   },
   "h274": {
     "inheritFrom": "h94",
     "id": "h274",
     "type": "holder",
-    "x": 107,
-    "y": 151,
+    "x": 106,
+    "y": 153,
     "z": 225,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 44.2
   },
   "h275": {
     "inheritFrom": "h94",
     "id": "h275",
     "type": "holder",
-    "x": 74,
-    "y": 118,
+    "x": 73,
+    "y": 120,
     "z": 134,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 44.2
   },
   "h276": {
     "inheritFrom": "h33",
     "id": "h276",
     "type": "holder",
-    "x": 349,
-    "y": 332,
+    "x": 353,
+    "y": 334,
     "z": 146,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -157.62
   },
   "h277": {
     "inheritFrom": "h33",
     "id": "h277",
     "type": "holder",
-    "x": 303,
-    "y": 312,
+    "x": 309,
+    "y": 315,
     "z": 145,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -157.62
   },
   "h278": {
     "inheritFrom": "h63",
     "id": "h278",
     "type": "holder",
-    "x": 343,
-    "y": 348,
+    "x": 346,
+    "y": 351,
     "z": 149,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -157.62
   },
   "h279": {
     "inheritFrom": "h63",
     "id": "h279",
     "type": "holder",
-    "x": 297,
-    "y": 330,
+    "x": 302,
+    "y": 332,
     "z": 148,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -157.62
   },
   "h280": {
     "inheritFrom": "h59",
     "id": "h280",
     "type": "holder",
-    "x": 218,
-    "y": 308,
+    "x": 226,
+    "y": 306,
     "z": 152,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 166.86
   },
   "h281": {
     "inheritFrom": "h59",
     "id": "h281",
     "type": "holder",
-    "x": 129,
+    "x": 134,
     "y": 328,
     "z": 158,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 166.86
   },
   "h282": {
     "inheritFrom": "h59",
     "id": "h282",
     "type": "holder",
-    "x": 85,
+    "x": 87,
     "y": 338,
     "z": 160,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 166.86
   },
   "h283": {
     "inheritFrom": "h59",
     "id": "h283",
     "type": "holder",
-    "x": 40,
-    "y": 348,
+    "x": 41,
+    "y": 349,
     "z": 162,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 166.86
   },
   "h284": {
     "inheritFrom": "h60",
     "id": "h284",
     "type": "holder",
-    "x": 221,
+    "x": 231,
     "y": 325,
     "z": 157,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 166.91
   },
   "h285": {
     "inheritFrom": "h60",
     "id": "h285",
     "type": "holder",
-    "x": 133,
-    "y": 345,
+    "x": 138,
+    "y": 347,
     "z": 161,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 166.91
   },
   "h286": {
     "inheritFrom": "h60",
     "id": "h286",
     "type": "holder",
-    "x": 89,
-    "y": 355,
+    "x": 92,
+    "y": 357,
     "z": 163,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 166.91
   },
   "h287": {
     "inheritFrom": "h60",
     "id": "h287",
     "type": "holder",
     "x": 45,
-    "y": 365,
+    "y": 368,
     "z": 164,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 166.91
   },
   "h288": {
     "inheritFrom": "h62",
     "id": "h288",
     "type": "holder",
-    "x": 260,
-    "y": 343,
+    "x": 261,
+    "y": 346,
     "z": 171,
-    "rotation": 90,
+    "rotation": -79.18,
     "parent": "Board"
   },
   "h289": {
     "inheritFrom": "h62",
     "id": "h289",
     "type": "holder",
-    "x": 214,
-    "y": 425,
+    "x": 215,
+    "y": 426,
     "z": 169,
-    "rotation": 142,
+    "rotation": -41.51,
     "parent": "Board"
   },
   "h290": {
     "inheritFrom": "h61",
     "id": "h290",
     "type": "holder",
-    "x": 117,
-    "y": 495,
+    "x": 112,
+    "y": 496,
     "z": 172,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 146.82
   },
   "h291": {
     "inheritFrom": "h54",
     "id": "h291",
     "type": "holder",
-    "x": 308,
+    "x": 312,
     "y": 572,
     "z": 177,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -149.21
   },
   "h292": {
     "inheritFrom": "h54",
     "id": "h292",
     "type": "holder",
-    "x": 265,
-    "y": 546,
+    "x": 271,
+    "y": 548,
     "z": 174,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -149.21
   },
   "h293": {
     "inheritFrom": "h53",
     "id": "h293",
     "type": "holder",
-    "x": 320,
-    "y": 512,
+    "x": 321,
+    "y": 513,
     "z": 181,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -11.04
   },
   "h294": {
     "inheritFrom": "h53",
     "id": "h294",
     "type": "holder",
-    "x": 273,
-    "y": 520,
+    "x": 274,
+    "y": 522,
     "z": 182,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -11.04
   },
   "h295": {
     "inheritFrom": "h57",
     "id": "h295",
     "type": "holder",
-    "x": 359,
+    "x": 360,
     "y": 407,
     "z": 192,
-    "rotation": 150,
+    "rotation": 149.83,
     "parent": "Board"
   },
   "h296": {
@@ -4817,64 +4974,68 @@
     "x": 288,
     "y": 465,
     "z": 194,
-    "rotation": 130,
+    "rotation": 133.17,
     "parent": "Board"
   },
   "h297": {
     "inheritFrom": "h57",
     "id": "h297",
     "type": "holder",
-    "x": 259,
+    "x": 258,
     "y": 501,
     "z": 195,
-    "rotation": 130,
+    "rotation": 126.99,
     "parent": "Board"
   },
   "h298": {
     "inheritFrom": "h57",
     "id": "h298",
     "type": "holder",
-    "x": 401,
-    "y": 389,
+    "x": 402,
+    "y": 387,
     "z": 191,
-    "rotation": 160,
+    "rotation": 159.95,
     "parent": "Board"
   },
   "h299": {
     "inheritFrom": "h32",
     "id": "h299",
     "type": "holder",
-    "x": 46,
-    "y": 437,
+    "x": 48,
+    "y": 440,
     "z": 197,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -121.99
   },
   "h300": {
     "inheritFrom": "h32",
     "id": "h300",
     "type": "holder",
-    "x": 23,
-    "y": 397,
+    "x": 25,
+    "y": 398,
     "z": 196,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -112.01
   },
   "h301": {
     "inheritFrom": "h31",
     "id": "h301",
     "type": "holder",
-    "x": 30,
-    "y": 443,
+    "x": 31,
+    "y": 448,
     "z": 200,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -121.98
   },
   "h302": {
     "inheritFrom": "h31",
     "id": "h302",
     "type": "holder",
-    "x": 7,
-    "y": 404,
+    "x": 8,
+    "y": 406,
     "z": 202,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": -112.78
   },
   "h303": {
     "inheritFrom": "h56",
@@ -4883,65 +5044,67 @@
     "x": 160,
     "y": 523,
     "z": 208,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 3.96
   },
   "h304": {
     "inheritFrom": "h56",
     "id": "h304",
     "type": "holder",
-    "x": 113,
+    "x": 114,
     "y": 520,
     "z": 207,
-    "parent": "Board"
+    "parent": "Board",
+    "rotation": 3.96
   },
   "h305": {
     "inheritFrom": "h55",
     "id": "h305",
     "type": "holder",
-    "x": 205,
-    "y": 580,
+    "x": 203,
+    "y": 582,
     "z": 223,
-    "rotation": 19,
+    "rotation": -157.89,
     "parent": "Board"
   },
   "h306": {
     "inheritFrom": "h55",
     "id": "h306",
     "type": "holder",
-    "x": 158,
-    "y": 562,
+    "x": 160,
+    "y": 563,
     "z": 222,
-    "rotation": 25,
+    "rotation": -153.97,
     "parent": "Board"
   },
   "h307": {
     "inheritFrom": "h55",
     "id": "h307",
     "type": "holder",
-    "x": 300,
-    "y": 611,
+    "x": 294,
+    "y": 610,
     "z": 218,
-    "rotation": 12,
+    "rotation": -168.31,
     "parent": "Board"
   },
   "h308": {
     "inheritFrom": "h55",
     "id": "h308",
     "type": "holder",
-    "x": 110,
-    "y": 540,
+    "x": 118,
+    "y": 541,
     "z": 210,
-    "rotation": 29,
+    "rotation": -150.43,
     "parent": "Board"
   },
   "h309": {
     "inheritFrom": "h55",
     "id": "h309",
     "type": "holder",
-    "x": 347,
-    "y": 621,
+    "x": 341,
+    "y": 617,
     "z": 217,
-    "rotation": 7,
+    "rotation": -176.44,
     "parent": "Board"
   },
   "Player 1 - Seat": {
@@ -10383,5 +10546,4702 @@
     "movable": false,
     "css": "text-align:center;color: #888; ",
     "text": "Your tickets\n\nKeep 2+\nat the start\n\nDrag unwanted ticket to red X"
+  },
+  "Route Template": {
+    "type": "line",
+    "id": "Route Template",
+    "x": -524,
+    "y": -144,
+    "width": 420,
+    "height": 60,
+    "parent": "Board",
+    "fixedParent": true,
+    "layer": -10,
+    "lineWidth": 0,
+    "lineStart": {
+      "x": 10,
+      "y": 30
+    },
+    "lineEnd": {
+      "x": 410,
+      "y": 30
+    },
+    "autoSpaceStops": false
+  },
+  "Route 1": {
+    "type": "line",
+    "id": "Route 1",
+    "x": 134,
+    "y": -20,
+    "width": 213,
+    "height": 22,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 203,
+      "y": 12
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "k9i7",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "821m",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h260",
+        "position": 0.2539
+      },
+      {
+        "widget": "h1",
+        "position": 0.5
+      },
+      {
+        "widget": "h259",
+        "position": 0.7461
+      }
+    ]
+  },
+  "Route 2": {
+    "type": "line",
+    "id": "Route 2",
+    "x": 327,
+    "y": -18,
+    "width": 336,
+    "height": 66,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 326,
+      "y": 56
+    },
+    "connectStart": {
+      "line": "k9i7",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "pv47",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h258",
+        "position": 0.1281
+      },
+      {
+        "widget": "h257",
+        "position": 0.2769
+      },
+      {
+        "widget": "h254",
+        "position": 0.4256
+      },
+      {
+        "widget": "h2",
+        "position": 0.5744
+      },
+      {
+        "widget": "h255",
+        "position": 0.7231
+      },
+      {
+        "widget": "h256",
+        "position": 0.8719
+      }
+    ]
+  },
+  "Route 3": {
+    "type": "line",
+    "id": "Route 3",
+    "x": 643,
+    "y": 28,
+    "width": 322,
+    "height": 142,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 312,
+      "y": 132
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "m0o7",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "pv47",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h205",
+        "position": 0.1354
+      },
+      {
+        "widget": "h204",
+        "position": 0.2812
+      },
+      {
+        "widget": "h3",
+        "position": 0.4271
+      },
+      {
+        "widget": "h203",
+        "position": 0.5729
+      },
+      {
+        "widget": "h206",
+        "position": 0.7188
+      },
+      {
+        "widget": "h207",
+        "position": 0.8646
+      }
+    ]
+  },
+  "Route 4": {
+    "type": "line",
+    "id": "Route 4",
+    "x": 945,
+    "y": 150,
+    "width": 152,
+    "height": 61,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 142,
+      "y": 51
+    },
+    "connectStart": {
+      "line": "m0o7",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "8ocd",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h193",
+        "position": 0.3296
+      },
+      {
+        "widget": "h4",
+        "position": 0.6704
+      }
+    ],
+    "controlStart": {
+      "x": 52,
+      "y": 31
+    },
+    "controlEnd": {
+      "x": 102,
+      "y": 21
+    }
+  },
+  "Route 5": {
+    "type": "line",
+    "id": "Route 5",
+    "x": 945,
+    "y": 47,
+    "width": 275,
+    "height": 123,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 265,
+      "y": 62
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 113
+    },
+    "connectStart": {
+      "line": "x85g",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "m0o7",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h199",
+        "position": 0.1601
+      },
+      {
+        "widget": "h198",
+        "position": 0.3301
+      },
+      {
+        "widget": "h5",
+        "position": 0.5
+      },
+      {
+        "widget": "h196",
+        "position": 0.6699
+      },
+      {
+        "widget": "h197",
+        "position": 0.8399
+      }
+    ],
+    "controlStart": {
+      "x": 182,
+      "y": 10
+    },
+    "controlEnd": {
+      "x": 74,
+      "y": 51
+    }
+  },
+  "Route 7": {
+    "type": "line",
+    "id": "Route 7",
+    "x": 1193,
+    "y": 105,
+    "width": 104,
+    "height": 106,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 94,
+      "y": 96
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "5dd4",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "x85g",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h181",
+        "position": 0.3039
+      },
+      {
+        "widget": "h7",
+        "position": 0.6961
+      }
+    ],
+    "controlStart": {
+      "x": 74,
+      "y": 61
+    },
+    "controlEnd": {
+      "x": 43,
+      "y": 34
+    }
+  },
+  "Route 6": {
+    "type": "line",
+    "id": "Route 6",
+    "x": 1206,
+    "y": 92,
+    "width": 105,
+    "height": 106,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 95,
+      "y": 96
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "5dd4",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "x85g",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h6",
+        "position": 0.3052
+      },
+      {
+        "widget": "h180",
+        "position": 0.6948
+      }
+    ],
+    "controlStart": {
+      "x": 74,
+      "y": 60
+    },
+    "controlEnd": {
+      "x": 43,
+      "y": 33
+    }
+  },
+  "Route 96": {
+    "type": "line",
+    "id": "Route 96",
+    "x": 1214,
+    "y": 191,
+    "width": 97,
+    "height": 108,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 87,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 98
+    },
+    "connectStart": {
+      "line": "5dd4",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "w8lu",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h96",
+        "position": 0.2987
+      },
+      {
+        "widget": "h177",
+        "position": 0.7013
+      }
+    ],
+    "controlStart": {
+      "x": 73,
+      "y": 48
+    },
+    "controlEnd": {
+      "x": 36,
+      "y": 68
+    }
+  },
+  "Route 8": {
+    "type": "line",
+    "id": "Route 8",
+    "x": 1200,
+    "y": 178,
+    "width": 97,
+    "height": 108,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 87,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 98
+    },
+    "connectStart": {
+      "line": "5dd4",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "w8lu",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h176",
+        "position": 0.2988
+      },
+      {
+        "widget": "h8",
+        "position": 0.7012
+      }
+    ],
+    "controlStart": {
+      "x": 73,
+      "y": 48
+    },
+    "controlEnd": {
+      "x": 36,
+      "y": 69
+    }
+  },
+  "Route 9": {
+    "type": "line",
+    "id": "Route 9",
+    "x": 1200,
+    "y": 99,
+    "width": 27,
+    "height": 194,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 17,
+      "y": 184
+    },
+    "connectStart": {
+      "line": "x85g",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "w8lu",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h179",
+        "position": 0.2272
+      },
+      {
+        "widget": "h9",
+        "position": 0.5
+      },
+      {
+        "widget": "h178",
+        "position": 0.7728
+      }
+    ]
+  },
+  "Route 10": {
+    "type": "line",
+    "id": "Route 10",
+    "x": 1077,
+    "y": 98,
+    "width": 143,
+    "height": 113,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 133,
+      "y": 11
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 103
+    },
+    "connectStart": {
+      "line": "x85g",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "8ocd",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h183",
+        "position": 0.2115
+      },
+      {
+        "widget": "h10",
+        "position": 0.5
+      },
+      {
+        "widget": "h184",
+        "position": 0.7885
+      }
+    ],
+    "controlStart": {
+      "x": 75,
+      "y": 10
+    },
+    "controlEnd": {
+      "x": 33,
+      "y": 55
+    }
+  },
+  "Route 12": {
+    "type": "line",
+    "id": "Route 12",
+    "x": 1087,
+    "y": 282,
+    "width": 143,
+    "height": 60,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 133,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 50
+    },
+    "connectStart": {
+      "line": "w8lu",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "ek3p",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h173",
+        "position": 0.3166
+      },
+      {
+        "widget": "h12",
+        "position": 0.6834
+      }
+    ],
+    "controlStart": {
+      "x": 94,
+      "y": 28
+    },
+    "controlEnd": {
+      "x": 52,
+      "y": 39
+    }
+  },
+  "Route 11": {
+    "type": "line",
+    "id": "Route 11",
+    "x": 1082,
+    "y": 263,
+    "width": 142,
+    "height": 60,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 132,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 50
+    },
+    "connectStart": {
+      "line": "w8lu",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "ek3p",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h11",
+        "position": 0.3154
+      },
+      {
+        "widget": "h172",
+        "position": 0.6846
+      }
+    ],
+    "controlStart": {
+      "x": 93,
+      "y": 29
+    },
+    "controlEnd": {
+      "x": 51,
+      "y": 40
+    }
+  },
+  "Route 13": {
+    "type": "line",
+    "id": "Route 13",
+    "x": 1077,
+    "y": 191,
+    "width": 28,
+    "height": 142,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 18,
+      "y": 132
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "ek3p",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "8ocd",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h13",
+        "position": 0.3057
+      },
+      {
+        "widget": "h182",
+        "position": 0.6943
+      }
+    ]
+  },
+  "Route 14": {
+    "type": "line",
+    "id": "Route 14",
+    "x": 912,
+    "y": 191,
+    "width": 185,
+    "height": 147,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 137
+    },
+    "lineEnd": {
+      "x": 175,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "v2um",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "8ocd",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h187",
+        "position": 0.1665
+      },
+      {
+        "widget": "h185",
+        "position": 0.3888
+      },
+      {
+        "widget": "h186",
+        "position": 0.6112
+      },
+      {
+        "widget": "h14",
+        "position": 0.8335
+      }
+    ],
+    "controlStart": {
+      "x": 36,
+      "y": 63
+    },
+    "controlEnd": {
+      "x": 135,
+      "y": 72
+    }
+  },
+  "Route 15": {
+    "type": "line",
+    "id": "Route 15",
+    "x": 772,
+    "y": 191,
+    "width": 325,
+    "height": 47,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 37
+    },
+    "lineEnd": {
+      "x": 315,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "cmjv",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "8ocd",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h192",
+        "position": 0.1137
+      },
+      {
+        "widget": "h191",
+        "position": 0.2682
+      },
+      {
+        "widget": "h190",
+        "position": 0.4227
+      },
+      {
+        "widget": "h189",
+        "position": 0.5773
+      },
+      {
+        "widget": "h188",
+        "position": 0.7318
+      },
+      {
+        "widget": "h15",
+        "position": 0.8863
+      }
+    ]
+  },
+  "Route 16": {
+    "type": "line",
+    "id": "Route 16",
+    "x": 772,
+    "y": 150,
+    "width": 193,
+    "height": 88,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 78
+    },
+    "lineEnd": {
+      "x": 183,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "cmjv",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "m0o7",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h195",
+        "position": 0.2465
+      },
+      {
+        "widget": "h194",
+        "position": 0.5
+      },
+      {
+        "widget": "h16",
+        "position": 0.7535
+      }
+    ],
+    "controlStart": {
+      "x": 59,
+      "y": 40
+    },
+    "controlEnd": {
+      "x": 124,
+      "y": 24
+    }
+  },
+  "Route 17": {
+    "type": "line",
+    "id": "Route 17",
+    "x": 418,
+    "y": 28,
+    "width": 245,
+    "height": 160,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 150
+    },
+    "lineEnd": {
+      "x": 235,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "uwi8",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "pv47",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h210",
+        "position": 0.2317
+      },
+      {
+        "widget": "h209",
+        "position": 0.4106
+      },
+      {
+        "widget": "h208",
+        "position": 0.5894
+      },
+      {
+        "widget": "h17",
+        "position": 0.7683
+      }
+    ],
+    "controlStart": {
+      "x": 89,
+      "y": 109
+    },
+    "controlEnd": {
+      "x": 151,
+      "y": 43
+    }
+  },
+  "Route 18": {
+    "type": "line",
+    "id": "Route 18",
+    "x": 643,
+    "y": 28,
+    "width": 149,
+    "height": 210,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 139,
+      "y": 200
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "cmjv",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "pv47",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h202",
+        "position": 0.1898
+      },
+      {
+        "widget": "h201",
+        "position": 0.3966
+      },
+      {
+        "widget": "h18",
+        "position": 0.6034
+      },
+      {
+        "widget": "h200",
+        "position": 0.8102
+      }
+    ]
+  },
+  "Route 19": {
+    "type": "line",
+    "id": "Route 19",
+    "x": 327,
+    "y": -18,
+    "width": 111,
+    "height": 206,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 101,
+      "y": 196
+    },
+    "connectStart": {
+      "line": "k9i7",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "uwi8",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h253",
+        "position": 0.1638
+      },
+      {
+        "widget": "h252",
+        "position": 0.3879
+      },
+      {
+        "widget": "h19",
+        "position": 0.6121
+      },
+      {
+        "widget": "h251",
+        "position": 0.8362
+      }
+    ]
+  },
+  "Route 20": {
+    "type": "line",
+    "id": "Route 20",
+    "x": 131,
+    "y": 54,
+    "width": 307,
+    "height": 134,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 297,
+      "y": 124
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "uwi8",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "rj57",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h262",
+        "position": 0.1156
+      },
+      {
+        "widget": "h261",
+        "position": 0.2693
+      },
+      {
+        "widget": "h20",
+        "position": 0.4231
+      },
+      {
+        "widget": "h263",
+        "position": 0.5769
+      },
+      {
+        "widget": "h264",
+        "position": 0.7307
+      },
+      {
+        "widget": "h265",
+        "position": 0.8844
+      }
+    ],
+    "controlStart": {
+      "x": 199,
+      "y": 92
+    },
+    "controlEnd": {
+      "x": 106,
+      "y": 45
+    }
+  },
+  "Route 21": {
+    "type": "line",
+    "id": "Route 21",
+    "x": 76,
+    "y": 47,
+    "width": 68,
+    "height": 70,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 60
+    },
+    "lineEnd": {
+      "x": 58,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "86gn",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "rj57",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h21",
+        "position": 0.5
+      }
+    ]
+  },
+  "Route 22": {
+    "type": "line",
+    "id": "Route 22",
+    "x": 89,
+    "y": 60,
+    "width": 69,
+    "height": 70,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 60
+    },
+    "lineEnd": {
+      "x": 59,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "86gn",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "rj57",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h22",
+        "position": 0.5
+      }
+    ]
+  },
+  "Route 23": {
+    "type": "line",
+    "id": "Route 23",
+    "x": 122,
+    "y": -21,
+    "width": 23,
+    "height": 94,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 84
+    },
+    "lineEnd": {
+      "x": 13,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "rj57",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "821m",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h23",
+        "position": 0.5
+      }
+    ]
+  },
+  "Route 24": {
+    "type": "line",
+    "id": "Route 24",
+    "x": 140,
+    "y": -20,
+    "width": 23,
+    "height": 94,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 84
+    },
+    "lineEnd": {
+      "x": 13,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "rj57",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "821m",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h24",
+        "position": 0.5
+      }
+    ]
+  },
+  "Route 25": {
+    "type": "line",
+    "id": "Route 25",
+    "x": 131,
+    "y": -18,
+    "width": 216,
+    "height": 92,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 206,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 82
+    },
+    "connectStart": {
+      "line": "k9i7",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "rj57",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h270",
+        "position": 0.1682
+      },
+      {
+        "widget": "h269",
+        "position": 0.3894
+      },
+      {
+        "widget": "h268",
+        "position": 0.6106
+      },
+      {
+        "widget": "h25",
+        "position": 0.8318
+      }
+    ],
+    "controlStart": {
+      "x": 154,
+      "y": 71
+    },
+    "controlEnd": {
+      "x": 82,
+      "y": 73
+    }
+  },
+  "Route 26": {
+    "type": "line",
+    "id": "Route 26",
+    "x": 300,
+    "y": 168,
+    "width": 138,
+    "height": 167,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 128,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 157
+    },
+    "connectStart": {
+      "line": "uwi8",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "59cj",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h267",
+        "position": 0.248
+      },
+      {
+        "widget": "h26",
+        "position": 0.5
+      },
+      {
+        "widget": "h266",
+        "position": 0.752
+      }
+    ]
+  },
+  "Route 27": {
+    "type": "line",
+    "id": "Route 27",
+    "x": 418,
+    "y": 168,
+    "width": 72,
+    "height": 237,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 62,
+      "y": 227
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "qcv9",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "uwi8",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h27",
+        "position": 0.1809
+      },
+      {
+        "widget": "h220",
+        "position": 0.3936
+      },
+      {
+        "widget": "h221",
+        "position": 0.6064
+      },
+      {
+        "widget": "h222",
+        "position": 0.8191
+      }
+    ],
+    "controlStart": {
+      "x": 39,
+      "y": 155
+    },
+    "controlEnd": {
+      "x": 24,
+      "y": 83
+    }
+  },
+  "Route 28": {
+    "type": "line",
+    "id": "Route 28",
+    "x": 418,
+    "y": 168,
+    "width": 374,
+    "height": 70,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 364,
+      "y": 60
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "cmjv",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "uwi8",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h212",
+        "position": 0.1678
+      },
+      {
+        "widget": "h211",
+        "position": 0.3007
+      },
+      {
+        "widget": "h28",
+        "position": 0.4336
+      },
+      {
+        "widget": "h213",
+        "position": 0.5664
+      },
+      {
+        "widget": "h214",
+        "position": 0.6993
+      },
+      {
+        "widget": "h215",
+        "position": 0.8322
+      }
+    ]
+  },
+  "Route 30": {
+    "type": "line",
+    "id": "Route 30",
+    "x": 25,
+    "y": 105,
+    "width": 87,
+    "height": 291,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 77,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 36,
+      "y": 281
+    },
+    "connectStart": {
+      "line": "86gn",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "nrzv",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h108",
+        "position": 0.1637
+      },
+      {
+        "widget": "h107",
+        "position": 0.3318
+      },
+      {
+        "widget": "h30",
+        "position": 0.5
+      },
+      {
+        "widget": "h105",
+        "position": 0.6682
+      },
+      {
+        "widget": "h106",
+        "position": 0.8363
+      }
+    ],
+    "controlStart": {
+      "x": 25,
+      "y": 92
+    },
+    "controlEnd": {
+      "x": 10,
+      "y": 187
+    }
+  },
+  "Route 29": {
+    "type": "line",
+    "id": "Route 29",
+    "x": 6,
+    "y": 102,
+    "width": 87,
+    "height": 291,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 77,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 37,
+      "y": 281
+    },
+    "connectStart": {
+      "line": "86gn",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "nrzv",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h104",
+        "position": 0.1637
+      },
+      {
+        "widget": "h103",
+        "position": 0.3319
+      },
+      {
+        "widget": "h29",
+        "position": 0.5
+      },
+      {
+        "widget": "h102",
+        "position": 0.6681
+      },
+      {
+        "widget": "h101",
+        "position": 0.8363
+      }
+    ],
+    "controlStart": {
+      "x": 25,
+      "y": 92
+    },
+    "controlEnd": {
+      "x": 10,
+      "y": 188
+    }
+  },
+  "Route 31": {
+    "type": "line",
+    "id": "Route 31",
+    "x": 33,
+    "y": 379,
+    "width": 93,
+    "height": 170,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 83,
+      "y": 160
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "0nfa",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "nrzv",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h31",
+        "position": 0.217
+      },
+      {
+        "widget": "h301",
+        "position": 0.5
+      },
+      {
+        "widget": "h302",
+        "position": 0.783
+      }
+    ],
+    "controlStart": {
+      "x": 64,
+      "y": 107
+    },
+    "controlEnd": {
+      "x": 18,
+      "y": 66
+    }
+  },
+  "Route 32": {
+    "type": "line",
+    "id": "Route 32",
+    "x": 51,
+    "y": 370,
+    "width": 93,
+    "height": 170,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 83,
+      "y": 160
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "0nfa",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "nrzv",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h32",
+        "position": 0.2172
+      },
+      {
+        "widget": "h299",
+        "position": 0.5
+      },
+      {
+        "widget": "h300",
+        "position": 0.7828
+      }
+    ],
+    "controlStart": {
+      "x": 63,
+      "y": 108
+    },
+    "controlEnd": {
+      "x": 17,
+      "y": 67
+    }
+  },
+  "Route 63": {
+    "type": "line",
+    "id": "Route 63",
+    "x": 296,
+    "y": 323,
+    "width": 190,
+    "height": 90,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 180,
+      "y": 80
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "qcv9",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "59cj",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h63",
+        "position": 0.2416
+      },
+      {
+        "widget": "h278",
+        "position": 0.5
+      },
+      {
+        "widget": "h279",
+        "position": 0.7584
+      }
+    ]
+  },
+  "Route 33": {
+    "type": "line",
+    "id": "Route 33",
+    "x": 303,
+    "y": 306,
+    "width": 190,
+    "height": 90,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 180,
+      "y": 80
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "qcv9",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "59cj",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h33",
+        "position": 0.2416
+      },
+      {
+        "widget": "h276",
+        "position": 0.5
+      },
+      {
+        "widget": "h277",
+        "position": 0.7584
+      }
+    ]
+  },
+  "Route 34": {
+    "type": "line",
+    "id": "Route 34",
+    "x": 787,
+    "y": 478,
+    "width": 181,
+    "height": 63,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 53
+    },
+    "lineEnd": {
+      "x": 171,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "8nof",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "918y",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h136",
+        "position": 0.2153
+      },
+      {
+        "widget": "h135",
+        "position": 0.5
+      },
+      {
+        "widget": "h34",
+        "position": 0.7847
+      }
+    ],
+    "controlStart": {
+      "x": 65,
+      "y": 46
+    },
+    "controlEnd": {
+      "x": 117,
+      "y": 23
+    }
+  },
+  "Route 35": {
+    "type": "line",
+    "id": "Route 35",
+    "x": 787,
+    "y": 521,
+    "width": 81,
+    "height": 181,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 71,
+      "y": 171
+    },
+    "connectStart": {
+      "line": "8nof",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "hetp",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h129",
+        "position": 0.2244
+      },
+      {
+        "widget": "h128",
+        "position": 0.5
+      },
+      {
+        "widget": "h35",
+        "position": 0.7756
+      }
+    ],
+    "controlStart": {
+      "x": 35,
+      "y": 62
+    },
+    "controlEnd": {
+      "x": 54,
+      "y": 115
+    }
+  },
+  "Route 37": {
+    "type": "line",
+    "id": "Route 37",
+    "x": 649,
+    "y": 501,
+    "width": 50,
+    "height": 136,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 40,
+      "y": 126
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "4v1g",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "g1f4",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h116",
+        "position": 0.3029
+      },
+      {
+        "widget": "h37",
+        "position": 0.6971
+      }
+    ],
+    "controlStart": {
+      "x": 23,
+      "y": 90
+    },
+    "controlEnd": {
+      "x": 13,
+      "y": 50
+    }
+  },
+  "Route 36": {
+    "type": "line",
+    "id": "Route 36",
+    "x": 668,
+    "y": 496,
+    "width": 49,
+    "height": 137,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 39,
+      "y": 127
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "4v1g",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "g1f4",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h117",
+        "position": 0.3039
+      },
+      {
+        "widget": "h36",
+        "position": 0.6961
+      }
+    ],
+    "controlStart": {
+      "x": 23,
+      "y": 90
+    },
+    "controlEnd": {
+      "x": 13,
+      "y": 50
+    }
+  },
+  "Route 39": {
+    "type": "line",
+    "id": "Route 39",
+    "x": 687,
+    "y": 318,
+    "width": 36,
+    "height": 91,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 26,
+      "y": 81
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "r6t9",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "zr1n",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h39",
+        "position": 0.5
+      }
+    ]
+  },
+  "Route 38": {
+    "type": "line",
+    "id": "Route 38",
+    "x": 705,
+    "y": 313,
+    "width": 37,
+    "height": 91,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 27,
+      "y": 81
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "r6t9",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "zr1n",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h38",
+        "position": 0.5
+      }
+    ]
+  },
+  "Route 40": {
+    "type": "line",
+    "id": "Route 40",
+    "x": 667,
+    "y": 391,
+    "width": 74,
+    "height": 132,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 64,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 122
+    },
+    "connectStart": {
+      "line": "r6t9",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "g1f4",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h40",
+        "position": 0.309
+      },
+      {
+        "widget": "h111",
+        "position": 0.691
+      }
+    ]
+  },
+  "Route 41": {
+    "type": "line",
+    "id": "Route 41",
+    "x": 650,
+    "y": 382,
+    "width": 74,
+    "height": 132,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 64,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 122
+    },
+    "connectStart": {
+      "line": "r6t9",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "g1f4",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h41",
+        "position": 0.309
+      },
+      {
+        "widget": "h112",
+        "position": 0.691
+      }
+    ]
+  },
+  "Route 43": {
+    "type": "line",
+    "id": "Route 43",
+    "x": 470,
+    "y": 375,
+    "width": 263,
+    "height": 28,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 253,
+      "y": 12
+    },
+    "connectStart": {
+      "line": "qcv9",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "r6t9",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h228",
+        "position": 0.207
+      },
+      {
+        "widget": "h227",
+        "position": 0.4023
+      },
+      {
+        "widget": "h43",
+        "position": 0.5977
+      },
+      {
+        "widget": "h226",
+        "position": 0.793
+      }
+    ],
+    "controlStart": {
+      "x": 91,
+      "y": 18
+    },
+    "controlEnd": {
+      "x": 171,
+      "y": 13
+    }
+  },
+  "Route 42": {
+    "type": "line",
+    "id": "Route 42",
+    "x": 469,
+    "y": 394,
+    "width": 263,
+    "height": 28,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 253,
+      "y": 12
+    },
+    "connectStart": {
+      "line": "qcv9",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "r6t9",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h231",
+        "position": 0.207
+      },
+      {
+        "widget": "h230",
+        "position": 0.4023
+      },
+      {
+        "widget": "h229",
+        "position": 0.5977
+      },
+      {
+        "widget": "h42",
+        "position": 0.793
+      }
+    ],
+    "controlStart": {
+      "x": 92,
+      "y": 18
+    },
+    "controlEnd": {
+      "x": 172,
+      "y": 13
+    }
+  },
+  "Route 44": {
+    "type": "line",
+    "id": "Route 44",
+    "x": 470,
+    "y": 316,
+    "width": 246,
+    "height": 89,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 79
+    },
+    "lineEnd": {
+      "x": 236,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "qcv9",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "zr1n",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h225",
+        "position": 0.2017
+      },
+      {
+        "widget": "h224",
+        "position": 0.4006
+      },
+      {
+        "widget": "h44",
+        "position": 0.5994
+      },
+      {
+        "widget": "h223",
+        "position": 0.7983
+      }
+    ],
+    "controlStart": {
+      "x": 75,
+      "y": 30
+    },
+    "controlEnd": {
+      "x": 159,
+      "y": 23
+    }
+  },
+  "Route 45": {
+    "type": "line",
+    "id": "Route 45",
+    "x": 1045,
+    "y": 569,
+    "width": 133,
+    "height": 239,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 83,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 98,
+      "y": 229
+    },
+    "connectStart": {
+      "line": "z59b",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "gnye",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h157",
+        "position": 0.1956
+      },
+      {
+        "widget": "h158",
+        "position": 0.3985
+      },
+      {
+        "widget": "h159",
+        "position": 0.6015
+      },
+      {
+        "widget": "h45",
+        "position": 0.8044
+      }
+    ],
+    "controlStart": {
+      "x": 10,
+      "y": 96
+    },
+    "controlEnd": {
+      "x": 123,
+      "y": 144
+    }
+  },
+  "Route 46": {
+    "type": "line",
+    "id": "Route 46",
+    "x": 1005,
+    "y": 543,
+    "width": 148,
+    "height": 265,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 138,
+      "y": 255
+    },
+    "connectStart": {
+      "line": "7ivc",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "gnye",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h155",
+        "position": 0.1563
+      },
+      {
+        "widget": "h154",
+        "position": 0.3282
+      },
+      {
+        "widget": "h46",
+        "position": 0.5
+      },
+      {
+        "widget": "h152",
+        "position": 0.6718
+      },
+      {
+        "widget": "h153",
+        "position": 0.8437
+      }
+    ]
+  },
+  "Route 47": {
+    "type": "line",
+    "id": "Route 47",
+    "x": 848,
+    "y": 636,
+    "width": 305,
+    "height": 172,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 295,
+      "y": 162
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 56
+    },
+    "connectStart": {
+      "line": "gnye",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "hetp",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h47",
+        "position": 0.1388
+      },
+      {
+        "widget": "h134",
+        "position": 0.2833
+      },
+      {
+        "widget": "h130",
+        "position": 0.4278
+      },
+      {
+        "widget": "h131",
+        "position": 0.5722
+      },
+      {
+        "widget": "h132",
+        "position": 0.7167
+      },
+      {
+        "widget": "h133",
+        "position": 0.8612
+      }
+    ],
+    "controlStart": {
+      "x": 205,
+      "y": 69
+    },
+    "controlEnd": {
+      "x": 149,
+      "y": 10
+    }
+  },
+  "Route 48": {
+    "type": "line",
+    "id": "Route 48",
+    "x": 729,
+    "y": 672,
+    "width": 139,
+    "height": 44,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 129,
+      "y": 20
+    },
+    "connectStart": {
+      "line": "gidn",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "hetp",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h127",
+        "position": 0.3072
+      },
+      {
+        "widget": "h48",
+        "position": 0.6928
+      }
+    ],
+    "controlStart": {
+      "x": 45,
+      "y": 34
+    },
+    "controlEnd": {
+      "x": 90,
+      "y": 30
+    }
+  },
+  "Route 49": {
+    "type": "line",
+    "id": "Route 49",
+    "x": 696,
+    "y": 609,
+    "width": 61,
+    "height": 77,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 51,
+      "y": 67
+    },
+    "connectStart": {
+      "line": "4v1g",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "gidn",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h49",
+        "position": 0.5
+      }
+    ],
+    "controlStart": {
+      "x": 18,
+      "y": 33
+    },
+    "controlEnd": {
+      "x": 32,
+      "y": 52
+    }
+  },
+  "Route 50": {
+    "type": "line",
+    "id": "Route 50",
+    "x": 680,
+    "y": 621,
+    "width": 61,
+    "height": 77,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 51,
+      "y": 67
+    },
+    "connectStart": {
+      "line": "4v1g",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "gidn",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h50",
+        "position": 0.5
+      }
+    ],
+    "controlStart": {
+      "x": 19,
+      "y": 32
+    },
+    "controlEnd": {
+      "x": 33,
+      "y": 51
+    }
+  },
+  "Route 51": {
+    "type": "line",
+    "id": "Route 51",
+    "x": 420,
+    "y": 615,
+    "width": 288,
+    "height": 35,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 278,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 18
+    },
+    "connectStart": {
+      "line": "4v1g",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "lttw",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h243",
+        "position": 0.2346
+      },
+      {
+        "widget": "h51",
+        "position": 0.4115
+      },
+      {
+        "widget": "h244",
+        "position": 0.5885
+      },
+      {
+        "widget": "h245",
+        "position": 0.7654
+      }
+    ],
+    "controlStart": {
+      "x": 189,
+      "y": 25
+    },
+    "controlEnd": {
+      "x": 99,
+      "y": 12
+    }
+  },
+  "Route 52": {
+    "type": "line",
+    "id": "Route 52",
+    "x": 420,
+    "y": 623,
+    "width": 329,
+    "height": 105,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 319,
+      "y": 59
+    },
+    "connectStart": {
+      "line": "lttw",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "gidn",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h239",
+        "position": 0.1347
+      },
+      {
+        "widget": "h238",
+        "position": 0.2808
+      },
+      {
+        "widget": "h242",
+        "position": 0.4269
+      },
+      {
+        "widget": "h52",
+        "position": 0.5731
+      },
+      {
+        "widget": "h240",
+        "position": 0.7192
+      },
+      {
+        "widget": "h241",
+        "position": 0.8653
+      }
+    ],
+    "controlStart": {
+      "x": 92,
+      "y": 73
+    },
+    "controlEnd": {
+      "x": 221,
+      "y": 95
+    }
+  },
+  "Route 53": {
+    "type": "line",
+    "id": "Route 53",
+    "x": 274,
+    "y": 504,
+    "width": 184,
+    "height": 52,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 42
+    },
+    "lineEnd": {
+      "x": 174,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "f381",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "wyka",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h294",
+        "position": 0.2157
+      },
+      {
+        "widget": "h293",
+        "position": 0.5
+      },
+      {
+        "widget": "h53",
+        "position": 0.7843
+      }
+    ]
+  },
+  "Route 54": {
+    "type": "line",
+    "id": "Route 54",
+    "x": 274,
+    "y": 536,
+    "width": 166,
+    "height": 107,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 156,
+      "y": 97
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "lttw",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "f381",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h54",
+        "position": 0.2205
+      },
+      {
+        "widget": "h291",
+        "position": 0.5
+      },
+      {
+        "widget": "h292",
+        "position": 0.7795
+      }
+    ]
+  },
+  "Route 55": {
+    "type": "line",
+    "id": "Route 55",
+    "x": 115,
+    "y": 525,
+    "width": 325,
+    "height": 130,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 315,
+      "y": 108
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "lttw",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "0nfa",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h309",
+        "position": 0.1358
+      },
+      {
+        "widget": "h307",
+        "position": 0.2815
+      },
+      {
+        "widget": "h55",
+        "position": 0.4272
+      },
+      {
+        "widget": "h305",
+        "position": 0.5728
+      },
+      {
+        "widget": "h306",
+        "position": 0.7185
+      },
+      {
+        "widget": "h308",
+        "position": 0.8642
+      }
+    ],
+    "controlStart": {
+      "x": 218,
+      "y": 120
+    },
+    "controlEnd": {
+      "x": 91,
+      "y": 63
+    }
+  },
+  "Route 56": {
+    "type": "line",
+    "id": "Route 56",
+    "x": 115,
+    "y": 525,
+    "width": 179,
+    "height": 31,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 169,
+      "y": 21
+    },
+    "connectStart": {
+      "line": "0nfa",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "f381",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h304",
+        "position": 0.2108
+      },
+      {
+        "widget": "h303",
+        "position": 0.5
+      },
+      {
+        "widget": "h56",
+        "position": 0.7892
+      }
+    ]
+  },
+  "Route 57": {
+    "type": "line",
+    "id": "Route 57",
+    "x": 274,
+    "y": 385,
+    "width": 216,
+    "height": 171,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 206,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 161
+    },
+    "connectStart": {
+      "line": "qcv9",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "f381",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h298",
+        "position": 0.1338
+      },
+      {
+        "widget": "h295",
+        "position": 0.3169
+      },
+      {
+        "widget": "h57",
+        "position": 0.5
+      },
+      {
+        "widget": "h296",
+        "position": 0.6831
+      },
+      {
+        "widget": "h297",
+        "position": 0.8662
+      }
+    ],
+    "controlStart": {
+      "x": 119,
+      "y": 30
+    },
+    "controlEnd": {
+      "x": 57,
+      "y": 89
+    }
+  },
+  "Route 58": {
+    "type": "line",
+    "id": "Route 58",
+    "x": 438,
+    "y": 385,
+    "width": 52,
+    "height": 139,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 42,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 129
+    },
+    "connectStart": {
+      "line": "qcv9",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "wyka",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h237",
+        "position": 0.3073
+      },
+      {
+        "widget": "h58",
+        "position": 0.6927
+      }
+    ]
+  },
+  "Route 60": {
+    "type": "line",
+    "id": "Route 60",
+    "x": 44,
+    "y": 324,
+    "width": 278,
+    "height": 80,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 268,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 70
+    },
+    "connectStart": {
+      "line": "59cj",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "nrzv",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h284",
+        "position": 0.1414
+      },
+      {
+        "widget": "h60",
+        "position": 0.3207
+      },
+      {
+        "widget": "h285",
+        "position": 0.5
+      },
+      {
+        "widget": "h286",
+        "position": 0.6793
+      },
+      {
+        "widget": "h287",
+        "position": 0.8586
+      }
+    ]
+  },
+  "Route 59": {
+    "type": "line",
+    "id": "Route 59",
+    "x": 40,
+    "y": 305,
+    "width": 277,
+    "height": 80,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 267,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 70
+    },
+    "connectStart": {
+      "line": "59cj",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "nrzv",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h280",
+        "position": 0.14
+      },
+      {
+        "widget": "h59",
+        "position": 0.32
+      },
+      {
+        "widget": "h281",
+        "position": 0.5
+      },
+      {
+        "widget": "h282",
+        "position": 0.68
+      },
+      {
+        "widget": "h283",
+        "position": 0.86
+      }
+    ]
+  },
+  "Route 61": {
+    "type": "line",
+    "id": "Route 61",
+    "x": 115,
+    "y": 457,
+    "width": 124,
+    "height": 88,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 114,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 78
+    },
+    "connectStart": {
+      "line": "waqo",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "0nfa",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h61",
+        "position": 0.3089
+      },
+      {
+        "widget": "h290",
+        "position": 0.6911
+      }
+    ]
+  },
+  "Route 62": {
+    "type": "line",
+    "id": "Route 62",
+    "x": 219,
+    "y": 315,
+    "width": 101,
+    "height": 162,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 152
+    },
+    "lineEnd": {
+      "x": 91,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "waqo",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "59cj",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h289",
+        "position": 0.2238
+      },
+      {
+        "widget": "h62",
+        "position": 0.5
+      },
+      {
+        "widget": "h288",
+        "position": 0.7762
+      }
+    ],
+    "controlStart": {
+      "x": 66,
+      "y": 116
+    },
+    "controlEnd": {
+      "x": 90,
+      "y": 77
+    }
+  },
+  "Route 64": {
+    "type": "line",
+    "id": "Route 64",
+    "x": 854,
+    "y": 550,
+    "width": 177,
+    "height": 159,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 167,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 149
+    },
+    "connectStart": {
+      "line": "7ivc",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "hetp",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h149",
+        "position": 0.1644
+      },
+      {
+        "widget": "h64",
+        "position": 0.3881
+      },
+      {
+        "widget": "h150",
+        "position": 0.6119
+      },
+      {
+        "widget": "h151",
+        "position": 0.8356
+      }
+    ],
+    "controlStart": {
+      "x": 108,
+      "y": 47
+    },
+    "controlEnd": {
+      "x": 54,
+      "y": 96
+    }
+  },
+  "Route 65": {
+    "type": "line",
+    "id": "Route 65",
+    "x": 841,
+    "y": 535,
+    "width": 177,
+    "height": 159,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 167,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 149
+    },
+    "connectStart": {
+      "line": "7ivc",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "hetp",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h146",
+        "position": 0.1644
+      },
+      {
+        "widget": "h65",
+        "position": 0.3881
+      },
+      {
+        "widget": "h147",
+        "position": 0.6119
+      },
+      {
+        "widget": "h148",
+        "position": 0.8356
+      }
+    ],
+    "controlStart": {
+      "x": 109,
+      "y": 48
+    },
+    "controlEnd": {
+      "x": 54,
+      "y": 96
+    }
+  },
+  "Route 66": {
+    "type": "line",
+    "id": "Route 66",
+    "x": 1106,
+    "y": 474,
+    "width": 64,
+    "height": 115,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 22,
+      "y": 105
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "z59b",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "jji3",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h66",
+        "position": 0.2963
+      },
+      {
+        "widget": "h167",
+        "position": 0.7037
+      }
+    ],
+    "controlStart": {
+      "x": 54,
+      "y": 81
+    },
+    "controlEnd": {
+      "x": 43,
+      "y": 26
+    }
+  },
+  "Route 67": {
+    "type": "line",
+    "id": "Route 67",
+    "x": 999,
+    "y": 466,
+    "width": 122,
+    "height": 89,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 79
+    },
+    "lineEnd": {
+      "x": 112,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "7ivc",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "jji3",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h165",
+        "position": 0.3077
+      },
+      {
+        "widget": "h67",
+        "position": 0.6923
+      }
+    ],
+    "controlStart": {
+      "x": 41,
+      "y": 52
+    },
+    "controlEnd": {
+      "x": 83,
+      "y": 40
+    }
+  },
+  "Route 68": {
+    "type": "line",
+    "id": "Route 68",
+    "x": 1010,
+    "y": 481,
+    "width": 121,
+    "height": 89,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 79
+    },
+    "lineEnd": {
+      "x": 111,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "7ivc",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "jji3",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h68",
+        "position": 0.3066
+      },
+      {
+        "widget": "h166",
+        "position": 0.6934
+      }
+    ],
+    "controlStart": {
+      "x": 41,
+      "y": 52
+    },
+    "controlEnd": {
+      "x": 83,
+      "y": 41
+    }
+  },
+  "Route 69": {
+    "type": "line",
+    "id": "Route 69",
+    "x": 1005,
+    "y": 543,
+    "width": 133,
+    "height": 46,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 123,
+      "y": 36
+    },
+    "connectStart": {
+      "line": "7ivc",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "z59b",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h156",
+        "position": 0.2974
+      },
+      {
+        "widget": "h69",
+        "position": 0.7026
+      }
+    ]
+  },
+  "Route 70": {
+    "type": "line",
+    "id": "Route 70",
+    "x": 948,
+    "y": 478,
+    "width": 77,
+    "height": 85,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 67,
+      "y": 75
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "7ivc",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "918y",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h70",
+        "position": 0.5
+      }
+    ]
+  },
+  "Route 71": {
+    "type": "line",
+    "id": "Route 71",
+    "x": 470,
+    "y": 385,
+    "width": 209,
+    "height": 134,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 199,
+      "y": 124
+    },
+    "connectStart": {
+      "line": "qcv9",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "g1f4",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h234",
+        "position": 0.1774
+      },
+      {
+        "widget": "h233",
+        "position": 0.3925
+      },
+      {
+        "widget": "h71",
+        "position": 0.6075
+      },
+      {
+        "widget": "h232",
+        "position": 0.8226
+      }
+    ],
+    "controlStart": {
+      "x": 68,
+      "y": 54
+    },
+    "controlEnd": {
+      "x": 138,
+      "y": 82
+    }
+  },
+  "Route 72": {
+    "type": "line",
+    "id": "Route 72",
+    "x": 659,
+    "y": 499,
+    "width": 148,
+    "height": 42,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 138,
+      "y": 32
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "8nof",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "g1f4",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h72",
+        "position": 0.3171
+      },
+      {
+        "widget": "h113",
+        "position": 0.6829
+      }
+    ]
+  },
+  "Route 74": {
+    "type": "line",
+    "id": "Route 74",
+    "x": 704,
+    "y": 223,
+    "width": 95,
+    "height": 118,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 85,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 108
+    },
+    "connectStart": {
+      "line": "cmjv",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "zr1n",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h125",
+        "position": 0.3088
+      },
+      {
+        "widget": "h74",
+        "position": 0.6912
+      }
+    ],
+    "controlStart": {
+      "x": 60,
+      "y": 43
+    },
+    "controlEnd": {
+      "x": 24,
+      "y": 68
+    }
+  },
+  "Route 73": {
+    "type": "line",
+    "id": "Route 73",
+    "x": 688,
+    "y": 212,
+    "width": 96,
+    "height": 118,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 86,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 108
+    },
+    "connectStart": {
+      "line": "cmjv",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "zr1n",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h126",
+        "position": 0.3098
+      },
+      {
+        "widget": "h73",
+        "position": 0.6902
+      }
+    ],
+    "controlStart": {
+      "x": 61,
+      "y": 42
+    },
+    "controlEnd": {
+      "x": 25,
+      "y": 67
+    }
+  },
+  "Route 75": {
+    "type": "line",
+    "id": "Route 75",
+    "x": 772,
+    "y": 218,
+    "width": 160,
+    "height": 120,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 150,
+      "y": 110
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "v2um",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "cmjv",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h75",
+        "position": 0.2253
+      },
+      {
+        "widget": "h124",
+        "position": 0.5
+      },
+      {
+        "widget": "h123",
+        "position": 0.7747
+      }
+    ],
+    "controlStart": {
+      "x": 112,
+      "y": 64
+    },
+    "controlEnd": {
+      "x": 57,
+      "y": 41
+    }
+  },
+  "Route 76": {
+    "type": "line",
+    "id": "Route 76",
+    "x": 696,
+    "y": 295,
+    "width": 236,
+    "height": 43,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 226,
+      "y": 33
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 31
+    },
+    "connectStart": {
+      "line": "v2um",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "zr1n",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h76",
+        "position": 0.1745
+      },
+      {
+        "widget": "h120",
+        "position": 0.3915
+      },
+      {
+        "widget": "h121",
+        "position": 0.6085
+      },
+      {
+        "widget": "h122",
+        "position": 0.8255
+      }
+    ],
+    "controlStart": {
+      "x": 154,
+      "y": 10
+    },
+    "controlEnd": {
+      "x": 82,
+      "y": 13
+    }
+  },
+  "Route 78": {
+    "type": "line",
+    "id": "Route 78",
+    "x": 911,
+    "y": 303,
+    "width": 193,
+    "height": 25,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 15
+    },
+    "lineEnd": {
+      "x": 183,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "v2um",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "ek3p",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h145",
+        "position": 0.2255
+      },
+      {
+        "widget": "h144",
+        "position": 0.5
+      },
+      {
+        "widget": "h78",
+        "position": 0.7745
+      }
+    ]
+  },
+  "Route 77": {
+    "type": "line",
+    "id": "Route 77",
+    "x": 912,
+    "y": 322,
+    "width": 193,
+    "height": 25,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 15
+    },
+    "lineEnd": {
+      "x": 183,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "v2um",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "ek3p",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h143",
+        "position": 0.2255
+      },
+      {
+        "widget": "h142",
+        "position": 0.5
+      },
+      {
+        "widget": "h77",
+        "position": 0.7745
+      }
+    ]
+  },
+  "Route 80": {
+    "type": "line",
+    "id": "Route 80",
+    "x": 1212,
+    "y": 273,
+    "width": 31,
+    "height": 139,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 14,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 129
+    },
+    "connectStart": {
+      "line": "w8lu",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "29mv",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h80",
+        "position": 0.3017
+      },
+      {
+        "widget": "h175",
+        "position": 0.6983
+      }
+    ],
+    "controlStart": {
+      "x": 21,
+      "y": 49
+    },
+    "controlEnd": {
+      "x": 18,
+      "y": 90
+    }
+  },
+  "Route 79": {
+    "type": "line",
+    "id": "Route 79",
+    "x": 1194,
+    "y": 272,
+    "width": 30,
+    "height": 139,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 14,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 129
+    },
+    "connectStart": {
+      "line": "w8lu",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "29mv",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h79",
+        "position": 0.3014
+      },
+      {
+        "widget": "h174",
+        "position": 0.6986
+      }
+    ],
+    "controlStart": {
+      "x": 20,
+      "y": 49
+    },
+    "controlEnd": {
+      "x": 17,
+      "y": 91
+    }
+  },
+  "Route 81": {
+    "type": "line",
+    "id": "Route 81",
+    "x": 1085,
+    "y": 313,
+    "width": 138,
+    "height": 99,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 128,
+      "y": 89
+    },
+    "connectStart": {
+      "line": "ek3p",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "29mv",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h171",
+        "position": 0.3328
+      },
+      {
+        "widget": "h81",
+        "position": 0.6672
+      }
+    ]
+  },
+  "Route 82": {
+    "type": "line",
+    "id": "Route 82",
+    "x": 1100,
+    "y": 384,
+    "width": 117,
+    "height": 102,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 92
+    },
+    "lineEnd": {
+      "x": 107,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "jji3",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "29mv",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h82",
+        "position": 0.313
+      },
+      {
+        "widget": "h168",
+        "position": 0.687
+      }
+    ]
+  },
+  "Route 83": {
+    "type": "line",
+    "id": "Route 83",
+    "x": 1112,
+    "y": 399,
+    "width": 117,
+    "height": 102,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 92
+    },
+    "lineEnd": {
+      "x": 107,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "jji3",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "29mv",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h83",
+        "position": 0.313
+      },
+      {
+        "widget": "h169",
+        "position": 0.687
+      }
+    ]
+  },
+  "Route 84": {
+    "type": "line",
+    "id": "Route 84",
+    "x": 420,
+    "y": 504,
+    "width": 38,
+    "height": 139,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 129
+    },
+    "lineEnd": {
+      "x": 28,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "lttw",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "wyka",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h250",
+        "position": 0.3027
+      },
+      {
+        "widget": "h84",
+        "position": 0.6973
+      }
+    ]
+  },
+  "Route 85": {
+    "type": "line",
+    "id": "Route 85",
+    "x": 948,
+    "y": 313,
+    "width": 157,
+    "height": 185,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 175
+    },
+    "lineEnd": {
+      "x": 147,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "918y",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "ek3p",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h162",
+        "position": 0.1741
+      },
+      {
+        "widget": "h85",
+        "position": 0.3914
+      },
+      {
+        "widget": "h160",
+        "position": 0.6086
+      },
+      {
+        "widget": "h161",
+        "position": 0.8259
+      }
+    ],
+    "controlStart": {
+      "x": 55,
+      "y": 121
+    },
+    "controlEnd": {
+      "x": 134,
+      "y": 86
+    }
+  },
+  "Route 86": {
+    "type": "line",
+    "id": "Route 86",
+    "x": 948,
+    "y": 453,
+    "width": 178,
+    "height": 45,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 35
+    },
+    "lineEnd": {
+      "x": 168,
+      "y": 31
+    },
+    "connectStart": {
+      "line": "918y",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "jji3",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h164",
+        "position": 0.2114
+      },
+      {
+        "widget": "h86",
+        "position": 0.5
+      },
+      {
+        "widget": "h163",
+        "position": 0.7886
+      }
+    ],
+    "controlStart": {
+      "x": 67,
+      "y": 14
+    },
+    "controlEnd": {
+      "x": 110,
+      "y": 10
+    }
+  },
+  "Route 87": {
+    "type": "line",
+    "id": "Route 87",
+    "x": 835,
+    "y": 324,
+    "width": 104,
+    "height": 113,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 94,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 103
+    },
+    "connectStart": {
+      "line": "v2um",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "5k17",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h119",
+        "position": 0.3105
+      },
+      {
+        "widget": "h87",
+        "position": 0.6895
+      }
+    ]
+  },
+  "Route 88": {
+    "type": "line",
+    "id": "Route 88",
+    "x": 821,
+    "y": 311,
+    "width": 103,
+    "height": 113,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 93,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 103
+    },
+    "connectStart": {
+      "line": "v2um",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "5k17",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h118",
+        "position": 0.3095
+      },
+      {
+        "widget": "h88",
+        "position": 0.6905
+      }
+    ]
+  },
+  "Route 89": {
+    "type": "line",
+    "id": "Route 89",
+    "x": 828,
+    "y": 313,
+    "width": 277,
+    "height": 118,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 267,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 108
+    },
+    "connectStart": {
+      "line": "ek3p",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "5k17",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h141",
+        "position": 0.155
+      },
+      {
+        "widget": "h140",
+        "position": 0.3275
+      },
+      {
+        "widget": "h89",
+        "position": 0.5
+      },
+      {
+        "widget": "h139",
+        "position": 0.6725
+      },
+      {
+        "widget": "h138",
+        "position": 0.845
+      }
+    ],
+    "controlStart": {
+      "x": 182,
+      "y": 45
+    },
+    "controlEnd": {
+      "x": 99,
+      "y": 86
+    }
+  },
+  "Route 91": {
+    "type": "line",
+    "id": "Route 91",
+    "x": 714,
+    "y": 377,
+    "width": 136,
+    "height": 44,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 126,
+      "y": 34
+    },
+    "connectStart": {
+      "line": "r6t9",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "connectEnd": {
+      "line": "5k17",
+      "position": 0.058824,
+      "offset": -9.5
+    },
+    "stops": [
+      {
+        "widget": "h110",
+        "position": 0.2995
+      },
+      {
+        "widget": "h91",
+        "position": 0.7005
+      }
+    ]
+  },
+  "Route 90": {
+    "type": "line",
+    "id": "Route 90",
+    "x": 711,
+    "y": 396,
+    "width": 135,
+    "height": 44,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 125,
+      "y": 34
+    },
+    "connectStart": {
+      "line": "r6t9",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "connectEnd": {
+      "line": "5k17",
+      "position": 0.058824,
+      "offset": 9.5
+    },
+    "stops": [
+      {
+        "widget": "h109",
+        "position": 0.2979
+      },
+      {
+        "widget": "h90",
+        "position": 0.7021
+      }
+    ]
+  },
+  "Route 92": {
+    "type": "line",
+    "id": "Route 92",
+    "x": 787,
+    "y": 411,
+    "width": 61,
+    "height": 130,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 120
+    },
+    "lineEnd": {
+      "x": 51,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "8nof",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "5k17",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h114",
+        "position": 0.2978
+      },
+      {
+        "widget": "h92",
+        "position": 0.7022
+      }
+    ]
+  },
+  "Route 93": {
+    "type": "line",
+    "id": "Route 93",
+    "x": 828,
+    "y": 411,
+    "width": 140,
+    "height": 87,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 130,
+      "y": 77
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "918y",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "5k17",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h93",
+        "position": 0.3272
+      },
+      {
+        "widget": "h137",
+        "position": 0.6728
+      }
+    ]
+  },
+  "Route 94": {
+    "type": "line",
+    "id": "Route 94",
+    "x": 83,
+    "y": 104,
+    "width": 237,
+    "height": 231,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 227,
+      "y": 221
+    },
+    "connectStart": {
+      "line": "86gn",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "59cj",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h275",
+        "position": 0.1134
+      },
+      {
+        "widget": "h274",
+        "position": 0.268
+      },
+      {
+        "widget": "h273",
+        "position": 0.4227
+      },
+      {
+        "widget": "h94",
+        "position": 0.5773
+      },
+      {
+        "widget": "h271",
+        "position": 0.732
+      },
+      {
+        "widget": "h272",
+        "position": 0.8866
+      }
+    ]
+  },
+  "Route 95": {
+    "type": "line",
+    "id": "Route 95",
+    "x": 420,
+    "y": 499,
+    "width": 259,
+    "height": 144,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 134
+    },
+    "lineEnd": {
+      "x": 249,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "lttw",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "g1f4",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h248",
+        "position": 0.1476
+      },
+      {
+        "widget": "h247",
+        "position": 0.3238
+      },
+      {
+        "widget": "h246",
+        "position": 0.5
+      },
+      {
+        "widget": "h95",
+        "position": 0.6762
+      },
+      {
+        "widget": "h249",
+        "position": 0.8524
+      }
+    ],
+    "controlStart": {
+      "x": 86,
+      "y": 87
+    },
+    "controlEnd": {
+      "x": 175,
+      "y": 62
+    }
+  },
+  "Route 97": {
+    "type": "line",
+    "id": "Route 97",
+    "x": 418,
+    "y": 168,
+    "width": 298,
+    "height": 168,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 288,
+      "y": 158
+    },
+    "connectStart": {
+      "line": "uwi8",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "zr1n",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h219",
+        "position": 0.1985
+      },
+      {
+        "widget": "h218",
+        "position": 0.3492
+      },
+      {
+        "widget": "h217",
+        "position": 0.5
+      },
+      {
+        "widget": "h97",
+        "position": 0.6508
+      },
+      {
+        "widget": "h216",
+        "position": 0.8015
+      }
+    ],
+    "controlStart": {
+      "x": 102,
+      "y": 60
+    },
+    "controlEnd": {
+      "x": 191,
+      "y": 116
+    }
+  },
+  "Route 98": {
+    "type": "line",
+    "id": "Route 98",
+    "x": 438,
+    "y": 499,
+    "width": 241,
+    "height": 31,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 231,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 10,
+      "y": 15
+    },
+    "connectStart": {
+      "line": "g1f4",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "wyka",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h235",
+        "position": 0.2854
+      },
+      {
+        "widget": "h98",
+        "position": 0.5
+      },
+      {
+        "widget": "h236",
+        "position": 0.7146
+      }
+    ],
+    "controlStart": {
+      "x": 158,
+      "y": 21
+    },
+    "controlEnd": {
+      "x": 83,
+      "y": 15
+    }
+  },
+  "Route 99": {
+    "type": "line",
+    "id": "Route 99",
+    "x": 1085,
+    "y": 313,
+    "width": 41,
+    "height": 181,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 10
+    },
+    "lineEnd": {
+      "x": 31,
+      "y": 171
+    },
+    "connectStart": {
+      "line": "ek3p",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "jji3",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h99",
+        "position": 0.3537
+      },
+      {
+        "widget": "h170",
+        "position": 0.6463
+      }
+    ]
+  },
+  "Route 100": {
+    "type": "line",
+    "id": "Route 100",
+    "x": 688,
+    "y": 521,
+    "width": 119,
+    "height": 114,
+    "inheritFrom": "Route Template",
+    "parent": "Board",
+    "lineStart": {
+      "x": 10,
+      "y": 104
+    },
+    "lineEnd": {
+      "x": 109,
+      "y": 10
+    },
+    "connectStart": {
+      "line": "4v1g",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "connectEnd": {
+      "line": "8nof",
+      "position": 0.058824,
+      "offset": 0
+    },
+    "stops": [
+      {
+        "widget": "h115",
+        "position": 0.3267
+      },
+      {
+        "widget": "h100",
+        "position": 0.6733
+      }
+    ],
+    "controlStart": {
+      "x": 47,
+      "y": 78
+    },
+    "controlEnd": {
+      "x": 82,
+      "y": 46
+    }
   }
 }

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -819,3 +819,61 @@ test('Line widget in edit mode', async t => {
   // random, so the compared state no longer depends on the seeded rand() stream
   await compareState(t, 'd35bd7362c7e87ea9ecb29895cc8d0b9');
 });
+
+// A stop does not have to be a child of the line, and one that is not gets
+// placed through global coordinates - which read the CSS transforms out of the
+// DOM. Moving the city the route is connected to moves the line's box in the
+// same batch, so without a flush the stops are laid out in the frame the line
+// had before the move and end up off the path by exactly that move.
+test('Line stops that are not children of the line', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    cityA: { id: 'cityA', type: 'basic', x: 100, y: 300, width: 40, height: 40 },
+    cityB: { id: 'cityB', type: 'basic', x: 600, y: 300, width: 40, height: 40 },
+    // the cars start out exactly where the line puts them: on the straight path
+    // from city to city, at 33% and 67% of its length
+    car1:  { id: 'car1',  type: 'basic', x: 255, y: 308, width: 60, height: 24, movable: false },
+    car2:  { id: 'car2',  type: 'basic', x: 425, y: 308, width: 60, height: 24, movable: false },
+    route: {
+      id: 'route', type: 'line', autoSpaceStops: false,
+      lineStart: { x: 120, y: 320 }, lineEnd: { x: 620, y: 320 },
+      connectStart: { line: 'cityA', position: 0.5 },
+      connectEnd: { line: 'cityB', position: 0.5 },
+      stops: [ { widget: 'car1', position: 0.33 }, { widget: 'car2', position: 0.67 } ]
+    }
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+  // entering edit mode is what puts the engine on window for the checks below
+  await t.click('#editButton');
+
+  // every mouse event of a drag is one batch, so move the city as one: the delta
+  // - and with it the line's new box - only reaches the DOM once it ends
+  const moveCity = ClientFunction((dx, dy) => {
+    const city = widgets.get('cityA');
+    batchStart();
+    return city.set('x', city.get('x')+dx)
+      .then(_=>city.set('y', city.get('y')+dy))
+      .then(_=>batchEnd());
+  });
+
+  // how far the stops sit from where the line's own layout puts them - the whole
+  // point of a stop is that it rides on the path, so this has to stay 0
+  const stopsOffPath = ClientFunction(() => {
+    const line = widgets.get('route');
+    return Math.max(...line.stopList().map(entry => {
+      const stop = widgets.get(entry.widget);
+      const p = line.stopCoordInParentFrame(stop, line.pointAtPosition(entry.position));
+      return Math.max(
+        Math.abs(Math.round(p.x - stop.get('width')/2) - stop.get('x')),
+        Math.abs(Math.round(p.y - stop.get('height')/2) - stop.get('y'))
+      );
+    }));
+  });
+
+  await t.expect(stopsOffPath()).eql(0);
+  await moveCity(120, -90);
+  await t.expect(stopsOffPath()).eql(0);
+  await moveCity(-120, 90);
+  await t.expect(stopsOffPath()).eql(0);
+});

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -834,12 +834,16 @@ test('Line stops that are not children of the line', async t => {
     // from city to city, at 33% and 67% of its length
     car1:  { id: 'car1',  type: 'basic', x: 255, y: 308, width: 60, height: 24, movable: false },
     car2:  { id: 'car2',  type: 'basic', x: 425, y: 308, width: 60, height: 24, movable: false },
+    // a third car in a frame of its own: it is placed through the holder's
+    // transform instead of the room's, at 50% of the path
+    holder: { id: 'holder', type: 'basic', x: 200, y: 100, width: 400, height: 400, movable: false },
+    car3:  { id: 'car3',  type: 'basic', parent: 'holder', x: 140, y: 208, width: 60, height: 24, movable: false },
     route: {
       id: 'route', type: 'line', autoSpaceStops: false,
       lineStart: { x: 120, y: 320 }, lineEnd: { x: 620, y: 320 },
       connectStart: { line: 'cityA', position: 0.5 },
       connectEnd: { line: 'cityB', position: 0.5 },
-      stops: [ { widget: 'car1', position: 0.33 }, { widget: 'car2', position: 0.67 } ]
+      stops: [ { widget: 'car1', position: 0.33 }, { widget: 'car3', position: 0.5 }, { widget: 'car2', position: 0.67 } ]
     }
   });
   await ClientFunction(prepareClient)();
@@ -871,9 +875,26 @@ test('Line stops that are not children of the line', async t => {
     }));
   });
 
+  // a routine can move the frame a stop lives in and re-lay out the line in the
+  // same batch - then it is the holder's transform that is one event behind.
+  // rotateStops is the cheapest property to re-lay out the stops with: it does
+  // not touch the line's own geometry, so only the holder's frame goes stale.
+  const moveHolderAndLayOutStops = ClientFunction((dx, dy, rotate) => {
+    const holder = widgets.get('holder');
+    batchStart();
+    return holder.set('x', holder.get('x')+dx)
+      .then(_=>holder.set('y', holder.get('y')+dy))
+      .then(_=>widgets.get('route').set('rotateStops', rotate))
+      .then(_=>batchEnd());
+  });
+
   await t.expect(stopsOffPath()).eql(0);
   await moveCity(120, -90);
   await t.expect(stopsOffPath()).eql(0);
   await moveCity(-120, 90);
+  await t.expect(stopsOffPath()).eql(0);
+  await moveHolderAndLayOutStops(70, -40, false);
+  await t.expect(stopsOffPath()).eql(0);
+  await moveHolderAndLayOutStops(-70, 40, true);
   await t.expect(stopsOffPath()).eql(0);
 });

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -844,6 +844,15 @@ test('Line stops that are not children of the line', async t => {
       connectStart: { line: 'cityA', position: 0.5 },
       connectEnd: { line: 'cityB', position: 0.5 },
       stops: [ { widget: 'car1', position: 0.33 }, { widget: 'car3', position: 0.5 }, { widget: 'car2', position: 0.67 } ]
+    },
+    // a second line between the same two cities, without stops of its own: it is
+    // only here to flush the delta in the middle of a batch, the way every
+    // connected line does
+    route2: {
+      id: 'route2', type: 'line',
+      lineStart: { x: 120, y: 340 }, lineEnd: { x: 620, y: 340 },
+      connectStart: { line: 'cityA', position: 0.5 },
+      connectEnd: { line: 'cityB', position: 0.5 }
     }
   });
   await ClientFunction(prepareClient)();
@@ -888,6 +897,26 @@ test('Line stops that are not children of the line', async t => {
       .then(_=>batchEnd());
   });
 
+  // the same, except the frame ends the batch where it started - with another
+  // line flushing while it is displaced. Nothing about this line or the holder
+  // has changed by the time the stops are laid out, but the DOM now holds the
+  // displaced transform, so only asking the DOM catches it.
+  const displaceHolderAndLayOutStops = ClientFunction((dx, dy, rotate) => {
+    const holder = widgets.get('holder');
+    batchStart();
+    return holder.set('x', holder.get('x')+dx)
+      .then(_=>holder.set('y', holder.get('y')+dy))
+      .then(_=>widgets.get('route2').applyConnections())
+      .then(_=>holder.set('x', holder.get('x')-dx))
+      .then(_=>holder.set('y', holder.get('y')-dy))
+      .then(_=>widgets.get('route').set('rotateStops', rotate))
+      .then(_=>batchEnd());
+  });
+
+  // a stop can be the frame another stop is placed in, and then the transform
+  // car3 is converted through is one the same pass has just written
+  const holderBecomesAStop = ClientFunction(() => widgets.get('route').addStop('holder', 0.15));
+
   await t.expect(stopsOffPath()).eql(0);
   await moveCity(120, -90);
   await t.expect(stopsOffPath()).eql(0);
@@ -896,5 +925,13 @@ test('Line stops that are not children of the line', async t => {
   await moveHolderAndLayOutStops(70, -40, false);
   await t.expect(stopsOffPath()).eql(0);
   await moveHolderAndLayOutStops(-70, 40, true);
+  await t.expect(stopsOffPath()).eql(0);
+  await displaceHolderAndLayOutStops(60, -30, false);
+  await t.expect(stopsOffPath()).eql(0);
+  await displaceHolderAndLayOutStops(-60, 30, true);
+  await t.expect(stopsOffPath()).eql(0);
+  await holderBecomesAStop();
+  await t.expect(stopsOffPath()).eql(0);
+  await moveCity(90, -60);
   await t.expect(stopsOffPath()).eql(0);
 });


### PR DESCRIPTION
## What this does

Every one of the 100 routes on the map of **All Aboard** (the Ticket to Ride style game in the public library) is now a **line widget** connected to the two city cards it runs between, with that route's train-car holders as its `stops`.

Before, the ~309 holders were placed by hand: each one had its own eyeballed `x`, `y` and `rotation`, so the spacing along a route was uneven, parallel double routes drifted apart, and moving a city meant nudging every holder around it by hand. Now the line owns the geometry — the holders are positioned and rotated by the path — and moving a city in edit mode drags every route to and from it along with it.

![map](https://agent.virtualtabletop.io/reports/pr/1531626854740394146/all-aboard-after.png)

## The map still looks the same

Rebuilt from the existing map rather than redrawn, so every route keeps its course, its colour, its length and its holder ids (the scoring routines select holders by their `route` property and are untouched):

* **City dots stay exactly where they are.** The dot is now centred in the city card's height (`faceTemplates` image `y: 0` → `4`, every city card `y` − 4) so that a connected line end point — which lands in the middle of the card — meets the middle of the dot. The city name sits 4px higher relative to the dot, which lines it up with the dot a little better than before.
* **Curved routes stay curved.** Where the hand-placed chain bent away from the straight connection (the Gulf coast, the Pacific coast, Miami…), the line is a cubic Bézier least-squares fitted to that chain, so it follows the same course.
* **Double routes are exactly parallel.** The two lines of a pair share one fitted centre path and get matching `-9.5` / `+9.5` connection offsets, which `applyConnections` turns into a parallel pair over the whole route.
* **Spacing rule:** the two city dots count as stops of the line as well, and everything in between is spaced evenly: the gap between two cars is the same as the gap between a car and the dot it faces. That keeps every route reaching out towards both of its cities (clearance 10.8–27.5px, against 9.1–38px on the hand-placed map) and gives the cars a visible seam (median gap 4.5px) so they can be counted.

The lines themselves are invisible (`lineWidth: 0`) and sit behind the holders (`layer: -10`), so the tracks stay the only thing you see and clicks/drops still land on the holders. Shared settings live in a `Route Template` line widget, the same way the holders already share a `Holder Template`.

## Engine fix that goes with it

`Line.positionAttachedWidgets()` now flushes the delta when the line has stops that are **not** its children (`hasExternalStops()`) — as the route holders are, since they stay children of the board.

Such a stop is positioned through global coordinates, which read the line's CSS transform. Inside a batch that transform still shows the state of the *previous* event, so after `normalizeGeometry()` moved the widget box — and it is that box move which triggers the layout — every stop landed off the path by exactly that move. Moving a city by 10px and back left its tracks 10px beside the line. `applyConnections()` already flushes for exactly this reason; the comment there describes the same trap.

## Testing

* `npm test` — 86 passed
* `npx testcafe chromium:headless tests/testcafe/editor.js` — 14 passed, including *Line widget in edit mode*
* `node validator/validate_gamefile_node.js "library/games/All Aboard/0.json"` — no new findings (the three pre-existing deck warnings are unchanged)
* Loaded the game in a browser and compared it side by side with the old map ([before](https://agent.virtualtabletop.io/reports/pr/1531626854740394146/all-aboard-before.png) / [after](https://agent.virtualtabletop.io/reports/pr/1531626854740394146/all-aboard-after.png)); moved a city and watched all six routes around it re-space and re-rotate; verified a nudge-and-back leaves every holder exactly where the file has it.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3064/pr-test (or any other room on that server)
