### PR TITLE
Fix pasting formatted HTML into the JSON editor (#2791)

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -223,6 +223,8 @@
   right: calc(var(--commandPaneWidth) + 1px);
   font-family: monospace;
   white-space: pre-wrap;
+  /* pasted HTML is usually indented with tabs - render them like the editor's own 2 space indent */
+  tab-size: 2;
   overflow-y: auto;
   overflow-wrap: break-word;
 }
@@ -235,18 +237,19 @@
   /* --linenumbers-digits gets set in jsonedit.js (jeColorize function) depending on the lines of the widget */
   width: calc(var(--linenumbers-digits) * 8px);
   text-align: right;
-  padding-right: 2px;
+  /* keep a gap so lines that start at column 0 don't touch the line number */
+  padding-right: 5px;
   color: var(--textDimColor1);
   vertical-align: top;
 }
 
 .jeLineContent {
   display: inline-block;
-  width: calc(100% - var(--linenumbers-digits) * 8px - 2px);
+  width: calc(100% - var(--linenumbers-digits) * 8px - 5px);
 }
 
 #jeText {
-  padding-left: calc(var(--linenumbers-digits) * 8px + 2px);
+  padding-left: calc(var(--linenumbers-digits) * 8px + 5px);
 }
 #jeText::selection {
   background-color: var(--backgroundHighlightColor1);

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3351,17 +3351,22 @@ function jePreProcessText(t, returnValidJSON=true) {
   if(returnValidJSON)
     return t;
 
-  // Convert \n escape sequences within JSON strings to actual newlines for display
+  // Convert \n and \t escape sequences within JSON strings to actual newlines and tabs for
+  // display. jePostProcessText turns them back into escapes, so the round trip keeps HTML that
+  // was pasted with tab indentation readable instead of showing a literal \t at the start of
+  // every line.
   let result = '';
   let inString = false;
   let escapeNext = false;
-  
+
   for (let i = 0; i < t.length; i++) {
     const char = t[i];
-    
+
     if (escapeNext) {
       if (inString && char === 'n') {
         result += '\n';
+      } else if (inString && char === 't') {
+        result += '\t';
       } else {
         result += '\\' + char;
       }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3257,9 +3257,9 @@ function jePostProcessObject(o) {
 
 function jePostProcessText(t) {
   // Convert actual newlines within JSON strings back to \n escape sequences.
-  // Windows clipboards typically use CRLF, so ignore \r and let the following \n be escaped.
-  // Other control characters (tabs especially, since HTML pasted from an external editor is
-  // usually indented with them) are not valid inside JSON strings either, so escape them too.
+  // Windows clipboards typically use CRLF, so drop the \r of a CRLF and let the following \n be
+  // escaped. Other control characters (tabs especially, since HTML pasted from an external editor
+  // is usually indented with them) are not valid inside JSON strings either, so escape them too.
   let result = '';
   let inString = false;
   let escapeNext = false;
@@ -3285,7 +3285,7 @@ function jePostProcessText(t) {
       continue;
     }
     
-    if (inString && char === '\r')
+    if (inString && char === '\r' && t[i+1] === '\n')
       continue;
     else if (inString && char === '\n')
       result += '\\n';

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3258,6 +3258,8 @@ function jePostProcessObject(o) {
 function jePostProcessText(t) {
   // Convert actual newlines within JSON strings back to \n escape sequences.
   // Windows clipboards typically use CRLF, so ignore \r and let the following \n be escaped.
+  // Other control characters (tabs especially, since HTML pasted from an external editor is
+  // usually indented with them) are not valid inside JSON strings either, so escape them too.
   let result = '';
   let inString = false;
   let escapeNext = false;
@@ -3287,6 +3289,10 @@ function jePostProcessText(t) {
       continue;
     else if (inString && char === '\n')
       result += '\\n';
+    else if (inString && char === '\t')
+      result += '\\t';
+    else if (inString && char.charCodeAt(0) < 0x20)
+      result += '\\u' + char.charCodeAt(0).toString(16).padStart(4, '0');
     else
       result += char;
   }

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -342,9 +342,16 @@ test('JSON editor: paste HTML that is indented with tabs', async t => {
     editor.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, key: 'v' }));
   })();
 
+  const getJSONText = ClientFunction(() => document.querySelector('#jeText').textContent);
+
   await t
     .expect(ClientFunction(() => widgets.get('target').get('html'))()).eql('<div>\n\t<span>tab\vbed</span>\r<hr>\n</div>')
     .expect(Selector('#jeCommands').textContent).notContains('SyntaxError')
+    // selecting the widget again has to show the tab indentation as an actual tab instead of a
+    // literal \t at the start of the line
+    .click('#topSurface', { offsetX: 10, offsetY: 10 })
+    .click('#w_target')
+    .expect(getJSONText()).contains('<div>\n\t<span>tab')
     .click('#editorSidebar [icon=data_object]')
     .pressKey('esc');
 });

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -320,6 +320,44 @@ test('Deck editor: symbol pickers and JSON fallback', async t => {
   await compareState(t, '5019957515d8552f09fed2340a4e1d3d');
 });
 
+test('JSON editor: paste HTML that is indented with tabs', async t => {
+  await setRoomState({
+    target: { id: 'target', type: 'basic', x: 200, y: 200, html: '<div>old</div>' }
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  await t
+    .click('#editButton')
+    .click('#editorSidebar [icon=data_object]')
+    .click('#w_target');
+
+  // HTML copied out of an external editor arrives with tab indentation (and CRLF on Windows),
+  // neither of which is valid inside a JSON string
+  await ClientFunction(() => {
+    const editor = document.querySelector('#jeText');
+    editor.focus();
+    const content = editor.textContent;
+    const start = content.indexOf('"html": "') + 9;
+    const range = document.createRange();
+    range.setStart(editor.firstChild, start);
+    range.setEnd(editor.firstChild, content.indexOf('"', start));
+    getSelection().removeAllRanges();
+    getSelection().addRange(range);
+
+    const clipboardData = new DataTransfer();
+    clipboardData.setData('text/plain', '<div>\r\n\t<span>tabbed</span>\r\n</div>');
+    editor.dispatchEvent(new ClipboardEvent('paste', { clipboardData, bubbles: true, cancelable: true }));
+    editor.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, key: 'v' }));
+  })();
+
+  await t
+    .expect(ClientFunction(() => widgets.get('target').get('html'))()).eql('<div>\n\t<span>tabbed</span>\n</div>')
+    .expect(Selector('#jeCommands').textContent).notContains('SyntaxError')
+    .click('#editorSidebar [icon=data_object]')
+    .pressKey('esc');
+});
+
 test('Deck editor: breadcrumb undo and redo', async t => {
   await setRoomState();
   await ClientFunction(prepareClient)();

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -333,16 +333,17 @@ test('JSON editor: paste HTML that is indented with tabs', async t => {
     .click('#w_target');
 
   // put into the editor what pasting HTML from an external editor puts there: tab indentation
-  // (and CRLF on Windows), neither of which is valid inside a JSON string
+  // (and CRLF on Windows), neither of which is valid inside a JSON string - plus a lone CR and a
+  // vertical tab, which have to survive as escapes instead of being dropped
   await ClientFunction(() => {
     const editor = document.querySelector('#jeText');
     editor.focus();
-    editor.textContent = editor.textContent.replace('<div>old</div>', '<div>\r\n\t<span>tabbed</span>\r\n</div>');
+    editor.textContent = editor.textContent.replace('<div>old</div>', '<div>\r\n\t<span>tab\vbed</span>\r<hr>\r\n</div>');
     editor.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, key: 'v' }));
   })();
 
   await t
-    .expect(ClientFunction(() => widgets.get('target').get('html'))()).eql('<div>\n\t<span>tabbed</span>\n</div>')
+    .expect(ClientFunction(() => widgets.get('target').get('html'))()).eql('<div>\n\t<span>tab\vbed</span>\r<hr>\n</div>')
     .expect(Selector('#jeCommands').textContent).notContains('SyntaxError')
     .click('#editorSidebar [icon=data_object]')
     .pressKey('esc');

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -332,22 +332,12 @@ test('JSON editor: paste HTML that is indented with tabs', async t => {
     .click('#editorSidebar [icon=data_object]')
     .click('#w_target');
 
-  // HTML copied out of an external editor arrives with tab indentation (and CRLF on Windows),
-  // neither of which is valid inside a JSON string
+  // put into the editor what pasting HTML from an external editor puts there: tab indentation
+  // (and CRLF on Windows), neither of which is valid inside a JSON string
   await ClientFunction(() => {
     const editor = document.querySelector('#jeText');
     editor.focus();
-    const content = editor.textContent;
-    const start = content.indexOf('"html": "') + 9;
-    const range = document.createRange();
-    range.setStart(editor.firstChild, start);
-    range.setEnd(editor.firstChild, content.indexOf('"', start));
-    getSelection().removeAllRanges();
-    getSelection().addRange(range);
-
-    const clipboardData = new DataTransfer();
-    clipboardData.setData('text/plain', '<div>\r\n\t<span>tabbed</span>\r\n</div>');
-    editor.dispatchEvent(new ClipboardEvent('paste', { clipboardData, bubbles: true, cancelable: true }));
+    editor.textContent = editor.textContent.replace('<div>old</div>', '<div>\r\n\t<span>tabbed</span>\r\n</div>');
     editor.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, key: 'v' }));
   })();
 


### PR DESCRIPTION
Fixes #2791.

Since #2736 the JSON editor shows multi-line HTML with real newlines and turns them back into `\n` escapes when the content is parsed (`jePostProcessText`). #2934 extended that to `\r` so Windows clipboards work. But **tabs** — which is how virtually every external editor (and "copy outer HTML" in browser dev tools) indents HTML — were still inserted literally, and a literal tab is not valid inside a JSON string. The result: pasting formatted HTML from anywhere outside VTT immediately breaks the whole widget with

```
SyntaxError: Bad control character in string literal in JSON at position …
```

and nothing you paste can be applied until you hunt down and delete every tab by hand.

## The change

`jePostProcessText` now escapes `\t` and any remaining C0 control character inside JSON strings, exactly like it already did for newlines. Nothing outside a string literal is touched.

`jePreProcessText` does the mirror image on the way back out: it already converted `\n` escapes to real newlines for display, and now does the same for `\t`. Without that half the paste worked but looked broken afterwards — the HTML was correctly indented until you clicked away, and re-selecting the widget redisplayed the very same value with a literal `\t` at the start of every line ([before](https://agent.virtualtabletop.io/reports/pr/1531691877470961916/3066-tabs-before.png) / [after](https://agent.virtualtabletop.io/reports/pr/1531691877470961916/3066-tabs-after.png)). Two small CSS touch-ups go with it: `tab-size: 2` on the editor so a pasted tab lines up with the editor's own 2-space indentation instead of jumping 8 columns, and 5px instead of 2px of padding on the line-number gutter so a line that starts at column 0 doesn't touch its line number.

While in there, only the `\r` of a CRLF is dropped now. A **lone** CR used to be deleted silently (pre-existing behaviour from #2934); it is escaped like every other control character instead, so text with classic-Mac line endings — or a CR inside a JS snippet in an `html` property — survives a paste.

Out of scope: a pasted **double quote** inside a string literal still ends the string and produces a syntax error, so HTML with `class="card"` still has to be pasted with single quotes (or escaped by hand). Auto-escaping quotes isn't safe to do blindly — the editor can't tell "paste this as literal text" from "paste this JSON fragment", and getting it wrong would corrupt content instead of just refusing it. That deserves its own issue and its own design; this PR is about the control characters, which are unambiguous.

## Testing

- TestCafe case in `tests/testcafe/editor.js` puts `<div>\r\n\t<span>tab\vbed</span>\r<hr>\r\n</div>` into a widget's `html` property the way a paste does — tab indentation, CRLF, a lone CR and a vertical tab — and asserts the widget ends up with that exact string (CRLF normalised to `\n`), that the editor reports no JSON error, and that re-selecting the widget shows the tab as a real tab again. Each of the three parts fails on `main` / with the respective hunk reverted.
- `npm test` (86 passed), the full `tests/testcafe/editor.js` suite (15 passed) and `tests/testcafe/compute-4.js` (the other suite that drives `#jeText`, 2 passed) run clean locally.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3066/pr-test (or any other room on that server)
