### PR TITLE
Add front/back image upload and text card sections to the new deck wizard

### DIFF
--- a/client/css/editor/deckeditor.css
+++ b/client/css/editor/deckeditor.css
@@ -693,37 +693,108 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   color: #fff;
 }
 
-.deckEditorNewDeckModes {
+/* The ways to create a deck are grouped into three expanders, only one of which is open at a time - so the
+   dialog opens as three short rows instead of a list of eight radio buttons. */
+.deckEditorNewDeckGroups {
   display: flex;
   flex-direction: column;
   gap: 8px;
   margin: 16px 0;
 }
 
-.deckEditorNewDeckModes label {
+.deckEditorNewDeckGroup {
+  border: 1px solid #0003;
+  border-radius: 6px;
+}
+
+.deckEditorNewDeckGroupHeader {
+  display: block;
+  position: relative;
+  width: 100%;
+  padding: 10px 40px 10px 12px;
+  border: none;
+  border-radius: 5px;
+  background: #0000000d;
+  color: inherit;
+  font-size: 15px;
+  font-weight: bold;
+  text-align: left;
+  text-transform: none;
+}
+
+.deckEditorNewDeckGroupHeader:hover {
+  background: #0000001a;
+}
+
+.deckEditorNewDeckGroupOpen .deckEditorNewDeckGroupHeader,
+.deckEditorNewDeckGroupOpen .deckEditorNewDeckGroupHeader:hover {
+  border-radius: 5px 5px 0 0;
+  background: var(--VTTblue);
+  color: #fff;
+}
+
+.deckEditorNewDeckGroupHeader span {
+  display: block;
+  font-size: 12px;
+  font-weight: normal;
+  opacity: 0.75;
+}
+
+.deckEditorNewDeckGroupHeader::after {
+  content: "expand_more";
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  font-family: "Material Symbols";
+  font-size: 24px;
+  font-weight: normal;
+}
+
+.deckEditorNewDeckGroupOpen .deckEditorNewDeckGroupHeader::after {
+  content: "expand_less";
+}
+
+/* The panel of the selected option is moved into the open group (see openNewDeckGroup), so a closed group is
+   nothing but its header. */
+.deckEditorNewDeckGroupBody {
+  display: none;
+  padding: 12px;
+}
+
+.deckEditorNewDeckGroupOpen .deckEditorNewDeckGroupBody {
+  display: block;
+}
+
+.deckEditorNewDeckModes {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: 8px;
+}
+
+.deckEditorNewDeckModes label {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: baseline;
+  column-gap: 8px;
   cursor: pointer;
 }
 
-/* Once a mode has been picked the list of options has done its job, so it collapses to the chosen one and
-   leaves the ~250px it occupies to the panel the user is now filling in. "Change" brings it back. */
-.deckEditorNewDeckModesCollapsed label:not(.deckEditorNewDeckModeSelected) {
+.deckEditorNewDeckModes label span {
+  grid-column: 2;
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+/* A group with a single way to create a deck (the blank one) needs no radio button - opening it is already
+   the choice, and its header says what it does. */
+.deckEditorNewDeckModesSingle {
   display: none;
 }
 
-#deckEditorNewDeckChangeMode {
-  display: none;
-  align-self: flex-start;
-  padding: 2px 8px;
-}
-
-.deckEditorNewDeckModesCollapsed #deckEditorNewDeckChangeMode {
-  display: inline-flex;
-}
-
-#deckEditorNewDeckPanel:not(:empty) {
+/* Separates a group's options from the panel of the selected one - the blank group shows no options, so
+   there is nothing to separate there. */
+.deckEditorNewDeckModes:not(.deckEditorNewDeckModesSingle) + #deckEditorNewDeckPanel:not(:empty) {
   border-top: 1px solid #0002;
   padding-top: 16px;
 }

--- a/client/css/editor/deckeditor.css
+++ b/client/css/editor/deckeditor.css
@@ -707,9 +707,38 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   cursor: pointer;
 }
 
+/* Once a mode has been picked the list of options has done its job, so it collapses to the chosen one and
+   leaves the ~250px it occupies to the panel the user is now filling in. "Change" brings it back. */
+.deckEditorNewDeckModesCollapsed label:not(.deckEditorNewDeckModeSelected) {
+  display: none;
+}
+
+#deckEditorNewDeckChangeMode {
+  display: none;
+  align-self: flex-start;
+  padding: 2px 8px;
+}
+
+.deckEditorNewDeckModesCollapsed #deckEditorNewDeckChangeMode {
+  display: inline-flex;
+}
+
 #deckEditorNewDeckPanel:not(:empty) {
   border-top: 1px solid #0002;
   padding-top: 16px;
+}
+
+/* The dialog itself is the scroll container, so pinning the action row to its bottom edge keeps the primary
+   action reachable no matter how tall the panel above it grows. The negative offset and the matching padding
+   make it cover the dialog's own bottom padding, so nothing scrolls through the gap below it. */
+#deckEditorNewDeckPanel .goButton,
+.deckEditorNewDeckButtonBar {
+  position: sticky;
+  bottom: -20px;
+  z-index: 1;
+  margin-top: 8px;
+  padding: 8px 0 20px;
+  background: var(--modalBackgroundColor);
 }
 
 /* Card sizes for a new empty deck: a wrapping row of radio chips, the first (the size decks have always been
@@ -766,6 +795,12 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   display: block;
   background: transparent;
   color: inherit;
+}
+
+/* The sidebar's "overflow-x: hidden" would make this module a scroll container of its own, which would stop
+   the sticky action row below from sticking to the dialog (the actual scroll container). */
+.deckEditorNewDeckModule.tune.editorModule {
+  overflow: visible;
 }
 
 @media (max-width: 700px) {

--- a/client/css/editor/sidebarModules.css
+++ b/client/css/editor/sidebarModules.css
@@ -171,6 +171,93 @@
 }
 
 
+/* Front/back image upload: one row per uploaded file, numbered in the order the files are paired in. */
+.tune.editorModule .imagePairList {
+  margin-bottom: 5px;
+}
+
+.tune.editorModule .imagePairEntry {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 3px;
+}
+
+.tune.editorModule .imagePairEntry b {
+  min-width: 25px;
+  text-align: right;
+}
+
+.tune.editorModule .imagePairEntry img {
+  width: 30px;
+  height: 40px;
+  object-fit: contain;
+  background: #0002;
+}
+
+.tune.editorModule .imagePairEntry span {
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tune.editorModule .imagePairStatus {
+  margin: 5px 0;
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+.tune.editorModule .imagePairStatus.imagePairMismatch {
+  color: #ff8080;
+  opacity: 1;
+}
+
+.tune.editorModule .imagePairOptions [type=number] {
+  width: 50px;
+}
+
+
+/* Text cards: the text input, the design grid and the preview of the first few cards. */
+.tune.editorModule .textCardsInput {
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 5px;
+}
+
+.tune.editorModule .textCardsDesign {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 5px 10px;
+  margin-bottom: 5px;
+}
+
+.tune.editorModule .textCardsDesign label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 5px;
+}
+
+.tune.editorModule .textCardsDesign .textCardsLabelWrap {
+  grid-column: 1 / -1;
+}
+
+.tune.editorModule .textCardsDesign input {
+  width: 60px;
+}
+
+.tune.editorModule .textCardsDesign .textCardsLabel {
+  flex-grow: 1;
+  width: auto;
+  min-width: 0;
+}
+
+.tune.editorModule .textCardsPreview {
+  text-align: center;
+}
+
+
 .tune.editorModule .ttsImportLink {
   display: flex;
   gap: 5px;

--- a/client/css/editor/sidebarModules.css
+++ b/client/css/editor/sidebarModules.css
@@ -268,6 +268,25 @@
   font-family: inherit;
 }
 
+/* How the typed text is cut into cards - one row of radios right under the textarea it describes. */
+.tune.editorModule .textCardsSplit {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 20px;
+  margin-bottom: 10px;
+}
+
+.tune.editorModule .textCardsSplit label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tune.editorModule .textCardsSplit span {
+  font-size: 11px;
+  opacity: 0.7;
+}
+
 .tune.editorModule .textCardsColumns {
   display: flex;
   align-items: flex-start;
@@ -320,10 +339,18 @@
   padding: 1px;
 }
 
+/* A textarea, so a deck label can carry the line breaks it is shown with on the card backs. */
+.tune.editorModule .textCardsDesign .textCardsLabelWrap {
+  align-items: flex-start;
+}
+
 .tune.editorModule .textCardsDesign .textCardsLabel {
   flex-grow: 1;
   width: auto;
   min-width: 0;
+  box-sizing: border-box;
+  font-family: inherit;
+  resize: vertical;
 }
 
 .tune.editorModule .textCardsPreview {

--- a/client/css/editor/sidebarModules.css
+++ b/client/css/editor/sidebarModules.css
@@ -25,6 +25,15 @@
   display: inline-flex;
 }
 
+/* The row with the primary action. Laid out as a flex row so a status text placed before the button - the
+   explanation of why it is disabled - sits next to it instead of somewhere further up the panel. */
+.editorModule .goButton.buttonBar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
 /* Shown by the Properties module when nothing is selected (see PropertiesModule.addDeck). Use the theme
    text color so the intro is readable in both themes (white on the dark editor theme, dark in light mode). */
 .editorModule .noSelectionIntro {
@@ -171,9 +180,29 @@
 }
 
 
-/* Front/back image upload: one row per uploaded file, numbered in the order the files are paired in. */
+/* Front/back image upload: two side-by-side lists, one row per uploaded file, numbered in the order the files
+   are paired in - so row n of the fronts and row n of the backs line up as the pair they are. */
+.tune.editorModule .imagePairColumns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 12px;
+  align-items: start;
+}
+
+.tune.editorModule .imagePairHint {
+  margin-bottom: 5px;
+  font-size: 11px;
+  opacity: 0.7;
+}
+
 .tune.editorModule .imagePairList {
   margin-bottom: 5px;
+}
+
+.tune.editorModule .imagePairList:empty::before {
+  content: attr(data-empty-hint);
+  font-size: 12px;
+  opacity: 0.7;
 }
 
 .tune.editorModule .imagePairEntry {
@@ -184,67 +213,111 @@
 }
 
 .tune.editorModule .imagePairEntry b {
-  min-width: 25px;
+  min-width: 20px;
   text-align: right;
 }
 
 .tune.editorModule .imagePairEntry img {
-  width: 30px;
-  height: 40px;
+  width: 48px;
+  height: 64px;
   object-fit: contain;
   background: #0002;
 }
 
