### PR TITLE
Improve the TTS importer: import tiles, tokens, dice, notes and seats

### DIFF
--- a/server/fileloader.mjs
+++ b/server/fileloader.mjs
@@ -43,7 +43,7 @@ async function downloadLink(link) {
     currentLinkStatus.etag = response.headers.get('etag');
     let states = null;
     if(TTS.isTTSlink(link)) {
-      states = await TTS.fromBSON(await response.buffer());
+      states = await TTS.fromBSON(await response.buffer(), link);
     } else {
       states = await readStatesFromBuffer(await response.buffer(), true);
     }

--- a/server/fileloader.mjs
+++ b/server/fileloader.mjs
@@ -163,7 +163,7 @@ async function readStatesFromLink(linkAndPath, includeVariantNameList) {
 async function readVariantsFromBuffer(buffer) {
   const zip = await JSZip.loadAsync(buffer);
   if(Object.keys(zip.files).filter(f=>f.match(/WorkshopUpload/)).length) {
-    return [ await TTS.fromZip(buffer) ];
+    return [ await TTS.fromZIP(buffer) ];
   } else if(zip.files['widgets.json']) {
     return [ await PCIO(buffer) ];
   } else {

--- a/server/ttsimport.mjs
+++ b/server/ttsimport.mjs
@@ -52,19 +52,29 @@ const invisibleObjects = /Trigger$|^(Fog|Custom_PDF|Custom_Audio|Tileset_)/;
 const pieceObjects = /^(Backgammon|Block|Checker|Chess|Chinese_Checkers_Piece|Chip|Coin|Domino|Figurine|Mahjong|Pawn|PlayerPawn|go_game_piece|reversi)/;
 const roundPieces = /^(Backgammon|Checker|Chip|Coin|PlayerPawn|go_game_piece|reversi)/;
 
+// Everything that has to stay unique or be remembered for the length of one
+// conversion. This cannot be module state: a conversion waits for images, so two
+// players importing a save at the same time would hand out the same widget IDs.
+function newImport() {
+  return {
+    usedIDs: new Set(),
+    nextID: 1,
+    // The fallback for an image whose dimensions could not be read is remembered for
+    // the current import only - a host that times out once should not keep every later
+    // import of that image pinned to a 1:1 aspect ratio.
+    failedImages: {}
+  };
+}
+
 const imgSizeCache = {};
-// The fallback for an image whose dimensions could not be read is remembered for
-// the current import only - a host that times out once should not keep every later
-// import of that image pinned to a 1:1 aspect ratio.
-let imgSizeFailed = {};
-async function imgSize(url) {
-  if(imgSizeCache[url] || imgSizeFailed[url])
-    return imgSizeCache[url] || imgSizeFailed[url];
+async function imgSize(url, imp) {
+  if(imgSizeCache[url] || imp.failedImages[url])
+    return imgSizeCache[url] || imp.failedImages[url];
 
   try {
     // only the first few KB are needed, but a host may ignore the Range header and
     // send the whole image - don't wait or buffer indefinitely for that
-    const r = await fetch(url, { headers: { 'Range': 'bytes=0-40000' }, signal: AbortSignal.timeout(15000), size: 20000000 });
+    const r = await fetch(url, { headers: { 'Range': 'bytes=0-40000' }, signal: AbortSignal.timeout(15000), size: 1000000 });
     const buffer = await r.buffer();
     if(buffer.toString('ascii', 1, 4) == 'PNG')
       return imgSizeCache[url] = [ buffer.readUInt32BE(16), buffer.readUInt32BE(20) ];
@@ -76,7 +86,7 @@ async function imgSize(url) {
   } catch(e) {
     Logging.log(`TTS import: could not read the dimensions of ${url}: ${e.toString()}`);
   }
-  return imgSizeFailed[url] = [ 1, 1 ];
+  return imp.failedImages[url] = [ 1, 1 ];
 }
 
 function collectImageURLs(objects, urls=new Set()) {
@@ -95,11 +105,11 @@ function collectImageURLs(objects, urls=new Set()) {
 // The images are only downloaded for their dimensions - a game can reference
 // hundreds of them, so fill the cache with a couple of parallel requests instead
 // of blocking the conversion of every single object on its own request.
-async function prefetchImageSizes(objects) {
+async function prefetchImageSizes(objects, imp) {
   const queue = [ ...collectImageURLs(objects) ].filter(url=>url && !imgSizeCache[url]);
   await Promise.all(Array.from({ length: 16 }, async _=>{
     while(queue.length)
-      await imgSize(queue.shift());
+      await imgSize(queue.shift(), imp);
   }));
 }
 
@@ -109,13 +119,11 @@ function processURL(url) {
   return match ? `https://steamusercontent-a.akamaihd.net${match[0]}` : u.replace(/^http:/, 'https:');
 }
 
-let nextID = 1;
-let usedIDs = new Set();
-function getID(o) {
-  let id = String(o.GUID || nextID++);
-  while(usedIDs.has(id))
-    id = `${id}-${nextID++}`;
-  usedIDs.add(id);
+function getID(o, imp) {
+  let id = String(o.GUID || imp.nextID++);
+  while(imp.usedIDs.has(id))
+    id = `${id}-${imp.nextID++}`;
+  imp.usedIDs.add(id);
   return id;
 }
 
@@ -176,8 +184,10 @@ function contrastColor(hex) {
   return r*0.3 + g*0.6 + b*0.1 > 128 ? '#000000' : '#ffffff';
 }
 
+// The html property of a widget goes through the property replacements, so a $ has
+// to be escaped as well to show a text that happens to contain ${...} as it is.
 function escapeHTML(text) {
-  return String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\$/g, '&#36;');
 }
 
 function shade(hex, factor) {
@@ -209,7 +219,7 @@ function place(o, widget) {
   return widget;
 }
 
-async function addDeck(o, parent=null) {
+async function addDeck(o, imp, parent=null) {
   const cardIDs = (o.DeckIDs || [ o.CardID ]).map(extractNumber).filter(id=>!isNaN(+id) && o.CustomDeck[Math.floor(+id/100)]);
   if(!cardIDs.length) {
     Logging.log(`TTS import: skipping ${o.Name} (${o.GUID}): no card refers to an existing CustomDeck entry`);
@@ -218,7 +228,7 @@ async function addDeck(o, parent=null) {
 
   const firstDeckID = Math.floor(cardIDs[0]/100);
 
-  let [ deckWidth, deckHeight ] = await imgSize(processURL(o.CustomDeck[firstDeckID].FaceURL));
+  let [ deckWidth, deckHeight ] = await imgSize(processURL(o.CustomDeck[firstDeckID].FaceURL), imp);
 
   const cardsPerRow = extractNumber(o.CustomDeck[firstDeckID].NumWidth)  || 10;
   const cardsPerCol = extractNumber(o.CustomDeck[firstDeckID].NumHeight) ||  7;
@@ -236,7 +246,7 @@ async function addDeck(o, parent=null) {
   cardHeight *= scale;
 
   const widgets = {};
-  const id = getID(o);
+  const id = getID(o, imp);
   const deck = {
     id,
     parent,
@@ -352,9 +362,9 @@ async function addDeck(o, parent=null) {
 // the button toggles whether the contents are shown. The holder is a child of the
 // button so that the two always stay together, and it accepts every widget type
 // because bags can hold anything in TTS.
-async function addBag(o, parent) {
-  const id = getID(o);
-  const contents = await addRecursive(o.ContainedObjects, id);
+async function addBag(o, imp, parent) {
+  const id = getID(o, imp);
+  const contents = await addRecursive(o.ContainedObjects, imp, id);
   // the cards of a stack live in its pile and a deck is invisible: what a player
   // gets out of the bag are the widgets that sit in the holder itself
   const children = Object.values(contents).filter(w=>w.parent == id && w.type != 'deck');
@@ -376,7 +386,9 @@ async function addBag(o, parent) {
     borderColor: shade(color, 0.6),
     textColor: contrastColor(color),
     borderRadius: '20px 20px 6px 6px',
-    css: 'padding: 2px 4px; font-size: 12px; line-height: 1.15',
+    // the border width is spelled out because the holder below is positioned inside
+    // it: both have to shrink by the same factor when the layout is scaled down
+    css: 'padding: 2px 4px; font-size: 12px; line-height: 1.15; border-width: 4px',
     clickRoutine: [
       {
         func: 'IF',
@@ -415,7 +427,7 @@ async function addBag(o, parent) {
   return widgets;
 }
 
-async function addImage(o, parent) {
+async function addImage(o, imp, parent) {
   const name = String(o.Name || '');
   const image = processURL(o.CustomImage.ImageURL);
   const back = o.CustomImage.ImageSecondaryURL ? processURL(o.CustomImage.ImageSecondaryURL) : null;
@@ -429,11 +441,11 @@ async function addImage(o, parent) {
   else if(name.match(/^Figurine/))
     base = baseSize.figurine * number(o.CustomImage.ImageScalar, 1);
 
-  const [ imageWidth, imageHeight ] = await imgSize(image);
+  const [ imageWidth, imageHeight ] = await imgSize(image, imp);
   const aspect = imageWidth && imageHeight ? imageWidth/imageHeight : 1;
 
   const widget = {
-    id: getID(o),
+    id: getID(o, imp),
     parent,
     width:  clamp(Math.round(base * t.scaleX * (aspect < 1 ? aspect : 1)), 8, 1600),
     height: clamp(Math.round(base * t.scaleZ / (aspect > 1 ? aspect : 1)), 8, 1000),
@@ -467,7 +479,7 @@ async function addImage(o, parent) {
   return { [widget.id]: place(o, widget) };
 }
 
-function addDice(o, parent) {
+function addDice(o, imp, parent) {
   // TTS gives every object that can be rolled a RotationValues list: one entry per
   // face with the value that is up in that rotation. That is the only way to know
   // the faces of a die that is just a mesh (Custom_Model), and it also gives the
@@ -486,7 +498,7 @@ function addDice(o, parent) {
   const size = clamp(Math.round(baseSize.dice * transformOf(o).scaleX), 40, 200);
 
   const widget = {
-    id: getID(o),
+    id: getID(o, imp),
     parent,
     type: 'dice',
     width: size,
@@ -512,7 +524,7 @@ function addDice(o, parent) {
   return { [widget.id]: place(o, widget) };
 }
 
-function addText(o, parent) {
+function addText(o, imp, parent) {
   const text = String((o.Text || {}).Text || '').trim();
   if(!text)
     return null;
@@ -520,7 +532,7 @@ function addText(o, parent) {
   const lines = text.split('\n');
   const fontSize = clamp(Math.round(number((o.Text || {}).fontSize, 64) * 0.35 * transformOf(o).scaleX), 10, 72);
   const widget = {
-    id: getID(o),
+    id: getID(o, imp),
     parent,
     type: 'label',
     text,
@@ -534,7 +546,7 @@ function addText(o, parent) {
 
 // A notecard holds as much text as its author typed, so the card grows with it
 // instead of cutting the text off at a fixed height. Its title is the heading.
-function addNotecard(o, parent) {
+function addNotecard(o, imp, parent) {
   const title = String(o.Nickname || '').trim();
   const body = String(o.Description || '').trim();
   const paragraphs = (title ? [ title ] : []).concat(body ? body.split('\n') : []);
@@ -545,7 +557,7 @@ function addNotecard(o, parent) {
   // is followed by an empty line
   const rows = paragraphs.reduce((sum, p)=>sum + Math.max(1, Math.ceil(p.length/38)), title && body ? 1 : 0);
   const widget = {
-    id: getID(o),
+    id: getID(o, imp),
     parent,
     width: 240,
     height: clamp(rows*15 + 16, 60, 500),
@@ -560,7 +572,7 @@ function addNotecard(o, parent) {
 // Meshes, asset bundles and the built-in 3D pieces have no 2D representation at
 // all, so they become plain colored pieces carrying their name. Unnamed ones are
 // usually decoration of the 3D table and are left out.
-function addPiece(o, parent) {
+function addPiece(o, imp, parent) {
   const name = String(o.Name || '');
   const text = String(o.Nickname || '').trim();
   if(!text && !name.match(pieceObjects))
@@ -569,7 +581,7 @@ function addPiece(o, parent) {
   const size = clamp(Math.round(baseSize.piece * transformOf(o).scaleX), 40, 400);
   const color = toColor(o.ColorDiffuse, '#cccccc');
   const widget = {
-    id: getID(o),
+    id: getID(o, imp),
     parent,
     width: size,
     height: size,
@@ -586,38 +598,49 @@ function addPiece(o, parent) {
   return { [widget.id]: place(o, widget) };
 }
 
-async function addObject(o, parent) {
+async function addObject(o, imp, parent) {
   const name = String(o.Name || '');
 
   if(name.match(invisibleObjects))
     return null;
   if(o.CustomDeck)
-    return await addDeck(o, parent);
+    return await addDeck(o, imp, parent);
   if(name.match(/Bag$/))
-    return await addBag(o, parent);
+    return await addBag(o, imp, parent);
   if(name == 'Custom_Dice' || name.match(/^Die_/))
-    return addDice(o, parent);
+    return addDice(o, imp, parent);
   if(name == '3DText')
-    return addText(o, parent);
+    return addText(o, imp, parent);
   if(name == 'Notecard')
-    return addNotecard(o, parent);
+    return addNotecard(o, imp, parent);
   if(Array.isArray(o.ContainedObjects) && o.ContainedObjects.length)
-    return await addRecursive(o.ContainedObjects, parent); // a stack of tokens/tiles or an unknown container
+    return await addRecursive(stackedAt(o), imp, parent); // a stack of tokens/tiles or an unknown container
   if(o.CustomImage && o.CustomImage.ImageURL)
-    return await addImage(o, parent);
+    return await addImage(o, imp, parent);
   if(rotationValues(o))
-    return addDice(o, parent); // a mesh that can be rolled, e.g. a Custom_Model die
-  return addPiece(o, parent);
+    return addDice(o, imp, parent); // a mesh that can be rolled, e.g. a Custom_Model die
+  return addPiece(o, imp, parent);
 }
 
-async function addRecursive(os, parent=null) {
+// The objects of a stack are all in the same spot on the TTS table, and the
+// transforms that are stored with them inside the stack are often the ones they had
+// before they were stacked - so they are put where the stack is instead of where
+// they claim to be, one above the other.
+function stackedAt(o) {
+  const t = transformOf(o);
+  return o.ContainedObjects.map((contained, index)=>contained && typeof contained == 'object' ? Object.assign({}, contained, {
+    Transform: Object.assign({}, transformOf(contained), { posX: t.posX, posY: t.posY + index/100, posZ: t.posZ, rotY: t.rotY })
+  }) : contained);
+}
+
+async function addRecursive(os, imp, parent=null) {
   const widgets = {};
 
   for(const o of os || []) {
     if(!o || typeof o != 'object')
       continue;
     try {
-      for(const widget of Object.values(await addObject(o, parent) || {})) {
+      for(const widget of Object.values(await addObject(o, imp, parent) || {})) {
         if(!widget.parent)
           delete widget.parent; // no parent is the default - don't spell it out
         widgets[widget.id] = widget;
@@ -634,13 +657,17 @@ async function addRecursive(os, parent=null) {
 // How much room a widget really takes up, as a box relative to its x/y. That is
 // not simply width x height: a widget rotated by 90 degrees is as high as it is
 // wide, and an opened bag reaches far below its button because the holder holding
-// the contents is a child of it. Both rotate and scale happen around the center of
-// the widget, so the box can start left of / above x/y and extend past width/height.
-function widgetExtent(widget, byParent) {
+// the contents is a child of it. The rotation happens around the center of the
+// widget, so the box can start left of / above x/y and extend past width/height.
+// Widgets nobody owns are hidden until a routine shows them - the holder of a bag
+// is only included when the room that an opened bag needs is being asked for.
+function widgetExtent(widget, byParent, includeHidden) {
   let x0 = 0, y0 = 0, x1 = widget.width || 0, y1 = widget.height || 0;
 
   for(const child of byParent[widget.id] || []) {
-    const box = widgetExtent(child, byParent);
+    if(!includeHidden && Array.isArray(child.owner) && !child.owner.length)
+      continue;
+    const box = widgetExtent(child, byParent, includeHidden);
     x0 = Math.min(x0, (child.x || 0) + box.x0);
     y0 = Math.min(y0, (child.y || 0) + box.y0);
     x1 = Math.max(x1, (child.x || 0) + box.x1);
@@ -664,6 +691,37 @@ function widgetExtent(widget, byParent) {
   return { x0, y0, x1, y1 };
 }
 
+// Every length the importer writes into a css string is a px value of its own
+// making, so scaling them all keeps fonts, paddings and borders in proportion with
+// the widget they belong to.
+function scaleLengths(css, factor) {
+  return String(css).replace(/(-?[0-9.]+)px/g, (all, length)=>`${Math.round(length*factor*100)/100}px`);
+}
+
+// Shrinking the layout makes the widgets themselves smaller instead of setting the
+// scale property on the top level ones: a card dragged out of a pile or a token
+// taken out of a bag becomes a top level widget itself, and would jump to full size
+// if the scale it is rendered with belonged to its former parent.
+function scaleWidget(widget, factor, keepPosition) {
+  for(const property of keepPosition ? [ 'width', 'height' ] : [ 'width', 'height', 'x', 'y' ])
+    if(typeof widget[property] == 'number')
+      widget[property] = Math.round(widget[property]*factor);
+
+  for(const property of [ 'css', 'faceCSS', 'borderRadius' ])
+    if(typeof widget[property] == 'string')
+      widget[property] = scaleLengths(widget[property], factor);
+    else if(typeof widget[property] == 'number')
+      widget[property] = Math.round(widget[property]*factor*100)/100;
+
+  if(widget.cardDefaults) {
+    widget.cardDefaults.width  = Math.round(widget.cardDefaults.width *factor);
+    widget.cardDefaults.height = Math.round(widget.cardDefaults.height*factor);
+    // enlarge is a multiple of the size of the card, which is smaller now: keep
+    // showing a card that is looked at as big as one of a native VTT game
+    widget.cardDefaults.enlarge = Math.round(clamp(4/factor, 4, 40));
+  }
+}
+
 function moveIntoBounds(widgets, top, bottom) {
   let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
 
@@ -674,8 +732,10 @@ function moveIntoBounds(widgets, top, bottom) {
 
   // Widgets that are not on the surface at all: children move with their parent,
   // and a deck is invisible and has no position. Counting a deck as a widget at
-  // (0, 0) would pull the whole bounding box to the origin.
-  const placed = Object.values(widgets).filter(w=>!w.parent && w.x !== undefined).map(w=>({ widget: w, box: widgetExtent(w, byParent) }));
+  // (0, 0) would pull the whole bounding box to the origin. The box of a widget is
+  // measured twice: as it is seen now, and as it is once a bag in it is opened.
+  const placed = Object.values(widgets).filter(w=>!w.parent && w.x !== undefined)
+    .map(w=>({ widget: w, box: widgetExtent(w, byParent, false), full: widgetExtent(w, byParent, true) }));
 
   // 1. Find bounding box for all parent-less widgets
   for(const { widget, box } of placed) {
@@ -694,30 +754,29 @@ function moveIntoBounds(widgets, top, bottom) {
   const offsetX =       (1600       - (maxX-minX)*scale)/2;
   const offsetY = top + (bottom-top - (maxY-minY)*scale)/2;
 
-  for(const { widget, box } of placed) {
-    const width  = box.x1 - box.x0;
-    const height = box.y1 - box.y0;
+  // 3. Make every widget smaller by that factor, children included: their x/y is
+  //    relative to their parent and shrinks with the rest of the layout.
+  if(scale < 1)
+    for(const widget of Object.values(widgets))
+      scaleWidget(widget, scale, !widget.parent);
 
-    // The objects are scaled along with the distances between them - scaling only
-    // the positions would let everything overlap on a table bigger than the surface.
-    const left = (widget.x + box.x0 + width /2 - minX)*scale + offsetX - width *scale/2;
-    const topY = (widget.y + box.y0 + height/2 - minY)*scale + offsetY - height*scale/2;
+  // 4. Put the top level widgets where the scaled down layout has them
+  for(const { widget, box, full } of placed) {
+    const left = (widget.x + box.x0 - minX)*scale + offsetX;
+    const topY = (widget.y + box.y0 - minY)*scale + offsetY;
 
-    // a widget that is higher than the band between the seats and the hand cannot
-    // be kept inside it - a full table board is allowed to use the whole surface
-    const fits = height*scale <= bottom-top;
-    const lo = fits ? top    : 0;
-    const hi = fits ? bottom : 1000;
+    // What is visible stays inside the band between the seats and the hand. What is
+    // only there once a bag has been opened just has to stay on the surface, which
+    // is where a player can reach it - outside of it, overflow: hidden swallows it.
+    const loX =        (box.x0 - full.x0)*scale;
+    const hiX = 1600 - (full.x1 - box.x0)*scale;
+    const loY = Math.max(top,               (box.y0 - full.y0)*scale);
+    const hiY = Math.min(bottom - (box.y1 - box.y0)*scale, 1000 - (full.y1 - box.y0)*scale);
 
-    // From the top left corner of the visible box back to x/y: the center of the
-    // widget stays in place while the box shrinks towards it, so x/y stay the top
-    // left corner of the unscaled, unrotated widget - which is not where it is seen.
-    const anchorX = (widget.width  || 0)/2*(1-scale) + box.x0*scale;
-    const anchorY = (widget.height || 0)/2*(1-scale) + box.y0*scale;
-    widget.x = Math.round(clamp(left, 0,  Math.max(0,  1600 - width *scale)) - anchorX);
-    widget.y = Math.round(clamp(topY, lo, Math.max(lo, hi   - height*scale)) - anchorY);
-    if(scale < 1)
-      widget.scale = scale;
+    // x/y is the top left corner of the unrotated widget, which is not where its box
+    // begins - a rotated widget sticks out of it on the side it turned towards.
+    widget.x = Math.round(clamp(left, loX, Math.max(loX, hiX)) - box.x0*scale);
+    widget.y = Math.round(clamp(topY, loY, Math.max(loY, hiY)) - box.y0*scale);
   }
 
   return widgets;
@@ -735,9 +794,8 @@ async function convertTTS(content, linkContent, workshop={}) {
         json = JSON.parse(await zip.files[file].async('string'));
   }
 
-  usedIDs = new Set();
-  imgSizeFailed = {};
-  await prefetchImageSizes(json.ObjectStates);
+  const imp = newImport();
+  await prefetchImageSizes(json.ObjectStates, imp);
 
   // Older saves list the hand zones in Hands.HandTransforms, newer ones store them
   // as HandTrigger objects with the player color in FogColor. VTT uses one hand for
@@ -749,7 +807,7 @@ async function convertTTS(content, linkContent, workshop={}) {
   const hasHand = handColors.length || json.Hands && json.Hands.Enable;
 
   // leave room for the seats at the top and the hand at the bottom
-  const widgets = moveIntoBounds(await addRecursive(json.ObjectStates), handColors.length ? 50 : 0, hasHand ? 810 : 1000);
+  const widgets = moveIntoBounds(await addRecursive(json.ObjectStates, imp), handColors.length ? 50 : 0, hasHand ? 810 : 1000);
 
   if(json.TableURL) {
     widgets.back = {
@@ -869,10 +927,12 @@ async function storeThumbnail(url) {
 }
 
 // Workshop descriptions are BBCode and can be pages long: keep the text, drop the
-// markup and cut it down to something that fits into the game details.
+// markup and cut it down to something that fits into the game details. Some of them
+// contain plain HTML as well, which the game details show as text.
 function plainText(text) {
   const result = String(text || '')
-    .replace(/\[\/?(b|i|u|h[1-3]|strike|spoiler|noparse|quote|code|list|olist|table|tr|td|th|img|url|previewyoutube)(=[^\]]*)?\]/gi, '')
+    .replace(/\[\/?(b|i|u|h[1-3]|strike|spoiler|noparse|quote|code|list|olist|table|tr|td|th|img|url|previewyoutube|hr|carousel|nolinebreak|sub|sup|size|color|center)(=[^\]]*)?\]/gi, '')
+    .replace(/<\/?(br|p|div|span|b|i|u|strong|em|ul|ol|li|a|img|font|hr|h[1-6]|table|tr|td|th)\b[^>]*>/gi, '')
     .replace(/\[\*\]/g, '- ')
     .replace(/\r/g, '')
     .replace(/\n{3,}/g, '\n\n')

--- a/server/ttsimport.mjs
+++ b/server/ttsimport.mjs
@@ -176,6 +176,10 @@ function contrastColor(hex) {
   return r*0.3 + g*0.6 + b*0.1 > 128 ? '#000000' : '#ffffff';
 }
 
+function escapeHTML(text) {
+  return String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 function shade(hex, factor) {
   return '#' + [ 1, 3, 5 ].map(i=>clamp(Math.round((parseInt(hex.substr(i, 2), 16) || 0) * factor), 0, 255).toString(16).padStart(2, '0')).join('');
 }
@@ -343,15 +347,18 @@ async function addDeck(o, parent=null) {
   return widgets;
 }
 
-// A bag becomes a button in the shape of a bag that carries the bag's name, with
-// a holder for the contents inside it. Clicking the button toggles whether the
-// contents are shown. The holder is a child of the button so that the two always
-// stay together, and it accepts every widget type because bags can hold anything
-// in TTS.
+// A bag becomes a button in the shape of a bag that carries the bag's name and the
+// number of objects inside it, with a holder for the contents inside it. Clicking
+// the button toggles whether the contents are shown. The holder is a child of the
+// button so that the two always stay together, and it accepts every widget type
+// because bags can hold anything in TTS.
 async function addBag(o, parent) {
   const id = getID(o);
   const contents = await addRecursive(o.ContainedObjects, id);
-  if(!Object.keys(contents).length)
+  // the cards of a stack live in its pile and a deck is invisible: what a player
+  // gets out of the bag are the widgets that sit in the holder itself
+  const children = Object.values(contents).filter(w=>w.parent == id && w.type != 'deck');
+  if(!children.length)
     return null; // a bag that is empty after the import is nothing to play with
 
   const color = toColor(o.ColorDiffuse, '#a97e4b');
@@ -364,12 +371,12 @@ async function addBag(o, parent) {
     type: 'button',
     width: 130,
     height: 54,
-    text: String(o.Nickname || '').trim() || 'Bag',
+    text: `${String(o.Nickname || '').trim() || 'Bag'} (${children.length})`,
     backgroundColor: color,
     borderColor: shade(color, 0.6),
     textColor: contrastColor(color),
     borderRadius: '20px 20px 6px 6px',
-    css: 'padding: 2px 4px; font-size: 11px; line-height: 1.15',
+    css: 'padding: 2px 4px; font-size: 12px; line-height: 1.15',
     clickRoutine: [
       {
         func: 'IF',
@@ -382,14 +389,21 @@ async function addBag(o, parent) {
     ]
   });
 
+  // the contents stack in one spot, so the holder only has to be big enough for the
+  // largest of them instead of being a mostly empty panel
+  const largest = property=>Math.max(...children.map(w=>w[property] || 0), 60);
+  const width = clamp(largest('width') + 24, 130, 340);
+
   widgets[id] = {
     id,
     parent: bagID,
     type: 'holder',
-    x: -4,
+    // the button positions its children inside its 4px border, and a holder that is
+    // wider than the button hangs over both of its sides evenly
+    x: Math.round(-4 + (130-width)/2),
     y: 50,
-    width: 130,
-    height: 190,
+    width,
+    height: clamp(largest('height') + 24, 80, 340),
     borderRadius: '0 0 6px 6px',
     color: '#ffffffdd',
     css: `border: 2px solid ${shade(color, 0.6)}`,
@@ -423,7 +437,6 @@ async function addImage(o, parent) {
     parent,
     width:  clamp(Math.round(base * t.scaleX * (aspect < 1 ? aspect : 1)), 8, 1600),
     height: clamp(Math.round(base * t.scaleZ / (aspect > 1 ? aspect : 1)), 8, 1000),
-    color: 'transparent',
     image
   };
 
@@ -479,14 +492,18 @@ function addDice(o, parent) {
     width: size,
     height: size,
     movable: true,
-    color: toColor(o.ColorDiffuse, 'white'),
+    color: toColor(o.ColorDiffuse, '#f0f0f0'),
     faces
   };
 
   // the face font is sized for a single digit, so word labels like 'Blue' need a
-  // smaller one to stay inside the face
-  if(hasLabels)
-    widget.faceCSS = `font-size: ${Math.round(size/4)}px; overflow: hidden`;
+  // smaller one: derived from the longest word so that a face like 'Black (Joker)'
+  // wraps into readable lines instead of being cut off
+  if(hasLabels) {
+    const longestWord = Math.max(...faces.map(f=>Math.max(...String(f).split(/\s+/).map(w=>w.length))), 2);
+    const fontSize = clamp(Math.round(size*1.4/longestWord), 6, Math.round(size/4));
+    widget.faceCSS = `font-size: ${fontSize}px; line-height: 1.1; word-break: break-word`;
+  }
 
   // the 3D shapes only exist for these face counts - anything else stays flat
   if(diceShapes.indexOf(faces.length) > -1)
@@ -515,17 +532,26 @@ function addText(o, parent) {
   return { [widget.id]: place(o, widget) };
 }
 
+// A notecard holds as much text as its author typed, so the card grows with it
+// instead of cutting the text off at a fixed height. Its title is the heading.
 function addNotecard(o, parent) {
-  const text = [ String(o.Nickname || '').trim(), String(o.Description || '').trim() ].filter(t=>t).join('\n\n');
+  const title = String(o.Nickname || '').trim();
+  const body = String(o.Description || '').trim();
+  const paragraphs = (title ? [ title ] : []).concat(body ? body.split('\n') : []);
+  if(!paragraphs.length)
+    return null;
+
+  // ~38 characters of the 13px font fit into a line of the 240px card, and the title
+  // is followed by an empty line
+  const rows = paragraphs.reduce((sum, p)=>sum + Math.max(1, Math.ceil(p.length/38)), title && body ? 1 : 0);
   const widget = {
     id: getID(o),
     parent,
-    type: 'label',
-    text,
     width: 240,
-    height: 160,
+    height: clamp(rows*15 + 16, 60, 500),
     movable: true,
-    css: 'background: #fdf8d8; color: #333333; border-radius: 4px; font-size: 13px'
+    html: (title ? `<b>${escapeHTML(title)}</b><br>${body ? '<br>' : ''}` : '') + escapeHTML(body).replace(/\n/g, '<br>'),
+    css: 'background: #fdf8d8; color: #333333; border-radius: 4px; font-size: 13px; padding: 6px 8px; box-sizing: border-box; overflow-wrap: break-word; overflow: hidden'
   };
 
   return { [widget.id]: place(o, widget) };
@@ -547,10 +573,11 @@ function addPiece(o, parent) {
     parent,
     width: size,
     height: size,
-    color,
     borderRadius: name.match(roundPieces) ? '50%' : 8,
     text,
-    css: `font-size: 10px; overflow: hidden; border: 1px solid #0006; color: ${contrastColor(color)}`
+    // a plain widget is not painted with its color property, and its text starts in
+    // the top left corner - which a round piece clips away
+    css: `background-color: ${color}; border: 1px solid #0006; color: ${contrastColor(color)}; font-size: 10px; line-height: 1.1; display: flex; align-items: center; justify-content: center; text-align: center; word-break: break-word; overflow: hidden`
   };
 
   if(o.Locked)
@@ -625,18 +652,32 @@ function moveIntoBounds(widgets, top, bottom) {
   // 2. Shrink the layout until it fits onto the surface and center it there. The
   //    layout is never stretched: objects that are next to each other in TTS
   //    should stay next to each other instead of being spread over the table.
-  const scale = Math.min(1, 1500/(maxX-minX || 1), (bottom-top-40)/(maxY-minY || 1));
+  const scale = Math.round(Math.min(1, 1500/(maxX-minX || 1), (bottom-top-40)/(maxY-minY || 1))*1000)/1000;
   const offsetX =       (1600       - (maxX-minX)*scale)/2;
   const offsetY = top + (bottom-top - (maxY-minY)*scale)/2;
 
   for(const widget of placed) {
+    const width  = widget.width  || 0;
+    const height = widget.height || 0;
+
+    // The objects are scaled along with the distances between them - scaling only
+    // the positions would let everything overlap on a table bigger than the surface.
+    // The scale property keeps the center of a widget in place, so its position is
+    // derived from the center as well, and x/y stay the top left corner of the
+    // unscaled widget: the visible box is centered inside it.
+    const inset = (1-scale)/2;
+    const left = (widget.x + width /2 - minX)*scale + offsetX - width *scale/2;
+    const topY = (widget.y + height/2 - minY)*scale + offsetY - height*scale/2;
+
     // a widget that is higher than the band between the seats and the hand cannot
     // be kept inside it - a full table board is allowed to use the whole surface
-    const fits = (widget.height || 0) <= bottom-top;
+    const fits = height*scale <= bottom-top;
     const lo = fits ? top    : 0;
     const hi = fits ? bottom : 1000;
-    widget.x = clamp(Math.round((widget.x - minX)*scale + offsetX),  0, Math.max(0,  1600 - (widget.width  || 0)));
-    widget.y = clamp(Math.round((widget.y - minY)*scale + offsetY), lo, Math.max(lo, hi   - (widget.height || 0)));
+    widget.x = Math.round(clamp(left, 0,  Math.max(0,  1600 - width *scale)) - width *inset);
+    widget.y = Math.round(clamp(topY, lo, Math.max(lo, hi   - height*scale)) - height*inset);
+    if(scale < 1)
+      widget.scale = scale;
   }
 
   return widgets;
@@ -694,6 +735,7 @@ async function convertTTS(content, linkContent, workshop={}) {
       dropOffsetY: 14,
       stackOffsetX: 40,
       childrenPerOwner: true,
+      text: 'Hand', // an empty holder is a blank band otherwise
       x: 50,
       y: 820,
       width: 1500,
@@ -701,19 +743,20 @@ async function convertTTS(content, linkContent, workshop={}) {
     };
   }
 
-  // The seats share one row above the table, so they get narrower when a game has
-  // hand zones for many of the twelve TTS player colors instead of running off the
-  // right edge of the surface.
+  // The seats share one centered row above the table, so they get narrower when a
+  // game has hand zones for many of the twelve TTS player colors instead of running
+  // off the right edge of the surface.
   const seatPitch = Math.min(155, Math.floor(1580/(handColors.length || 1)));
+  const seatOffset = Math.round((1600 - handColors.length*seatPitch)/2);
 
   handColors.forEach((color, index)=>{
     widgets[`seat-${index+1}`] = {
       id: `seat-${index+1}`,
       type: 'seat',
       index: index+1,
-      x: 20 + index*seatPitch,
+      x: seatOffset + index*seatPitch,
       y: 5,
-      width: seatPitch - 5,
+      width: seatPitch - 10,
       height: 40,
       color: playerColors[color] || '#999999',
       colorEmpty: playerColors[color] || '#999999',

--- a/server/ttsimport.mjs
+++ b/server/ttsimport.mjs
@@ -1,7 +1,11 @@
+import fs from 'fs';
+
+import CRC32 from 'crc-32';
 import JSZip from 'jszip';
 import fetch from 'node-fetch';
 import { BSON } from 'bson';
 
+import Config from './config.mjs';
 import Logging from './logging.mjs';
 
 // A TTS unit is about an inch, which is 50px on the VTT surface (a poker card is
@@ -638,7 +642,7 @@ function moveIntoBounds(widgets, top, bottom) {
   return widgets;
 }
 
-async function convertTTS(content, linkContent) {
+async function convertTTS(content, linkContent, workshop={}) {
   let json = {};
 
   if(linkContent) {
@@ -717,22 +721,23 @@ async function convertTTS(content, linkContent) {
     };
   });
 
-  widgets._meta = {
-    info: {
-      name: json.SaveName,
-      importerTemp: 'TTS',
-      importerTime: +new Date()
-    },
-    version: 5
-  };
+  const info = Object.assign({}, workshop, {
+    importerTemp: 'TTS',
+    importerTime: +new Date()
+  });
+  // the name of the save wins over the title of the workshop item it came from
+  if(json.SaveName)
+    info.name = String(json.SaveName);
+
+  widgets._meta = { info, version: 5 };
 
   return widgets;
 }
 
-async function fromBSON(content) {
+async function fromBSON(content, link) {
   return {
     TTS: {
-      '0.json': await convertTTS(null, content)
+      '0.json': await convertTTS(null, content, link ? await workshopMeta(link) : {})
     }
   };
 }
@@ -745,17 +750,107 @@ function isTTSlink(link) {
   return link.match(/\?id=([0-9]+)/);
 }
 
+async function publishedFileDetails(id) {
+  return (await (await fetch('http://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/v1', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: `itemcount=1&publishedfileids[0]=${id}`
+  })).json()).response.publishedfiledetails[0];
+}
+
 async function resolveLink(link) {
   const id = isTTSlink(link);
   if(!id)
     return link;
 
   Logging.log(`resolving TTS link with ID ${id[1]}`);
-  return (await (await fetch('http://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/v1', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: `itemcount=1&publishedfileids[0]=${id[1]}`
-  })).json()).response.publishedfiledetails[0].file_url;
+  return (await publishedFileDetails(id[1])).file_url;
+}
+
+// The workshop thumbnail becomes the image of the imported game. It is stored as an
+// asset like an uploaded image so that the game keeps its picture even when the
+// workshop item disappears - and asked for at 400px because the full size preview is
+// a multi-megapixel PNG.
+async function storeThumbnail(url) {
+  try {
+    const request = `${url}${url.indexOf('?') > -1 ? '&' : '?'}imw=400&imh=400&ima=fit&impolicy=Letterbox`;
+    const content = Buffer.from(await (await fetch(request, { signal: AbortSignal.timeout(15000), size: 20000000 })).arrayBuffer());
+    const asset = `${CRC32.buf(content)}_${content.length}`;
+    if(!Config.resolveAsset(asset))
+      fs.writeFileSync(`${Config.directory('assets')}/${asset}`, content);
+    return `/assets/${asset}`;
+  } catch(e) {
+    Logging.log(`TTS import: could not store the workshop thumbnail ${url}: ${e.toString()}`);
+    return null;
+  }
+}
+
+// Workshop descriptions are BBCode and can be pages long: keep the text, drop the
+// markup and cut it down to something that fits into the game details.
+function plainText(text) {
+  const result = String(text || '')
+    .replace(/\[\/?(b|i|u|h[1-3]|strike|spoiler|noparse|quote|code|list|olist|table|tr|td|th|img|url|previewyoutube)(=[^\]]*)?\]/gi, '')
+    .replace(/\[\*\]/g, '- ')
+    .replace(/\r/g, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+  return result.length > 800 ? `${result.substr(0, 800).replace(/\s+\S*$/, '')}…` : result;
+}
+
+function numericTags(tags, pattern) {
+  return [ ...new Set(tags.map(t=>(t.match(pattern) || [])[1]).filter(n=>n !== undefined).map(Number)) ].sort((a, b)=>a-b);
+}
+
+function range(values, asSpan) {
+  const last = values[values.length-1];
+  if(values[0] == last)
+    return String(last);
+  return asSpan ? `${values[0]}-${last}` : values.join(',');
+}
+
+// The workshop page of a game knows things that its save file does not: a thumbnail,
+// a description and tags for the player count ('2', '4+') and the playing time
+// ('30 minutes'). They become the metadata that the game shelf shows and filters by.
+async function workshopMeta(link) {
+  const id = isTTSlink(link);
+  if(!id)
+    return {};
+
+  let details;
+  try {
+    details = await publishedFileDetails(id[1]) || {};
+  } catch(e) {
+    Logging.log(`TTS import: could not read the workshop details of ${link}: ${e.toString()}`);
+    return {};
+  }
+
+  const meta = { attribution: `Imported from the Tabletop Simulator Steam Workshop:\nhttps://steamcommunity.com/sharedfiles/filedetails/?id=${id[1]}` };
+  const tags = (details.tags || []).map(t=>String((t || {}).tag || ''));
+
+  if(details.title)
+    meta.name = String(details.title);
+
+  if(details.preview_url) {
+    const image = await storeThumbnail(String(details.preview_url).replace(/^http:/, 'https:'));
+    if(image)
+      meta.image = image;
+  }
+
+  const description = plainText(details.description);
+  if(description)
+    meta.description = description;
+
+  // the player counts are tagged one by one and can be open ended ('4+'), the playing
+  // times are the ends of a span
+  const players = numericTags(tags, /^([0-9]+)\+?$/);
+  if(players.length)
+    meta.players = tags.some(t=>t.match(/^[0-9]+\+$/)) ? `${players[0]}+` : range(players, players[players.length-1]-players[0]+1 == players.length);
+
+  const minutes = numericTags(tags, /^([0-9]+)\+? minutes$/);
+  if(minutes.length)
+    meta.time = range(minutes, true);
+
+  return meta;
 }
 
 export default {

--- a/server/ttsimport.mjs
+++ b/server/ttsimport.mjs
@@ -927,12 +927,12 @@ async function storeThumbnail(url) {
 }
 
 // Workshop descriptions are BBCode and can be pages long: keep the text, drop the
-// markup and cut it down to something that fits into the game details. Some of them
-// contain plain HTML as well, which the game details show as text.
+// markup and cut it down to something that fits into the game details. The plain
+// HTML that some of them contain is left alone: the game details write the
+// description with innerText, so it is shown as the text it is.
 function plainText(text) {
   const result = String(text || '')
     .replace(/\[\/?(b|i|u|h[1-3]|strike|spoiler|noparse|quote|code|list|olist|table|tr|td|th|img|url|previewyoutube|hr|carousel|nolinebreak|sub|sup|size|color|center)(=[^\]]*)?\]/gi, '')
-    .replace(/<\/?(br|p|div|span|b|i|u|strong|em|ul|ol|li|a|img|font|hr|h[1-6]|table|tr|td|th)\b[^>]*>/gi, '')
     .replace(/\[\*\]/g, '- ')
     .replace(/\r/g, '')
     .replace(/\n{3,}/g, '\n\n')

--- a/server/ttsimport.mjs
+++ b/server/ttsimport.mjs
@@ -631,20 +631,58 @@ async function addRecursive(os, parent=null) {
   return widgets;
 }
 
+// How much room a widget really takes up, as a box relative to its x/y. That is
+// not simply width x height: a widget rotated by 90 degrees is as high as it is
+// wide, and an opened bag reaches far below its button because the holder holding
+// the contents is a child of it. Both rotate and scale happen around the center of
+// the widget, so the box can start left of / above x/y and extend past width/height.
+function widgetExtent(widget, byParent) {
+  let x0 = 0, y0 = 0, x1 = widget.width || 0, y1 = widget.height || 0;
+
+  for(const child of byParent[widget.id] || []) {
+    const box = widgetExtent(child, byParent);
+    x0 = Math.min(x0, (child.x || 0) + box.x0);
+    y0 = Math.min(y0, (child.y || 0) + box.y0);
+    x1 = Math.max(x1, (child.x || 0) + box.x1);
+    y1 = Math.max(y1, (child.y || 0) + box.y1);
+  }
+
+  if(widget.rotation) {
+    const rad = widget.rotation*Math.PI/180;
+    const cos = Math.abs(Math.cos(rad)), sin = Math.abs(Math.sin(rad));
+    // rotate the box around the center of the widget and take the upright box
+    // around the result - that is what the surface has to have room for
+    const cx = (widget.width || 0)/2, cy = (widget.height || 0)/2;
+    const mx = (x0+x1)/2 - cx,        my = (y0+y1)/2 - cy;
+    const hw = (x1-x0)/2,             hh = (y1-y0)/2;
+    const rx = cx + Math.cos(rad)*mx - Math.sin(rad)*my;
+    const ry = cy + Math.sin(rad)*mx + Math.cos(rad)*my;
+    x0 = rx - (hw*cos + hh*sin); x1 = rx + (hw*cos + hh*sin);
+    y0 = ry - (hw*sin + hh*cos); y1 = ry + (hw*sin + hh*cos);
+  }
+
+  return { x0, y0, x1, y1 };
+}
+
 function moveIntoBounds(widgets, top, bottom) {
   let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+
+  const byParent = {};
+  for(const widget of Object.values(widgets))
+    if(widget.parent)
+      (byParent[widget.parent] = byParent[widget.parent] || []).push(widget);
 
   // Widgets that are not on the surface at all: children move with their parent,
   // and a deck is invisible and has no position. Counting a deck as a widget at
   // (0, 0) would pull the whole bounding box to the origin.
-  const placed = Object.values(widgets).filter(w=>!w.parent && w.x !== undefined);
+  const placed = Object.values(widgets).filter(w=>!w.parent && w.x !== undefined).map(w=>({ widget: w, box: widgetExtent(w, byParent) }));
 
   // 1. Find bounding box for all parent-less widgets
-  for(const widget of placed) {
-    minX = Math.min(minX, widget.x);
-    minY = Math.min(minY, widget.y);
-    maxX = Math.max(maxX, widget.x + (widget.width  || 0));
-    maxY = Math.max(maxY, widget.y + (widget.height || 0));
+  for(const { widget, box } of placed) {
+    minX = Math.min(minX, widget.x + box.x0);
+    minY = Math.min(minY, widget.y + box.y0);
+    maxX = Math.max(maxX, widget.x + box.x1);
+    maxY = Math.max(maxY, widget.y + box.y1);
   }
   if(minX > maxX)
     return widgets;
@@ -656,26 +694,28 @@ function moveIntoBounds(widgets, top, bottom) {
   const offsetX =       (1600       - (maxX-minX)*scale)/2;
   const offsetY = top + (bottom-top - (maxY-minY)*scale)/2;
 
-  for(const widget of placed) {
-    const width  = widget.width  || 0;
-    const height = widget.height || 0;
+  for(const { widget, box } of placed) {
+    const width  = box.x1 - box.x0;
+    const height = box.y1 - box.y0;
 
     // The objects are scaled along with the distances between them - scaling only
     // the positions would let everything overlap on a table bigger than the surface.
-    // The scale property keeps the center of a widget in place, so its position is
-    // derived from the center as well, and x/y stay the top left corner of the
-    // unscaled widget: the visible box is centered inside it.
-    const inset = (1-scale)/2;
-    const left = (widget.x + width /2 - minX)*scale + offsetX - width *scale/2;
-    const topY = (widget.y + height/2 - minY)*scale + offsetY - height*scale/2;
+    const left = (widget.x + box.x0 + width /2 - minX)*scale + offsetX - width *scale/2;
+    const topY = (widget.y + box.y0 + height/2 - minY)*scale + offsetY - height*scale/2;
 
     // a widget that is higher than the band between the seats and the hand cannot
     // be kept inside it - a full table board is allowed to use the whole surface
     const fits = height*scale <= bottom-top;
     const lo = fits ? top    : 0;
     const hi = fits ? bottom : 1000;
-    widget.x = Math.round(clamp(left, 0,  Math.max(0,  1600 - width *scale)) - width *inset);
-    widget.y = Math.round(clamp(topY, lo, Math.max(lo, hi   - height*scale)) - height*inset);
+
+    // From the top left corner of the visible box back to x/y: the center of the
+    // widget stays in place while the box shrinks towards it, so x/y stay the top
+    // left corner of the unscaled, unrotated widget - which is not where it is seen.
+    const anchorX = (widget.width  || 0)/2*(1-scale) + box.x0*scale;
+    const anchorY = (widget.height || 0)/2*(1-scale) + box.y0*scale;
+    widget.x = Math.round(clamp(left, 0,  Math.max(0,  1600 - width *scale)) - anchorX);
+    widget.y = Math.round(clamp(topY, lo, Math.max(lo, hi   - height*scale)) - anchorY);
     if(scale < 1)
       widget.scale = scale;
   }

--- a/server/ttsimport.mjs
+++ b/server/ttsimport.mjs
@@ -62,9 +62,89 @@ function newImport() {
     // The fallback for an image whose dimensions could not be read is remembered for
     // the current import only - a host that times out once should not keep every later
     // import of that image pinned to a 1:1 aspect ratio.
-    failedImages: {}
+    failedImages: {},
+    // Everything that could not be brought over from TTS ends up in
+    // _meta.info.importerWarnings, which the game details show as import notes.
+    warnings: [],
+    warned: new Set(),
+    warningGroups: {},
+    suppressedWarnings: 0
   };
 }
+
+// A mod can hold thousands of objects, so the report is capped: it is shown in the
+// interface and stored in the room, which nobody is served by filling with
+// thousands of lines.
+const maxWarnings = 100;
+
+function warn(imp, text) {
+  if(imp.warned.has(text))
+    return;
+  imp.warned.add(text);
+  if(imp.warnings.length < maxWarnings)
+    imp.warnings.push(text);
+  else
+    ++imp.suppressedWarnings;
+}
+
+// A note that names the object it is about would repeat itself once per object, so
+// the objects that share a problem are collected under one key and turned into a
+// single line naming them once the whole save has been read.
+function warnAbout(imp, key, o, message) {
+  const group = imp.warningGroups[key] = imp.warningGroups[key] || { names: [], count: 0, message };
+  const name = objectName(o);
+  if(group.names.indexOf(name) == -1)
+    group.names.push(name);
+  ++group.count;
+}
+
+// how an object is called in a note - the name its author gave it if it has one
+function objectName(o) {
+  return `"${String((o || {}).Nickname || '').trim() || String((o || {}).Name || '').trim() || 'unnamed'}"`;
+}
+
+// a list of object names, shortened so that a mod full of them stays readable -
+// objects that share a name are counted instead of naming one of them for all
+function objectNames(names, count) {
+  let list = names[0];
+  if(names.length > 3)
+    list = `${names.slice(0, 3).join(', ')} and ${names.length-3} more`;
+  else if(names.length > 1)
+    list = `${names.slice(0, -1).join(', ')} and ${names[names.length-1]}`;
+  return names.length == 1 && count > 1 ? `${count}× ${list}` : list;
+}
+
+function importWarnings(imp) {
+  for(const group of Object.values(imp.warningGroups))
+    warn(imp, group.message(objectNames(group.names, group.count), group.count));
+  if(imp.suppressedWarnings)
+    imp.warnings.push(`${imp.suppressedWarnings} more note${imp.suppressedWarnings > 1 ? 's are' : ' is'} not listed here.`);
+  return imp.warnings;
+}
+
+// 'The 1 decal' - a note about how many of something a save has counts only when
+// there is more than one of it
+function many(count, singular, plural) {
+  return count > 1 ? `The ${count} ${plural}` : `The ${singular}`;
+}
+
+// what an object that exists in 3D only is called in a note
+function invisibleLabel(name) {
+  if(name.match(/^Custom_PDF/))
+    return 'A PDF';
+  if(name.match(/^Custom_Audio/))
+    return 'An audio player';
+  if(name.match(/^Fog/))
+    return 'A hidden zone';
+  if(name.match(/^Tileset_/))
+    return '3D scenery';
+  if(name.match(/Trigger$/))
+    return 'A zone';
+  return `An object of type "${name}"`;
+}
+
+// scripting is the one thing a mod can be built on that has no counterpart at all
+const scriptWarning = 'This mod is scripted (Lua/XML UI) - VirtualTabletop cannot run that script, so everything it automated has to be done by hand.';
 
 const imgSizeCache = {};
 async function imgSize(url, imp) {
@@ -222,6 +302,7 @@ function place(o, widget) {
 async function addDeck(o, imp, parent=null) {
   const cardIDs = (o.DeckIDs || [ o.CardID ]).map(extractNumber).filter(id=>!isNaN(+id) && o.CustomDeck[Math.floor(+id/100)]);
   if(!cardIDs.length) {
+    warnAbout(imp, 'deck without images', o, (names, count)=>`The card images of ${names} are not part of the save, so ${count > 1 ? 'those decks were' : 'that deck was'} not imported.`);
     Logging.log(`TTS import: skipping ${o.Name} (${o.GUID}): no card refers to an existing CustomDeck entry`);
     return null;
   }
@@ -368,8 +449,12 @@ async function addBag(o, imp, parent) {
   // the cards of a stack live in its pile and a deck is invisible: what a player
   // gets out of the bag are the widgets that sit in the holder itself
   const children = Object.values(contents).filter(w=>w.parent == id && w.type != 'deck');
-  if(!children.length)
-    return null; // a bag that is empty after the import is nothing to play with
+  if(!children.length) {
+    // a bag that is empty after the import is nothing to play with
+    if(Array.isArray(o.ContainedObjects) && o.ContainedObjects.length)
+      warnAbout(imp, 'empty bag', o, (names, count)=>`Nothing that ${names} holds could be imported, so ${count > 1 ? 'those bags are' : 'that bag is'} not on the table.`);
+    return null;
+  }
 
   const color = toColor(o.ColorDiffuse, '#a97e4b');
   const bagID = `${id}-bag`;
@@ -443,6 +528,9 @@ async function addImage(o, imp, parent) {
 
   const [ imageWidth, imageHeight ] = await imgSize(image, imp);
   const aspect = imageWidth && imageHeight ? imageWidth/imageHeight : 1;
+
+  if(imp.failedImages[image])
+    warnAbout(imp, 'unreadable image', o, (names, count)=>`The image of ${names} could not be read from the server it is stored on - ${count > 1 ? 'those objects are' : 'that object is'} square instead of having the shape of the image.`);
 
   const widget = {
     id: getID(o, imp),
@@ -575,8 +663,15 @@ function addNotecard(o, imp, parent) {
 function addPiece(o, imp, parent) {
   const name = String(o.Name || '');
   const text = String(o.Nickname || '').trim();
-  if(!text && !name.match(pieceObjects))
+  const mesh = o.CustomMesh || name.match(/^Custom_(Model|Assetbundle)/);
+  if(!text && !name.match(pieceObjects)) {
+    if(mesh)
+      warnAbout(imp, 'unnamed mesh', o, (names, count)=>`${names} ${count > 1 ? 'are 3D models' : 'is a 3D model'} without a name and without an image - ${count > 1 ? 'they were' : 'it was'} left out, as an unnamed model is usually decoration of the TTS table.`);
     return null;
+  }
+
+  if(mesh)
+    warnAbout(imp, 'mesh as piece', o, (names, count)=>`${names} ${count > 1 ? 'are 3D models' : 'is a 3D model'} that cannot be shown in 2D - ${count > 1 ? 'they are on the table as colored pieces carrying their names' : 'it is on the table as a colored piece carrying its name'}.`);
 
   const size = clamp(Math.round(baseSize.piece * transformOf(o).scaleX), 40, 400);
   const color = toColor(o.ColorDiffuse, '#cccccc');
@@ -601,8 +696,16 @@ function addPiece(o, imp, parent) {
 async function addObject(o, imp, parent) {
   const name = String(o.Name || '');
 
-  if(name.match(invisibleObjects))
+  if(name.match(invisibleObjects)) {
+    // the hand zones are not lost - they become the seats
+    if(name != 'HandTrigger')
+      warnAbout(imp, `invisible ${name}`, o, (names, count)=>`${invisibleLabel(name)} cannot be shown on a 2D table: ${names} ${count > 1 ? 'were' : 'was'} not imported.`);
     return null;
+  }
+  if(String(o.LuaScript || '').trim() || String(o.XmlUI || '').trim())
+    warn(imp, scriptWarning);
+  if(o.States && Object.keys(o.States).length)
+    warnAbout(imp, 'object states', o, (names, count)=>`${names} ${count > 1 ? 'have' : 'has'} several states in TTS - only the state that was on the table was imported.`);
   if(o.CustomDeck)
     return await addDeck(o, imp, parent);
   if(name.match(/Bag$/))
@@ -647,6 +750,7 @@ async function addRecursive(os, imp, parent=null) {
       }
     } catch(e) {
       // one broken object should not fail the whole import
+      warnAbout(imp, 'broken object', o, (names, count)=>`${names} could not be converted and ${count > 1 ? 'were' : 'was'} left out.`);
       Logging.log(`TTS import: skipping ${o.Name} (${o.GUID}): ${e.toString()}`);
     }
   }
@@ -722,7 +826,7 @@ function scaleWidget(widget, factor, keepPosition) {
   }
 }
 
-function moveIntoBounds(widgets, top, bottom) {
+function moveIntoBounds(widgets, imp, top, bottom) {
   let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
 
   const byParent = {};
@@ -756,9 +860,11 @@ function moveIntoBounds(widgets, top, bottom) {
 
   // 3. Make every widget smaller by that factor, children included: their x/y is
   //    relative to their parent and shrinks with the rest of the layout.
-  if(scale < 1)
+  if(scale < 1) {
+    warn(imp, `The table of this mod is bigger than the VirtualTabletop surface, so everything on it was scaled down to ${Math.round(scale*100)}% of the size it has in TTS.`);
     for(const widget of Object.values(widgets))
       scaleWidget(widget, scale, !widget.parent);
+  }
 
   // 4. Put the top level widgets where the scaled down layout has them
   for(const { widget, box, full } of placed) {
@@ -780,6 +886,38 @@ function moveIntoBounds(widgets, top, bottom) {
   }
 
   return widgets;
+}
+
+// Parts of a save that are not objects on the table and therefore never reach
+// addObject: the notebook, the table itself and the settings around it.
+function reportSaveContents(json, imp, seats) {
+  if(String(json.LuaScript || '').trim() || String(json.XmlUI || '').trim())
+    warn(imp, scriptWarning);
+
+  const pages = Object.keys(json.TabStates || {}).length;
+  if(pages)
+    warn(imp, `The notebook of this mod (${pages} page${pages > 1 ? 's' : ''}) was not imported - VirtualTabletop keeps rules text in the game details instead.`);
+
+  const snapPoints = (json.SnapPoints || []).length;
+  if(snapPoints)
+    warn(imp, `${many(snapPoints, 'snap point of the table was', 'snap points of the table were')} not imported - objects can be dropped anywhere, and only a holder keeps them in place.`);
+
+  const decals = (json.Decals || []).length;
+  if(decals)
+    warn(imp, `${many(decals, 'decal on the table was', 'decals on the table were')} not imported.`);
+
+  const drawn = (json.VectorLines || []).length;
+  if(drawn)
+    warn(imp, `${many(drawn, 'line drawn on the table was', 'lines drawn on the table were')} not imported.`);
+
+  if((json.Turns || {}).Enable)
+    warn(imp, 'The turn order of this mod was not imported - whose turn it is has to be agreed on by the players.');
+
+  if(seats > 1)
+    warn(imp, `VirtualTabletop has one hand for all players instead of one zone each: the ${seats} hand zones became seats, and every player sees their own cards in the hand at the bottom.`);
+
+  if([ ...collectImageURLs(json.ObjectStates) ].some(url=>url.match(/^https?:/)))
+    warn(imp, 'The images of this game are still loaded from the servers they are stored on - they disappear from the table if the mod is taken down there.');
 }
 
 async function convertTTS(content, linkContent, workshop={}) {
@@ -807,7 +945,9 @@ async function convertTTS(content, linkContent, workshop={}) {
   const hasHand = handColors.length || json.Hands && json.Hands.Enable;
 
   // leave room for the seats at the top and the hand at the bottom
-  const widgets = moveIntoBounds(await addRecursive(json.ObjectStates, imp), handColors.length ? 50 : 0, hasHand ? 810 : 1000);
+  const widgets = moveIntoBounds(await addRecursive(json.ObjectStates, imp), imp, handColors.length ? 50 : 0, hasHand ? 810 : 1000);
+
+  reportSaveContents(json, imp, handColors.length);
 
   if(json.TableURL) {
     widgets.back = {
@@ -869,6 +1009,12 @@ async function convertTTS(content, linkContent, workshop={}) {
   // the name of the save wins over the title of the workshop item it came from
   if(json.SaveName)
     info.name = String(json.SaveName);
+
+  const warnings = importWarnings(imp);
+  if(warnings.length) {
+    info.importerWarnings = warnings;
+    Logging.log(`TTS import: ${warnings.length} import notes: ${warnings.join(' ')}`);
+  }
 
   widgets._meta = { info, version: 5 };
 

--- a/server/ttsimport.mjs
+++ b/server/ttsimport.mjs
@@ -26,6 +26,7 @@ const baseSize = {
 // colors that hand zones (and therefore VTT seats) are defined for.
 const diceSides = { Die_4: 4, Die_6: 6, Die_6_Rounded: 6, Die_8: 8, Die_10: 10, Die_12: 12, Die_20: 20, Die_Piecepack: 6 };
 const customDiceSides = [ 4, 6, 8, 10, 12, 20 ];
+const diceShapes = [ 2, 4, 6, 8, 10, 12, 20 ];
 const playerColors = {
   White:  '#ffffff',
   Brown:  '#703a16',
@@ -136,6 +137,17 @@ function transformOf(o) {
   };
 }
 
+// The faces of a rollable object, or null if it isn't one. Numeric labels stay
+// numbers so that they are rendered like the faces of a regular die.
+function rotationValues(o) {
+  if(!Array.isArray(o.RotationValues) || o.RotationValues.length < 2)
+    return null;
+  return o.RotationValues.map(r=>{
+    const value = String((r || {}).Value === undefined ? '' : r.Value).trim();
+    return value !== '' && !isNaN(+value) ? +value : value;
+  });
+}
+
 function isFaceDown(o) {
   const rotZ = (transformOf(o).rotZ % 360 + 360) % 360;
   return rotZ > 90 && rotZ < 270;
@@ -151,6 +163,10 @@ function toColor(color, fallback=null) {
 function contrastColor(hex) {
   const [ r, g, b ] = [ 1, 3, 5 ].map(i=>parseInt(hex.substr(i, 2), 16) || 0);
   return r*0.3 + g*0.6 + b*0.1 > 128 ? '#000000' : '#ffffff';
+}
+
+function shade(hex, factor) {
+  return '#' + [ 1, 3, 5 ].map(i=>clamp(Math.round((parseInt(hex.substr(i, 2), 16) || 0) * factor), 0, 255).toString(16).padStart(2, '0')).join('');
 }
 
 // Positions the widget where the object was on the TTS table: x/y are the center
@@ -313,50 +329,61 @@ async function addDeck(o, parent=null) {
   return widgets;
 }
 
-// A bag becomes a holder that is hidden until its button is clicked - and hides
-// itself again when it is clicked. Bags can hold anything in TTS, so unlike a
-// regular holder this one accepts every widget type.
+// A bag becomes a button in the shape of a bag that carries the bag's name, with
+// a holder for the contents inside it. Clicking the button toggles whether the
+// contents are shown. The holder is a child of the button so that the two always
+// stay together, and it accepts every widget type because bags can hold anything
+// in TTS.
 async function addBag(o, parent) {
-  const widgets = {};
   const id = getID(o);
+  const contents = await addRecursive(o.ContainedObjects, id);
+  if(!Object.keys(contents).length)
+    return null; // a bag that is empty after the import is nothing to play with
 
-  widgets[id] = place(o, {
-    id,
-    parent,
-    type: 'holder',
-    width: 120,
-    height: 170,
-    dropTarget: {},
-    owner: [],
-    clickable: true,
-    clickRoutine: [
-      {
-        func: 'SET',
-        collection: [ id ],
-        property: 'owner',
-        value: []
-      }
-    ]
-  });
+  const color = toColor(o.ColorDiffuse, '#a97e4b');
+  const bagID = `${id}-bag`;
+  const widgets = {};
 
-  widgets[`${id}-toggle`] = place(o, {
-    id: `${id}-toggle`,
+  widgets[bagID] = place(o, {
+    id: bagID,
     parent,
     type: 'button',
-    width: 120,
-    height: 40,
-    text: o.Nickname || 'Open\nBag',
+    width: 130,
+    height: 54,
+    text: String(o.Nickname || '').trim() || 'Bag',
+    backgroundColor: color,
+    borderColor: shade(color, 0.6),
+    textColor: contrastColor(color),
+    borderRadius: '20px 20px 6px 6px',
+    css: 'padding: 2px 4px; font-size: 11px; line-height: 1.15',
     clickRoutine: [
       {
-        func: 'SET',
-        collection: [ id ],
-        property: 'owner'
+        func: 'IF',
+        operand1: `\${PROPERTY owner OF ${id}}`,
+        relation: '==',
+        operand2: null,
+        thenRoutine: [ { func: 'SET', collection: [ id ], property: 'owner', value: [] } ],
+        elseRoutine: [ { func: 'SET', collection: [ id ], property: 'owner' } ]
       }
     ]
   });
 
-  if(o.ContainedObjects)
-    Object.assign(widgets, await addRecursive(o.ContainedObjects, id));
+  widgets[id] = {
+    id,
+    parent: bagID,
+    type: 'holder',
+    x: -4,
+    y: 50,
+    width: 130,
+    height: 190,
+    borderRadius: '0 0 6px 6px',
+    color: '#ffffffdd',
+    css: `border: 2px solid ${shade(color, 0.6)}`,
+    dropTarget: {},
+    owner: []
+  };
+
+  Object.assign(widgets, contents);
   return widgets;
 }
 
@@ -414,13 +441,23 @@ async function addImage(o, parent) {
 }
 
 function addDice(o, parent) {
-  let sides = diceSides[String(o.Name || '')];
-  if(o.CustomImage && o.CustomImage.CustomDice)
-    sides = customDiceSides[number(o.CustomImage.CustomDice.Type, 1)];
-  if(!(sides > 1))
-    sides = 6;
+  // TTS gives every object that can be rolled a RotationValues list: one entry per
+  // face with the value that is up in that rotation. That is the only way to know
+  // the faces of a die that is just a mesh (Custom_Model), and it also gives the
+  // real labels of dice that don't simply count from 1.
+  let faces = rotationValues(o);
+  if(!faces) {
+    let sides = diceSides[String(o.Name || '')];
+    if(o.CustomImage && o.CustomImage.CustomDice)
+      sides = customDiceSides[number(o.CustomImage.CustomDice.Type, 1)];
+    if(!(sides > 1))
+      sides = 6;
+    faces = Array.from({ length: sides }, (unused, i)=>i+1);
+  }
 
+  const hasLabels = faces.some(f=>typeof f == 'string');
   const size = clamp(Math.round(baseSize.dice * transformOf(o).scaleX), 40, 200);
+
   const widget = {
     id: getID(o),
     parent,
@@ -429,9 +466,17 @@ function addDice(o, parent) {
     height: size,
     movable: true,
     color: toColor(o.ColorDiffuse, 'white'),
-    faces: Array.from({ length: sides }, (unused, i)=>i+1),
-    shape3d: true
+    faces
   };
+
+  // the face font is sized for a single digit, so word labels like 'Blue' need a
+  // smaller one to stay inside the face
+  if(hasLabels)
+    widget.faceCSS = `font-size: ${Math.round(size/4)}px; overflow: hidden`;
+
+  // the 3D shapes only exist for these face counts - anything else stays flat
+  if(diceShapes.indexOf(faces.length) > -1)
+    widget.shape3d = true;
 
   return { [widget.id]: place(o, widget) };
 }
@@ -519,6 +564,8 @@ async function addObject(o, parent) {
     return await addRecursive(o.ContainedObjects, parent); // a stack of tokens/tiles or an unknown container
   if(o.CustomImage && o.CustomImage.ImageURL)
     return await addImage(o, parent);
+  if(rotationValues(o))
+    return addDice(o, parent); // a mesh that can be rolled, e.g. a Custom_Model die
   return addPiece(o, parent);
 }
 

--- a/server/ttsimport.mjs
+++ b/server/ttsimport.mjs
@@ -1,37 +1,110 @@
-import fs from 'fs';
-import path from 'path';
 import JSZip from 'jszip';
 import fetch from 'node-fetch';
 import { BSON } from 'bson';
 
 import Logging from './logging.mjs';
 
+// A TTS unit is about an inch, which is 50px on the VTT surface (a poker card is
+// 3.5 units / 160px high). TTS tables are much bigger than the VTT surface, so
+// the layout gets scaled down into the visible area by moveIntoBounds afterwards.
+const pixelsPerUnit = 50;
+
+// TTS objects are 3D meshes and planes without a size we could read, so these
+// are the on-table footprints (in pixels, for an object at TTS scale 1) that
+// come closest to how big the objects look in TTS. They are multiplied with the
+// scale of the object.
+const baseSize = {
+  board:    600,
+  tile:     150,
+  token:    100,
+  figurine:  60,
+  dice:      50,
+  piece:     50
+};
+
+// TTS dice objects, the values of CustomImage.CustomDice.Type and the TTS player
+// colors that hand zones (and therefore VTT seats) are defined for.
+const diceSides = { Die_4: 4, Die_6: 6, Die_6_Rounded: 6, Die_8: 8, Die_10: 10, Die_12: 12, Die_20: 20, Die_Piecepack: 6 };
+const customDiceSides = [ 4, 6, 8, 10, 12, 20 ];
+const playerColors = {
+  White:  '#ffffff',
+  Brown:  '#703a16',
+  Red:    '#da1917',
+  Orange: '#f3631c',
+  Yellow: '#e6e42d',
+  Green:  '#31b32b',
+  Teal:   '#21b198',
+  Blue:   '#118ed7',
+  Purple: '#9741da',
+  Pink:   '#f570ce',
+  Grey:   '#808080',
+  Black:  '#404040'
+};
+
+// objects that only make sense in 3D: invisible zones and objects that are
+// nothing but a mesh, a sound or a PDF
+const invisibleObjects = /Trigger$|^(Fog|Custom_PDF|Custom_Audio|Tileset_)/;
+const pieceObjects = /^(Backgammon|Block|Checker|Chess|Chinese_Checkers_Piece|Chip|Coin|Domino|Figurine|Mahjong|Pawn|PlayerPawn|go_game_piece|reversi)/;
+const roundPieces = /^(Backgammon|Checker|Chip|Coin|PlayerPawn|go_game_piece|reversi)/;
+
 const imgSizeCache = {};
 async function imgSize(url) {
   if(imgSizeCache[url])
     return imgSizeCache[url];
 
-  const r = await fetch(url, { headers: { 'Range': 'bytes=0-40000' } });
-  const buffer = await r.buffer();
-  fs.writeFileSync('/tmp/out', buffer);
-  if(buffer.toString('ascii', 1, 4) == 'PNG')
-    return imgSizeCache[url] = [ buffer.readUInt32BE(16), buffer.readUInt32BE(20) ];
-  for(let offset=4; offset<buffer.length; offset+=2) {
-    offset += buffer.readUInt16BE(offset);
-    if([ 0xC0, 0xC1, 0xC2 ].indexOf(buffer[offset+1])>-1)
-      return imgSizeCache[url] = [ buffer.readUInt16BE(offset+7), buffer.readUInt16BE(offset+5) ];
+  try {
+    const r = await fetch(url, { headers: { 'Range': 'bytes=0-40000' } });
+    const buffer = await r.buffer();
+    if(buffer.toString('ascii', 1, 4) == 'PNG')
+      return imgSizeCache[url] = [ buffer.readUInt32BE(16), buffer.readUInt32BE(20) ];
+    for(let offset=4; offset<buffer.length; offset+=2) {
+      offset += buffer.readUInt16BE(offset);
+      if([ 0xC0, 0xC1, 0xC2 ].indexOf(buffer[offset+1])>-1)
+        return imgSizeCache[url] = [ buffer.readUInt16BE(offset+7), buffer.readUInt16BE(offset+5) ];
+    }
+  } catch(e) {
+    Logging.log(`TTS import: could not read the dimensions of ${url}: ${e.toString()}`);
   }
   return imgSizeCache[url] = [ 1, 1 ];
 }
 
+function collectImageURLs(objects, urls=new Set()) {
+  for(const o of objects || []) {
+    if(o && typeof o == 'object') {
+      for(const deck of Object.values(o.CustomDeck || {}))
+        urls.add(processURL(deck.FaceURL));
+      if(o.CustomImage && o.CustomImage.ImageURL)
+        urls.add(processURL(o.CustomImage.ImageURL));
+      collectImageURLs(o.ContainedObjects, urls);
+    }
+  }
+  return urls;
+}
+
+// The images are only downloaded for their dimensions - a game can reference
+// hundreds of them, so fill the cache with a couple of parallel requests instead
+// of blocking the conversion of every single object on its own request.
+async function prefetchImageSizes(objects) {
+  const queue = [ ...collectImageURLs(objects) ].filter(url=>url && !imgSizeCache[url]);
+  await Promise.all(Array.from({ length: 16 }, async _=>{
+    while(queue.length)
+      await imgSize(queue.shift());
+  }));
+}
+
 function processURL(url) {
-  const match = url.match(/\/ugc\/[0-9]+\/[0-9A-F]+\//);
-  return match ? `https://steamusercontent-a.akamaihd.net${match[0]}` : url.replace(/^http:/, 'https:');
+  const match = String(url || '').match(/\/ugc\/[0-9]+\/[0-9A-F]+\//);
+  return match ? `https://steamusercontent-a.akamaihd.net${match[0]}` : String(url || '').replace(/^http:/, 'https:');
 }
 
 let nextID = 1;
+let usedIDs = new Set();
 function getID(o) {
-  return o.GUID || nextID++;
+  let id = String(o.GUID || nextID++);
+  while(usedIDs.has(id))
+    id = `${id}-${nextID++}`;
+  usedIDs.add(id);
+  return id;
 }
 
 function extractNumber(property) {
@@ -41,8 +114,76 @@ function extractNumber(property) {
     return property;
 }
 
+function number(property, fallback) {
+  const n = +extractNumber(property);
+  return isNaN(n) ? fallback : n;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function transformOf(o) {
+  const t = o.Transform || {};
+  return {
+    posX:   number(t.posX, 0),
+    posY:   number(t.posY, 0),
+    posZ:   number(t.posZ, 0),
+    rotY:   number(t.rotY, 0),
+    rotZ:   number(t.rotZ, 0),
+    scaleX: number(t.scaleX, 1) || 1,
+    scaleZ: number(t.scaleZ, 1) || 1
+  };
+}
+
+function isFaceDown(o) {
+  const rotZ = (transformOf(o).rotZ % 360 + 360) % 360;
+  return rotZ > 90 && rotZ < 270;
+}
+
+function toColor(color, fallback=null) {
+  if(typeof color != 'object' || color === null)
+    return fallback;
+  const channel = c=>clamp(Math.round(number(c, 0)*255), 0, 255).toString(16).padStart(2, '0');
+  return `#${channel(color.r)}${channel(color.g)}${channel(color.b)}`;
+}
+
+function contrastColor(hex) {
+  const [ r, g, b ] = [ 1, 3, 5 ].map(i=>parseInt(hex.substr(i, 2), 16) || 0);
+  return r*0.3 + g*0.6 + b*0.1 > 128 ? '#000000' : '#ffffff';
+}
+
+// Positions the widget where the object was on the TTS table: x/y are the center
+// of the object, the height above the table becomes the stacking order and the
+// rotation around the vertical axis becomes the widget rotation. TTS spawns most
+// objects rotated by 180° (facing the camera), so only the part of the rotation
+// that actually turns the object on the table is kept.
+function place(o, widget) {
+  const t = transformOf(o);
+
+  let rotation = (t.rotY % 180 + 180) % 180;
+  if(rotation > 90)
+    rotation -= 180;
+  if(Math.round(rotation))
+    widget.rotation = Math.round(rotation);
+
+  if(widget.parent)
+    return widget;
+
+  widget.x = Math.round(800 + t.posX*pixelsPerUnit - (widget.width  || 0)/2);
+  widget.y = Math.round(500 - t.posZ*pixelsPerUnit - (widget.height || 0)/2);
+  if(t.posY > 0)
+    widget.z = Math.round(t.posY*10);
+
+  return widget;
+}
+
 async function addDeck(o, parent=null) {
-  const firstDeckID = Math.floor(extractNumber((o.DeckIDs || [ o.CardID ])[0])/100);
+  const cardIDs = (o.DeckIDs || [ o.CardID ]).map(extractNumber).filter(id=>!isNaN(+id) && o.CustomDeck[Math.floor(+id/100)]);
+  if(!cardIDs.length)
+    return null;
+
+  const firstDeckID = Math.floor(cardIDs[0]/100);
 
   let [ deckWidth, deckHeight ] = await imgSize(processURL(o.CustomDeck[firstDeckID].FaceURL));
 
@@ -122,8 +263,7 @@ async function addDeck(o, parent=null) {
   };
 
   const cardCounts = {};
-  for(let cardID of o.DeckIDs || [ o.CardID ]) {
-    cardID = extractNumber(cardID);
+  for(const cardID of cardIDs) {
     const deckID = Math.floor(cardID/100);
     const offset = cardID%100;
 
@@ -148,114 +288,291 @@ async function addDeck(o, parent=null) {
       type: 'card',
       parent: `${id}-pile`,
       deck: id,
-      cardType: cardID
+      cardType: String(cardID)
     };
+    if(!isFaceDown(o))
+      widgets[`${id}-${cardID}-${i}`].activeFace = 1;
   }
   if(Object.keys(widgets).length > 2) {
-    widgets[`${id}-pile`] = {
+    widgets[`${id}-pile`] = place(o, {
       id: `${id}-pile`,
       parent,
       type: 'pile',
-      width: cardWidth,
-      height: cardHeight,
-      x: 800+extractNumber(o.Transform.posX)*25,
-      y: 500-extractNumber(o.Transform.posZ)*25,
-    };
+      width: Math.round(cardWidth),
+      height: Math.round(cardHeight)
+    });
   } else {
-    for(const widget in widgets) {
-      if(widgets[widget].type != 'deck') {
-        widgets[widget].x = 800+extractNumber(o.Transform.posX)*25;
-        widgets[widget].y = 500+extractNumber(o.Transform.posZ)*25;
-        widgets[widget].parent = parent;
-      }
-    }
+    // a single card doesn't need a pile - place it on the table directly
+    const position = place(o, { parent, width: Math.round(cardWidth), height: Math.round(cardHeight) });
+    delete position.width;
+    delete position.height;
+    for(const widget of Object.values(widgets))
+      Object.assign(widget, position);
   }
   widgets[id] = deck;
   return widgets;
 }
 
+// A bag becomes a holder that is hidden until its button is clicked - and hides
+// itself again when it is clicked. Bags can hold anything in TTS, so unlike a
+// regular holder this one accepts every widget type.
 async function addBag(o, parent) {
   const widgets = {};
-  widgets[o.GUID] = {
-    id: o.GUID,
+  const id = getID(o);
+
+  widgets[id] = place(o, {
+    id,
     parent,
     type: 'holder',
+    width: 120,
+    height: 170,
+    dropTarget: {},
     owner: [],
     clickable: true,
     clickRoutine: [
       {
         func: 'SET',
-        collection: [ o.GUID ],
+        collection: [ id ],
         property: 'owner',
         value: []
       }
     ]
-  };
-  widgets[`${o.GUID}-toggle`] = {
-    id: `${o.GUID}-toggle`,
+  });
+
+  widgets[`${id}-toggle`] = place(o, {
+    id: `${id}-toggle`,
     parent,
     type: 'button',
+    width: 120,
+    height: 40,
+    text: o.Nickname || 'Open\nBag',
     clickRoutine: [
       {
         func: 'SET',
-        collection: [ o.GUID ],
+        collection: [ id ],
         property: 'owner'
       }
-    ],
-    x: 800+extractNumber(o.Transform.posX)*25,
-    y: 500-extractNumber(o.Transform.posZ)*25,
-    text: o.Nickname || 'Open\nBag'
-  };
+    ]
+  });
+
   if(o.ContainedObjects)
-    Object.assign(widgets, await addRecursive(o.ContainedObjects, o.GUID));
+    Object.assign(widgets, await addRecursive(o.ContainedObjects, id));
   return widgets;
+}
+
+async function addImage(o, parent) {
+  const name = String(o.Name || '');
+  const image = processURL(o.CustomImage.ImageURL);
+  const back = o.CustomImage.ImageSecondaryURL ? processURL(o.CustomImage.ImageSecondaryURL) : null;
+  const t = transformOf(o);
+
+  let base = baseSize.tile;
+  if(name.match(/^Custom_Board/))
+    base = baseSize.board;
+  else if(name.match(/^Custom_Token/))
+    base = baseSize.token;
+  else if(name.match(/^Figurine/))
+    base = baseSize.figurine * number(o.CustomImage.ImageScalar, 1);
+
+  const [ imageWidth, imageHeight ] = await imgSize(image);
+  const aspect = imageWidth && imageHeight ? imageWidth/imageHeight : 1;
+
+  const widget = {
+    id: getID(o),
+    parent,
+    width:  clamp(Math.round(base * t.scaleX * (aspect < 1 ? aspect : 1)), 8, 1600),
+    height: clamp(Math.round(base * t.scaleZ / (aspect > 1 ? aspect : 1)), 8, 1000),
+    color: 'transparent',
+    image
+  };
+
+  const tile = o.CustomImage.CustomTile;
+  if(tile) {
+    // Box, Hex, Circle and Rounded custom tiles - the outline is all that can be kept
+    if(number(tile.Type, 0) == 1)
+      widget.css = 'clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%)';
+    if(number(tile.Type, 0) == 2)
+      widget.borderRadius = '50%';
+    if(number(tile.Type, 0) == 3)
+      widget.borderRadius = 12;
+  }
+
+  if(back) {
+    widget.faces = [ { image }, { image: back } ];
+    widget.activeFace = isFaceDown(o) ? 1 : 0;
+  }
+
+  if(o.Locked)
+    widget.movable = false;
+
+  // locked and really big objects are the board and the background of a TTS table:
+  // put them below the cards and pieces instead of on top of them
+  if(o.Locked || name.match(/^Custom_Board/) || widget.width > 400 && widget.height > 400)
+    widget.layer = -4;
+
+  return { [widget.id]: place(o, widget) };
+}
+
+function addDice(o, parent) {
+  let sides = diceSides[String(o.Name || '')];
+  if(o.CustomImage && o.CustomImage.CustomDice)
+    sides = customDiceSides[number(o.CustomImage.CustomDice.Type, 1)];
+  if(!(sides > 1))
+    sides = 6;
+
+  const size = clamp(Math.round(baseSize.dice * transformOf(o).scaleX), 40, 200);
+  const widget = {
+    id: getID(o),
+    parent,
+    type: 'dice',
+    width: size,
+    height: size,
+    movable: true,
+    color: toColor(o.ColorDiffuse, 'white'),
+    faces: Array.from({ length: sides }, (unused, i)=>i+1),
+    shape3d: true
+  };
+
+  return { [widget.id]: place(o, widget) };
+}
+
+function addText(o, parent) {
+  const text = String((o.Text || {}).Text || '').trim();
+  if(!text)
+    return null;
+
+  const lines = text.split('\n');
+  const fontSize = clamp(Math.round(number((o.Text || {}).fontSize, 64) * 0.35 * transformOf(o).scaleX), 10, 72);
+  const widget = {
+    id: getID(o),
+    parent,
+    type: 'label',
+    text,
+    width:  clamp(Math.round(fontSize*0.62*Math.max(...lines.map(l=>l.length))), 40, 800),
+    height: Math.round(lines.length*fontSize*1.3),
+    css: `font-size: ${fontSize}px; color: ${toColor((o.Text || {}).colorstate, '#6d6d6d')}`
+  };
+
+  return { [widget.id]: place(o, widget) };
+}
+
+function addNotecard(o, parent) {
+  const text = [ String(o.Nickname || '').trim(), String(o.Description || '').trim() ].filter(t=>t).join('\n\n');
+  const widget = {
+    id: getID(o),
+    parent,
+    type: 'label',
+    text,
+    width: 240,
+    height: 160,
+    movable: true,
+    css: 'background: #fdf8d8; color: #333333; border-radius: 4px; font-size: 13px'
+  };
+
+  return { [widget.id]: place(o, widget) };
+}
+
+// Meshes, asset bundles and the built-in 3D pieces have no 2D representation at
+// all, so they become plain colored pieces carrying their name. Unnamed ones are
+// usually decoration of the 3D table and are left out.
+function addPiece(o, parent) {
+  const name = String(o.Name || '');
+  const text = String(o.Nickname || '').trim();
+  if(!text && !name.match(pieceObjects))
+    return null;
+
+  const size = clamp(Math.round(baseSize.piece * transformOf(o).scaleX), 40, 400);
+  const color = toColor(o.ColorDiffuse, '#cccccc');
+  const widget = {
+    id: getID(o),
+    parent,
+    width: size,
+    height: size,
+    color,
+    borderRadius: name.match(roundPieces) ? '50%' : 8,
+    text,
+    css: `font-size: 10px; overflow: hidden; border: 1px solid #0006; color: ${contrastColor(color)}`
+  };
+
+  if(o.Locked)
+    widget.movable = false;
+
+  return { [widget.id]: place(o, widget) };
+}
+
+async function addObject(o, parent) {
+  const name = String(o.Name || '');
+
+  if(name.match(invisibleObjects))
+    return null;
+  if(o.CustomDeck)
+    return await addDeck(o, parent);
+  if(name.match(/Bag$/))
+    return await addBag(o, parent);
+  if(name == 'Custom_Dice' || name.match(/^Die_/))
+    return addDice(o, parent);
+  if(name == '3DText')
+    return addText(o, parent);
+  if(name == 'Notecard')
+    return addNotecard(o, parent);
+  if(Array.isArray(o.ContainedObjects) && o.ContainedObjects.length)
+    return await addRecursive(o.ContainedObjects, parent); // a stack of tokens/tiles or an unknown container
+  if(o.CustomImage && o.CustomImage.ImageURL)
+    return await addImage(o, parent);
+  return addPiece(o, parent);
 }
 
 async function addRecursive(os, parent=null) {
   const widgets = {};
 
-  for(const o of os) {
-    if(o.CustomDeck)
-      Object.assign(widgets, await addDeck(o, parent));
-    else if(o.Name == 'Bag')
-      Object.assign(widgets, await addBag(o, parent));
-    else if(o.ContainedObjects && o.Name != 'DeckCustom' && o.Name != 'Deck')
-      Object.assign(widgets, await addRecursive(o.ContainedObjects, parent));
+  for(const o of os || []) {
+    if(!o || typeof o != 'object')
+      continue;
+    try {
+      for(const widget of Object.values(await addObject(o, parent) || {})) {
+        if(!widget.parent)
+          delete widget.parent; // no parent is the default - don't spell it out
+        widgets[widget.id] = widget;
+      }
+    } catch(e) {
+      // one broken object should not fail the whole import
+      Logging.log(`TTS import: skipping ${o.Name} (${o.GUID}): ${e.toString()}`);
+    }
   }
 
   return widgets;
 }
 
-function moveIntoBounds(widgets) {
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+function moveIntoBounds(widgets, top, bottom) {
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
 
-    // 1. Find bounding box for all parent-less widgets
-    for (let key in widgets) {
-        let widget = widgets[key];
-        if (widget.parent) continue;
-        minX = Math.min(minX, (widget.x||0));
-        minY = Math.min(minY, (widget.y||0));
-        maxX = Math.max(maxX, (widget.x||0));
-        maxY = Math.max(maxY, (widget.y||0));
-    }
-
-    const visibleWidth = 1400;
-    const visibleHeight = (widgets.hand !== undefined) ? 600 : 800;
-
-    // 2. Adjust each widget's position based on its proportional distance from bounding box edge
-    for (let key in widgets) {
-        let widget = widgets[key];
-        if (widget.parent || key=='hand') continue;
-
-        // Proportional movement
-        let proportionX = (widget.x - minX) / (maxX - minX);
-        widget.x = 50 + proportionX * visibleWidth;
-
-        let proportionY = (widget.y - minY) / (maxY - minY);
-        widget.y = 50 + proportionY * visibleHeight;
-    }
-
+  // 1. Find bounding box for all parent-less widgets
+  for(const widget of Object.values(widgets)) {
+    if(widget.parent)
+      continue;
+    minX = Math.min(minX, widget.x || 0);
+    minY = Math.min(minY, widget.y || 0);
+    maxX = Math.max(maxX, (widget.x || 0) + (widget.width  || 0));
+    maxY = Math.max(maxY, (widget.y || 0) + (widget.height || 0));
+  }
+  if(minX > maxX)
     return widgets;
+
+  // 2. Shrink the layout until it fits onto the surface and center it there. The
+  //    layout is never stretched: objects that are next to each other in TTS
+  //    should stay next to each other instead of being spread over the table.
+  const scale = Math.min(1, 1500/(maxX-minX || 1), (bottom-top-40)/(maxY-minY || 1));
+  const offsetX =       (1600       - (maxX-minX)*scale)/2;
+  const offsetY = top + (bottom-top - (maxY-minY)*scale)/2;
+
+  for(const widget of Object.values(widgets)) {
+    if(widget.parent)
+      continue;
+    widget.x = clamp(Math.round(((widget.x || 0) - minX)*scale + offsetX),   0, Math.max(0,   1600 - (widget.width  || 0)));
+    widget.y = clamp(Math.round(((widget.y || 0) - minY)*scale + offsetY), top, Math.max(top, bottom - (widget.height || 0)));
+  }
+
+  return widgets;
 }
 
 async function convertTTS(content, linkContent) {
@@ -263,7 +580,6 @@ async function convertTTS(content, linkContent) {
 
   if(linkContent) {
     json = BSON.deserialize(linkContent);
-    fs.writeFileSync('/tmp/tts.json', JSON.stringify(json, null, '  '));
   } else {
     const zip = await JSZip.loadAsync(content);
     for(var file in zip.files)
@@ -271,11 +587,20 @@ async function convertTTS(content, linkContent) {
         json = JSON.parse(await zip.files[file].async('string'));
   }
 
-  const widgets = await addRecursive(json.ObjectStates);
+  usedIDs = new Set();
+  await prefetchImageSizes(json.ObjectStates);
+
+  const handColors = ((json.Hands || {}).HandTransforms || []).map(h=>String((h || {}).Color || '')).filter(c=>c);
+  const hasHand = handColors.length || json.Hands && json.Hands.Enable;
+
+  // leave room for the seats at the top and the hand at the bottom
+  const widgets = moveIntoBounds(await addRecursive(json.ObjectStates), handColors.length ? 50 : 0, hasHand ? 810 : 1000);
 
   if(json.TableURL) {
     widgets.back = {
       id: 'back',
+      x: 0,
+      y: 0,
       width: 1600,
       height: 1000,
       layer: -9,
@@ -285,7 +610,7 @@ async function convertTTS(content, linkContent) {
     };
   }
 
-  if(json.Hands && json.Hands.Enable) {
+  if(hasHand) {
     widgets.hand = {
       id: 'hand',
       type: 'holder',
@@ -302,6 +627,23 @@ async function convertTTS(content, linkContent) {
     };
   }
 
+  // TTS defines one hand zone per player color - VTT uses one hand for all
+  // players, so the colors become the seats that share it
+  handColors.forEach((color, index)=>{
+    widgets[`seat-${index+1}`] = {
+      id: `seat-${index+1}`,
+      type: 'seat',
+      index: index+1,
+      x: 20 + index*155,
+      y: 5,
+      width: 150,
+      height: 40,
+      color: playerColors[color] || '#999999',
+      colorEmpty: playerColors[color] || '#999999',
+      hideWhenUnused: true
+    };
+  });
+
   widgets._meta = {
     info: {
       name: json.SaveName,
@@ -311,7 +653,7 @@ async function convertTTS(content, linkContent) {
     version: 5
   };
 
-  return moveIntoBounds(widgets);
+  return widgets;
 }
 
 async function fromBSON(content) {

--- a/server/ttsimport.mjs
+++ b/server/ttsimport.mjs
@@ -49,12 +49,18 @@ const pieceObjects = /^(Backgammon|Block|Checker|Chess|Chinese_Checkers_Piece|Ch
 const roundPieces = /^(Backgammon|Checker|Chip|Coin|PlayerPawn|go_game_piece|reversi)/;
 
 const imgSizeCache = {};
+// The fallback for an image whose dimensions could not be read is remembered for
+// the current import only - a host that times out once should not keep every later
+// import of that image pinned to a 1:1 aspect ratio.
+let imgSizeFailed = {};
 async function imgSize(url) {
-  if(imgSizeCache[url])
-    return imgSizeCache[url];
+  if(imgSizeCache[url] || imgSizeFailed[url])
+    return imgSizeCache[url] || imgSizeFailed[url];
 
   try {
-    const r = await fetch(url, { headers: { 'Range': 'bytes=0-40000' } });
+    // only the first few KB are needed, but a host may ignore the Range header and
+    // send the whole image - don't wait or buffer indefinitely for that
+    const r = await fetch(url, { headers: { 'Range': 'bytes=0-40000' }, signal: AbortSignal.timeout(15000), size: 20000000 });
     const buffer = await r.buffer();
     if(buffer.toString('ascii', 1, 4) == 'PNG')
       return imgSizeCache[url] = [ buffer.readUInt32BE(16), buffer.readUInt32BE(20) ];
@@ -66,12 +72,12 @@ async function imgSize(url) {
   } catch(e) {
     Logging.log(`TTS import: could not read the dimensions of ${url}: ${e.toString()}`);
   }
-  return imgSizeCache[url] = [ 1, 1 ];
+  return imgSizeFailed[url] = [ 1, 1 ];
 }
 
 function collectImageURLs(objects, urls=new Set()) {
   for(const o of objects || []) {
-    if(o && typeof o == 'object') {
+    if(o && typeof o == 'object' && !String(o.Name || '').match(invisibleObjects)) {
       for(const deck of Object.values(o.CustomDeck || {}))
         urls.add(processURL(deck.FaceURL));
       if(o.CustomImage && o.CustomImage.ImageURL)
@@ -94,8 +100,9 @@ async function prefetchImageSizes(objects) {
 }
 
 function processURL(url) {
-  const match = String(url || '').match(/\/ugc\/[0-9]+\/[0-9A-F]+\//);
-  return match ? `https://steamusercontent-a.akamaihd.net${match[0]}` : String(url || '').replace(/^http:/, 'https:');
+  const u = String(url || '');
+  const match = u.match(/\/ugc\/[0-9]+\/[0-9A-F]+\//);
+  return match ? `https://steamusercontent-a.akamaihd.net${match[0]}` : u.replace(/^http:/, 'https:');
 }
 
 let nextID = 1;
@@ -196,8 +203,10 @@ function place(o, widget) {
 
 async function addDeck(o, parent=null) {
   const cardIDs = (o.DeckIDs || [ o.CardID ]).map(extractNumber).filter(id=>!isNaN(+id) && o.CustomDeck[Math.floor(+id/100)]);
-  if(!cardIDs.length)
+  if(!cardIDs.length) {
+    Logging.log(`TTS import: skipping ${o.Name} (${o.GUID}): no card refers to an existing CustomDeck entry`);
     return null;
+  }
 
   const firstDeckID = Math.floor(cardIDs[0]/100);
 
@@ -309,7 +318,8 @@ async function addDeck(o, parent=null) {
     if(!isFaceDown(o))
       widgets[`${id}-${cardID}-${i}`].activeFace = 1;
   }
-  if(Object.keys(widgets).length > 2) {
+  // widgets only holds the cards at this point - two of them still need a pile
+  if(Object.keys(widgets).length > 1) {
     widgets[`${id}-pile`] = place(o, {
       id: `${id}-pile`,
       parent,
@@ -593,14 +603,17 @@ async function addRecursive(os, parent=null) {
 function moveIntoBounds(widgets, top, bottom) {
   let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
 
+  // Widgets that are not on the surface at all: children move with their parent,
+  // and a deck is invisible and has no position. Counting a deck as a widget at
+  // (0, 0) would pull the whole bounding box to the origin.
+  const placed = Object.values(widgets).filter(w=>!w.parent && w.x !== undefined);
+
   // 1. Find bounding box for all parent-less widgets
-  for(const widget of Object.values(widgets)) {
-    if(widget.parent)
-      continue;
-    minX = Math.min(minX, widget.x || 0);
-    minY = Math.min(minY, widget.y || 0);
-    maxX = Math.max(maxX, (widget.x || 0) + (widget.width  || 0));
-    maxY = Math.max(maxY, (widget.y || 0) + (widget.height || 0));
+  for(const widget of placed) {
+    minX = Math.min(minX, widget.x);
+    minY = Math.min(minY, widget.y);
+    maxX = Math.max(maxX, widget.x + (widget.width  || 0));
+    maxY = Math.max(maxY, widget.y + (widget.height || 0));
   }
   if(minX > maxX)
     return widgets;
@@ -612,11 +625,14 @@ function moveIntoBounds(widgets, top, bottom) {
   const offsetX =       (1600       - (maxX-minX)*scale)/2;
   const offsetY = top + (bottom-top - (maxY-minY)*scale)/2;
 
-  for(const widget of Object.values(widgets)) {
-    if(widget.parent)
-      continue;
-    widget.x = clamp(Math.round(((widget.x || 0) - minX)*scale + offsetX),   0, Math.max(0,   1600 - (widget.width  || 0)));
-    widget.y = clamp(Math.round(((widget.y || 0) - minY)*scale + offsetY), top, Math.max(top, bottom - (widget.height || 0)));
+  for(const widget of placed) {
+    // a widget that is higher than the band between the seats and the hand cannot
+    // be kept inside it - a full table board is allowed to use the whole surface
+    const fits = (widget.height || 0) <= bottom-top;
+    const lo = fits ? top    : 0;
+    const hi = fits ? bottom : 1000;
+    widget.x = clamp(Math.round((widget.x - minX)*scale + offsetX),  0, Math.max(0,  1600 - (widget.width  || 0)));
+    widget.y = clamp(Math.round((widget.y - minY)*scale + offsetY), lo, Math.max(lo, hi   - (widget.height || 0)));
   }
 
   return widgets;
@@ -635,9 +651,16 @@ async function convertTTS(content, linkContent) {
   }
 
   usedIDs = new Set();
+  imgSizeFailed = {};
   await prefetchImageSizes(json.ObjectStates);
 
-  const handColors = ((json.Hands || {}).HandTransforms || []).map(h=>String((h || {}).Color || '')).filter(c=>c);
+  // Older saves list the hand zones in Hands.HandTransforms, newer ones store them
+  // as HandTrigger objects with the player color in FogColor. VTT uses one hand for
+  // all players, so only the set of colors matters - they become the seats.
+  const handColors = [ ...new Set([
+    ...((json.Hands || {}).HandTransforms || []).map(h=>String((h || {}).Color || '')),
+    ...(json.ObjectStates || []).map(o=>o && String(o.Name || '') == 'HandTrigger' ? String(o.FogColor || '') : '')
+  ].filter(c=>c)) ];
   const hasHand = handColors.length || json.Hands && json.Hands.Enable;
 
   // leave room for the seats at the top and the hand at the bottom
@@ -674,16 +697,19 @@ async function convertTTS(content, linkContent) {
     };
   }
 
-  // TTS defines one hand zone per player color - VTT uses one hand for all
-  // players, so the colors become the seats that share it
+  // The seats share one row above the table, so they get narrower when a game has
+  // hand zones for many of the twelve TTS player colors instead of running off the
+  // right edge of the surface.
+  const seatPitch = Math.min(155, Math.floor(1580/(handColors.length || 1)));
+
   handColors.forEach((color, index)=>{
     widgets[`seat-${index+1}`] = {
       id: `seat-${index+1}`,
       type: 'seat',
       index: index+1,
-      x: 20 + index*155,
+      x: 20 + index*seatPitch,
       y: 5,
-      width: 150,
+      width: seatPitch - 5,
       height: 40,
       color: playerColors[color] || '#999999',
       colorEmpty: playerColors[color] || '#999999',

--- a/tests/server/ttsimport.test.js
+++ b/tests/server/ttsimport.test.js
@@ -1,0 +1,182 @@
+import { BSON } from 'bson';
+
+import TTS from '../../server/ttsimport.mjs';
+
+// The importer only downloads images to read their dimensions, so the fixtures use
+// data URLs holding nothing but a PNG header: the tests never touch the network.
+function png(width, height) {
+  const header = Buffer.alloc(24);
+  header.write('\x89PNG\r\n\x1a\n', 0, 'binary');
+  header.write('IHDR', 12);
+  header.writeUInt32BE(width, 16);
+  header.writeUInt32BE(height, 20);
+  return `data:image/png;base64,${header.toString('base64')}`;
+}
+
+async function convert(save) {
+  const widgets = (await TTS.fromBSON(BSON.serialize(save))).TTS['0.json'];
+  delete widgets._meta;
+  return widgets;
+}
+
+function objects(...ObjectStates) {
+  return { SaveName: 'test', ObjectStates };
+}
+
+function die(GUID, posX) {
+  return { Name: 'Die_6', GUID, Transform: { posX, posZ: 0 } };
+}
+
+function deck(GUID, DeckIDs) {
+  return {
+    Name: 'DeckCustom',
+    GUID,
+    Transform: { posX: 0, posZ: 0 },
+    DeckIDs,
+    CustomDeck: { 1: { FaceURL: png(300, 400), BackURL: png(300, 400), NumWidth: 1, NumHeight: 1 } }
+  };
+}
+
+function typed(widgets, type) {
+  return Object.values(widgets).filter(w=>(w.type || 'basic') == type);
+}
+
+describe('TTS import: dice', () => {
+  it('turns anything with RotationValues into a die using those values as faces', async () => {
+    const widgets = await convert(objects({
+      Name: 'Custom_Model',
+      GUID: 'mesh',
+      Transform: { posX: 0, posZ: 0 },
+      RotationValues: [ 'Blue', 'Red', 'Green', 'Yellow', 'Black', 'Orange' ].map(Value=>({ Value }))
+    }));
+
+    expect(typed(widgets, 'dice').length).toBe(1);
+    expect(widgets.mesh.faces).toEqual([ 'Blue', 'Red', 'Green', 'Yellow', 'Black', 'Orange' ]);
+    expect(widgets.mesh.shape3d).toBe(true);
+  });
+
+  it('keeps numeric labels as numbers and stays flat for face counts without a 3D shape', async () => {
+    const widgets = await convert(objects({
+      Name: 'Custom_Model',
+      GUID: 'three',
+      Transform: { posX: 0, posZ: 0 },
+      RotationValues: [ { Value: '1' }, { Value: '2' }, { Value: '3' } ]
+    }));
+
+    expect(widgets.three.faces).toEqual([ 1, 2, 3 ]);
+    expect(widgets.three.shape3d).toBe(undefined);
+  });
+
+  it('falls back to the face count of a built-in die', async () => {
+    const widgets = await convert(objects({ Name: 'Die_20', GUID: 'd20', Transform: { posX: 0, posZ: 0 } }));
+    expect(widgets.d20.faces.length).toBe(20);
+  });
+});
+
+describe('TTS import: bags', () => {
+  it('skips bags that have no contents left after the import', async () => {
+    const widgets = await convert(objects(
+      { Name: 'Bag', GUID: 'empty', Transform: { posX: 0, posZ: 0 } },
+      { Name: 'Infinite_Bag', GUID: 'pdfsOnly', Transform: { posX: 2, posZ: 0 }, ContainedObjects: [ { Name: 'Custom_PDF', GUID: 'pdf' } ] }
+    ));
+
+    expect(Object.keys(widgets)).toEqual([]);
+  });
+
+  it('puts the holder of a bag inside the button that toggles it', async () => {
+    const widgets = await convert(objects({
+      Name: 'Custom_Model_Bag',
+      GUID: 'bag',
+      Nickname: 'Tokens',
+      Transform: { posX: 0, posZ: 0 },
+      ContainedObjects: [ die('inBag', 0) ]
+    }));
+
+    expect(widgets['bag-bag'].type).toBe('button');
+    expect(widgets['bag-bag'].text).toBe('Tokens');
+    expect(widgets.bag.type).toBe('holder');
+    expect(widgets.bag.parent).toBe('bag-bag');
+    expect(widgets.bag.owner).toEqual([]);
+    expect(widgets.inBag.parent).toBe('bag');
+
+    // clicking the button hides the holder when it is visible and vice versa
+    const toggle = widgets['bag-bag'].clickRoutine[0];
+    expect(toggle.operand1).toBe('${PROPERTY owner OF bag}');
+    expect(toggle.thenRoutine[0].value).toEqual([]);
+    expect(toggle.elseRoutine[0].value).toBe(undefined);
+  });
+});
+
+describe('TTS import: layout', () => {
+  it('gives a two card deck a pile but places a single card directly', async () => {
+    const two = await convert(objects(deck('two', [ 100, 101 ])));
+    expect(typed(two, 'pile').length).toBe(1);
+    expect(typed(two, 'card').every(c=>c.parent == 'two-pile')).toBe(true);
+
+    const one = await convert(objects(deck('one', [ 100 ])));
+    expect(typed(one, 'pile').length).toBe(0);
+    expect(one['one-100-1'].x).toBeGreaterThan(0);
+  });
+
+  it('does not let the positionless deck widget pull the layout to the origin', async () => {
+    const withoutDeck = await convert(objects(die('a', -2), die('b', 2)));
+    const withDeck = await convert(objects(die('a', -2), die('b', 2), deck('d', [ 100 ])));
+
+    expect(withDeck.d.x).toBe(undefined);
+    // the deck is invisible, so adding it must not move the dice around it
+    expect(withDeck.a.x - withoutDeck.a.x).toBe(withDeck.b.x - withoutDeck.b.x);
+    expect(withoutDeck.a.x + withoutDeck.b.x).toBe(1600 - 50);
+  });
+
+  it('keeps every placed widget on the surface', async () => {
+    const widgets = await convert({
+      SaveName: 'test',
+      Hands: { Enable: true, HandTransforms: [ { Color: 'Red' } ] },
+      ObjectStates: [ die('a', -40), die('b', 40), { Name: 'Custom_Board', GUID: 'board', Locked: true, Transform: { posX: 0, posZ: 0, scaleX: 8, scaleZ: 8 }, CustomImage: { ImageURL: png(1600, 1000) } } ]
+    });
+
+    for(const widget of Object.values(widgets)) {
+      if(widget.parent || widget.x === undefined)
+        continue;
+      expect(widget.x).toBeGreaterThanOrEqual(0);
+      expect(widget.y).toBeGreaterThanOrEqual(0);
+      expect(widget.x + (widget.width  || 0)).toBeLessThanOrEqual(1600);
+      expect(widget.y + (widget.height || 0)).toBeLessThanOrEqual(1000);
+    }
+  });
+});
+
+describe('TTS import: seats', () => {
+  it('reads the hand zones of both save formats and only keeps one seat per color', async () => {
+    const widgets = await convert({
+      SaveName: 'test',
+      Hands: { Enable: true, Hiding: 0 },
+      ObjectStates: [
+        die('a', 0),
+        { Name: 'HandTrigger', GUID: 'h1', FogColor: 'Red' },
+        { Name: 'HandTrigger', GUID: 'h2', FogColor: 'Blue' },
+        { Name: 'HandTrigger', GUID: 'h3', FogColor: 'Blue' }
+      ]
+    });
+
+    expect(typed(widgets, 'seat').map(s=>s.color)).toEqual([ '#da1917', '#118ed7' ]);
+    expect(widgets.hand.type).toBe('holder');
+  });
+
+  it('fits the seats onto the surface even with a hand zone per TTS color', async () => {
+    const colors = [ 'White', 'Brown', 'Red', 'Orange', 'Yellow', 'Green', 'Teal', 'Blue', 'Purple', 'Pink', 'Grey', 'Black' ];
+    const widgets = await convert({
+      SaveName: 'test',
+      Hands: { Enable: true, HandTransforms: colors.map(Color=>({ Color })) },
+      ObjectStates: [ die('a', 0) ]
+    });
+
+    const seats = typed(widgets, 'seat');
+    expect(seats.length).toBe(12);
+    for(const seat of seats)
+      expect(seat.x + seat.width).toBeLessThanOrEqual(1600);
+    // and they don't overlap each other
+    for(let i=1; i<seats.length; ++i)
+      expect(seats[i].x).toBeGreaterThanOrEqual(seats[i-1].x + seats[i-1].width);
+  });
+});

--- a/tests/server/ttsimport.test.js
+++ b/tests/server/ttsimport.test.js
@@ -20,6 +20,12 @@ async function convert(save) {
   return widgets;
 }
 
+// what the importer could not bring over - the game details show it as import notes
+async function importNotes(save) {
+  const widgets = (await TTS.fromBSON(BSON.serialize(save))).TTS['0.json'];
+  return widgets._meta.info.importerWarnings;
+}
+
 function objects(...ObjectStates) {
   return { SaveName: 'test', ObjectStates };
 }
@@ -312,6 +318,66 @@ describe('TTS import: layout', () => {
     // the whole table smaller - but it does have to stay reachable once it is
     expect(withBag.board.width).toBe(withoutBag.board.width);
     expectOnSurface(withBag, 810);
+  });
+});
+
+describe('TTS import: import notes', () => {
+  it('says nothing about a save that came over completely', async () => {
+    expect(await importNotes(objects(die('a', -2), die('b', 2)))).toBe(undefined);
+  });
+
+  it('reports the objects and the settings that could not be translated', async () => {
+    const notes = await importNotes({
+      SaveName: 'test',
+      LuaScript: 'function onLoad() end',
+      TabStates: { 0: { title: 'Rules' } },
+      Turns: { Enable: true },
+      ObjectStates: [
+        die('a', 0),
+        { Name: 'Custom_PDF', GUID: 'pdf', Nickname: 'Rulebook', Transform: { posX: 2, posZ: 0 } },
+        { Name: 'Custom_Model', GUID: 'mesh', Nickname: 'Castle', Transform: { posX: 4, posZ: 0 } },
+        { Name: 'Die_6', GUID: 'states', Nickname: 'Weather', Transform: { posX: 6, posZ: 0 }, States: { 2: {} } }
+      ]
+    });
+
+    expect(notes.join('\n')).toMatch(/scripted/);
+    expect(notes.join('\n')).toMatch(/notebook of this mod \(1 page\)/);
+    expect(notes.join('\n')).toMatch(/turn order/);
+    expect(notes.join('\n')).toMatch(/"Rulebook" was not imported/);
+    expect(notes.join('\n')).toMatch(/"Castle" is a 3D model/);
+    expect(notes.join('\n')).toMatch(/"Weather" has several states/);
+  });
+
+  it('names the objects that share a problem in a single note', async () => {
+    const tokens = [ 'Wood', 'Stone', 'Gold', 'Wheat', 'Sheep' ].map((Nickname, index)=>({
+      Name: 'Custom_PDF',
+      GUID: `pdf${index}`,
+      Nickname,
+      Transform: { posX: index, posZ: 0 }
+    }));
+    const notes = await importNotes(objects(die('a', 0), ...tokens));
+
+    const note = notes.filter(n=>n.match(/^A PDF/));
+    expect(note.length).toBe(1);
+    // five names would be a wall of text - the first few of them stand for the rest
+    expect(note[0]).toMatch(/"Wood", "Stone", "Gold" and 2 more were not imported/);
+
+    // objects without a name of their own are counted instead of being listed
+    const unnamed = await importNotes(objects(die('a', 0), ...tokens.map(t=>Object.assign({}, t, { Nickname: '' }))));
+    expect(unnamed.filter(n=>n.match(/^A PDF/))[0]).toMatch(/5× "Custom_PDF" were not imported/);
+  });
+
+  it('caps a report that a broken mod would fill with thousands of lines', async () => {
+    const scenery = Array.from({ length: 150 }, (unused, index)=>({
+      Name: `Tileset_${index}`,
+      GUID: `scenery${index}`,
+      Nickname: `Chair ${index}`,
+      Transform: { posX: index, posZ: 0 }
+    }));
+    const notes = await importNotes(objects(die('a', 0), ...scenery));
+
+    expect(notes.length).toBe(101);
+    expect(notes[100]).toBe('50 more notes are not listed here.');
   });
 });
 

--- a/tests/server/ttsimport.test.js
+++ b/tests/server/ttsimport.test.js
@@ -93,7 +93,8 @@ describe('TTS import: bags', () => {
     }));
 
     expect(widgets['bag-bag'].type).toBe('button');
-    expect(widgets['bag-bag'].text).toBe('Tokens');
+    // the number of objects a player gets out of the bag is part of its label
+    expect(widgets['bag-bag'].text).toBe('Tokens (1)');
     expect(widgets.bag.type).toBe('holder');
     expect(widgets.bag.parent).toBe('bag-bag');
     expect(widgets.bag.owner).toEqual([]);
@@ -135,14 +136,37 @@ describe('TTS import: layout', () => {
       ObjectStates: [ die('a', -40), die('b', 40), { Name: 'Custom_Board', GUID: 'board', Locked: true, Transform: { posX: 0, posZ: 0, scaleX: 8, scaleZ: 8 }, CustomImage: { ImageURL: png(1600, 1000) } } ]
     });
 
+    // x/y are the corner of the unscaled widget, the visible box is centered in it
     for(const widget of Object.values(widgets)) {
       if(widget.parent || widget.x === undefined)
         continue;
-      expect(widget.x).toBeGreaterThanOrEqual(0);
-      expect(widget.y).toBeGreaterThanOrEqual(0);
-      expect(widget.x + (widget.width  || 0)).toBeLessThanOrEqual(1600);
-      expect(widget.y + (widget.height || 0)).toBeLessThanOrEqual(1000);
+      const scale = widget.scale || 1;
+      const left = widget.x + (widget.width  || 0)*(1-scale)/2;
+      const top  = widget.y + (widget.height || 0)*(1-scale)/2;
+      expect(left).toBeGreaterThanOrEqual(0);
+      expect(top).toBeGreaterThanOrEqual(0);
+      expect(left + (widget.width  || 0)*scale).toBeLessThanOrEqual(1600);
+      expect(top  + (widget.height || 0)*scale).toBeLessThanOrEqual(1000);
     }
+  });
+
+  it('scales the objects along with the distances between them', async () => {
+    const widgets = await convert(objects(die('a', -40), die('b', 40)));
+
+    // 80 TTS units are 4000px and have to fit into 1500
+    expect(widgets.a.scale).toBeCloseTo(1500/4050, 2);
+    expect(widgets.b.scale).toBe(widgets.a.scale);
+
+    // the dice keep touching the left and the right end of the layout
+    const center = w=>w.x + w.width/2;
+    expect(center(widgets.b) - center(widgets.a)).toBeCloseTo(4000*widgets.a.scale, 0);
+    expect(center(widgets.a) + center(widgets.b)).toBe(1600);
+  });
+
+  it('leaves a layout that fits alone', async () => {
+    const widgets = await convert(objects(die('a', -2), die('b', 2)));
+    expect(widgets.a.scale).toBe(undefined);
+    expect(widgets.a.x).toBe(675);
   });
 });
 

--- a/tests/server/ttsimport.test.js
+++ b/tests/server/ttsimport.test.js
@@ -1,3 +1,4 @@
+import JSZip from 'jszip';
 import { BSON } from 'bson';
 
 import TTS from '../../server/ttsimport.mjs';
@@ -63,17 +64,28 @@ function corners(widget, widgets) {
   return points;
 }
 
+// A widget nobody owns - the holder of a closed bag - and everything inside it is
+// hidden until a routine shows it.
+function isHidden(widget, widgets) {
+  for(let node = widget; node; node = widgets[node.parent])
+    if(Array.isArray(node.owner) && !node.owner.length)
+      return true;
+  return false;
+}
+
 // Every widget of the room has to be reachable, children included: the surface is
-// overflow: hidden, so anything outside of it cannot be clicked at all.
+// overflow: hidden, so anything outside of it cannot be clicked at all. What is
+// visible right away also has to stay inside the band that is left for the table.
 function expectOnSurface(widgets, bottom=1000) {
   for(const widget of Object.values(widgets)) {
     if(widget.id == 'hand' || widget.x === undefined && !widget.parent)
       continue;
+    const limit = isHidden(widget, widgets) ? 1000 : bottom;
     for(const [ x, y ] of corners(widget, widgets)) {
       expect(x).toBeGreaterThanOrEqual(0);
       expect(y).toBeGreaterThanOrEqual(0);
       expect(x).toBeLessThanOrEqual(1600);
-      expect(y).toBeLessThanOrEqual(bottom);
+      expect(y).toBeLessThanOrEqual(limit);
     }
   }
 }
@@ -145,6 +157,56 @@ describe('TTS import: bags', () => {
   });
 });
 
+describe('TTS import: decks', () => {
+  it('turns the cards of a deck lying face up face up', async () => {
+    const up = await convert(objects(deck('up', [ 100, 101 ])));
+    expect(typed(up, 'card').map(c=>c.activeFace)).toEqual([ 1, 1 ]);
+
+    // rotZ 180 is a deck lying on the table upside down, which is the default face
+    const down = await convert(objects(Object.assign(deck('down', [ 100, 101 ]), { Transform: { posX: 0, posZ: 0, rotZ: 180 } })));
+    expect(typed(down, 'card').map(c=>c.activeFace)).toEqual([ undefined, undefined ]);
+  });
+});
+
+describe('TTS import: stacks', () => {
+  it('puts the objects of a stack where the stack is', async () => {
+    const widgets = await convert(objects(
+      { Name: 'Custom_Tile', GUID: 'stack', Transform: { posX: 6, posZ: 0 }, CustomImage: { ImageURL: png(100, 100) }, ContainedObjects: [ die('one', 0), die('two', -6) ] },
+      die('reference', 6)
+    ));
+
+    // the transforms stored with the objects inside a stack are frequently the ones
+    // they had before they were stacked - going by them scatters the stack
+    expect(widgets.one.x).toBe(widgets.reference.x);
+    expect(widgets.two.x).toBe(widgets.reference.x);
+  });
+});
+
+describe('TTS import: files', () => {
+  it('converts a save from a workshop upload zip', async () => {
+    const zip = new JSZip();
+    zip.file('WorkshopUpload', '');
+    zip.file('save.json', JSON.stringify(objects(die('a', 0))));
+
+    const widgets = await TTS.fromZIP(await zip.generateAsync({ type: 'nodebuffer' }));
+    expect(widgets.a.type).toBe('dice');
+    expect(widgets._meta.info.importerTemp).toBe('TTS');
+  });
+
+  it('keeps the widget IDs of two imports that run at the same time apart', async () => {
+    // two objects with the same GUID: the second one has to get an ID of its own
+    const twins = SaveName=>({ SaveName, ObjectStates: [ die('twin', -2), die('twin', 2) ] });
+
+    const alone = await convert(twins('alone'));
+    const [ first, second ] = await Promise.all([ convert(twins('first')), convert(twins('second')) ]);
+
+    // an import may not take IDs away from another one that is still running
+    expect(Object.keys(alone)).toEqual([ 'twin', 'twin-1' ]);
+    expect(Object.keys(first)).toEqual(Object.keys(alone));
+    expect(Object.keys(second)).toEqual(Object.keys(alone));
+  });
+});
+
 describe('TTS import: layout', () => {
   it('gives a two card deck a pile but places a single card directly', async () => {
     const two = await convert(objects(deck('two', [ 100, 101 ])));
@@ -183,9 +245,8 @@ describe('TTS import: layout', () => {
 
     // 1200x75 fits as it is, but turned by 90 degrees the same board is 1200px high
     expect(flat.board.width).toBe(1200);
-    expect(flat.board.scale).toBe(undefined);
     expect(upright.board.rotation).toBe(90);
-    expect(upright.board.scale).toBeLessThan(1);
+    expect(upright.board.width).toBeLessThan(1200);
     expectOnSurface(upright);
   });
 
@@ -205,23 +266,52 @@ describe('TTS import: layout', () => {
     expectOnSurface(widgets, 810);
   });
 
-  it('scales the objects along with the distances between them', async () => {
+  it('makes the objects smaller along with the distances between them', async () => {
     const widgets = await convert(objects(die('a', -40), die('b', 40)));
 
     // 80 TTS units are 4000px and have to fit into 1500
-    expect(widgets.a.scale).toBeCloseTo(1500/4050, 2);
-    expect(widgets.b.scale).toBe(widgets.a.scale);
+    const factor = Math.round(1500/4050*1000)/1000;
+    expect(widgets.a.width).toBe(Math.round(50*factor));
+    expect(widgets.b.width).toBe(widgets.a.width);
+    // the widget itself is smaller instead of being rendered scaled down: a card
+    // dragged out of a scaled pile would jump to full size
+    expect(widgets.a.scale).toBe(undefined);
 
     // the dice keep touching the left and the right end of the layout
     const center = w=>w.x + w.width/2;
-    expect(center(widgets.b) - center(widgets.a)).toBeCloseTo(4000*widgets.a.scale, 0);
-    expect(center(widgets.a) + center(widgets.b)).toBe(1600);
+    expect(center(widgets.b) - center(widgets.a)).toBeCloseTo(4000*factor, 0);
+    expect(center(widgets.a) + center(widgets.b)).toBeCloseTo(1600, -1);
+  });
+
+  it('gives the cards of a shrunk deck the size of their pile', async () => {
+    const widgets = await convert(objects(deck('d', [ 100, 101 ]), die('far', 40)));
+
+    // the cards are children of the pile and have to shrink with it - and they keep
+    // that size when a player drags one out onto the table
+    expect(widgets.d.cardDefaults.width).toBeLessThan(120);
+    expect(widgets.d.cardDefaults.width).toBe(widgets['d-pile'].width);
+    expect(widgets.d.cardDefaults.height).toBe(widgets['d-pile'].height);
   });
 
   it('leaves a layout that fits alone', async () => {
     const widgets = await convert(objects(die('a', -2), die('b', 2)));
     expect(widgets.a.scale).toBe(undefined);
+    expect(widgets.a.width).toBe(50);
     expect(widgets.a.x).toBe(675);
+  });
+
+  it('does not shrink the layout for the holder of a closed bag', async () => {
+    const board = { Name: 'Custom_Board', GUID: 'board', Transform: { posX: 0, posZ: 0, scaleX: 2, scaleZ: 2 }, CustomImage: { ImageURL: png(600, 600) } };
+    const bag = { Name: 'Bag', GUID: 'bag', Transform: { posX: 0, posZ: -6 }, ContainedObjects: [ die('inBag', 0) ] };
+    const table = (...ObjectStates)=>({ SaveName: 'test', Hands: { Enable: true, HandTransforms: [ { Color: 'Red' } ] }, ObjectStates });
+
+    const withoutBag = await convert(table(board));
+    const withBag = await convert(table(board, bag));
+
+    // the holder is not on the screen until the bag is opened, so it must not make
+    // the whole table smaller - but it does have to stay reachable once it is
+    expect(withBag.board.width).toBe(withoutBag.board.width);
+    expectOnSurface(withBag, 810);
   });
 });
 

--- a/tests/server/ttsimport.test.js
+++ b/tests/server/ttsimport.test.js
@@ -23,8 +23,8 @@ function objects(...ObjectStates) {
   return { SaveName: 'test', ObjectStates };
 }
 
-function die(GUID, posX) {
-  return { Name: 'Die_6', GUID, Transform: { posX, posZ: 0 } };
+function die(GUID, posX, posZ=0) {
+  return { Name: 'Die_6', GUID, Transform: { posX, posZ } };
 }
 
 function deck(GUID, DeckIDs) {
@@ -39,6 +39,43 @@ function deck(GUID, DeckIDs) {
 
 function typed(widgets, type) {
   return Object.values(widgets).filter(w=>(w.type || 'basic') == type);
+}
+
+// The corners a widget ends up covering, the way the client renders it: a widget is
+// a rectangle at x/y, and every widget in its parent chain scales and rotates its
+// contents around its own center (`translate() rotate() scale()` with the default
+// transform-origin). So x/y is not necessarily the top left corner on screen.
+function corners(widget, widgets) {
+  let points = [ [ 0, 0 ], [ widget.width || 0, 0 ], [ widget.width || 0, widget.height || 0 ], [ 0, widget.height || 0 ] ];
+
+  for(let node = widget; node; node = widgets[node.parent]) {
+    const cx = (node.width || 0)/2, cy = (node.height || 0)/2;
+    const rad = (node.rotation || 0)*Math.PI/180, scale = node.scale || 1;
+    points = points.map(([ x, y ])=>{
+      const dx = (x - cx)*scale, dy = (y - cy)*scale;
+      return [
+        (node.x || 0) + cx + dx*Math.cos(rad) - dy*Math.sin(rad),
+        (node.y || 0) + cy + dx*Math.sin(rad) + dy*Math.cos(rad)
+      ];
+    });
+  }
+
+  return points;
+}
+
+// Every widget of the room has to be reachable, children included: the surface is
+// overflow: hidden, so anything outside of it cannot be clicked at all.
+function expectOnSurface(widgets, bottom=1000) {
+  for(const widget of Object.values(widgets)) {
+    if(widget.id == 'hand' || widget.x === undefined && !widget.parent)
+      continue;
+    for(const [ x, y ] of corners(widget, widgets)) {
+      expect(x).toBeGreaterThanOrEqual(0);
+      expect(y).toBeGreaterThanOrEqual(0);
+      expect(x).toBeLessThanOrEqual(1600);
+      expect(y).toBeLessThanOrEqual(bottom);
+    }
+  }
 }
 
 describe('TTS import: dice', () => {
@@ -136,18 +173,36 @@ describe('TTS import: layout', () => {
       ObjectStates: [ die('a', -40), die('b', 40), { Name: 'Custom_Board', GUID: 'board', Locked: true, Transform: { posX: 0, posZ: 0, scaleX: 8, scaleZ: 8 }, CustomImage: { ImageURL: png(1600, 1000) } } ]
     });
 
-    // x/y are the corner of the unscaled widget, the visible box is centered in it
-    for(const widget of Object.values(widgets)) {
-      if(widget.parent || widget.x === undefined)
-        continue;
-      const scale = widget.scale || 1;
-      const left = widget.x + (widget.width  || 0)*(1-scale)/2;
-      const top  = widget.y + (widget.height || 0)*(1-scale)/2;
-      expect(left).toBeGreaterThanOrEqual(0);
-      expect(top).toBeGreaterThanOrEqual(0);
-      expect(left + (widget.width  || 0)*scale).toBeLessThanOrEqual(1600);
-      expect(top  + (widget.height || 0)*scale).toBeLessThanOrEqual(1000);
-    }
+    expectOnSurface(widgets);
+  });
+
+  it('fits a rotated object by the space it really covers', async () => {
+    const board = rotY=>({ Name: 'Custom_Board', GUID: 'board', Transform: { posX: 0, posZ: 0, rotY, scaleX: 2, scaleZ: 2 }, CustomImage: { ImageURL: png(1600, 100) } });
+    const flat = await convert(objects(board(0)));
+    const upright = await convert(objects(board(90)));
+
+    // 1200x75 fits as it is, but turned by 90 degrees the same board is 1200px high
+    expect(flat.board.width).toBe(1200);
+    expect(flat.board.scale).toBe(undefined);
+    expect(upright.board.rotation).toBe(90);
+    expect(upright.board.scale).toBeLessThan(1);
+    expectOnSurface(upright);
+  });
+
+  it('leaves room for the holder of a bag at the bottom of the layout', async () => {
+    const widgets = await convert({
+      SaveName: 'test',
+      Hands: { Enable: true, HandTransforms: [ { Color: 'Red' } ] },
+      ObjectStates: [
+        die('top', 0, 6),
+        { Name: 'Bag', GUID: 'bag', Transform: { posX: 0, posZ: -6 }, ContainedObjects: [ deck('inBag', [ 100, 101 ]) ] }
+      ]
+    });
+
+    // the holder is only visible while the bag is open, but it still has to fit into
+    // the band between the seats and the hand instead of being cut off by the surface
+    expect(widgets.bag.parent).toBe('bag-bag');
+    expectOnSurface(widgets, 810);
   });
 
   it('scales the objects along with the distances between them', async () => {

--- a/validator/validate_gamefile.js
+++ b/validator/validate_gamefile.js
@@ -1129,7 +1129,7 @@ function validateGameFile(data, checkMeta) {
                 'name', 'image', 'rules', 'bgg', 'year', 'mode', 'time', 'attribution', 
                 'lastUpdate', 'language', 'showName', 'skill', 'description', 'similarImage', 
                 'similarName', 'similarDesigner', 'similarAwards', 'ruleText', 'helpText', 
-                'players', 'variant', 'variantImage', 'importer', 'importerTime', 'usesAIImagery'
+                'players', 'variant', 'variantImage', 'importer', 'importerTemp', 'importerTime', 'usesAIImagery'
             ];
             for (const prop of Object.keys(data._meta.info)) {
                 if (!infoProps.includes(prop)) {


### PR DESCRIPTION
## Goal

Make the Tabletop Simulator importer bring over as much of a mod as can
reasonably exist in 2D, instead of only decks and bags.

## The problem

`server/ttsimport.mjs` only converted objects with a `CustomDeck` (decks/cards)
and objects literally named `Bag`. Everything else was dropped silently, so most
workshop games imported as an almost empty table:

| Workshop game | widgets before | widgets after |
| --- | --- | --- |
| Seven-Part Pact Glyph Dice | 1 (an empty holder) | 22 (21 dice) |
| Valkyries of Ran | 65 (bags only) | 1140 |
| D&D5e 3.0 | 48 (bags only) | 1631 |
| Dead by Daylight: The Board Game | 287 | 505 |
| Bloodborne: The Board Game | 3215 | 6657 |

Before / after of the same mod (Dead by Daylight, imported from its workshop link):

| before | after |
| --- | --- |
| ![before](https://agent.virtualtabletop.io/reports/pr/1532144119172825155/tts-import-before.png) | ![after](https://agent.virtualtabletop.io/reports/pr/1532144119172825155/tts-import-after.png) |

A dice-only mod, which used to import as a single empty holder:

![dice](https://agent.virtualtabletop.io/reports/pr/1532144119172825155/tts-import-dice.png)

## What is imported now

- **Images** — `Custom_Board`, `Custom_Tile`, `Custom_Token`, `Figurine_Custom`
  and anything else with a `CustomImage`: an image widget whose aspect ratio comes
  from the image and whose size comes from the TTS scale, with the custom tile
  outline (hex via `clip-path`, circle, rounded), `ImageSecondaryURL` as a second
  face so the object can be flipped, and boards/locked objects put below cards and
  pieces (and not movable, like a pinned TTS object).
- **Dice** — `Die_4` … `Die_20` and `Custom_Dice` become `dice` widgets with the
  matching face count, `shape3d` and the object color. Anything else that TTS can
  roll is recognized by its `RotationValues` list (one entry per face with the value
  that ends up on top) and gets those values as its faces — that is the only way to
  find the dice of a mod whose dice are plain `Custom_Model` meshes, and it also
  gives the real labels of a die that a mod relabelled.
- **Text** — `Notecard` (nickname + description) and `3DText` become labels using
  the TTS text color and font size.
- **3D-only objects** — meshes, asset bundles and built-in pieces have no 2D
  representation, so *named* ones become plain colored pieces carrying their name
  (unnamed ones are usually 3D table decoration and are still skipped). This keeps
  a game playable: you can move the piece and give it an image later.
- **Seats** — the TTS hand zones' player colors become seats above the hand holder.
  Both save formats are read: older saves list the zones in `Hands.HandTransforms`,
  newer ones store them as `HandTrigger` objects with the color in `FogColor`.
- **Per object**: rotation on the table, face-up/face-down (`rotZ`) for cards and
  two-sided tiles, and the height above the table as the stacking order (`z`).
- **Bags** — a button in the bag's TTS color carrying the bag's name, with a holder
  for the contents as its child so the two cannot drift apart when the layout is
  scaled. Clicking the button toggles the contents open and closed. All bag types
  (`Infinite_Bag`, `Custom_Model_Bag`, …) are covered, they sit where the bag was and
  accept every widget type, not just cards. A bag that would be empty after the
  import (empty in TTS, or holding nothing that has a 2D representation) is skipped.
- Invisible TTS objects (hand/scripting/fog triggers, PDFs, tileset scenery) are
  skipped on purpose.
- **Metadata** — a game imported from a workshop link takes the thumbnail of the
  workshop page as its library image (stored as an asset, so it survives the item
  being removed), the title as its name when the save has none, the description
  (BBCode stripped) and the player-count and playing-time tags as
  `_meta.info.players`/`time`, which the game shelf shows and filters by. The
  workshop link is recorded as the attribution. Only the item ID the player entered
  is used, so nothing is fetched that the importer wasn't fetching already.
- **An import report** — everything the importer could not bring over is collected
  in `_meta.info.importerWarnings`, the report the PCIO importer introduced: the
  game details show it as **Import notes** and the tile in the shelf gets an info
  badge. Objects that only exist in 3D, a deck whose card images are missing from
  the save, a bag that came out empty, a 3D model that became a colored piece, an
  object with several TTS states — and what is not an object at all: the mod's
  Lua/XML scripting, its notebook, snap points, decals, drawn lines, the turn
  order, the one hand VirtualTabletop has for all players, the images that stay
  linked to their server, and the factor the table was scaled down by. A note that
  is about objects names them instead of repeating itself once per object, and the
  report is deduplicated and capped at 100 lines.

  ![import notes](https://agent.virtualtabletop.io/reports/pr/1532144119172825155/tts-import-notes.png)

## Robustness / layout

- A single broken object (e.g. a card referencing a missing `CustomDeck` entry) is
  logged and skipped instead of aborting the whole import.
- Duplicate GUIDs no longer overwrite each other — that alone silently lost
  thousands of objects in big mods.
- Image dimensions are prefetched with 16 parallel range requests instead of one
  blocking request per object (Bloodborne: 17s → 4s, and that is with ~4× more
  objects converted).
- `moveIntoBounds` now scales the layout down uniformly and centers it instead of
  stretching it to fill the table. Stretching tore apart objects that belong
  together (and blew tiny position differences up to the full table width), and it
  could leave widgets partially off the surface; widget sizes are taken into
  account now. Positions use 50px per TTS unit, which matches the 160px card size
  the importer already produced. Widgets without a position (the invisible `deck`
  widgets) no longer count as widgets at (0, 0), which used to pull the bounding box
  of every game containing a deck to the origin. Every widget is measured by the
  box it really covers rather than by its `width`/`height`: rotated around the center
  of the widget the way the client renders it, and with the children folded in, so a
  board turned by 90° and the holder of an opened bag stay on the surface too.
- `cardType` is written as a string and an explicit `parent: null` is no longer
  emitted, so an imported game no longer produces hundreds of false-positive
  errors in the edit-mode validator.

## Also fixed

- `server/fileloader.mjs` called `TTS.fromZip`, but the module exports `fromZIP` —
  uploading a TTS workshop **zip** threw a `TypeError`. Verified with a synthetic
  `WorkshopUpload` zip: it imports correctly now.
- Removed the leftover `/tmp/out` and `/tmp/tts.json` debug dumps that were written
  on every import.
- `importerTemp` was missing from the game file validator's known `_meta.info`
  properties, so every imported game (TTS and PCIO) reported it as an unknown
  property in edit mode.

## Testing

- `npm test` passes (172 tests, including the new `tests/server/ttsimport.test.js`
  which runs fixtures through `TTS.fromBSON` without touching the network).
- Imported the five workshop games from the table above through the real code path
  (`/api/decksFromLink` and `PUT /addState/<room>/<id>/link/<name>`), loaded them in
  a browser and checked the result: no client errors, no widgets outside the
  surface, no NaN positions.
- Ran `validator/validate_gamefile_node.js` on the converted games: clean apart
  from the pre-existing `_meta.info` metadata warnings that any freshly imported
  game has.
- No client code and no widget properties changed, so the TestCafe state hashes are
  unaffected.
- Imported a workshop mod through this branch into a real client and read the
  report out of the DOM: the info badge shows on the tile and the notes render in
  the game details (screenshot above).


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3070/pr-test (or any other room on that server)




