### PR TITLE
Fix client crash when enabling Debug panel during an INPUT prompt

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -534,10 +534,6 @@ body.jsonEdit #toolbar {
   white-space: normal;
 }
 
-#jeLog {
-  margin-left: -40px;
-}
-
 @media (max-width: 1000px) {
   #jeLog {
     right: var(--commandPaneWidth);
@@ -574,8 +570,22 @@ body.jsonEdit #toolbar {
   margin-top: 20px;
 }
 
-/* has no expander arrow, so it needs the indentation the arrow would otherwise provide */
-.jeLogNote    { color: var(--textDimColor1); font-style: italic; margin-left: 38px; }
+/* a message about the log itself rather than a logged routine, so make it a readable callout */
+.jeLogNote {
+  color: var(--textColor);
+  background-color: var(--backgroundHighlightColor1);
+  border-left: 3px solid var(--textHighlightColor2);
+  border-radius: 4px;
+  padding: 8px 10px;
+  margin: 10px 0 10px 20px;
+  font-family: Arial, sans-serif;
+}
+.jeLogNote .jeLogWidget,
+.jeLogNote .jeLogProperty {
+  font-family: monospace;
+  font-weight: bold;
+}
+
 .jeLogSkipped { color: var(--textDimColor1); }
 .jeLogSummary { color: var(--textHighlightColor4); }
 .jeLogResult  { color: var(--textHighlightColor2); }

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -574,6 +574,8 @@ body.jsonEdit #toolbar {
   margin-top: 20px;
 }
 
+/* has no expander arrow, so it needs the indentation the arrow would otherwise provide */
+.jeLogNote    { color: var(--textDimColor1); font-style: italic; margin-left: 38px; }
 .jeLogSkipped { color: var(--textDimColor1); }
 .jeLogSummary { color: var(--textHighlightColor4); }
 .jeLogResult  { color: var(--textHighlightColor2); }

--- a/client/js/editor/sidebar/json.js
+++ b/client/js/editor/sidebar/json.js
@@ -89,7 +89,7 @@ class DebugModule extends SidebarModule {
   }
 
   button_clearButton() {
-    jeLoggingHTML = '';
+    jeLoggingClear();
     $('#jeLog').innerHTML = '';
   }
 