+/* The delete button follows the file name directly instead of being pushed to the far edge of the column. */
 .tune.editorModule .imagePairEntry span {
-  flex-grow: 1;
+  flex: 0 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.tune.editorModule .imagePairStatus {
-  margin: 5px 0;
+.tune.editorModule .imagePairStatus,
+.tune.editorModule .textCardsStatus {
+  flex-grow: 1;
+  text-align: left;
   font-size: 12px;
   opacity: 0.7;
 }
 
 .tune.editorModule .imagePairStatus.imagePairMismatch {
-  color: #ff8080;
+  color: var(--negativeInput);
   opacity: 1;
 }
 
+.tune.editorModule .imagePairOptions {
+  margin: 5px 0;
+}
+
+.tune.editorModule .imagePairOptions label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .tune.editorModule .imagePairOptions [type=number] {
-  width: 50px;
+  width: 60px;
 }
 
 
-/* Text cards: the text input, the design grid and the preview of the first few cards. */
+/* Text cards: the text input, then the design grid and the preview of the first card side by side. */
 .tune.editorModule .textCardsInput {
   width: 100%;
   box-sizing: border-box;
   margin-bottom: 5px;
+  font-family: inherit;
+}
+
+.tune.editorModule .textCardsColumns {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.tune.editorModule .textCardsColumn {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.tune.editorModule .textCardsPreviewColumn {
+  flex: 0 0 auto;
 }
 
 .tune.editorModule .textCardsDesign {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 5px 10px;
+  gap: 5px 16px;
   margin-bottom: 5px;
 }
 
+/* Each input hugs its own label: right-aligning them across a 1fr column would park the input of one field
+   next to the label of the next one. */
 .tune.editorModule .textCardsDesign label {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 5px;
+  gap: 8px;
 }
 
-.tune.editorModule .textCardsDesign .textCardsLabelWrap {
+.tune.editorModule .textCardsDesign .textCardsLabelWrap,
+.tune.editorModule .textCardsDesign .textCardsHint {
   grid-column: 1 / -1;
+}
+
+.tune.editorModule .textCardsDesign .textCardsHint {
+  font-size: 11px;
+  opacity: 0.7;
 }
 
 .tune.editorModule .textCardsDesign input {
   width: 60px;
+}
+
+/* Distinguish the color swatches from the number fields at a glance - a white swatch at input width reads as
+   an empty text box. */
+.tune.editorModule .textCardsDesign input[type=color] {
+  width: 40px;
+  height: 24px;
+  padding: 1px;
 }
 
 .tune.editorModule .textCardsDesign .textCardsLabel {
@@ -254,7 +327,13 @@
 }
 
 .tune.editorModule .textCardsPreview {
-  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.tune.editorModule .textCardsPreviewCard {
+  position: relative;
+  transform-origin: top left;
 }
 
 

--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -1193,6 +1193,13 @@ button:disabled:hover {
   cursor: not-allowed;
 }
 
+/* The colored variants above are more specific than button:disabled, so a disabled green/red icon button
+   would keep its full color and not look disabled at all. */
+button[icon]:disabled,
+button[icon]:disabled:hover {
+  background-color: #808080;
+}
+
 .ui-button {
   background-color: var(--VTTblue);
   padding: 0 8px;

--- a/client/editor.html
+++ b/client/editor.html
@@ -230,17 +230,37 @@
     <div id="deckEditorNewDeckDialog" class="deckEditorModal">
       <button id="deckEditorNewDeckClose" icon="close" title="Close"></button>
       <h1>Add a new deck</h1>
-      <p>Add blank deck or choose an existing one to add to the game</p>
-      <div class="deckEditorNewDeckModes">
-        <label><input type="radio" name="deckEditorNewDeckMode" value="empty" checked>Empty deck &mdash; design its faces and card types here in the deck editor</label>
-        <label><input type="radio" name="deckEditorNewDeckMode" value="library">Browse the public library of ready-made decks</label>
-        <label><input type="radio" name="deckEditorNewDeckMode" value="traditional">Traditional deck (standard, Spanish, German, Swiss, tarot, hanafuda, mahjong, dominoes)</label>
-        <label><input type="radio" name="deckEditorNewDeckMode" value="custom">Custom deck of cards (define suits and ranks)</label>
-        <label><input type="radio" name="deckEditorNewDeckMode" value="images">Upload one image per card or tiled images &mdash; one shared back for the whole deck</label>
-        <label><input type="radio" name="deckEditorNewDeckMode" value="imagePairs">Upload a separate front and back image for every card</label>
-        <label><input type="radio" name="deckEditorNewDeckMode" value="text">Text cards &mdash; one card per line of text</label>
-        <label><input type="radio" name="deckEditorNewDeckMode" value="tts">Import from Tabletop Simulator</label>
-        <button id="deckEditorNewDeckChangeMode" icon="expand_more">Change</button>
+      <p>Where should the cards come from? Open one of the three sections.</p>
+      <div class="deckEditorNewDeckGroups">
+        <div class="deckEditorNewDeckGroup" id="deckEditorNewDeckGroupBlank">
+          <button class="deckEditorNewDeckGroupHeader">New blank deck<span>Start from nothing and design the faces and card types here in the deck editor</span></button>
+          <div class="deckEditorNewDeckGroupBody">
+            <div class="deckEditorNewDeckModes deckEditorNewDeckModesSingle">
+              <label><input type="radio" name="deckEditorNewDeckMode" value="empty" checked>Empty deck</label>
+            </div>
+          </div>
+        </div>
+        <div class="deckEditorNewDeckGroup" id="deckEditorNewDeckGroupExisting">
+          <button class="deckEditorNewDeckGroupHeader">Use an existing deck<span>Take a deck that is already finished, from the library or another game</span></button>
+          <div class="deckEditorNewDeckGroupBody">
+            <div class="deckEditorNewDeckModes">
+              <label><input type="radio" name="deckEditorNewDeckMode" value="library"><b>Public library</b><span>Browse the ready-made decks shared in the public library</span></label>
+              <label><input type="radio" name="deckEditorNewDeckMode" value="traditional"><b>Traditional deck</b><span>Standard, Spanish, German, Swiss, tarot, hanafuda, mahjong or dominoes</span></label>
+              <label><input type="radio" name="deckEditorNewDeckMode" value="tts"><b>Tabletop Simulator</b><span>Import a deck from a Tabletop Simulator save file</span></label>
+            </div>
+          </div>
+        </div>
+        <div class="deckEditorNewDeckGroup" id="deckEditorNewDeckGroupCustom">
+          <button class="deckEditorNewDeckGroupHeader">Create a custom deck<span>Let the editor build the cards from your own suits, images or texts</span></button>
+          <div class="deckEditorNewDeckGroupBody">
+            <div class="deckEditorNewDeckModes">
+              <label><input type="radio" name="deckEditorNewDeckMode" value="custom"><b>Suits and ranks</b><span>One card for every combination of a suit and a rank</span></label>
+              <label><input type="radio" name="deckEditorNewDeckMode" value="images"><b>One image per card</b><span>Upload one image per card or tiled images &mdash; one shared back for the whole deck</span></label>
+              <label><input type="radio" name="deckEditorNewDeckMode" value="imagePairs"><b>A front and a back image per card</b><span>Upload all fronts and all backs &mdash; they are paired up by file name</span></label>
+              <label><input type="radio" name="deckEditorNewDeckMode" value="text"><b>Text cards</b><span>One card per line of text</span></label>
+            </div>
+          </div>
+        </div>
       </div>
       <div id="deckEditorNewDeckPanel"></div>
     </div>

--- a/client/editor.html
+++ b/client/editor.html
@@ -237,6 +237,8 @@
         <label><input type="radio" name="deckEditorNewDeckMode" value="traditional">Traditional deck (standard, Spanish, German, Swiss, tarot, hanafuda, mahjong, dominoes)</label>
         <label><input type="radio" name="deckEditorNewDeckMode" value="custom">Custom deck of cards (define suits and ranks)</label>
         <label><input type="radio" name="deckEditorNewDeckMode" value="images">Upload one image per card or tiled images</label>
+        <label><input type="radio" name="deckEditorNewDeckMode" value="imagePairs">Upload a front and a back image for every card</label>
+        <label><input type="radio" name="deckEditorNewDeckMode" value="text">Text cards &mdash; one card per line of text</label>
         <label><input type="radio" name="deckEditorNewDeckMode" value="tts">Import from Tabletop Simulator</label>
       </div>
       <div id="deckEditorNewDeckPanel"></div>

--- a/client/editor.html
+++ b/client/editor.html
@@ -236,10 +236,11 @@
         <label><input type="radio" name="deckEditorNewDeckMode" value="library">Browse the public library of ready-made decks</label>
         <label><input type="radio" name="deckEditorNewDeckMode" value="traditional">Traditional deck (standard, Spanish, German, Swiss, tarot, hanafuda, mahjong, dominoes)</label>
         <label><input type="radio" name="deckEditorNewDeckMode" value="custom">Custom deck of cards (define suits and ranks)</label>
-        <label><input type="radio" name="deckEditorNewDeckMode" value="images">Upload one image per card or tiled images</label>
-        <label><input type="radio" name="deckEditorNewDeckMode" value="imagePairs">Upload a front and a back image for every card</label>
+        <label><input type="radio" name="deckEditorNewDeckMode" value="images">Upload one image per card or tiled images &mdash; one shared back for the whole deck</label>
+        <label><input type="radio" name="deckEditorNewDeckMode" value="imagePairs">Upload a separate front and back image for every card</label>
         <label><input type="radio" name="deckEditorNewDeckMode" value="text">Text cards &mdash; one card per line of text</label>
         <label><input type="radio" name="deckEditorNewDeckMode" value="tts">Import from Tabletop Simulator</label>
+        <button id="deckEditorNewDeckChangeMode" icon="expand_more">Change</button>
       </div>
       <div id="deckEditorNewDeckPanel"></div>
     </div>

--- a/client/editor.html
+++ b/client/editor.html
@@ -257,7 +257,7 @@
               <label><input type="radio" name="deckEditorNewDeckMode" value="custom"><b>Suits and ranks</b><span>One card for every combination of a suit and a rank</span></label>
               <label><input type="radio" name="deckEditorNewDeckMode" value="images"><b>One image per card</b><span>Upload one image per card or tiled images &mdash; one shared back for the whole deck</span></label>
               <label><input type="radio" name="deckEditorNewDeckMode" value="imagePairs"><b>A front and a back image per card</b><span>Upload all fronts and all backs &mdash; they are paired up by file name</span></label>
-              <label><input type="radio" name="deckEditorNewDeckMode" value="text"><b>Text cards</b><span>One card per line of text</span></label>
+              <label><input type="radio" name="deckEditorNewDeckMode" value="text"><b>Text cards</b><span>One card per line, or per paragraph when a card needs line breaks</span></label>
             </div>
           </div>
         </div>

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -3172,7 +3172,8 @@ class DeckEditor {
 
   // "Add New Deck" opens a small submenu offering every existing way to create a deck. Rather than
   // reinventing those flows, we reuse the ones the properties sidebar already implements (traditional,
-  // custom, image upload, TTS import) by rendering them, and the public-library and empty-deck flows.
+  // custom, image upload, front/back image upload, text cards, TTS import) by rendering them, and the
+  // public-library and empty-deck flows.
   openNewDeckOverlay() {
     if(!this.deckCreator)
       this.deckCreator = new PropertiesModule();
@@ -3188,9 +3189,9 @@ class DeckEditor {
     showOverlay();
   }
 
-  // Each mode renders its existing creation flow into the overlay's panel. traditional/custom/images/tts
-  // (and the library) add a fresh deck to the game; once that lands as a delta, deckEditorReceiveDelta
-  // switches the editor to it (this.pendingNewDeck). "empty" opens the new deck here directly.
+  // Each mode renders its existing creation flow into the overlay's panel. Every mode except "empty" adds a
+  // fresh deck to the game; once that lands as a delta, deckEditorReceiveDelta switches the editor to it
+  // (this.pendingNewDeck). "empty" opens the new deck here directly.
   renderNewDeckPanel(mode) {
     const panel = $('#deckEditorNewDeckPanel');
     panel.innerHTML = '';
@@ -3233,6 +3234,10 @@ class DeckEditor {
         this.deckCreator.deckGenerator(moduleDOM);
       else if(mode == 'images')
         this.deckCreator.deckImages(moduleDOM);
+      else if(mode == 'imagePairs')
+        this.deckCreator.deckImagePairs(moduleDOM);
+      else if(mode == 'text')
+        this.deckCreator.deckTextCards(moduleDOM);
       else if(mode == 'tts')
         this.deckCreator.deckImportTTS(moduleDOM);
     }

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -265,11 +265,9 @@ class DeckEditor {
     $('#deckEditorAddDeck').onclick = _=>this.openNewDeckOverlay();
     $('#deckEditorNewDeckClose').onclick = _=>this.closeNewDeckOverlay();
     for(const radio of $a('#deckEditorNewDeckOverlay input[name=deckEditorNewDeckMode]'))
-      radio.onchange = _=>{
-        this.renderNewDeckPanel(radio.value);
-        this.setNewDeckModesCollapsed(true);
-      };
-    $('#deckEditorNewDeckChangeMode').onclick = _=>this.setNewDeckModesCollapsed(false);
+      radio.onchange = _=>this.renderNewDeckPanel(radio.value);
+    for(const header of $a('#deckEditorNewDeckOverlay .deckEditorNewDeckGroupHeader'))
+      header.onclick = _=>this.openNewDeckGroup(header.parentNode);
     $('#deckEditorUndo').onclick = _=>this.undo();
     $('#deckEditorRedo').onclick = _=>this.redo();
     $('#deckEditorCardView').onclick = _=>this.setRoomVisible(!this.roomVisible);
@@ -3181,21 +3179,24 @@ class DeckEditor {
   openNewDeckOverlay() {
     if(!this.deckCreator)
       this.deckCreator = new PropertiesModule();
-    // Always start on the "empty deck" default so the submenu is predictable each time it opens.
-    const empty = $('#deckEditorNewDeckOverlay input[value=empty]');
-    empty.checked = true;
-    this.renderNewDeckPanel('empty');
-    this.setNewDeckModesCollapsed(false);
+    // Always start on the blank deck group so the submenu is predictable each time it opens.
+    this.openNewDeckGroup($('#deckEditorNewDeckGroupBlank'));
     showOverlay('deckEditorNewDeckOverlay');
   }
 
-  // All eight ways to create a deck are on offer while the dialog opens; picking one collapses the list to
-  // the chosen entry so the panel doing the actual work isn't pushed off the bottom of the dialog.
-  setNewDeckModesCollapsed(collapsed) {
-    const modes = $('#deckEditorNewDeckOverlay .deckEditorNewDeckModes');
-    for(const label of $a('label', modes))
-      label.classList.toggle('deckEditorNewDeckModeSelected', $('input', label).checked);
-    modes.classList.toggle('deckEditorNewDeckModesCollapsed', collapsed);
+  // The ways to create a deck are grouped into three expanders - a blank deck, an existing deck, a custom
+  // deck - of which only one is open at a time, so the dialog shows three short rows instead of a wall of
+  // options. Opening a group closes the others and moves the panel doing the actual work into it, right
+  // below the options it belongs to. A group offering several ways waits for one of them to be picked; the
+  // blank deck group has only the one, so opening it is already the choice and its panel shows right away.
+  openNewDeckGroup(group) {
+    for(const other of $a('#deckEditorNewDeckOverlay .deckEditorNewDeckGroup'))
+      other.classList.toggle('deckEditorNewDeckGroupOpen', other == group);
+    const modes = $a('input[name=deckEditorNewDeckMode]', group);
+    for(const radio of $a('#deckEditorNewDeckOverlay input[name=deckEditorNewDeckMode]'))
+      radio.checked = modes.length == 1 && radio == modes[0];
+    $('.deckEditorNewDeckGroupBody', group).append($('#deckEditorNewDeckPanel'));
+    this.renderNewDeckPanel(modes.length == 1 ? modes[0].value : null);
   }
 
   closeNewDeckOverlay() {
@@ -3203,13 +3204,16 @@ class DeckEditor {
     showOverlay();
   }
 
-  // Each mode renders its existing creation flow into the overlay's panel. Every mode except "empty" adds a
-  // fresh deck to the game; once that lands as a delta, deckEditorReceiveDelta switches the editor to it
-  // (this.pendingNewDeck). "empty" opens the new deck here directly.
+  // Each mode renders its existing creation flow into the overlay's panel (no mode picked yet: nothing to
+  // render). Every mode except "empty" adds a fresh deck to the game; once that lands as a delta,
+  // deckEditorReceiveDelta switches the editor to it (this.pendingNewDeck). "empty" opens the new deck here
+  // directly.
   renderNewDeckPanel(mode) {
     const panel = $('#deckEditorNewDeckPanel');
     panel.innerHTML = '';
-    this.pendingNewDeck = mode != 'empty';
+    this.pendingNewDeck = !!mode && mode != 'empty';
+    if(!mode)
+      return;
     if(mode == 'empty') {
       // Card size first, then the (optional) deck id: the size decides what the starter faces and the holder
       // are built at, and it is the harder one to change afterwards.

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -265,7 +265,11 @@ class DeckEditor {
     $('#deckEditorAddDeck').onclick = _=>this.openNewDeckOverlay();
     $('#deckEditorNewDeckClose').onclick = _=>this.closeNewDeckOverlay();
     for(const radio of $a('#deckEditorNewDeckOverlay input[name=deckEditorNewDeckMode]'))
-      radio.onchange = _=>this.renderNewDeckPanel(radio.value);
+      radio.onchange = _=>{
+        this.renderNewDeckPanel(radio.value);
+        this.setNewDeckModesCollapsed(true);
+      };
+    $('#deckEditorNewDeckChangeMode').onclick = _=>this.setNewDeckModesCollapsed(false);
     $('#deckEditorUndo').onclick = _=>this.undo();
     $('#deckEditorRedo').onclick = _=>this.redo();
     $('#deckEditorCardView').onclick = _=>this.setRoomVisible(!this.roomVisible);
@@ -3181,7 +3185,17 @@ class DeckEditor {
     const empty = $('#deckEditorNewDeckOverlay input[value=empty]');
     empty.checked = true;
     this.renderNewDeckPanel('empty');
+    this.setNewDeckModesCollapsed(false);
     showOverlay('deckEditorNewDeckOverlay');
+  }
+
+  // All eight ways to create a deck are on offer while the dialog opens; picking one collapses the list to
+  // the chosen entry so the panel doing the actual work isn't pushed off the bottom of the dialog.
+  setNewDeckModesCollapsed(collapsed) {
+    const modes = $('#deckEditorNewDeckOverlay .deckEditorNewDeckModes');
+    for(const label of $a('label', modes))
+      label.classList.toggle('deckEditorNewDeckModeSelected', $('input', label).checked);
+    modes.classList.toggle('deckEditorNewDeckModesCollapsed', collapsed);
   }
 
   closeNewDeckOverlay() {

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1363,10 +1363,18 @@ class PropertiesModule extends SidebarModule {
   }
 
   // "min"/"max" on a number input only constrain its spinner - a typed or pasted value is passed through
-  // unchanged. The copy counts multiply with the number of card types, so clamp them to the declared range
-  // before they reach the card-creation loop.
-  copiesFromInput(input) {
-    return Math.min(+input.max || Infinity, Math.max(+input.min || 1, Math.round(+input.value) || 1));
+  // unchanged, so everything read back from one goes through here and is clamped to the range the input
+  // itself declares. An emptied or unparsable field falls back to the minimum, which also keeps the defaults
+  // in the HTML templates from having to be repeated in the code that reads them.
+  numberFromInput(input) {
+    const min = +input.min || 1;
+    return Math.min(+input.max || Infinity, Math.max(min, Math.round(+input.value) || min));
+  }
+
+  // Card type names end up in the card widget ids, so strip anything awkward there and keep them short; the
+  // caller's fallback is used when a name has nothing usable left (e.g. a "______ + ______" card text).
+  cardTypeName(name, fallback) {
+    return name.replace(/[^A-Za-z0-9 ]+/g, ' ').replace(/\s+/g, ' ').trim().substr(0, 30).trim() || fallback;
   }
 
   // Two bulk uploads - all the card fronts and all the card backs - matched into pairs by sorting both lists
@@ -1402,7 +1410,14 @@ class PropertiesModule extends SidebarModule {
       const bar = div(columns, 'buttonBar', `<button icon=upload>${label}</button>`);
       $('button', bar).onclick = _=>uploadAsset((imagePath, fileName)=>{
         if(imagePath) {
-          list.push({ imagePath, fileName });
+          const entry = { imagePath, fileName };
+          list.push(entry);
+          // The card size is derived from the first front image's aspect ratio, and naturalWidth/naturalHeight
+          // stay 0 until the browser has decoded it - so measure the image as soon as it is available instead
+          // of whenever "Add to game" happens to be clicked.
+          const probe = new Image();
+          probe.onload = _=>entry.aspectRatio = probe.naturalWidth / probe.naturalHeight;
+          probe.src = mapAssetURLs(imagePath);
           render();
         }
       });
@@ -1454,14 +1469,14 @@ class PropertiesModule extends SidebarModule {
     render();
 
     addButton.onclick = async _=>{
-      const copies = this.copiesFromInput($('input', options));
+      const copies = this.numberFromInput($('input', options));
       const cardTypes = {};
       const counts = {};
       for(const [ index, front ] of fronts.entries()) {
         const back = backs.length == 1 ? backs[0] : backs[index];
         // Two files can share a name (they come from separate uploads); a "(2)" suffix rather than a plain
         // number keeps the generated card ids apart from the "<card type> <copy number>" ids below.
-        const base = front.fileName.replace(/\.[^.]+$/, '') || `card ${index+1}`;
+        const base = this.cardTypeName(front.fileName.replace(/\.[^.]+$/, ''), `card ${index+1}`);
         let cardType = base;
         for(let i=2; Object.prototype.hasOwnProperty.call(cardTypes, cardType); ++i)
           cardType = `${base} (${i})`;
@@ -1504,11 +1519,10 @@ class PropertiesModule extends SidebarModule {
       };
 
       // Keep the default card height and take the width from the first front image's aspect ratio, so the
-      // cards aren't distorted (same approach as the single-image flow above).
-      const firstFront = $('img', frontList);
-      const cardWidth = firstFront && firstFront.naturalHeight
-        ? Math.round(firstFront.naturalWidth / firstFront.naturalHeight * 160)
-        : 103;
+      // cards aren't distorted (same approach as the single-image flow above). Falls back to the default card
+      // size while the image hasn't been decoded yet.
+      const aspectRatio = fronts[0].aspectRatio;
+      const cardWidth = aspectRatio ? Math.round(aspectRatio*160) : 103;
       if(cardWidth != 103)
         deck.cardDefaults = { width: cardWidth };
 
@@ -1559,10 +1573,10 @@ class PropertiesModule extends SidebarModule {
     const cardTexts = _=>textarea.value.split('\n').map(line=>line.trim()).filter(line=>line.length);
 
     const deckDefinition = (texts, id)=>{
-      const number = (selector, fallback)=>+$(selector, design).value || fallback;
-      const width    = number('.textCardsWidth', 150);
-      const height   = number('.textCardsHeight', 233);
-      const fontSize = number('.textCardsFontSize', 16);
+      const number = selector=>this.numberFromInput($(selector, design));
+      const width    = number('.textCardsWidth');
+      const height   = number('.textCardsHeight');
+      const fontSize = number('.textCardsFontSize');
       const color    = $('.textCardsColor', design).value;
       const label    = $('.textCardsLabel', design).value.trim();
       const padding  = Math.max(4, Math.round(width/12));
@@ -1587,10 +1601,8 @@ class PropertiesModule extends SidebarModule {
 
       const cardTypes = {};
       for(const [ index, text ] of texts.entries()) {
-        // Card type names end up in the card widget ids, so strip anything awkward there and keep them short;
-        // fall back to a running number when a line has nothing usable left (e.g. "______ + ______"). Repeated
-        // lines get a "(2)" suffix, which can't collide with the "<card type> <copy number>" card ids.
-        const base = text.replace(/[^A-Za-z0-9 ]+/g, ' ').replace(/\s+/g, ' ').trim().substr(0, 30).trim() || `card ${index+1}`;
+        // Repeated lines get a "(2)" suffix, which can't collide with the "<card type> <copy number>" card ids.
+        const base = this.cardTypeName(text, `card ${index+1}`);
         let cardType = base;
         for(let i=2; Object.prototype.hasOwnProperty.call(cardTypes, cardType); ++i)
           cardType = `${base} (${i})`;
@@ -1642,7 +1654,7 @@ class PropertiesModule extends SidebarModule {
 
       // Spell out what "Add to game" will create: the copies multiplier is easy to miss, and it decides
       // whether addDeckWithCards asks for confirmation.
-      const copies = this.copiesFromInput($('.textCardsCopies', design));
+      const copies = this.numberFromInput($('.textCardsCopies', design));
       const cards = texts.length * copies;
       status.innerText = texts.length
         ? `${texts.length} card type${texts.length == 1 ? '' : 's'} × ${copies} = ${cards} card${cards == 1 ? '' : 's'}.`
@@ -1659,7 +1671,7 @@ class PropertiesModule extends SidebarModule {
       if(!texts.length)
         return;
       const deck = deckDefinition(texts, generateUniqueWidgetID());
-      const copies = this.copiesFromInput($('.textCardsCopies', design));
+      const copies = this.numberFromInput($('.textCardsCopies', design));
       const counts = {};
       for(const cardType in deck.cardTypes)
         counts[cardType] = copies;
@@ -6636,8 +6648,7 @@ class PropertiesModule extends SidebarModule {
       const parent = new BasicWidget().renderReadonlyCopyRaw({}, button).domElement;
       const faceTemplates = widget.get('faceTemplates');
       widgets.set(widget.id, widget);
-      const cardTypeNames = Object.keys(widget.get('cardTypes'));
-      for(const cardType of shuffleArray(cardTypeNames).slice(0, 5)) {
+      for(const cardType of shuffleArray(Object.keys(widget.get('cardTypes'))).slice(0, 5)) {
         new Card().renderReadonlyCopyRaw(Object.assign({
           deck: widget.id,
           cardType,

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1381,26 +1381,38 @@ class PropertiesModule extends SidebarModule {
     intro.innerText = 'Upload all card fronts and all card backs. Both lists are sorted by file name and then matched up in that order, so front1.jpg is paired with back1.jpg. Upload a single back image to use it for every card.';
     target.append(intro);
 
-    const addUploadSection = (title, list, label)=>{
-      this.addSubHeader(title, target);
-      const listDOM = div(target, 'imagePairList');
-      const bar = div(target, 'buttonBar', `<button icon=upload>${label}</button>`);
+    // Fronts and backs go into a two-column grid, filled row by row (both headers, both hints, both lists,
+    // both upload buttons) so that row n of the fronts and row n of the backs - the pair - are on one line.
+    const columns = div(target, 'imagePairColumns');
+    this.addSubHeader('Card fronts', columns);
+    this.addSubHeader('Card backs', columns);
+    div(columns, 'imagePairHint', 'One image per card.');
+    // The single-back shortcut is only worth knowing before you upload, not after it has turned into a mismatch.
+    div(columns, 'imagePairHint', 'One per card, or a single one for every card.');
+
+    const addList = (emptyHint)=>{
+      const listDOM = div(columns, 'imagePairList');
+      listDOM.dataset.emptyHint = emptyHint;
+      return listDOM;
+    };
+    const frontList = addList('No front images yet');
+    const backList  = addList('No back images yet');
+
+    for(const [ list, label ] of [ [ fronts, 'Upload fronts...' ], [ backs, 'Upload backs...' ] ]) {
+      const bar = div(columns, 'buttonBar', `<button icon=upload>${label}</button>`);
       $('button', bar).onclick = _=>uploadAsset((imagePath, fileName)=>{
         if(imagePath) {
           list.push({ imagePath, fileName });
           render();
         }
       });
-      return listDOM;
-    };
+    }
 
-    const frontList = addUploadSection('Card fronts', fronts, 'Upload fronts...');
-    const backList  = addUploadSection('Card backs',  backs,  'Upload backs...');
+    const options = div(target, 'imagePairOptions', '<label>Copies of each card<input type=number min=1 max=99 value=1></label>');
 
-    const status = div(target, 'imagePairStatus');
-    const options = div(target, 'imagePairOptions', 'Copies of each card: <input type=number min=1 max=99 value=1>');
-
-    div(target, 'goButton buttonBar', '<button icon=add class=green disabled>Add to game</button>');
+    // The status explains why "Add to game" is disabled, so it belongs right next to it.
+    div(target, 'goButton buttonBar', '<span class=imagePairStatus></span><button icon=add class=green disabled>Add to game</button>');
+    const status = $('.imagePairStatus', target);
     const addButton = $('.goButton [icon=add]', target);
 
     const renderList = (list, listDOM, pairedWith)=>{
@@ -1510,7 +1522,7 @@ class PropertiesModule extends SidebarModule {
   // everything beyond that is done afterwards in the deck editor.
   deckTextCards(target) {
     const intro = document.createElement('p');
-    intro.innerText = 'Type or paste the card texts, one card per line. Each line becomes a card type whose "text" property holds that line, so you can edit the wording later in the deck editor.';
+    intro.innerText = 'Type or paste the card texts, one card per line. Each line becomes a card type - one distinct card design, of which the copies below are duplicates - whose "text" property holds that line, so you can edit the wording later in the deck editor.';
     target.append(intro);
 
     this.addSubHeader('Card texts', target);
@@ -1520,21 +1532,28 @@ class PropertiesModule extends SidebarModule {
     textarea.placeholder = 'The first card\nThe second card\n...';
     target.append(textarea);
 
-    this.addSubHeader('Card design', target);
-    const design = div(target, 'textCardsDesign', `
+    // Design inputs and preview side by side: the preview is exactly what you want to look at while changing
+    // the font size and the colors, so it must not be pushed below the fold by the inputs that drive it.
+    const columns = div(target, 'textCardsColumns');
+    const designColumn = div(columns, 'textCardsColumn');
+    this.addSubHeader('Card design', designColumn);
+    const design = div(designColumn, 'textCardsDesign', `
       <label>Card color<input class=textCardsBackground type=color value="#000000"></label>
       <label>Text color<input class=textCardsColor type=color value="#ffffff"></label>
-      <label>Font size<input class=textCardsFontSize type=number min=6 max=72 value=16></label>
-      <label>Card width<input class=textCardsWidth type=number min=20 max=600 value=150></label>
-      <label>Card height<input class=textCardsHeight type=number min=20 max=600 value=233></label>
+      <label>Font size<input class=textCardsFontSize type=number min=6 max=72 value=16>px</label>
+      <label>Card width<input class=textCardsWidth type=number min=20 max=600 value=150>px</label>
+      <label>Card height<input class=textCardsHeight type=number min=20 max=600 value=233>px</label>
       <label>Copies of each card<input class=textCardsCopies type=number min=1 max=99 value=1></label>
-      <label class=textCardsLabelWrap>Deck label - shown on the card backs<input class=textCardsLabel type=text placeholder="optional, e.g. the deck name"></label>
+      <label class=textCardsLabelWrap>Deck label<input class=textCardsLabel type=text placeholder="optional, e.g. the deck name"></label>
+      <span class=textCardsHint>The deck label is shown large on the card backs and small along the bottom edge of the fronts.</span>
     `);
 
-    this.addSubHeader('Preview', target);
-    const preview = div(target, 'textCardsPreview');
+    const previewColumn = div(columns, 'textCardsColumn textCardsPreviewColumn');
+    this.addSubHeader('Preview (first card)', previewColumn);
+    const preview = div(previewColumn, 'textCardsPreview');
 
-    div(target, 'goButton buttonBar', '<button icon=add class=green disabled>Add to game</button>');
+    div(target, 'goButton buttonBar', '<span class=textCardsStatus></span><button icon=add class=green disabled>Add to game</button>');
+    const status = $('.textCardsStatus', target);
     const addButton = $('.goButton [icon=add]', target);
 
     const cardTexts = _=>textarea.value.split('\n').map(line=>line.trim()).filter(line=>line.length);
@@ -1561,7 +1580,9 @@ class PropertiesModule extends SidebarModule {
         height: height - 2*padding,
         textAlign: 'left',
         color,
-        css: { 'font-weight': 'bold', 'line-height': '1.25em' }
+        // Clip instead of spilling over the rounded card edge (or over the deck label) when a text is longer
+        // than the box it was given at the chosen font size.
+        css: { 'font-weight': 'bold', 'line-height': '1.25em', 'overflow': 'hidden' }
       }, properties);
 
       const cardTypes = {};
@@ -1593,15 +1614,39 @@ class PropertiesModule extends SidebarModule {
       };
     };
 
-    // One id for every preview render: renderWidgetButton briefly registers the preview deck in "widgets", so
-    // it needs an id that is not in use, but generating a fresh one per keystroke would be wasteful.
+    // One id for every preview render: the preview deck is briefly registered in "widgets" so the preview card
+    // can read its faces from it, which needs an id that is not in use - but generating a fresh one on every
+    // keystroke would be wasteful.
     const previewID = generateUniqueWidgetID();
     const updatePreview = _=>{
       const texts = cardTexts();
-      const deck = deckDefinition(texts.length ? texts.slice(0, 5) : [ 'Your card text goes here.' ], previewID);
+      const deck = deckDefinition([ texts.length ? texts[0] : 'Your card text goes here.' ], previewID);
+      const { width, height } = deck.cardDefaults;
+      // A single upright card at (up to) its real size - the fanned five-card thumbnail renderWidgetButton
+      // draws is far too small to judge the font size, the colors or where the text wraps, which is the only
+      // reason to look at a preview here. Scaling happens on a wrapper so the card keeps its own transform.
+      const scale = Math.min(1, 200/Math.max(width, height));
       preview.innerHTML = '';
-      // Keep the card types in their typed order - a shuffled preview would jump around on every keystroke.
-      this.renderWidgetButton(new Deck(deck.id), deck, preview, false);
+      preview.style.width = `${Math.round(width*scale)}px`;
+      preview.style.height = `${Math.round(height*scale)}px`;
+      const box = div(preview, 'textCardsPreviewCard');
+      box.style.width = `${width}px`;
+      box.style.height = `${height}px`;
+      box.style.transform = `scale(${scale})`;
+
+      const previewDeck = new Deck(previewID);
+      previewDeck.renderReadonlyCopyRaw(JSON.parse(JSON.stringify(deck)), box).domElement.remove();
+      widgets.set(previewID, previewDeck);
+      new Card().renderReadonlyCopyRaw({ deck: previewID, cardType: Object.keys(deck.cardTypes)[0], activeFace: 1 }, box);
+      widgets.delete(previewID);
+
+      // Spell out what "Add to game" will create: the copies multiplier is easy to miss, and it decides
+      // whether addDeckWithCards asks for confirmation.
+      const copies = this.copiesFromInput($('.textCardsCopies', design));
+      const cards = texts.length * copies;
+      status.innerText = texts.length
+        ? `${texts.length} card type${texts.length == 1 ? '' : 's'} × ${copies} = ${cards} card${cards == 1 ? '' : 's'}.`
+        : 'Type or paste at least one line of text above.';
       addButton.disabled = !texts.length;
     };
     textarea.oninput = updatePreview;
@@ -6574,7 +6619,7 @@ class PropertiesModule extends SidebarModule {
     }
   }
 
-  renderWidgetButton(widget, state, target, shuffleCardTypes=true) {
+  renderWidgetButton(widget, state, target) {
     const button = document.createElement('button');
     button.className = 'widgetSelectionButton';
     target.appendChild(button);
@@ -6588,7 +6633,7 @@ class PropertiesModule extends SidebarModule {
       const faceTemplates = widget.get('faceTemplates');
       widgets.set(widget.id, widget);
       const cardTypeNames = Object.keys(widget.get('cardTypes'));
-      for(const cardType of (shuffleCardTypes ? shuffleArray(cardTypeNames) : cardTypeNames).slice(0, 5)) {
+      for(const cardType of shuffleArray(cardTypeNames).slice(0, 5)) {
         new Card().renderReadonlyCopyRaw(Object.assign({
           deck: widget.id,
           cardType,

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1362,6 +1362,13 @@ class PropertiesModule extends SidebarModule {
     };
   }
 
+  // "min"/"max" on a number input only constrain its spinner - a typed or pasted value is passed through
+  // unchanged. The copy counts multiply with the number of card types, so clamp them to the declared range
+  // before they reach the card-creation loop.
+  copiesFromInput(input) {
+    return Math.min(+input.max || Infinity, Math.max(+input.min || 1, Math.round(+input.value) || 1));
+  }
+
   // Two bulk uploads - all the card fronts and all the card backs - matched into pairs by sorting both lists
   // by file name, so front1.jpg gets back1.jpg as its back. Numbers are compared numerically so front2 sorts
   // before front10. Unlike deckImages (one shared back for the whole deck) every card type carries its own
@@ -1418,8 +1425,11 @@ class PropertiesModule extends SidebarModule {
         list.sort((a, b)=>a.fileName.localeCompare(b.fileName, undefined, { numeric: true }));
       const sharedBack = backs.length == 1;
       const paired = fronts.length && backs.length && (sharedBack || fronts.length == backs.length);
-      renderList(fronts, frontList, sharedBack ? null : backs);
-      renderList(backs, backList, sharedBack ? null : fronts);
+      // Only claim a pairing in the tooltips while the counts actually match - otherwise the rows would
+      // promise pairs that "Add to game" is refusing to create.
+      const showPairs = paired && !sharedBack;
+      renderList(fronts, frontList, showPairs ? backs : null);
+      renderList(backs, backList, showPairs ? fronts : null);
       if(!fronts.length || !backs.length)
         status.innerText = 'Upload at least one front image and one back image.';
       else if(paired)
@@ -1432,7 +1442,7 @@ class PropertiesModule extends SidebarModule {
     render();
 
     addButton.onclick = async _=>{
-      const copies = Math.max(1, +$('input', options).value || 1);
+      const copies = this.copiesFromInput($('input', options));
       const cardTypes = {};
       const counts = {};
       for(const [ index, front ] of fronts.entries()) {
@@ -1441,7 +1451,7 @@ class PropertiesModule extends SidebarModule {
         // number keeps the generated card ids apart from the "<card type> <copy number>" ids below.
         const base = front.fileName.replace(/\.[^.]+$/, '') || `card ${index+1}`;
         let cardType = base;
-        for(let i=2; cardTypes[cardType] !== undefined; ++i)
+        for(let i=2; Object.prototype.hasOwnProperty.call(cardTypes, cardType); ++i)
           cardType = `${base} (${i})`;
         cardTypes[cardType] = { image: front.imagePath, backImage: back.imagePath };
         counts[cardType] = copies;
@@ -1537,6 +1547,10 @@ class PropertiesModule extends SidebarModule {
       const color    = $('.textCardsColor', design).value;
       const label    = $('.textCardsLabel', design).value.trim();
       const padding  = Math.max(4, Math.round(width/12));
+      // With a deck label the front gets a small footer along its bottom edge, so the card text has to stop
+      // above it - text objects don't clip, a long text would just run over the label.
+      const footerSize   = Math.max(6, Math.round(fontSize/2));
+      const footerHeight = label ? Math.round(footerSize*1.4) : 0;
 
       const colorBox = _=>({ type: 'image', x: 0, y: 0, width, height, color: $('.textCardsBackground', design).value, value: '' });
       const textObject = properties=>Object.assign({
@@ -1557,17 +1571,15 @@ class PropertiesModule extends SidebarModule {
         // lines get a "(2)" suffix, which can't collide with the "<card type> <copy number>" card ids.
         const base = text.replace(/[^A-Za-z0-9 ]+/g, ' ').replace(/\s+/g, ' ').trim().substr(0, 30).trim() || `card ${index+1}`;
         let cardType = base;
-        for(let i=2; cardTypes[cardType] !== undefined; ++i)
+        for(let i=2; Object.prototype.hasOwnProperty.call(cardTypes, cardType); ++i)
           cardType = `${base} (${i})`;
         cardTypes[cardType] = { text };
       }
 
       const back = { radius: 8, objects: [ colorBox() ] };
-      const front = { radius: 8, objects: [ colorBox(), textObject({ dynamicProperties: { value: 'text', fontSize: 'fontSize' } }) ] };
+      const front = { radius: 8, objects: [ colorBox(), textObject({ height: height - 2*padding - footerHeight, dynamicProperties: { value: 'text', fontSize: 'fontSize' } }) ] };
       if(label) {
         // The back is just the label at 1.5x, the front repeats it small along the bottom edge.
-        const footerSize = Math.max(6, Math.round(fontSize/2));
-        const footerHeight = Math.round(footerSize*1.4);
         back.objects.push(textObject({ value: label, fontSize: Math.round(fontSize*1.5) }));
         front.objects.push(textObject({ value: label, fontSize: footerSize, y: height - padding - footerHeight, height: footerHeight }));
       }
@@ -1588,7 +1600,8 @@ class PropertiesModule extends SidebarModule {
       const texts = cardTexts();
       const deck = deckDefinition(texts.length ? texts.slice(0, 5) : [ 'Your card text goes here.' ], previewID);
       preview.innerHTML = '';
-      this.renderWidgetButton(new Deck(deck.id), deck, preview);
+      // Keep the card types in their typed order - a shuffled preview would jump around on every keystroke.
+      this.renderWidgetButton(new Deck(deck.id), deck, preview, false);
       addButton.disabled = !texts.length;
     };
     textarea.oninput = updatePreview;
@@ -1601,7 +1614,7 @@ class PropertiesModule extends SidebarModule {
       if(!texts.length)
         return;
       const deck = deckDefinition(texts, generateUniqueWidgetID());
-      const copies = Math.max(1, +$('.textCardsCopies', design).value || 1);
+      const copies = this.copiesFromInput($('.textCardsCopies', design));
       const counts = {};
       for(const cardType in deck.cardTypes)
         counts[cardType] = copies;
@@ -1692,6 +1705,12 @@ class PropertiesModule extends SidebarModule {
   }
 
   async addDeckWithCards(deck, type, counts) {
+    // Every card becomes a widget of its own inside a single batch, so a long list of card types multiplied
+    // by a high copy count can keep the client busy for a long time - ask before creating a whole lot of them.
+    const totalCards = Object.keys(deck.cardTypes || {}).reduce((sum, cardType)=>sum + (counts ? counts[cardType] || 0 : 1), 0);
+    if(totalCards > 500 && !confirm(`This creates ${totalCards} cards. Adding that many at once takes a while and makes the game harder to work with.\n\nCreate them anyway?`))
+      return;
+
     batchStart();
     setDeltaCause(`${getPlayerDetails().playerName} added ${type} deck "${deck.id}" in editor`);
 
@@ -6555,7 +6574,7 @@ class PropertiesModule extends SidebarModule {
     }
   }
 
-  renderWidgetButton(widget, state, target) {
+  renderWidgetButton(widget, state, target, shuffleCardTypes=true) {
     const button = document.createElement('button');
     button.className = 'widgetSelectionButton';
     target.appendChild(button);
@@ -6568,7 +6587,8 @@ class PropertiesModule extends SidebarModule {
       const parent = new BasicWidget().renderReadonlyCopyRaw({}, button).domElement;
       const faceTemplates = widget.get('faceTemplates');
       widgets.set(widget.id, widget);
-      for(const cardType of shuffleArray(Object.keys(widget.get('cardTypes'))).slice(0, 5)) {
+      const cardTypeNames = Object.keys(widget.get('cardTypes'));
+      for(const cardType of (shuffleCardTypes ? shuffleArray(cardTypeNames) : cardTypeNames).slice(0, 5)) {
         new Card().renderReadonlyCopyRaw(Object.assign({
           deck: widget.id,
           cardType,

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1750,9 +1750,13 @@ class PropertiesModule extends SidebarModule {
   }
 
   async addDeckWithCards(deck, type, counts) {
+    // Some callers fill counts straight from a number input, where .value is a string - coerce so that the
+    // counts are summed rather than concatenated.
+    const copiesOf = cardType => counts ? Number(counts[cardType]) || 0 : 1;
+
     // Every card becomes a widget of its own inside a single batch, so a long list of card types multiplied
     // by a high copy count can keep the client busy for a long time - ask before creating a whole lot of them.
-    const totalCards = Object.keys(deck.cardTypes || {}).reduce((sum, cardType)=>sum + (counts ? counts[cardType] || 0 : 1), 0);
+    const totalCards = Object.keys(deck.cardTypes || {}).reduce((sum, cardType)=>sum + copiesOf(cardType), 0);
     if(totalCards > 500 && !confirm(`This creates ${totalCards} cards. Adding that many at once takes a while and makes the game harder to work with.\n\nCreate them anyway?`))
       return;
 
@@ -1802,7 +1806,7 @@ class PropertiesModule extends SidebarModule {
     await addWidgetLocal({ type: 'pile', id: holderID+'P', parent: holderID, width: cardWidth, height: cardHeight });
 
     for(const cardType in deck.cardTypes) {
-      const count = counts ? counts[cardType] || 0 : 1;
+      const count = copiesOf(cardType);
       for(let i=1; i<=count; ++i)
         await addWidgetLocal({
           type: 'card',

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1531,20 +1531,29 @@ class PropertiesModule extends SidebarModule {
   }
 
   // A deck of plain text cards in the shape of the "Cards Against Humanity" decks in the library: every typed
-  // line becomes a card type with a "text" property, the front face renders it through a dynamic property and
+  // text - one per line, or one per blank-line-separated block when the card text needs line breaks of its own
+  // - becomes a card type with a "text" property, the front face renders it through a dynamic property and
   // the back face shows an optional deck label. Colors, font size and card size are the only design choices -
   // everything beyond that is done afterwards in the deck editor.
   deckTextCards(target) {
     const intro = document.createElement('p');
-    intro.innerText = 'Type or paste the card texts, one card per line. Each line becomes a card type - one distinct card design, of which the copies below are duplicates - whose "text" property holds that line, so you can edit the wording later in the deck editor.';
+    intro.innerText = 'Type or paste the card texts. Each card becomes a card type - one distinct card design, of which the copies below are duplicates - whose "text" property holds its text, so you can edit the wording later in the deck editor.';
     target.append(intro);
 
     this.addSubHeader('Card texts', target);
     const textarea = document.createElement('textarea');
     textarea.className = 'textCardsInput';
     textarea.rows = 8;
-    textarea.placeholder = 'The first card\nThe second card\n...';
     target.append(textarea);
+
+    // Where one card ends and the next begins. One card per line is what you want for a pasted list, but it
+    // leaves no way to put a line break inside a card - blank line mode spends an empty line on the separator
+    // and gives the line breaks back to the card text.
+    const split = div(target, 'textCardsSplit', `
+      <label><input type=radio name=textCardsSplit value=line checked>One card per line</label>
+      <label><input type=radio name=textCardsSplit value=block>Blank line between cards<span>lets a card's text span several lines</span></label>
+    `);
+    const splitOnBlankLines = _=>$('input[value=block]', split).checked;
 
     // Design inputs and preview side by side: the preview is exactly what you want to look at while changing
     // the font size and the colors, so it must not be pushed below the fold by the inputs that drive it.
@@ -1558,8 +1567,8 @@ class PropertiesModule extends SidebarModule {
       <label>Card width<input class=textCardsWidth type=number min=20 max=600 value=150>px</label>
       <label>Card height<input class=textCardsHeight type=number min=20 max=600 value=233>px</label>
       <label>Copies of each card<input class=textCardsCopies type=number min=1 max=99 value=1></label>
-      <label class=textCardsLabelWrap>Deck label<input class=textCardsLabel type=text placeholder="optional, e.g. the deck name"></label>
-      <span class=textCardsHint>The deck label is shown large on the card backs and small along the bottom edge of the fronts.</span>
+      <label class=textCardsLabelWrap>Deck label<textarea class=textCardsLabel rows=2 placeholder="optional, e.g. the deck name"></textarea></label>
+      <span class=textCardsHint>The deck label is shown large on the card backs - line breaks included - and small along the bottom edge of the fronts.</span>
     `);
 
     const previewColumn = div(columns, 'textCardsColumn textCardsPreviewColumn');
@@ -1570,7 +1579,12 @@ class PropertiesModule extends SidebarModule {
     const status = $('.textCardsStatus', target);
     const addButton = $('.goButton [icon=add]', target);
 
-    const cardTexts = _=>textarea.value.split('\n').map(line=>line.trim()).filter(line=>line.length);
+    // Line breaks that survive into a card's text render as line breaks on the card itself, so the only work
+    // here is trimming: every line loses its surrounding spaces and a card loses its leading/trailing blanks.
+    const cardTexts = _=>textarea.value
+      .split(splitOnBlankLines() ? /\n[ \t]*\n/ : '\n')
+      .map(card=>card.split('\n').map(line=>line.trim()).join('\n').replace(/^\n+|\n+$/g, ''))
+      .filter(card=>card.length);
 
     const deckDefinition = (texts, id)=>{
       const number = selector=>this.numberFromInput($(selector, design));
@@ -1578,7 +1592,7 @@ class PropertiesModule extends SidebarModule {
       const height   = number('.textCardsHeight');
       const fontSize = number('.textCardsFontSize');
       const color    = $('.textCardsColor', design).value;
-      const label    = $('.textCardsLabel', design).value.trim();
+      const label    = $('.textCardsLabel', design).value.split('\n').map(line=>line.trim()).join('\n').replace(/^\n+|\n+$/g, '');
       const padding  = Math.max(4, Math.round(width/12));
       // With a deck label the front gets a small footer along its bottom edge, so the card text has to stop
       // above it - text objects don't clip, a long text would just run over the label.
@@ -1601,7 +1615,7 @@ class PropertiesModule extends SidebarModule {
 
       const cardTypes = {};
       for(const [ index, text ] of texts.entries()) {
-        // Repeated lines get a "(2)" suffix, which can't collide with the "<card type> <copy number>" card ids.
+        // Repeated texts get a "(2)" suffix, which can't collide with the "<card type> <copy number>" card ids.
         const base = this.cardTypeName(text, `card ${index+1}`);
         let cardType = base;
         for(let i=2; Object.prototype.hasOwnProperty.call(cardTypes, cardType); ++i)
@@ -1612,9 +1626,10 @@ class PropertiesModule extends SidebarModule {
       const back = { radius: 8, objects: [ colorBox() ] };
       const front = { radius: 8, objects: [ colorBox(), textObject({ height: height - 2*padding - footerHeight, dynamicProperties: { value: 'text', fontSize: 'fontSize' } }) ] };
       if(label) {
-        // The back is just the label at 1.5x, the front repeats it small along the bottom edge.
+        // The back is just the label at 1.5x, the front repeats it small along the bottom edge - where a
+        // multi-line label has no room, so there it becomes a single line.
         back.objects.push(textObject({ value: label, fontSize: Math.round(fontSize*1.5) }));
-        front.objects.push(textObject({ value: label, fontSize: footerSize, y: height - padding - footerHeight, height: footerHeight }));
+        front.objects.push(textObject({ value: label.replace(/\n/g, ' '), fontSize: footerSize, y: height - padding - footerHeight, height: footerHeight }));
       }
 
       return {
@@ -1660,10 +1675,16 @@ class PropertiesModule extends SidebarModule {
         ? `${texts.length} card type${texts.length == 1 ? '' : 's'} × ${copies} = ${cards} card${cards == 1 ? '' : 's'}.`
         : 'Type or paste at least one line of text above.';
       addButton.disabled = !texts.length;
+      // The placeholder is where the split mode is easiest to show rather than explain.
+      textarea.placeholder = splitOnBlankLines()
+        ? 'The first card,\nwhich runs over two lines\n\nThe second card\n...'
+        : 'The first card\nThe second card\n...';
     };
     textarea.oninput = updatePreview;
-    for(const input of $a('input', design))
+    for(const input of $a('input, textarea', design))
       input.oninput = updatePreview;
+    for(const radio of $a('input', split))
+      radio.onchange = updatePreview;
     updatePreview();
 
     addButton.onclick = async _=>{

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -897,8 +897,8 @@ class PropertiesModule extends SidebarModule {
   }
 
   // Shown when the Properties module is open with nothing selected. The deck-creation flows themselves
-  // (deckTraditional/deckGenerator/deckImages/deckImportTTS) now live in the deck editor's "Add New Deck"
-  // submenu, so this just points the user at the two starting actions.
+  // (deckTraditional/deckGenerator/deckImages/deckImagePairs/deckTextCards/deckImportTTS) now live in the
+  // deck editor's "Add New Deck" submenu, so this just points the user at the two starting actions.
   addDeck() {
     this.addHeader('Edit widgets');
 
@@ -1359,6 +1359,253 @@ class PropertiesModule extends SidebarModule {
       }
 
       await this.addDeckWithCards(deck, 'image', counts);
+    };
+  }
+
+  // Two bulk uploads - all the card fronts and all the card backs - matched into pairs by sorting both lists
+  // by file name, so front1.jpg gets back1.jpg as its back. Numbers are compared numerically so front2 sorts
+  // before front10. Unlike deckImages (one shared back for the whole deck) every card type carries its own
+  // back image, which the back face reads through a dynamic property.
+  deckImagePairs(target) {
+    const fronts = [];
+    const backs = [];
+
+    const intro = document.createElement('p');
+    intro.innerText = 'Upload all card fronts and all card backs. Both lists are sorted by file name and then matched up in that order, so front1.jpg is paired with back1.jpg. Upload a single back image to use it for every card.';
+    target.append(intro);
+
+    const addUploadSection = (title, list, label)=>{
+      this.addSubHeader(title, target);
+      const listDOM = div(target, 'imagePairList');
+      const bar = div(target, 'buttonBar', `<button icon=upload>${label}</button>`);
+      $('button', bar).onclick = _=>uploadAsset((imagePath, fileName)=>{
+        if(imagePath) {
+          list.push({ imagePath, fileName });
+          render();
+        }
+      });
+      return listDOM;
+    };
+
+    const frontList = addUploadSection('Card fronts', fronts, 'Upload fronts...');
+    const backList  = addUploadSection('Card backs',  backs,  'Upload backs...');
+
+    const status = div(target, 'imagePairStatus');
+    const options = div(target, 'imagePairOptions', 'Copies of each card: <input type=number min=1 max=99 value=1>');
+
+    div(target, 'goButton buttonBar', '<button icon=add class=green disabled>Add to game</button>');
+    const addButton = $('.goButton [icon=add]', target);
+
+    const renderList = (list, listDOM, pairedWith)=>{
+      listDOM.innerHTML = '';
+      for(const [ index, entry ] of list.entries()) {
+        const row = div(listDOM, 'imagePairEntry', `<b></b><img src="${mapAssetURLs(entry.imagePath)}"><span></span><button icon=delete title="Remove this image"></button>`);
+        $('b', row).innerText = `${index+1}.`;
+        $('span', row).innerText = entry.fileName;
+        if(pairedWith && pairedWith[index])
+          row.title = `Paired with ${pairedWith[index].fileName}`;
+        $('button', row).onclick = _=>{
+          list.splice(list.indexOf(entry), 1);
+          render();
+        };
+      }
+    };
+
+    // Both lists always render in the order they will be paired in, so the numbers in front of the file names
+    // are the pairing itself - no separate pair list needed.
+    const render = _=>{
+      for(const list of [ fronts, backs ])
+        list.sort((a, b)=>a.fileName.localeCompare(b.fileName, undefined, { numeric: true }));
+      const sharedBack = backs.length == 1;
+      const paired = fronts.length && backs.length && (sharedBack || fronts.length == backs.length);
+      renderList(fronts, frontList, sharedBack ? null : backs);
+      renderList(backs, backList, sharedBack ? null : fronts);
+      if(!fronts.length || !backs.length)
+        status.innerText = 'Upload at least one front image and one back image.';
+      else if(paired)
+        status.innerText = `${fronts.length} card${fronts.length == 1 ? '' : ' types'}${sharedBack ? ', all sharing the single back image' : ', each front paired with the back in the same position'}.`;
+      else
+        status.innerText = `${fronts.length} fronts but ${backs.length} backs - upload the same number of each, or a single back for all cards.`;
+      status.classList.toggle('imagePairMismatch', !!(fronts.length && backs.length && !paired));
+      addButton.disabled = !paired;
+    };
+    render();
+
+    addButton.onclick = async _=>{
+      const copies = Math.max(1, +$('input', options).value || 1);
+      const cardTypes = {};
+      const counts = {};
+      for(const [ index, front ] of fronts.entries()) {
+        const back = backs.length == 1 ? backs[0] : backs[index];
+        // Two files can share a name (they come from separate uploads); a "(2)" suffix rather than a plain
+        // number keeps the generated card ids apart from the "<card type> <copy number>" ids below.
+        const base = front.fileName.replace(/\.[^.]+$/, '') || `card ${index+1}`;
+        let cardType = base;
+        for(let i=2; cardTypes[cardType] !== undefined; ++i)
+          cardType = `${base} (${i})`;
+        cardTypes[cardType] = { image: front.imagePath, backImage: back.imagePath };
+        counts[cardType] = copies;
+      }
+
+      const deck = {
+        id: generateUniqueWidgetID(),
+        type: 'deck',
+        cardTypes,
+        faceTemplates: [
+          {
+            "objects": [
+              {
+                "type": "image",
+                "color": "transparent",
+                "dynamicProperties": {
+                  "value": "backImage",
+                  "height": "height",
+                  "width": "width"
+                }
+              }
+            ]
+          },
+          {
+            "objects": [
+              {
+                "type": "image",
+                "color": "transparent",
+                "dynamicProperties": {
+                  "value": "image",
+                  "height": "height",
+                  "width": "width"
+                }
+              }
+            ]
+          }
+        ]
+      };
+
+      // Keep the default card height and take the width from the first front image's aspect ratio, so the
+      // cards aren't distorted (same approach as the single-image flow above).
+      const firstFront = $('img', frontList);
+      const cardWidth = firstFront && firstFront.naturalHeight
+        ? Math.round(firstFront.naturalWidth / firstFront.naturalHeight * 160)
+        : 103;
+      if(cardWidth != 103)
+        deck.cardDefaults = { width: cardWidth };
+
+      await this.addDeckWithCards(deck, 'front/back image', counts);
+    };
+  }
+
+  // A deck of plain text cards in the shape of the "Cards Against Humanity" decks in the library: every typed
+  // line becomes a card type with a "text" property, the front face renders it through a dynamic property and
+  // the back face shows an optional deck label. Colors, font size and card size are the only design choices -
+  // everything beyond that is done afterwards in the deck editor.
+  deckTextCards(target) {
+    const intro = document.createElement('p');
+    intro.innerText = 'Type or paste the card texts, one card per line. Each line becomes a card type whose "text" property holds that line, so you can edit the wording later in the deck editor.';
+    target.append(intro);
+
+    this.addSubHeader('Card texts', target);
+    const textarea = document.createElement('textarea');
+    textarea.className = 'textCardsInput';
+    textarea.rows = 8;
+    textarea.placeholder = 'The first card\nThe second card\n...';
+    target.append(textarea);
+
+    this.addSubHeader('Card design', target);
+    const design = div(target, 'textCardsDesign', `
+      <label>Card color<input class=textCardsBackground type=color value="#000000"></label>
+      <label>Text color<input class=textCardsColor type=color value="#ffffff"></label>
+      <label>Font size<input class=textCardsFontSize type=number min=6 max=72 value=16></label>
+      <label>Card width<input class=textCardsWidth type=number min=20 max=600 value=150></label>
+      <label>Card height<input class=textCardsHeight type=number min=20 max=600 value=233></label>
+      <label>Copies of each card<input class=textCardsCopies type=number min=1 max=99 value=1></label>
+      <label class=textCardsLabelWrap>Deck label - shown on the card backs<input class=textCardsLabel type=text placeholder="optional, e.g. the deck name"></label>
+    `);
+
+    this.addSubHeader('Preview', target);
+    const preview = div(target, 'textCardsPreview');
+
+    div(target, 'goButton buttonBar', '<button icon=add class=green disabled>Add to game</button>');
+    const addButton = $('.goButton [icon=add]', target);
+
+    const cardTexts = _=>textarea.value.split('\n').map(line=>line.trim()).filter(line=>line.length);
+
+    const deckDefinition = (texts, id)=>{
+      const number = (selector, fallback)=>+$(selector, design).value || fallback;
+      const width    = number('.textCardsWidth', 150);
+      const height   = number('.textCardsHeight', 233);
+      const fontSize = number('.textCardsFontSize', 16);
+      const color    = $('.textCardsColor', design).value;
+      const label    = $('.textCardsLabel', design).value.trim();
+      const padding  = Math.max(4, Math.round(width/12));
+
+      const colorBox = _=>({ type: 'image', x: 0, y: 0, width, height, color: $('.textCardsBackground', design).value, value: '' });
+      const textObject = properties=>Object.assign({
+        type: 'text',
+        x: padding,
+        y: padding,
+        width: width - 2*padding,
+        height: height - 2*padding,
+        textAlign: 'left',
+        color,
+        css: { 'font-weight': 'bold', 'line-height': '1.25em' }
+      }, properties);
+
+      const cardTypes = {};
+      for(const [ index, text ] of texts.entries()) {
+        // Card type names end up in the card widget ids, so strip anything awkward there and keep them short;
+        // fall back to a running number when a line has nothing usable left (e.g. "______ + ______"). Repeated
+        // lines get a "(2)" suffix, which can't collide with the "<card type> <copy number>" card ids.
+        const base = text.replace(/[^A-Za-z0-9 ]+/g, ' ').replace(/\s+/g, ' ').trim().substr(0, 30).trim() || `card ${index+1}`;
+        let cardType = base;
+        for(let i=2; cardTypes[cardType] !== undefined; ++i)
+          cardType = `${base} (${i})`;
+        cardTypes[cardType] = { text };
+      }
+
+      const back = { radius: 8, objects: [ colorBox() ] };
+      const front = { radius: 8, objects: [ colorBox(), textObject({ dynamicProperties: { value: 'text', fontSize: 'fontSize' } }) ] };
+      if(label) {
+        // The back is just the label at 1.5x, the front repeats it small along the bottom edge.
+        const footerSize = Math.max(6, Math.round(fontSize/2));
+        const footerHeight = Math.round(footerSize*1.4);
+        back.objects.push(textObject({ value: label, fontSize: Math.round(fontSize*1.5) }));
+        front.objects.push(textObject({ value: label, fontSize: footerSize, y: height - padding - footerHeight, height: footerHeight }));
+      }
+
+      return {
+        id,
+        type: 'deck',
+        cardDefaults: { width, height, fontSize },
+        cardTypes,
+        faceTemplates: [ back, front ]
+      };
+    };
+
+    // One id for every preview render: renderWidgetButton briefly registers the preview deck in "widgets", so
+    // it needs an id that is not in use, but generating a fresh one per keystroke would be wasteful.
+    const previewID = generateUniqueWidgetID();
+    const updatePreview = _=>{
+      const texts = cardTexts();
+      const deck = deckDefinition(texts.length ? texts.slice(0, 5) : [ 'Your card text goes here.' ], previewID);
+      preview.innerHTML = '';
+      this.renderWidgetButton(new Deck(deck.id), deck, preview);
+      addButton.disabled = !texts.length;
+    };
+    textarea.oninput = updatePreview;
+    for(const input of $a('input', design))
+      input.oninput = updatePreview;
+    updatePreview();
+
+    addButton.onclick = async _=>{
+      const texts = cardTexts();
+      if(!texts.length)
+        return;
+      const deck = deckDefinition(texts, generateUniqueWidgetID());
+      const copies = Math.max(1, +$('.textCardsCopies', design).value || 1);
+      const counts = {};
+      for(const cardType in deck.cardTypes)
+        counts[cardType] = copies;
+      await this.addDeckWithCards(deck, 'text', counts);
     };
   }
 

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -782,7 +782,7 @@ test('Deck editor: add a deck of text cards from the new deck wizard', async t =
     .typeText('.textCardsCopies', '2', { replace: true })
     .click('#deckEditorNewDeckPanel .goButton [icon=add]')
     .expect(Selector('#deckEditorStrip .deckEditorStripCard').count).eql(3); // the wizard's deck is now open
-  await compareState(t, 'e5bc265b4af231b7f838092b4fc2c825');
+  await compareState(t, '94d9f0542c71541a5e20ae14a37499b1');
 });
 
 // The wizard's front/back image section: both uploads are sorted by file name - numerically, so front2 comes

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -767,6 +767,7 @@ test('Deck editor: add a deck of text cards from the new deck wizard', async t =
     .click('#editButton')
     .click('#editorToolbar [icon=style]') // opens the (empty) deck editor
     .click('#deckEditorAddDeck')
+    .click('#deckEditorNewDeckGroupCustom .deckEditorNewDeckGroupHeader') // open the "Create a custom deck" section
     .click('#deckEditorNewDeckOverlay input[value=text]');
 
   // A multi-line value in one go - typeText would send the newlines as key presses.
@@ -816,6 +817,7 @@ test('Deck editor: pair front and back images in the new deck wizard', async t =
     .click('#editButton')
     .click('#editorToolbar [icon=style]') // opens the (empty) deck editor
     .click('#deckEditorAddDeck')
+    .click('#deckEditorNewDeckGroupCustom .deckEditorNewDeckGroupHeader') // open the "Create a custom deck" section
     .click('#deckEditorNewDeckOverlay input[value=imagePairs]');
 
   // The uploads go through a file picker that can't be driven from a test, so uploadAsset is replaced by a
@@ -871,6 +873,7 @@ test('Deck editor: mismatched and shared card backs in the new deck wizard', asy
     .click('#editButton')
     .click('#editorToolbar [icon=style]') // opens the (empty) deck editor
     .click('#deckEditorAddDeck')
+    .click('#deckEditorNewDeckGroupCustom .deckEditorNewDeckGroupHeader') // open the "Create a custom deck" section
     .click('#deckEditorNewDeckOverlay input[value=imagePairs]');
 
   const stubUploadOf = ClientFunction(assets => {
@@ -926,6 +929,7 @@ test('Deck editor: a few uploaded card fronts are added without a large-deck con
     .click('#editButton')
     .click('#editorToolbar [icon=style]') // opens the (empty) deck editor
     .click('#deckEditorAddDeck')
+    .click('#deckEditorNewDeckGroupCustom .deckEditorNewDeckGroupHeader') // open the "Create a custom deck" section
     .click('#deckEditorNewDeckOverlay input[value=images]');
 
   // The file picker can't be driven from a test - hand the wizard the asset paths the server would return.

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -776,6 +776,17 @@ test('Deck editor: add a deck of text cards from the new deck wizard', async t =
     textarea.dispatchEvent(new Event('input', { bubbles: true }));
   })();
 
+  // A typed value ignores the input's "min"/"max", so an out-of-range card width must be clamped to the
+  // declared range (20-600) rather than reaching the deck - here visible on the real-size preview card.
+  const setDesignValue = ClientFunction((selector, value) => {
+    const input = document.querySelector(selector);
+    input.value = value;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await setDesignValue('.textCardsWidth', '-50');
+  await t.expect(Selector('.textCardsPreviewCard').getStyleProperty('width')).eql('20px');
+  await setDesignValue('.textCardsWidth', '150');
+
   await t
     .typeText('.textCardsLabel', 'Test Deck')
     .typeText('.textCardsFontSize', '20', { replace: true })
@@ -845,6 +856,60 @@ test('Deck editor: pair front and back images in the new deck wizard', async t =
     'front10: front10.png + back10.png'
   ]);
   await t.expect(deck.width).eql(107); // 40x60 fronts at the default card height of 160
+});
+
+// The other states of the same section: unequal numbers of fronts and backs keep "Add to game" disabled until
+// the lists are made to match again by deleting an image, and a single back image is shared by every card.
+test('Deck editor: mismatched and shared card backs in the new deck wizard', async t => {
+  const asset = fileName=>`data:image/svg+xml;base64,${Buffer.from(`<svg xmlns="http://www.w3.org/2000/svg" width="40" height="60"><title>${fileName}</title></svg>`).toString('base64')}`;
+
+  await setRoomState();
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  await t
+    .click('#editButton')
+    .click('#editorToolbar [icon=style]') // opens the (empty) deck editor
+    .click('#deckEditorAddDeck')
+    .click('#deckEditorNewDeckOverlay input[value=imagePairs]');
+
+  const stubUploadOf = ClientFunction(assets => {
+    window.uploadAsset = callback => {
+      for(const [ fileName, imagePath ] of assets)
+        callback(imagePath, fileName);
+    };
+  });
+  const uploadButton = Selector('#deckEditorNewDeckPanel [icon=upload]');
+  const addButton = Selector('#deckEditorNewDeckPanel .goButton [icon=add]');
+  const status = Selector('.imagePairStatus');
+  const backs = Selector('.imagePairList').nth(1).find('.imagePairEntry');
+
+  await stubUploadOf([ 'front1.png', 'front2.png', 'front3.png' ].map(fileName=>[ fileName, asset(fileName) ]));
+  await t.click(uploadButton.nth(0));
+  await stubUploadOf([ 'back1.png', 'back2.png' ].map(fileName=>[ fileName, asset(fileName) ]));
+  await t.click(uploadButton.nth(1));
+
+  await t
+    .expect(status.innerText).contains('3 fronts but 2 backs')
+    .expect(status.hasClass('imagePairMismatch')).ok()
+    .expect(addButton.hasAttribute('disabled')).ok();
+
+  // Deleting one of the two backs leaves a single back image, which is shared by all three cards.
+  await t
+    .click(backs.nth(1).find('[icon=delete]'))
+    .expect(backs.count).eql(1)
+    .expect(status.innerText).contains('all sharing the single back image')
+    .expect(addButton.hasAttribute('disabled')).notOk();
+
+  await t
+    .click(addButton)
+    .expect(Selector('#deckEditorStrip .deckEditorStripCard').count).eql(3); // the wizard's deck is now open
+
+  await t.expect(await ClientFunction(() => {
+    let deck = null;
+    widgets.forEach(w => { if(w.get('type') == 'deck') deck = w; });
+    return Object.values(deck.get('cardTypes')).map(c=>c.backImage);
+  })()).eql(Array(3).fill(asset('back1.png')));
 });
 
 // The "one image per card" section fills the copy counts straight from its number inputs, so they arrive as

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -754,6 +754,37 @@ test('Deck editor: toolbar button opens an empty editor when the game has none',
     .expect(Selector('body').hasClass('deckEditorActive')).notOk();
 });
 
+// The "Add a new deck" wizard's text-cards section: every typed line becomes a card type with a "text"
+// property, the design inputs shape the two faces and the deck lands in a holder with cards, like the other
+// wizard sections. Card type names are derived from the text, deduplicated, and fall back to a running number
+// when a line has no usable characters (the "______" line below).
+test('Deck editor: add a deck of text cards from the new deck wizard', async t => {
+  await setRoomState();
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  await t
+    .click('#editButton')
+    .click('#editorToolbar [icon=style]') // opens the (empty) deck editor
+    .click('#deckEditorAddDeck')
+    .click('#deckEditorNewDeckOverlay input[value=text]');
+
+  // A multi-line value in one go - typeText would send the newlines as key presses.
+  await ClientFunction(() => {
+    const textarea = document.querySelector('.textCardsInput');
+    textarea.value = 'A short one.\n______ + ______ = ______.\nA short one.';
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+  })();
+
+  await t
+    .typeText('.textCardsLabel', 'Test Deck')
+    .typeText('.textCardsFontSize', '20', { replace: true })
+    .typeText('.textCardsCopies', '2', { replace: true })
+    .click('#deckEditorNewDeckPanel .goButton [icon=add]')
+    .expect(Selector('#deckEditorStrip .deckEditorStripCard').count).eql(3); // the wizard's deck is now open
+  await compareState(t, '42db3cfd13dc76fc8e79f6eac5be71d9');
+});
+
 test('Line widget in edit mode', async t => {
   await t.resizeWindow(1280, 800);
   await setRoomState();

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -847,6 +847,45 @@ test('Deck editor: pair front and back images in the new deck wizard', async t =
   await t.expect(deck.width).eql(107); // 40x60 fronts at the default card height of 160
 });
 
+// The "one image per card" section fills the copy counts straight from its number inputs, so they arrive as
+// strings - a handful of single-copy fronts must not be mistaken for a large deck by the shared confirmation.
+test('Deck editor: a few uploaded card fronts are added without a large-deck confirmation', async t => {
+  const asset = fileName=>`data:image/svg+xml;base64,${Buffer.from(`<svg xmlns="http://www.w3.org/2000/svg" width="40" height="60"><title>${fileName}</title></svg>`).toString('base64')}`;
+  const fronts = [ 'card1.png', 'card2.png', 'card3.png', 'card4.png' ];
+
+  await setRoomState();
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  await t
+    .click('#editButton')
+    .click('#editorToolbar [icon=style]') // opens the (empty) deck editor
+    .click('#deckEditorAddDeck')
+    .click('#deckEditorNewDeckOverlay input[value=images]');
+
+  // The file picker can't be driven from a test - hand the wizard the asset paths the server would return.
+  await ClientFunction(assets => {
+    window.uploadAsset = callback => {
+      for(const [ fileName, imagePath ] of assets)
+        callback(imagePath, fileName);
+    };
+  })(fronts.map(fileName=>[ fileName, asset(fileName) ]));
+
+  // Declining a confirmation would abort the whole deck, so this asserts twice: no dialog, and the cards exist.
+  await t
+    .setNativeDialogHandler(() => false)
+    .click('#deckEditorNewDeckPanel #frontsButton')
+    .click('#deckEditorNewDeckPanel .goButton [icon=add]')
+    .expect(Selector('#deckEditorStrip .deckEditorStripCard').count).eql(4); // the wizard's deck is now open
+
+  await t.expect(await t.getNativeDialogHistory()).eql([]);
+  await t.expect(await ClientFunction(() => {
+    let cards = 0;
+    widgets.forEach(w => { if(w.get('type') == 'card') ++cards; });
+    return cards;
+  })()).eql(4);
+});
+
 test('Line widget in edit mode', async t => {
   await t.resizeWindow(1280, 800);
   await setRoomState();

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -782,7 +782,69 @@ test('Deck editor: add a deck of text cards from the new deck wizard', async t =
     .typeText('.textCardsCopies', '2', { replace: true })
     .click('#deckEditorNewDeckPanel .goButton [icon=add]')
     .expect(Selector('#deckEditorStrip .deckEditorStripCard').count).eql(3); // the wizard's deck is now open
-  await compareState(t, '42db3cfd13dc76fc8e79f6eac5be71d9');
+  await compareState(t, 'e5bc265b4af231b7f838092b4fc2c825');
+});
+
+// The wizard's front/back image section: both uploads are sorted by file name - numerically, so front2 comes
+// before front10 - and then matched up position by position, giving every card type its own back image. The
+// card size comes from the aspect ratio of the first front image.
+test('Deck editor: pair front and back images in the new deck wizard', async t => {
+  // 40x60 SVGs, one per file name so the pairing is visible in the resulting cardTypes.
+  const asset = fileName=>`data:image/svg+xml;base64,${Buffer.from(`<svg xmlns="http://www.w3.org/2000/svg" width="40" height="60"><title>${fileName}</title></svg>`).toString('base64')}`;
+  const fronts = [ 'front10.png', 'front2.png', 'front1.png' ];
+  const backs  = [ 'back2.png', 'back10.png', 'back1.png' ];
+  const fileNameOfAsset = {};
+  for(const fileName of [ ...fronts, ...backs ])
+    fileNameOfAsset[asset(fileName)] = fileName;
+
+  await setRoomState();
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  await t
+    .click('#editButton')
+    .click('#editorToolbar [icon=style]') // opens the (empty) deck editor
+    .click('#deckEditorAddDeck')
+    .click('#deckEditorNewDeckOverlay input[value=imagePairs]');
+
+  // The uploads go through a file picker that can't be driven from a test, so uploadAsset is replaced by a
+  // stub handing the wizard the asset paths the server would have returned for the files below.
+  const stubUploadOf = ClientFunction(assets => {
+    window.uploadAsset = callback => {
+      for(const [ fileName, imagePath ] of assets)
+        callback(imagePath, fileName);
+    };
+  });
+  const uploadButton = Selector('#deckEditorNewDeckPanel [icon=upload]');
+
+  await stubUploadOf(fronts.map(fileName=>[ fileName, asset(fileName) ]));
+  await t.click(uploadButton.nth(0));
+  await stubUploadOf(backs.map(fileName=>[ fileName, asset(fileName) ]));
+  await t.click(uploadButton.nth(1));
+
+  // The card width is read from the first front image, so wait until the browser knows its size.
+  const firstFrontHeight = ClientFunction(() => document.querySelector('.imagePairList img').naturalHeight);
+  await t.expect(firstFrontHeight()).eql(60);
+
+  await t
+    .click('#deckEditorNewDeckPanel .goButton [icon=add]')
+    .expect(Selector('#deckEditorStrip .deckEditorStripCard').count).eql(3); // the wizard's deck is now open
+
+  const deck = await ClientFunction(() => {
+    let deck = null;
+    widgets.forEach(w => { if(w.get('type') == 'deck') deck = w; });
+    return {
+      width: deck.get('cardDefaults').width,
+      pairs: Object.entries(deck.get('cardTypes')).map(([ cardType, c ])=>`${cardType}: ${fileNameOfAsset[c.image]} + ${fileNameOfAsset[c.backImage]}`)
+    };
+  }, { dependencies: { fileNameOfAsset } })();
+
+  await t.expect(deck.pairs).eql([
+    'front1: front1.png + back1.png',
+    'front2: front2.png + back2.png',
+    'front10: front10.png + back10.png'
+  ]);
+  await t.expect(deck.width).eql(107); // 40x60 fronts at the default card height of 160
 });
 
 test('Line widget in edit mode', async t => {

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -797,6 +797,60 @@ test('Deck editor: add a deck of text cards from the new deck wizard', async t =
   await compareState(t, '94d9f0542c71541a5e20ae14a37499b1');
 });
 
+// The other way of cutting the typed text into cards: with a blank line as the separator a card's text keeps
+// the line breaks inside it, and the deck label - a textarea - carries its own onto the card backs, where the
+// front's one-line footer flattens them back into spaces.
+test('Deck editor: text cards with line breaks in the new deck wizard', async t => {
+  await setRoomState();
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  await t
+    .click('#editButton')
+    .click('#editorToolbar [icon=style]') // opens the (empty) deck editor
+    .click('#deckEditorAddDeck')
+    .click('#deckEditorNewDeckGroupCustom .deckEditorNewDeckGroupHeader') // open the "Create a custom deck" section
+    .click('#deckEditorNewDeckOverlay input[value=text]')
+    .click('.textCardsSplit input[value=block]');
+
+  // Indented lines, a doubled separator and a trailing blank line: all of them are trimmed away, so this is
+  // two card types, the first of which is two lines long.
+  await ClientFunction(() => {
+    for(const [ selector, value ] of [
+      [ '.textCardsInput', 'Cards that make\n   you think twice\n\n\nA short one.\n\n' ],
+      [ '.textCardsLabel', 'Line\nBreak\nDeck' ]
+    ]) {
+      const element = document.querySelector(selector);
+      element.value = value;
+      element.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  })();
+
+  await t
+    .expect(Selector('.textCardsStatus').innerText).eql('2 card types × 1 = 2 cards.')
+    .expect(Selector('.textCardsPreviewCard .cardFace.active .cardFaceObject').nth(1).textContent).eql('Cards that make\nyou think twice')
+    .click('#deckEditorNewDeckPanel .goButton [icon=add]')
+    .expect(Selector('#deckEditorStrip .deckEditorStripCard').count).eql(2); // the wizard's deck is now open
+
+  const deck = await ClientFunction(() => {
+    let deck = null;
+    widgets.forEach(w => { if(w.get('type') == 'deck') deck = w; });
+    return {
+      cardTypes: deck.get('cardTypes'),
+      back: deck.get('faceTemplates')[0].objects[1].value,
+      footer: deck.get('faceTemplates')[1].objects[2].value
+    };
+  })();
+
+  await t
+    .expect(deck.cardTypes).eql({
+      'Cards that make you think twic': { text: 'Cards that make\nyou think twice' },
+      'A short one': { text: 'A short one.' }
+    })
+    .expect(deck.back).eql('Line\nBreak\nDeck')
+    .expect(deck.footer).eql('Line Break Deck');
+});
+
 // The wizard's front/back image section: both uploads are sorted by file name - numerically, so front2 comes
 // before front10 - and then matched up position by position, giving every card type its own back image. The
 // card size comes from the aspect ratio of the first front image.


### PR DESCRIPTION
## Goal

Make the deck editor's **"Add a new deck"** wizard cover two common ways of building a deck that it could not do before: uploading a **separate front and back image for every card**, and a **plain text deck** in the style of the Cards Against Humanity decks in the public library.

Two follow-ups from the PR discussion are in here as well: the option list was [regrouped into three collapsible sections](https://github.com/ArnoldSmith86/virtualtabletop/pull/3071#issuecomment-5163259566) so that adding a deck is easier to understand, and the text-cards section [can now hold line breaks](https://github.com/ArnoldSmith86/virtualtabletop/pull/3071#issuecomment-5171069596), both inside a card's text and in the deck label.

## What changed

### Three sections instead of eight radio buttons

The dialog's flat list of ways to create a deck is now three expanders, only one open at a time (`openNewDeckGroup`):

- **New blank deck** — the empty deck flow. Open and selected when the dialog opens, so its card size / deck id form is right there; being the only way in its section, it needs no radio button of its own.
- **Use an existing deck** — public library, traditional decks, Tabletop Simulator import.
- **Create a custom deck** — suits and ranks, one image per card, a front and a back image per card, text cards.

Every option is a short title plus a one-line explanation, and the panel of the option you pick is rendered inside the open section, right under the options it belongs to. The old "collapse the list once a mode is picked, `Change` to bring it back" mechanic is gone — the sections keep the dialog short by themselves.

### The two new ways to build a deck

Two new sections (`client/editor.html` option list → `renderNewDeckPanel` → two new `PropertiesModule` flows next to the existing `deckImages`/`deckImportTTS` ones):

### "Upload a front and a back image for every card"

- Two bulk uploads: all card fronts, all card backs.
- Both lists are sorted by file name (numbers compared numerically, so `front2` sorts before `front10`) and then matched up **by position** — `front1.jpg` gets `back1.jpg`. The lists are rendered in that pairing order and numbered, each row with a thumbnail, the file name and a delete button, so the pairing is visible before adding anything.
- A status line reports the pairing (`3 card types, each front paired with the back in the same position.`) or, when the counts don't match, says so and keeps "Add to game" disabled. Uploading exactly **one** back image uses it for every card.
- Every card type carries its own `backImage`, which face 0 renders through a dynamic property (`deckImages` can only give the whole deck one shared back). Card width comes from the first front image's aspect ratio, plus a "copies of each card" input.

### "Text cards — one card per line of text"

- A textarea plus a radio row that picks how the typed text is cut into cards: **one card per line** (right for a pasted list) or **a blank line between cards**, which lets a card`s text span several lines. Each card becomes a card type whose `text` property holds its text; face 1 renders it through a dynamic property, exactly like the `prompt`/`response` decks of Cards Against Humanity.
- Design inputs: card color, text color, font size, card width/height, copies per card and an optional deck label that is shown large on the backs and small along the bottom of the fronts. The label is a textarea too, so it can be shown across several lines on the backs the way the Cards Against Humanity backs are - the one-line footer on the fronts flattens it. A live preview of the first card updates as you type.
- Card type names are derived from the text (sanitized and shortened), fall back to a running number when a line has no usable characters (`______ + ______`), and repeats get a `(2)` suffix that cannot collide with the generated `<card type> <copy number>` card ids.

Both sections build their deck through the existing `addDeckWithCards`, so the result is the familiar holder + `Recall & Shuffle` button + pile of cards, and `pendingNewDeck` opens the new deck in the deck editor afterwards.

## Screenshots

| | |
|---|---|
| The dialog as it opens: three sections, the blank deck one open | ![blank](https://agent.virtualtabletop.io/reports/pr/1532145112908435497/wizard-blank-open.png) |
| "Use an existing deck" opened | ![existing](https://agent.virtualtabletop.io/reports/pr/1532145112908435497/wizard-existing-open.png) |
| "Create a custom deck" opened | ![custom](https://agent.virtualtabletop.io/reports/pr/1532145112908435497/wizard-custom-open.png) |
| Front/back upload, files matched by name | ![pairing](https://agent.virtualtabletop.io/reports/pr/1532145112908435497/newdeck-front-back-pairing.png) |
| The resulting cards, fronts and per-card backs | ![result](https://agent.virtualtabletop.io/reports/pr/1532145112908435497/newdeck-front-back-result.png) |
| Text cards section | ![text](https://agent.virtualtabletop.io/reports/pr/1532145112908435497/newdeck-text-cards.png) |
| …with the live preview | ![preview](https://agent.virtualtabletop.io/reports/pr/1532145112908435497/newdeck-text-cards-preview.png) |
| Text cards with line breaks, and the deck label across three lines | ![linebreaks](https://agent.virtualtabletop.io/reports/pr/1532145112908435497/pr3071-linebreaks-wizard.png) · [the resulting back](https://agent.virtualtabletop.io/reports/pr/1532145112908435497/pr3071-linebreaks-back.png) |

## Testing

- New TestCafe test `Deck editor: add a deck of text cards from the new deck wizard` drives the text section (including a duplicate line and a line without usable characters) and compares the resulting room state hash.
- `Deck editor: text cards with line breaks in the new deck wizard` drives the blank-line mode with an indented line, a doubled separator and a trailing blank line, and asserts the resulting `cardTypes`, the multi-line back label and the flattened front footer.
- `npm test` (jest, 86 tests) and the full `tests/testcafe/editor.js` suite (20 tests) pass locally in headless Chromium.
- The image-upload section was verified manually in a browser: files uploaded out of order end up paired `F1↔B1`, `F2↔B2`, `F3↔B3`, and each card's back face renders its own image.
- No widget/routine properties were added, so `validator/` and `jeCommands` need no updates; a game file created with both new sections validates cleanly with `validate_gamefile_node.js`.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3071/pr-test (or any other room on that server)