@@ -98,7 +98,7 @@ class DebugModule extends SidebarModule {
 
     $('#clearLogButton').disabled = $('#autoClearLog').checked;
     if($('#clearLogButton').disabled)
-      jeLoggingHTML = '';
+      jeLoggingClear();
   }
 
   button_filter() {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3085,38 +3085,44 @@ export function jeLoggingRoutineEnd(variables, collections) {
     return; // defensive: unmatched End, should not happen since #2672
   if( jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine', 'Moves'].indexOf( jeHTMLStack[0][3] ) == -1 ) jeLoggingHTML += '</div></div>';
   --jeLoggingDepth;
-  if(!jeLoggingDepth) {
-    $('#jeLog').innerHTML = jeLoggingHTML + '</div></div>';
+  if(!jeLoggingDepth)
+    jeLoggingRenderLog(jeLoggingHTML + '</div></div>');
+}
 
-    // Make it so clicking on the arrows expands the subtree
-    const expanders = document.getElementsByClassName('jeExpander');
-    let i;
-    for (i=0; i < expanders.length; i++) {
-      expanders[i].addEventListener('click', function() {
-        this.classList.toggle('jeExpander-down');
-        this.parentNode.querySelector('.jeLogNested').classList.toggle('active');
-        if(this.classList.contains('jeExpander-down')) {
-          this.classList.add('manuallyExpanded');
-          this.parentNode.querySelector('.jeLogNested').classList.add('manuallyExpanded');
-        } else {
-          this.classList.remove('manuallyExpanded');
-          this.parentNode.querySelector('.jeLogNested').classList.remove('manuallyExpanded');
-        }
-      });
-    }
-    // Make expander arrows that are parents of nodes with problems show up red.
-    const problems = document.getElementsByClassName('jeLogHasProblems');
-    for (i=0; i<problems.length; i++) {
-      let node = problems[i];
-      while (node && node.id != 'jeLog') {
-        if(node.classList.contains('jeLogOperation') || node.classList.contains('jeLog')) {
-          node.firstElementChild.classList.remove('jeExpander');
-          node.firstElementChild.classList.add('jeRedExpander')
-        }
-        node = node.parentNode;
+// Put the log into the panel. Everything that depends on the rendered DOM (the expander click
+// handlers and the filter) has to be applied again afterwards, so all rendering goes through here.
+function jeLoggingRenderLog(logHTML) {
+  $('#jeLog').innerHTML = logHTML;
+
+  // Make it so clicking on the arrows expands the subtree
+  const expanders = document.getElementsByClassName('jeExpander');
+  let i;
+  for (i=0; i < expanders.length; i++) {
+    expanders[i].addEventListener('click', function() {
+      this.classList.toggle('jeExpander-down');
+      this.parentNode.querySelector('.jeLogNested').classList.toggle('active');
+      if(this.classList.contains('jeExpander-down')) {
+        this.classList.add('manuallyExpanded');
+        this.parentNode.querySelector('.jeLogNested').classList.add('manuallyExpanded');
+      } else {
+        this.classList.remove('manuallyExpanded');
+        this.parentNode.querySelector('.jeLogNested').classList.remove('manuallyExpanded');
       }
+    });
+  }
+  // Make expander arrows that are parents of nodes with problems show up red.
+  const problems = document.getElementsByClassName('jeLogHasProblems');
+  for (i=0; i<problems.length; i++) {
+    let node = problems[i];
+    while (node && node.id != 'jeLog') {
+      if(node.classList.contains('jeLogOperation') || node.classList.contains('jeLog')) {
+        node.firstElementChild.classList.remove('jeExpander');
+        node.firstElementChild.classList.add('jeRedExpander')
+      }
+      node = node.parentNode;
     }
   }
+
   if($('#jeLogFilter') && $('#jeLogFilter').value)
     jeLoggingFilterLog($('#jeLogFilter').value);
 }
@@ -3131,14 +3137,15 @@ export function jeLoggingRoutineNotLogged(widget, property) {
     jeLoggingHTML = '';
     jeRoutineResetOnNextLog = false;
   }
+  const routine = typeof property == 'string'
+    ? `<span class="jeLogWidget">${html(widget.get('id'))}</span> <span class="jeLogProperty">${html(property)}</span>`
+    : `an inline routine of <span class="jeLogWidget">${html(widget.get('id'))}</span>`;
   jeLoggingHTML += `
     <div class="jeLog jeLogNote">
-      <span class="jeLogWidget">${html(widget.get('id'))}</span>
-      <span class="jeLogProperty">${html(typeof property == 'string' ? property : '--custom--')}</span>
-      was not logged because logging was enabled after it had already started.
+      ${routine} was already running when the Debug panel was opened, so it could not be recorded. Run it again to see its log.
     </div>
   `;
-  $('#jeLog').innerHTML = jeLoggingHTML;
+  jeLoggingRenderLog(jeLoggingHTML);
 }
 
 export function jeLoggingRoutineOperationStart(original, applied) {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3072,6 +3072,8 @@ export function jeLoggingRoutineStart(widget, property, initialVariables, initia
 }
 
 export function jeLoggingRoutineEnd(variables, collections) {
+  if(!jeLoggingDepth)
+    return; // no matching jeLoggingRoutineStart (logging was enabled mid-routine)
   if( jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine', 'Moves'].indexOf( jeHTMLStack[0][3] ) == -1 ) jeLoggingHTML += '</div></div>';
   --jeLoggingDepth;
   if(!jeLoggingDepth) {
@@ -3131,6 +3133,11 @@ export function jeLoggingRoutineOperationEnd(problems, variables, collections, s
     collDisplay[name] = collections[name].map(w=>`${html(w.get('id'))} (${html(w.get('type')||'basic')})`);
 
   const savedHTML = jeHTMLStack.shift();
+  if(!savedHTML) {
+    // No matching jeLoggingRoutineOperationStart (logging was enabled mid-routine). Nothing to close.
+    jeRoutineResult = '';
+    return;
+  }
   const original = savedHTML[1];
   const originalText = jeLoggingJSON(original);
   const applied = savedHTML[2];

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3049,6 +3049,15 @@ let jeLoggingHTML = '';
 let jeLoggingDepth = 0;
 let jeHTMLStack = [];
 
+// Empty the log. Operations of a routine that is currently running have the log so far saved on
+// jeHTMLStack, so that has to be emptied too - otherwise jeLoggingRoutineOperationEnd prepends it
+// again and resurrects what was just cleared.
+function jeLoggingClear() {
+  jeLoggingHTML = '';
+  for(const entry of jeHTMLStack)
+    entry[0] = '';
+}
+
 function jeLoggingJSON(obj) {
   return html(JSON.stringify(obj, null, '  ').split('\n').slice(1, -1).join('\n'));
 }
@@ -3073,7 +3082,7 @@ export function jeLoggingRoutineStart(widget, property, initialVariables, initia
 
 export function jeLoggingRoutineEnd(variables, collections) {
   if(!jeLoggingDepth)
-    return; // no matching jeLoggingRoutineStart (logging was enabled mid-routine)
+    return; // defensive: unmatched End, should not happen since #2672
   if( jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine', 'Moves'].indexOf( jeHTMLStack[0][3] ) == -1 ) jeLoggingHTML += '</div></div>';
   --jeLoggingDepth;
   if(!jeLoggingDepth) {
@@ -3112,6 +3121,26 @@ export function jeLoggingRoutineEnd(variables, collections) {
     jeLoggingFilterLog($('#jeLogFilter').value);
 }
 
+// Called instead of jeLoggingRoutineEnd when logging was switched on while the routine was already
+// running (e.g. the Debug module was opened while the routine waited for an INPUT). That routine
+// cannot be logged retroactively, so leave a note explaining the gap instead of showing nothing.
+export function jeLoggingRoutineNotLogged(widget, property) {
+  if(jeLoggingDepth || jeHTMLStack.length || !$('#jeLog'))
+    return;
+  if(jeRoutineResetOnNextLog) {
+    jeLoggingHTML = '';
+    jeRoutineResetOnNextLog = false;
+  }
+  jeLoggingHTML += `
+    <div class="jeLog jeLogNote">
+      <span class="jeLogWidget">${html(widget.get('id'))}</span>
+      <span class="jeLogProperty">${html(typeof property == 'string' ? property : '--custom--')}</span>
+      was not logged because logging was enabled after it had already started.
+    </div>
+  `;
+  $('#jeLog').innerHTML = jeLoggingHTML;
+}
+
 export function jeLoggingRoutineOperationStart(original, applied) {
   let fcn;
   if (typeof applied == 'string')
@@ -3134,7 +3163,7 @@ export function jeLoggingRoutineOperationEnd(problems, variables, collections, s
 
   const savedHTML = jeHTMLStack.shift();
   if(!savedHTML) {
-    // No matching jeLoggingRoutineOperationStart (logging was enabled mid-routine). Nothing to close.
+    // defensive: unmatched End, should not happen since #2672. Nothing to close.
     jeRoutineResult = '';
     return;
   }
@@ -3901,7 +3930,7 @@ export function jeToggle() {
   }
   jeEnabled = !jeEnabled;
   setJEenabled(jeEnabled);
-  jeLoggingHTML = '';
+  jeLoggingClear();
   if(jeEnabled) {
     $('body').classList.add('jsonEdit');
     if(jeWidget && !widgets.has(jeWidget.id))

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -958,7 +958,12 @@ export class Widget extends StateManaged {
 
     if(tracingEnabled && typeof property == 'string')
       sendTraceEvent('evaluateRoutine', { id: this.get('id'), property });
-    if(jeRoutineLogging)
+
+    // Capture the routine logging state once, at the start of the routine. Toggling the Debug
+    // panel while the routine is suspended (e.g. waiting for an INPUT modal) would otherwise
+    // mismatch the jeLogging start/end calls and crash the client. (#2672)
+    const routineLogging = jeRoutineLogging;
+    if(routineLogging)
       jeLoggingRoutineStart(this, property, initialVariables, initialCollections, byReference);
 
     let variables = initialVariables;
@@ -1003,10 +1008,10 @@ export class Widget extends StateManaged {
         property: typeof property == 'string' ? property : 'literal'
       };
 
-      if(jeRoutineLogging) jeLoggingRoutineOperationStart(original, a)
+      if(routineLogging) jeLoggingRoutineOperationStart(original, a)
 
       if(a.skip) {
-        if(jeRoutineLogging) jeLoggingRoutineOperationEnd(problems, variables, collections, true);
+        if(routineLogging) jeLoggingRoutineOperationEnd(problems, variables, collections, true);
         continue;
       }
 
@@ -1069,12 +1074,12 @@ export class Widget extends StateManaged {
             variables[variable][index] = await getValue(variables[variable][index]);
           else
             variables[variable] = await getValue(variables[variable]);
-          if(jeRoutineLogging) jeLoggingRoutineOperationSummary(a.substr(4), JSON.stringify(variables[variable]));
+          if(routineLogging) jeLoggingRoutineOperationSummary(a.substr(4), JSON.stringify(variables[variable]));
         } else {
           const comment = a.match(new RegExp('^(?://(.*))?\x24'));
           if (comment) {
             // ignore (but log) blank and comment only lines
-            if(jeRoutineLogging) jeLoggingRoutineOperationSummary(comment[1]||'');
+            if(routineLogging) jeLoggingRoutineOperationSummary(comment[1]||'');
           } else {
             const withoutVars = evaluateVariables(a).replace(/false|null/g, 0).replace(/true/g, 1);
             const mathExpression = withoutVars.match(new RegExp(`^${left} += +([() 0-9.&|!*/+-]+)(?: +//.*)?`+'\x24'));
@@ -1094,7 +1099,7 @@ export class Widget extends StateManaged {
                 variables[variable][index] = result;
               else
                 variables[variable] = result;
-              if(jeRoutineLogging) jeLoggingRoutineOperationSummary(a.substr(4) + ' => ' + mathExpression[5], JSON.stringify(result));
+              if(routineLogging) jeLoggingRoutineOperationSummary(a.substr(4) + ' => ' + mathExpression[5], JSON.stringify(result));
             } else {
               problems.push(`String '${a}' could not be interpreted as a valid expression. Please check your syntax and note that many characters have to be escaped.`);
             }
@@ -1142,7 +1147,7 @@ export class Widget extends StateManaged {
             variables[a.variable] = result.variable;
             collections[a.collection] = result.collection;
 
-            if(jeRoutineLogging) {
+            if(routineLogging) {
               const theWidget = a.widget != this.get('id') ? `in ${a.widget}` : '';
               if (a.return) {
                 let returnCollection = result.collection.map(w=>w.get('id')).join(',');
@@ -1213,7 +1218,7 @@ export class Widget extends StateManaged {
           problems.push(`Collection ${a.collection} is empty.`);
         }
 
-        if(jeRoutineLogging) {
+        if(routineLogging) {
           if(a.mode == 'set')
             jeLoggingRoutineOperationSummary(`color index of ${phrase}`, `${JSON.stringify(a.value)}`)
           else if(a.mode == 'change')
@@ -1237,7 +1242,7 @@ export class Widget extends StateManaged {
           for(let i=0; i<a.count; ++i)
             for(const w of collections[collection])
               await w.click(a.mode);
-          if(jeRoutineLogging) {
+          if(routineLogging) {
             const theCount = a.count ? `${a.count} times` : '';
             jeLoggingRoutineOperationSummary( `'${a.collection}' ${theCount}`)
           }
@@ -1259,7 +1264,7 @@ export class Widget extends StateManaged {
             }
           }
           collections[a.collection]=c;
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationSummary( `'${a.source}'`, `'${JSON.stringify(a.collection)}'`);
         }
       }
@@ -1308,7 +1313,7 @@ export class Widget extends StateManaged {
           }
           theItem = `${a.collection}`
         }
-        if(jeRoutineLogging)
+        if(routineLogging)
           jeLoggingRoutineOperationSummary( `'${theItem}'`, `${JSON.stringify(variables[a.variable])}`)
 
       }
@@ -1317,7 +1322,7 @@ export class Widget extends StateManaged {
         setDefaults(a, { milliseconds: 0 });
         flushDelta();
         await sleep(a.milliseconds);
-        if(jeRoutineLogging)
+        if(routineLogging)
           jeLoggingRoutineOperationSummary(` for ${a.milliseconds} milliseconds`);
       }
 
@@ -1330,7 +1335,7 @@ export class Widget extends StateManaged {
             for(const c in collections)
               collections[c] = collections[c].filter(x=>x!=w);
           }
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationSummary( `'${a.collection}'`)
         }
       }
@@ -1348,7 +1353,7 @@ export class Widget extends StateManaged {
                 c.flip && await c.flip(a.face,a.faceCycle);
             });
           }
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationSummary(`holder '${a.holder}'`);
         } else if(collection = getCollection(a.collection)) {
           if(collections[collection].length) {
@@ -1357,7 +1362,7 @@ export class Widget extends StateManaged {
           } else {
             problems.push(`Collection ${a.collection} is empty.`);
           }
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationSummary(`collection '${a.collection}'`);
         }
       }
@@ -1376,10 +1381,10 @@ export class Widget extends StateManaged {
             collectionBackups[add] = collections[add];
             collections[add] = addCollections[add];
           }
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationStart( "loopRoutine", "loopRoutine" );
           await this.evaluateRoutine(a.loopRoutine, variables, collections, (depth || 0) + 1, true);
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationEnd([], variables, collections, false);
           for(const add in addVariables) {
             if(variableBackups[add] !== undefined)
@@ -1397,7 +1402,7 @@ export class Widget extends StateManaged {
         if(a.in) {
           for(const key in a.in)
             await callWithAdditionalValues({ key, value: a.in[key] }, {});
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationSummary( `elements in '${JSON.stringify(a.in)}'`);
         } else if(a.range) {
           let range = [...asArray(a.range)];
@@ -1435,12 +1440,12 @@ export class Widget extends StateManaged {
 
           for (let index=start; (step > 0) ? index <= end : index >= end; index += step)
             await callWithAdditionalValues({ value: index });
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationSummary( `values in range '${JSON.stringify(a.range)}'`);
         } else if(collection = getCollection(a.collection)) {
           for(const widget of collections[collection])
             await callWithAdditionalValues({ widgetID: widget.get('id') }, { DEFAULT: [ widget ] });
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationSummary( `widgets in '${a.collection}'`);
         }
       }
@@ -1495,7 +1500,7 @@ export class Widget extends StateManaged {
           } else {
             problems.push(`Collection ${a.collection} is empty.`);
           }
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationSummary(`${a.aggregation} of '${mainProperty}' in '${a.collection}'`, `var ${a.variable} = ${JSON.stringify(variables[a.variable])}`);
         }
       }
@@ -1513,7 +1518,7 @@ export class Widget extends StateManaged {
           const branch = condition ? 'thenRoutine' : 'elseRoutine';
           if(Array.isArray(a[branch]))
             await this.evaluateRoutine(a[branch], variables, collections, (depth || 0) + 1, true);
-          if(jeRoutineLogging) {
+          if(routineLogging) {
             if (a.condition === undefined)
               jeLoggingRoutineOperationSummary(`'${original.operand1}' ${a.relation} '${original.operand2}'`, `${JSON.stringify(condition)}`)
             else
@@ -1581,7 +1586,7 @@ export class Widget extends StateManaged {
             Object.assign(variables, result.variables);
             Object.assign(collections, result.collections);
           }
-          if(jeRoutineLogging) {
+          if(routineLogging) {
             let varList = [];
             let valueList = [];
             a.fields.forEach(f=>{
@@ -1594,7 +1599,7 @@ export class Widget extends StateManaged {
           }
         } catch(e) {
           abortRoutine = true;
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationSummary("INPUT cancelled");
         }
       }
@@ -1609,7 +1614,7 @@ export class Widget extends StateManaged {
             await w(a.label, async widget=>{
               await widget.setText(a.value, a.mode, problems)
             });
-            if(jeRoutineLogging) {
+            if(routineLogging) {
               if(a.mode == 'inc' || a.mode == 'dec')
                 jeLoggingRoutineOperationSummary(`${a.mode} '${a.label}' by ${a.value}`)
               else if(a.mode == 'append')
@@ -1622,7 +1627,7 @@ export class Widget extends StateManaged {
           if(collections[collection].length) {
             for(const c of collections[collection])
               await c.setText(a.value, a.mode, problems);
-            if(jeRoutineLogging) {
+            if(routineLogging) {
               if(a.mode == 'inc' || a.mode == 'dec')
                 jeLoggingRoutineOperationSummary(`${a.mode} widgets in '${a.collection}' by ${a.value}`)
               else if(a.mode == 'append')
@@ -1712,7 +1717,7 @@ export class Widget extends StateManaged {
                 await target.updateAfterShuffle();
             });
           }
-          if(jeRoutineLogging) {
+          if(routineLogging) {
             const logCount = count==1 ? '1 widget' : `${count == 999999 ? 'all' : count} widgets`;
             jeLoggingRoutineOperationSummary(`${logCount} from '${a.from || a.collection}' to '${a.to}'`)
           }
@@ -1738,7 +1743,7 @@ export class Widget extends StateManaged {
               await c.set('parent', null);
             }
           });
-          if(jeRoutineLogging) {
+          if(routineLogging) {
             const count = a.count==1 ? '1 widget' : `${a.count} widgets`;
             jeLoggingRoutineOperationSummary(`${count} from '${a.from}' to (${a.x}, ${a.y})`)
           }
@@ -1796,7 +1801,7 @@ export class Widget extends StateManaged {
               problems.push(`Holder ${holder} does not have a deck.`);
             }
           };
-          if(jeRoutineLogging) {
+          if(routineLogging) {
             jeLoggingRoutineOperationSummary(`'${a.holder}' ${a.owned ? ' (including hands)' : ''}`);
           }
         }
@@ -1813,7 +1818,7 @@ export class Widget extends StateManaged {
             }
           }
         }
-        if (jeRoutineLogging) {
+        if (routineLogging) {
           jeLoggingRoutineOperationSummary(`Reset properties for widgets with property '${a.property}'`);
         }
       }
@@ -1831,7 +1836,7 @@ export class Widget extends StateManaged {
               for(const c of holder.children().slice(0, a.count))
                 await c.rotate(a.angle, a.mode);
             });
-            if(jeRoutineLogging) {
+            if(routineLogging) {
               jeLoggingRoutineOperationSummary(`${a.count == 999999 ? '' : a.count} ${a.count==1 ? 'widget' : 'widgets'} in '${a.holder}' ${mode} ${a.angle}`);
             }
           }
@@ -1839,7 +1844,7 @@ export class Widget extends StateManaged {
           if(collections[collection].length) {
             for(const c of collections[collection].slice(0, a.count))
               await c.rotate(a.angle, a.mode);
-            if(jeRoutineLogging)
+            if(routineLogging)
               jeLoggingRoutineOperationSummary(`${a.count == 999999 ? '' : a.count} ${a.count==1 ? 'widget' : 'widgets'} in '${a.collection}' ${mode} ${a.angle}`);
           } else {
             problems.push(`Collection ${a.collection} is empty.`);
@@ -1880,7 +1885,7 @@ export class Widget extends StateManaged {
           await seats[i].set(String(a.property), newScore);
         }
 
-        if(jeRoutineLogging) {
+        if(routineLogging) {
           const phrase = round===null ? 'new round' : `round ${a.round}`;
           const seatIds = seats.map(w => w.get('id'));
           if(a.mode == 'inc' || a.mode == 'dec')
@@ -1940,7 +1945,7 @@ export class Widget extends StateManaged {
           if(a.sortBy)
             await sortWidgets(collections[a.collection], a.sortBy);
 
-          if(jeRoutineLogging) {
+          if(routineLogging) {
             let selectedWidgets = collections[a.collection].map(w=>w.get('id')).join(',');
             if(!collections[a.collection].length || collections[a.collection].length >= 5)
               selectedWidgets = `(${collections[a.collection].length} widgets)`;
@@ -1991,7 +1996,7 @@ export class Widget extends StateManaged {
             }
           }
         }
-        if(jeRoutineLogging)
+        if(routineLogging)
           jeLoggingRoutineOperationSummary(`'${a.property}' ${a.relation} ${JSON.stringify(a.value)} for widgets in '${a.collection}'`);
       }
 
@@ -2005,7 +2010,7 @@ export class Widget extends StateManaged {
               if(typeof holder.updateAfterShuffle == 'function')
                 await holder.updateAfterShuffle();
             });
-            if(jeRoutineLogging)
+            if(routineLogging)
               jeLoggingRoutineOperationSummary(`holder ${a.holder}`);
           }
         } else if(collection = getCollection(a.collection)) {
@@ -2014,7 +2019,7 @@ export class Widget extends StateManaged {
           } else {
             problems.push(`Collection ${a.collection} is empty.`);
           }
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationSummary(`collection '${a.collection}'`);
         }
       }
@@ -2036,7 +2041,7 @@ export class Widget extends StateManaged {
                 await holder.updateAfterShuffle();
             });
           }
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationSummary(`widgets in '${a.holder}' by ${key}${reverse}`);
         } else if(collection = getCollection(a.collection)) {
           if(collections[collection].length) {
@@ -2048,7 +2053,7 @@ export class Widget extends StateManaged {
           } else {
             problems.push(`Collection ${a.collection} is empty.`);
           }
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationSummary(`widgets in '${a.collection}' by ${key}${reverse}`);
         }
       }
@@ -2094,7 +2099,7 @@ export class Widget extends StateManaged {
             }
           }
           if(moves.length) {
-            if(jeRoutineLogging)
+            if(routineLogging)
               jeLoggingRoutineOperationStart("Moves", "Moves");
             for(const move of moves) {
               // the collection is named after the seat it comes from so that the
@@ -2120,14 +2125,14 @@ export class Widget extends StateManaged {
                   collections[collection] = shadowed;
               }
             }
-            if(jeRoutineLogging)
+            if(routineLogging)
               jeLoggingRoutineOperationEnd([], variables, collections, false);
           }
-          if(jeRoutineLogging) {
+          if(routineLogging) {
             const how = a.direction == 'random' ? `hands in a random seat order by ${a.interval}` : `hands ${a.direction} by ${a.interval}`;
             jeLoggingRoutineOperationSummary(moves.length ? `${how}${a.keepOrder ? ', keeping the card order' : ''}` : 'no seat with a player has a valid hand, nothing to swap');
           }
-        } else if(jeRoutineLogging) {
+        } else if(routineLogging) {
           jeLoggingRoutineOperationSummary('less than two seats with a player, nothing to swap');
         }
       }
@@ -2175,7 +2180,7 @@ export class Widget extends StateManaged {
             }
           }
         };
-        if(jeRoutineLogging &&
+        if(routineLogging &&
            (a.timer != undefined || (collection && collections[collection].length))) {
           const phrase = (a.timer == undefined) ? `timers in '${a.collection}'` : `'${a.timer}'`;
           if(a.mode == 'set')
@@ -2192,11 +2197,11 @@ export class Widget extends StateManaged {
         const uploadedAsset = await uploadAsset(null, a.fileTypes);
         if(!String(uploadedAsset).match(/^\/assets\/[0-9_-]+$/)) {
           variables[a.variable] = false;
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationSummary("UPLOAD cancelled");
         } else {
           variables[a.variable] = uploadedAsset;
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationSummary(`'${a.variable}'`, `${JSON.stringify(variables[a.variable])}`);
         }
       }
@@ -2212,7 +2217,7 @@ export class Widget extends StateManaged {
         let c = (a.source=='all' ? allSeats : collections[getCollection(a.source)].filter(w=>w.get('type')=='seat')).filter(w=>w.get('player'));
 
         if (c.length == 0) {
-          if(jeRoutineLogging)
+          if(routineLogging)
             jeLoggingRoutineOperationSummary(`No active seats found in collection ${a.source}.`);
         } else {
           if (c.length > 1) {
@@ -2271,7 +2276,7 @@ export class Widget extends StateManaged {
             }
           }
 
-          if(jeRoutineLogging) {
+          if(routineLogging) {
             if (target) {
               const indexList = c.map(w => w.get('index'));
               const turn = target.get('index');
@@ -2288,14 +2293,14 @@ export class Widget extends StateManaged {
         for(const [ key, value ] of Object.entries(a.variables||{}))
           variables[key] = value;
 
-        if(jeRoutineLogging) {
+        if(routineLogging) {
           jeLoggingRoutineOperationSummary(`${Object.entries(a.variables||{}).map(e=>`${e[0]}=${JSON.stringify(e[1])}`).join(', ')}`);
         }
       }
 
-      if(jeRoutineLogging) jeLoggingRoutineOperationEnd(problems, variables, collections, false);
+      if(routineLogging) jeLoggingRoutineOperationEnd(problems, variables, collections, false);
 
-      if(!jeRoutineLogging && problems.length)
+      if(!routineLogging && problems.length)
         console.log(problems);
 
       if(abortRoutine)
@@ -2303,7 +2308,7 @@ export class Widget extends StateManaged {
 
     } // End iterate over functions in routine
 
-    if(jeRoutineLogging) jeLoggingRoutineEnd(variables, collections);
+    if(routineLogging) jeLoggingRoutineEnd(variables, collections);
 
     batchEnd();
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -961,7 +961,9 @@ export class Widget extends StateManaged {
 
     // Capture the routine logging state once, at the start of the routine. Toggling the Debug
     // panel while the routine is suspended (e.g. waiting for an INPUT modal) would otherwise
-    // mismatch the jeLogging start/end calls and crash the client. (#2672)
+    // mismatch the jeLogging start/end calls and crash the client. (#2672) A routine that was
+    // already running when logging got enabled can not be logged retroactively - it adds a note
+    // to the log instead (see jeLoggingRoutineNotLogged at the end of this function).
     const routineLogging = jeRoutineLogging;
     if(routineLogging)
       jeLoggingRoutineStart(this, property, initialVariables, initialCollections, byReference);
@@ -2308,7 +2310,10 @@ export class Widget extends StateManaged {
 
     } // End iterate over functions in routine
 
-    if(routineLogging) jeLoggingRoutineEnd(variables, collections);
+    if(routineLogging)
+      jeLoggingRoutineEnd(variables, collections);
+    else if(jeRoutineLogging)
+      jeLoggingRoutineNotLogged(this, property); // logging was enabled while this routine was running
 
     batchEnd();
 

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -858,6 +858,6 @@ test('Enabling the Debug module while a routine waits for INPUT does not abort t
   await t.expect(await ClientFunction(() => widgets.get('label').get('text'))()).eql('done');
   await t.expect(await ClientFunction(() => window.debugToggleErrors)()).eql([]);
   // the running routine can not be logged retroactively - the log explains the gap instead
-  await t.expect(Selector('#jeLog .jeLogNote').innerText).contains('was not logged');
+  await t.expect(Selector('#jeLog .jeLogNote').innerText).contains('could not be recorded');
   await compareState(t, 'ae64bb637f9aff6df4fe20773602a8e0');
 });

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -819,3 +819,45 @@ test('Line widget in edit mode', async t => {
   // random, so the compared state no longer depends on the seeded rand() stream
   await compareState(t, 'd35bd7362c7e87ea9ecb29895cc8d0b9');
 });
+
+test('Enabling the Debug module while a routine waits for INPUT does not abort the routine', async t => {
+  await setRoomState({
+    button: {
+      id: 'button',
+      type: 'button',
+      clickRoutine: [
+        { func: 'LABEL', label: 'label', value: 'start' },
+        { func: 'INPUT', header: 'Continue?', fields: [ { type: 'string', variable: 'answer', value: 'yes' } ] },
+        { func: 'LABEL', label: 'label', value: 'done' }
+      ]
+    },
+    label: { id: 'label', type: 'label', y: 100, text: '' }
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+  await ClientFunction(() => {
+    window.debugToggleErrors = [];
+    window.addEventListener('error', event => window.debugToggleErrors.push(String(event.error || event.message)));
+    window.addEventListener('unhandledrejection', event => window.debugToggleErrors.push(String(event.reason)));
+  })();
+
+  // enter edit mode with the Debug module closed, then start the routine and let it suspend on INPUT
+  await t
+    .click('#editButton')
+    .expect(Selector('#editorSidebar [icon=pest_control]').visible).ok(); // edit mode finished loading
+  await ClientFunction(() => {
+    widgets.get('button').evaluateRoutine('clickRoutine', {}, {});
+  })();
+  await t.expect(Selector('#buttonInputOverlay').visible).ok();
+
+  // opening Debug now switches routine logging on in the middle of the suspended routine (#2672)
+  await t
+    .click('#editorSidebar [icon=pest_control]')
+    .click('#buttonInputGo');
+
+  await t.expect(await ClientFunction(() => widgets.get('label').get('text'))()).eql('done');
+  await t.expect(await ClientFunction(() => window.debugToggleErrors)()).eql([]);
+  // the running routine can not be logged retroactively - the log explains the gap instead
+  await t.expect(Selector('#jeLog .jeLogNote').innerText).contains('was not logged');
+  await compareState(t, 'ae64bb637f9aff6df4fe20773602a8e0');
+});


### PR DESCRIPTION
Fixes #2672

### Problem
`evaluateRoutine` checks the *live* `jeRoutineLogging` global at every logging call site. A routine that suspends on an `INPUT` modal can have logging switched on mid-flight (open Edit mode → click a confirm button → choose *Debug* → press OK). The operation's `jeLoggingRoutineOperationStart` never ran, but `jeLoggingRoutineOperationEnd` did, so `jeHTMLStack.shift()` returned `undefined` and `savedHTML[1]` threw `Cannot read properties of undefined (reading '1')`. The mirror case (logging switched *off* mid-routine) leaked entries on the stack.

This is not only a console error: the exception aborts the rest of the routine, so the game is left in a half-applied state.

### Fix
- Snapshot `jeRoutineLogging` into a local `routineLogging` const at the start of `evaluateRoutine` and use it for every logging call in that invocation, so start/end calls always pair up.
- Defensive guards in `jsonedit.js`: `jeLoggingRoutineOperationEnd` returns early on an empty stack, `jeLoggingRoutineEnd` returns early at depth 0.

### Consequence, and how it is surfaced
A routine that was *already running* when logging got enabled cannot be logged retroactively — the whole invocation stays unlogged. Previously that produced a partial (crashing) log; now the Debug panel would just stay empty with no hint why, which reads as a second bug. So such a routine now writes a note to the log, naming the widget and the routine and saying what to do about it:

![Debug panel showing the note](https://agent.virtualtabletop.io/reports/pr/1531843930839318788/pr3068-note-light.png)

Since that note is usually the *only* thing in the panel it is rendered as a callout (theme variables, so it works in dark mode too) rather than in the panel's dimmed metadata style.

### Also fixed
- Clearing the log (the *Clear* button, or any incoming full state while the Debug module is open) only emptied `jeLoggingHTML` and not the log saved on `jeHTMLStack`, so the next operation end prepended it again and resurrected what had just been cleared. Clearing now empties both.
- The DOM-dependent parts of rendering the log (expander click handlers, red expanders, the active filter) moved from `jeLoggingRoutineEnd` into `jeLoggingRenderLog()`, so every render re-attaches them — writing the note no longer kills the expanders of the entries already in the log.
- `#jeLog` still carried `margin-left: -40px` from when the log was positioned inside `#jsonEditor`; since the log became its own sidebar module that made it stick out to the left of the panel, clipping the top-level entries' ▶ arrows. Removed.

### Test
New TestCafe test in `tests/testcafe/editor.js` (the first Debug-panel coverage there): it starts a `LABEL` / `INPUT` / `LABEL` routine in edit mode, opens the Debug module while the INPUT overlay is up, presses *Go* and then checks that the label reached `done`, that no page error fired, that the log carries the note, and that the room state hash matches. On `main` it fails with the exact `Cannot read properties of undefined (reading '1')` from #2672.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3068/pr-test (or any other room on that server)
