### PR TITLE
Import modern PCIO files (schema 6+) and report what cannot be translated

### DIFF
--- a/client/css/overlays/states.css
+++ b/client/css/overlays/states.css
@@ -369,6 +369,14 @@ div:nth-of-type(2) > .list > .roomState .star {
   display: block;
 }
 
+.roomState > i.importNotes {
+  right: 0;
+}
+
+.roomState.hasImportNotes > i.importNotes {
+  display: block;
+}
+
 .roomState.hideMainName .details h3 {
   display: none;
 }
@@ -920,6 +928,16 @@ div:nth-of-type(2) > .list > .roomState .star {
 
 #helpTexts [contenteditable="true"] {
   padding: 5px;
+}
+
+#importNotes {
+  margin: 0;
+  padding-left: 20px;
+  white-space: normal;
+}
+
+#importNotes li {
+  margin-bottom: 6px;
 }
 
 @media (max-width: 1260px), (max-height: 787px), (min-width: 1421px) and (min-height: 888px) {

--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -476,6 +476,8 @@ function fillStatesList(states, starred, activeState, returnServer, activePlayer
       entry.className += ' savedGame';
     if(state.usesAIImagery)
       entry.className += ' has-ai-badge';
+    if(Array.isArray(state.importerWarnings) && state.importerWarnings.length)
+      entry.className += ' hasImportNotes';
     if(activeState && (activeState.stateID == state.id || activeState.saveStateID == state.id || activeState.linkStateID == state.id)) {
       entry.className += ' activeGame';
       saveButton.style.display = 'inline-flex';
@@ -677,6 +679,19 @@ function fillStatesList(states, starred, activeState, returnServer, activePlayer
   loadGameFromURLproperties(states);
 }
 
+// everything an importer could not translate - one line per note so that a long
+// report scans instead of reading as one wall of text
+function fillImportNotes(warnings) {
+  warnings = Array.isArray(warnings) ? warnings : [];
+  $('#importNotesHeading').textContent = warnings.length ? `Import notes (${warnings.length})` : 'Import notes';
+  $('#importNotes').innerHTML = '';
+  for(const warning of warnings) {
+    const li = document.createElement('li');
+    li.textContent = warning;
+    $('#importNotes').appendChild(li);
+  }
+}
+
 function fillStateDetails(states, state, dom) {
   toggleClass($('#statesOverlay'), 'withDetails', detailsInSidebar);
   if(!detailsInSidebar)
@@ -689,6 +704,7 @@ function fillStateDetails(states, state, dom) {
     dom.scrollTop = 0;
 
   applyValuesToDOM($('#stateDetailsOverlay'), Object.assign({ showName: true }, state));
+  fillImportNotes(state.importerWarnings);
   const sn = typeof state.showName === 'undefined' ? true : state.showName;
   $('#showName').checked = sn === true || sn === 'only main';
   $('#showNameSimilar').checked = sn === true || sn === 'only similar';

--- a/client/room.html
+++ b/client/room.html
@@ -167,6 +167,7 @@
           <img>
           <button icon="star_rate" class="star"></button>
           <i class="material-symbols linked">link</i>
+          <i class="material-symbols importNotes" title="This game was imported - the game details list what could not be translated">info</i>
           <span class="ai-badge" title="Uses AI generated imagery">AI</span>
           <div class="details">
             <h3>Name</h3>
@@ -348,7 +349,9 @@
         </div>
         <button class="prettyButton next"><i class="material-symbols">arrow_forward</i></button>
       </div>
-      <div id="helpTexts" data-showfor="ruleText|helpText|attribution|usesAIImagery">
+      <div id="helpTexts" data-showfor="ruleText|helpText|attribution|usesAIImagery|importerWarnings">
+        <h3 data-showfor="importerWarnings" id="importNotesHeading">Import notes</h3>
+        <ul data-showfor="importerWarnings" id="importNotes"></ul>
         <h3 data-showfor="ruleText">How to play the game</h3>
         <div data-field="ruleText" data-html="true"></div>
         <h3 data-showfor="helpText">How to use this implementation</h3>

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -2,6 +2,7 @@ import fs from 'fs';
 import JSZip from 'jszip';
 
 import Config from './config.mjs';
+import Logging from './logging.mjs';
 
 const pieceColors = {
   default: '#000000',
@@ -15,9 +16,34 @@ const pieceColors = {
   white:   '#ffffff'
 };
 
+// PCIO font IDs mapped onto the closest font VirtualTabletop ships
+const pcioFonts = {
+  'abbasy-calligraphy':  'Handwriting',
+  'fivecomputers':       'Gugi',
+  'iansui':              'Handwriting Casual',
+  'opensans-light':      'Roboto',
+  'opensans-regular':    'Roboto',
+  'opensans-semibold':   'Roboto',
+  'opensans-bold':       'Roboto',
+  'unquiet-spirits':     'Creepster',
+  'westminstergotisch':  'Metamorphous'
+};
+
 export default async function convertPCIO(content) {
   const zip = await JSZip.loadAsync(content);
   const widgets = JSON.parse(await zip.files['widgets.json'].async('string'));
+
+  // the file format version lives in its own zip member since PCIO schema 3
+  let schemaVersion = 0;
+  if(zip.files['schemaVersion'])
+    schemaVersion = +(await zip.files['schemaVersion'].async('string')) || 0;
+
+  // everything that could not be translated ends up in _meta.info.importerWarnings
+  const warnings = [];
+  function warn(text) {
+    if(warnings.indexOf(text) == -1)
+      warnings.push(text);
+  }
 
   const nameMap = {};
   try {
@@ -27,7 +53,12 @@ export default async function convertPCIO(content) {
   } catch(e) {}
 
   for(const filename in zip.files) {
-    if(filename.match(/^\/?userassets/) && zip.files[filename]._data && zip.files[filename]._data.uncompressedSize < 2097152) {
+    if(filename.match(/^\/?userassets/) && zip.files[filename]._data) {
+      // 10 MiB is the same limit that FileLoader applies to assets in .vtt files
+      if(zip.files[filename]._data.uncompressedSize >= 10485760) {
+        warn(`Asset ${filename} is bigger than 10 MiB and was not imported.`);
+        continue;
+      }
       const targetFile = zip.files[filename]._data.crc32 + '_' + zip.files[filename]._data.uncompressedSize;
       nameMap['package://' + filename] = '/assets/' + targetFile;
       if(!Config.resolveAsset(targetFile))
@@ -51,8 +82,84 @@ export default async function convertPCIO(content) {
         const suit = match[1][0].toUpperCase();
         name = `/i/cards-default/${face}${suit}.svg`;
       }
+
+      const spanish = /https:\/\/playingcards\.io\/img\/cards-spanish\/(coins|cups|swords|clubs)-([0-9]+).svg/.exec(name);
+      if(spanish)
+        name = `/i/cards-spanish/${spanish[2]}${{coins:'Coin',cups:'Cup',swords:'Sword',clubs:'Club'}[spanish[1]]}.svg`;
+
+      const german = /https:\/\/playingcards\.io\/img\/cards-german\/(acorns|bells|hearts|leaves)-([0-9]+).svg/.exec(name);
+      if(german)
+        name = `/i/cards-german/${german[2]}${{acorns:'Acorn',bells:'Bell',hearts:'Heart',leaves:'Leaf'}[german[1]]}.svg`;
+
+      if(name.match(/^https:\/\/playingcards\.io\/img\//))
+        warn(`Images in ${name.replace(/^https:\/\/playingcards\.io|[^/]*$/g, '')} have no VirtualTabletop equivalent and stay linked to playingcards.io.`);
     }
     return nameMap[name] || name;
+  }
+
+  // PCIO fill object (solid colour or gradient) as a CSS background/color value
+  function pcioFill(fill) {
+    if(!fill || typeof fill != 'object')
+      return null;
+    if(fill.type == 'color')
+      return fill.color;
+    if(!Array.isArray(fill.stops) || !fill.stops.length)
+      return null;
+    const stops = fill.stops.map(function(stop, i, all) {
+      let position = stop.position !== undefined ? stop.position : stop.offset;
+      if(position === undefined)
+        position = all.length > 1 ? i/(all.length-1) : 0;
+      return `${stop.color} ${Math.round((position > 1 ? position/100 : position)*100)}%`;
+    }).join(', ');
+    if(fill.type == 'radialGradient')
+      return `radial-gradient(circle, ${stops})`;
+    if(fill.type == 'conicGradient')
+      return `conic-gradient(from ${fill.angle || 0}deg, ${stops})`;
+    return `linear-gradient(${(fill.angle || 0) + 180}deg, ${stops})`;
+  }
+
+  // PCIO applies mainBackground/mainOutlines/mainTextStyle/mainBorderRadius to
+  // holders, buttons, labels, counters and seats alike - translate them to CSS
+  function pcioStyle(widget, w, css=[]) {
+    const background = pcioFill((widget.mainBackground || {}).fill);
+    if(background && !(w.classes || '').match(/transparent/))
+      css.push(`background: ${background}`);
+
+    if(Array.isArray(widget.mainOutlines)) {
+      const outline = widget.mainOutlines.filter(o=>o && o.size && pcioFill(o.fill)).pop();
+      if(outline) {
+        css.push(`border: ${outline.size}px solid ${pcioFill(outline.fill)}`, 'box-sizing: border-box');
+        if(widget.mainOutlines.length > 1)
+          warn('Stacked outlines are not supported and were collapsed into a single border.');
+      } else if(!(w.classes || '').match(/transparent/)) {
+        css.push('border-color: transparent');
+      }
+    }
+
+    const text = widget.mainTextStyle;
+    if(text && typeof text == 'object') {
+      if(text.size)
+        css.push(`font-size: ${Math.round(text.size)}px`);
+      if(text.size && text.lineHeight)
+        css.push(`line-height: ${Math.round(text.size*text.lineHeight)}px`);
+      if(text.align)
+        css.push(`text-align: ${text.align}`);
+      const color = pcioFill(text.mainFill);
+      if(color)
+        css.push(`color: ${color}`);
+      if(text.font && pcioFonts[text.font])
+        css.push(`font-family: ${pcioFonts[text.font]}`);
+      else if(text.font)
+        warn(`Font ${text.font} is not available in VirtualTabletop.`);
+      if(Array.isArray(text.outlines) && text.outlines.length)
+        warn('Outlined text is not supported.');
+    }
+
+    if(typeof widget.mainBorderRadius == 'number')
+      w.borderRadius = widget.mainBorderRadius;
+    if(css.length)
+      w.css = (w.css ? w.css.replace(/;\s*$/, '') + '; ' : '') + css.join('; ');
+    return w;
   }
 
   function addDimensions(w, widget, defaultWidth=100, defaultHeight=100) {
@@ -63,36 +170,116 @@ export default async function convertPCIO(content) {
   }
 
   function importWidgetQuery(routine, args, legacySource, holdersParam, collectionParam, target) {
-    if(args.objects) {
-      if(args.objects.type == 'reference') {
-        target[collectionParam] = args.objects.questionId;
-      } else if(args.objects.collections && args.objects.collections.length) {
-        routine.push({
-          func: 'SELECT',
-          property: 'parent',
-          relation: 'in',
-          value: args.objects.holders,
-          type: 'card'
-        });
+    const objects = args.objects || args.customObjects;
+    if(objects && objects.type == 'reference') {
+      target[collectionParam] = objects.questionId;
+      return target;
+    }
+    if(objects && objects.type == 'literal' && Array.isArray(objects.value)) {
+      routine.push({
+        func: 'SELECT',
+        property: 'id',
+        relation: 'in',
+        value: objects.value
+      });
+      return target;
+    }
+    if(objects && objects.type == 'query') {
+      const holders = objects.holders || [];
+      const collections = objects.collections || [];
+      if(Array.isArray(objects.queryWidgetTypes) && objects.queryWidgetTypes.filter(t=>t != 'card' && t != 'piece').length)
+        warn(`An automation looks for ${objects.queryWidgetTypes.join('/')} but only cards and pieces are selected.`);
+      if(holders.length && !collections.length) {
+        target[holdersParam] = holders;
+        return target;
+      }
+      routine.push(holders.length ? {
+        func: 'SELECT',
+        property: 'parent',
+        relation: 'in',
+        value: holders,
+        type: 'card'
+      } : {
+        func: 'SELECT',
+        property: 'type',
+        value: 'card',
+        type: 'card'
+      });
+      // choosers are cards in VTT but PCIO never includes them in a query
+      const chooserDecks = widgets.filter(w=>w && w.type == 'cardDeck' && w.collectionType == 'choosers').map(w=>w.id);
+      if(chooserDecks.length) {
         routine.push({
           func: 'SELECT',
           source: 'DEFAULT',
           property: 'deck',
           relation: 'in',
-          value: args.objects.collections
+          value: chooserDecks,
+          mode: 'remove'
         });
-      } else {
-        target[holdersParam] = args.objects.holders;
       }
-    } else {
-      target[holdersParam] = args[legacySource].value;
+      if(collections.length) {
+        routine.push({
+          func: 'SELECT',
+          source: 'DEFAULT',
+          property: 'deck',
+          relation: 'in',
+          value: collections
+        });
+      }
+      return target;
     }
+    if(args[legacySource])
+      target[holdersParam] = args[legacySource].value;
     return target;
+  }
+
+  // ROTATE for one of PCIO's rotation modes, null if it has no equivalent
+  function rotateOperation(target, routine, mode, setRotation) {
+    if(mode == 'cw' || mode == 'ccw')
+      return Object.assign(target, { func: 'ROTATE', angle: mode == 'ccw' ? -90 : 90 });
+    if(mode == 'set')
+      return Object.assign(target, { func: 'ROTATE', angle: setRotation || 0, mode: 'set' });
+    if(mode == 'random') {
+      routine.push('var pcioRotation = randRange 0 360 45');
+      return Object.assign(target, { func: 'ROTATE', angle: '${pcioRotation}', mode: 'set' });
+    }
+    warn(`Rotating objects to "${mode}" (fit to holder) has no VirtualTabletop equivalent.`);
+    return null;
+  }
+
+  // PCIO stores the turn direction in the room while VTT's TURN takes it per
+  // call: a hidden label holds the direction so it can be read and reversed
+  function turnDirection() {
+    if(!output.pcioTurnDirection) {
+      output.pcioTurnDirection = {
+        id: 'pcioTurnDirection',
+        type: 'label',
+        text: 'forward',
+        x: -200,
+        y: -100,
+        movable: false,
+        movableInEdit: false
+      };
+    }
+    return 'pcioTurnDirection';
+  }
+
+  // PCIO renamed cardPile to holder in schema 6 without changing its properties
+  // and used 'rotation' before it became 'r' - normalize both so that the rest
+  // of the importer only has to deal with one spelling
+  for(const widget of widgets) {
+    if(!widget || typeof widget != 'object')
+      continue;
+    if(widget.type == 'holder')
+      widget.type = 'cardPile';
+    if(widget.r === undefined && typeof widget.rotation == 'number' && widget.type != 'spinner')
+      widget.r = widget.rotation;
   }
 
   const pileHasDeck = {};
   const pileOverlaps = {};
   const pileTransparent = {};
+  const turnAtSeat = {};
 
   for(const widget of widgets) {
     if(widget.type == 'cardDeck' && widget.parent)
@@ -161,6 +348,14 @@ export default async function convertPCIO(content) {
   }
 
   for(const widget of widgets) {
+    if(!widget || typeof widget != 'object')
+      continue;
+    if(!widget.type) {
+      // schema 6 files contain records that only carry styling for an attached label
+      warn(`Ignored a widget without a type (${widget.id}).`);
+      continue;
+    }
+
     const w = {};
 
     w.id = widget.id;
@@ -210,10 +405,53 @@ export default async function convertPCIO(content) {
       w.image = `https://playingcards.io/img/pieces/${widget.color}-${widget.pieceType}.svg`;
       addDimensions(w, widget);
     } else if(widget.type == 'dice') {
+      // PCIO dice are backed by a cardDeck whose cardTypes hold the faces
       w.type = 'dice';
+      const deck = byID[widget.deck];
+      if(deck && deck.cardTypes) {
+        const faces = Object.entries(deck.cardTypes);
+        const pips = faces.every(([ , face ], i)=>String(face.image || '').match(new RegExp(`/img/dice-basic/${i+1}.svg$`)));
+        if(!pips) {
+          w.faces = faces.map(function([ , face ]) {
+            if(face.image)
+              return { image: mapName(face.image) };
+            if(face.label !== undefined)
+              return { value: face.label };
+            return {};
+          });
+        }
+        w.width  = deck.cardWidth  || 50;
+        w.height = deck.cardHeight || 50;
+        const activeFace = faces.findIndex(([ key ])=>key == widget.diceValue);
+        if(activeFace > 0)
+          w.activeFace = activeFace;
+      }
+      addDimensions(w, widget, w.width || 50, w.height || 50);
+    } else if(widget.type == 'urlButton') {
+      // VTT cannot open a link from a button - show it so it can be copied
+      w.type = 'button';
+      w.text = widget.label || 'Open';
+      addDimensions(w, widget, 80, 80);
+      const url = widget.clickURL || widget.url;
+      if(url) {
+        w.clickRoutine = [
+          {
+            func: 'INPUT',
+            header: w.text,
+            fields: [
+              { type: 'text',   text: 'PlayingCards.io opened this link in a new tab:' },
+              { type: 'string', label: 'Link', value: url, variable: 'url' }
+            ]
+          }
+        ];
+      }
+      pcioStyle(widget, w);
+      warn('Webpage buttons cannot open a link in VirtualTabletop - they now show the link instead.');
     } else if(widget.type == 'hand') {
-      if(widget.enabled === false)
+      if(widget.enabled === false) {
+        warn('A disabled hand was not imported.');
         continue;
+      }
       w.type = 'holder';
       w.onEnter = { activeFace: 1 };
       w.onLeave = { activeFace: 0 };
@@ -230,6 +468,9 @@ export default async function convertPCIO(content) {
       w.childrenPerOwner = true;
       w.width = widget.width || 1500;
       w.height = widget.height || 180;
+      if(widget.allowedDecks && widget.allowedDecks.length)
+        w.dropTarget = widget.allowedDecks.map(d=>({deck:d}));
+      pcioStyle(widget, w);
     } else if(widget.type == 'cardPile') {
       w.type = 'holder';
       if(pileTransparent[w.id])
@@ -255,6 +496,13 @@ export default async function convertPCIO(content) {
         w.preventPiles = true;
       if(widget.layoutType == 'freeform')
         w.alignChildren = false;
+      if(widget.layoutType == 'grid') {
+        // VTT holders can only spread along one axis
+        w.alignChildren = false;
+        warn(`Holder ${widget.label || widget.id} uses PCIO's grid layout which has no VirtualTabletop equivalent - imported as freeform.`);
+      }
+      if(widget.spreadMulti == 'multi' && widget.layoutType == 'spread')
+        warn(`Holder ${widget.label || widget.id} spreads cards into multiple groups which VirtualTabletop cannot do - all cards are in one row.`);
 
       if(widget.layoutType == 'spread') {
         if(widget.spreadDirection == 'down') {
@@ -287,8 +535,10 @@ export default async function convertPCIO(content) {
       if(widget.layoutType != 'spread' && widget.layoutType != 'freeform')
         w.inheritChildZ = true;
 
+      pcioStyle(widget, w);
+
       if(widget.label) {
-        output[widget.id + '_label'] = {
+        output[widget.id + '_label'] = pcioStyle({ mainTextStyle: widget.mainTextStyle }, {
           id: widget.id + '_label',
           parent: widget.id,
           x: -(w.width || 111) * 0.1,
@@ -299,7 +549,7 @@ export default async function convertPCIO(content) {
           text: widget.label,
           twoRowBottomAlign: true,
           movableInEdit: false
-        };
+        });
         if(widget.allowPlayerEditLabel)
           output[widget.id + '_label'].editable = true;
       }
@@ -361,13 +611,22 @@ export default async function convertPCIO(content) {
         w.cardDefaults.height = widget.cardHeight;
       if(widget.enlarge)
         w.cardDefaults.enlarge = 3;
-      if(widget.cardOverlapH === 0)
+      if(widget.cardOverlapH === 0 && !widget.cardOverlapV)
         w.cardDefaults.overlap = false;
       if(widget.onRemoveFromHand === null)
         w.cardDefaults.ignoreOnLeave = true;
+      if(widget.allowPlayerMove === false)
+        w.cardDefaults.movable = false;
+      if(widget.allowPlayerClick === false)
+        w.cardDefaults.clickable = false;
+      if(Array.isArray(widget.snapAngles) && widget.snapAngles.length > 1)
+        warn('Card rotation snapping (snapAngles) has no VirtualTabletop equivalent.');
+      if(widget.showUnflipped)
+        warn('"Show unflipped side to owner" has no VirtualTabletop equivalent.');
 
       for(const face of w.faceTemplates) {
-        face.border = face.includeBorder ? 1 : false;
+        // includeBorder is a boolean in old files and light/heavy in new ones
+        face.border = face.includeBorder ? { light: 1, heavy: 1.5 }[face.includeBorder] || 1 : false;
         face.radius = face.includeRadius ? 8 : false;
         delete face.includeBorder;
         delete face.includeRadius;
@@ -378,6 +637,13 @@ export default async function convertPCIO(content) {
           object.height = object.h;
           delete object.w;
           delete object.h;
+          if(object.textFont) {
+            if(pcioFonts[object.textFont])
+              object.css = `font-family: ${pcioFonts[object.textFont]}`;
+            else
+              warn(`Font ${object.textFont} is not available in VirtualTabletop.`);
+            delete object.textFont;
+          }
         }
         face.objects.unshift({
           width:     w.cardDefaults.width  || 103,
@@ -527,9 +793,13 @@ export default async function convertPCIO(content) {
       w.y += 5;
       w.width = widget.width || 140;
       w.height = widget.height || 44;
-      w.css = 'font-size: 30px;';
       w.text = widget.counterValue;
       w.editable = true;
+      pcioStyle(widget, w, (widget.mainTextStyle || {}).size ? [] : [ 'font-size: 30px' ]);
+      if(widget.counterMin !== undefined && widget.counterMin !== null || widget.counterMax !== undefined && widget.counterMax !== null)
+        warn(`Counter ${widget.label || widget.id} has minimum/maximum bounds which are not enforced after the import.`);
+
+      const counterStep = Math.abs(+widget.counterStep) || 1;
 
       function addCounterButton(suffix, x, text, value) {
         output[widget.id + suffix] = {
@@ -550,8 +820,8 @@ export default async function convertPCIO(content) {
         if(x)
           output[widget.id + suffix].x += x;
       }
-      addCounterButton('_decrementButton', 0,                  '-', -1);
-      addCounterButton('_incrementButton', w.width - w.height, '+',  1);
+      addCounterButton('_decrementButton', 0,                  '-', -counterStep);
+      addCounterButton('_incrementButton', w.width - w.height, '+',  counterStep);
 
       if(widget.label) {
         output[widget.id + 'label'] = {
@@ -566,31 +836,41 @@ export default async function convertPCIO(content) {
       }
     } else if(widget.type == 'labelText') {
       const weight = widget.bold ? 'bold' : 'normal';
+      const style = widget.mainTextStyle || {};
+      const size = Math.round(style.size || widget.textSize || 18) - 2;
       w.type = 'label';
       w.text = widget.labelContent;
       w.css = {
         default: {
-          'line-height': `${widget.textSize-2}px`,
-          'font-size':   `${widget.textSize-2}px`,
+          'line-height': `${style.lineHeight ? Math.round(size*style.lineHeight) : size}px`,
+          'font-size':   `${size}px`,
           'font-weight': weight,
-          'text-align':  widget.textAlign
+          'text-align':  style.align || widget.textAlign
         },
         ' textarea': {
           'letter-spacing': '-1px'
         }
       };
+      const color = pcioFill(style.mainFill);
+      if(color)
+        w.css.default.color = color;
+      if(style.font && pcioFonts[style.font])
+        w.css.default['font-family'] = pcioFonts[style.font];
+      else if(style.font)
+        warn(`Font ${style.font} is not available in VirtualTabletop.`);
       addDimensions(w, widget, 100, 20);
-      w.height = widget.textSize * 3.5;
+      w.height = (size+2) * 3.5;
     } else if(widget.type == 'separator') {
       w.movable = false;
       w.layer = -1;
-      w.css = `background:#ddd`;
+      w.css = `background:${pcioFill((widget.mainBackground || {}).fill) || '#ddd'}`;
+      const thickness = widget.mainThickness || 1;
       if(widget.separatorType == 'horizontal') {
         w.width  = widget.width || 150;
-        w.height = 1;
+        w.height = thickness;
       } else {
         w.height = widget.height || 150;
-        w.width  = 1;
+        w.width  = thickness;
       }
     } else if(widget.type == 'seat') {
       w.type = 'seat';
@@ -599,6 +879,8 @@ export default async function convertPCIO(content) {
       w.hideWhenUnused = true;
       if(typeof widget.seatIndex == 'number')
         w.index = widget.seatIndex + 1;
+      if(widget.flipTableForSeated)
+        warn('"Flip table for seated player" has no VirtualTabletop equivalent.');
       w.x = (widget.x || 0) + 69;
       w.y = (widget.y || 0) - 38;
       w.height = 42;
@@ -801,6 +1083,8 @@ export default async function convertPCIO(content) {
         w.end = 0
       }
       w.milliseconds = widget.pauseTime||w.start
+      if(widget.timerStart)
+        w.paused = false
       var id = widget.id
       output[widget.id + 'P'] = {
         parent: id,
@@ -890,21 +1174,49 @@ export default async function convertPCIO(content) {
       }
 
       if(widget.type == 'turnButton') {
-        w.clickRoutine.push({
-          func: 'TURN'
-        });
+        if(widget.playersCanReverse || widget.turnCCW) {
+          if(widget.turnCCW)
+            output[turnDirection()].text = 'backward';
+          w.clickRoutine.push({
+            func: 'TURN',
+            turnCycle: `\${PROPERTY text OF ${turnDirection()}}`
+          });
+        } else {
+          w.clickRoutine.push({
+            func: 'TURN'
+          });
+        }
+        if(widget.currentTurn && byID[widget.currentTurn])
+          turnAtSeat[widget.currentTurn] = true;
+        if(widget.playersCanReverse)
+          warn('Players cannot reverse the turn direction by clicking the turn button - use the "Reverse turn direction" button that was added instead.');
       }
 
-      for(let c of widget.clickRoutine ? (widget.clickRoutine.steps || widget.clickRoutine) : []) {
+      const steps = [];
+      for(const step of widget.clickRoutine ? (widget.clickRoutine.steps || widget.clickRoutine) : [])
+        // PCIO wraps every step into { id, branches: [ { func, args } ] } since schema 6
+        for(const branch of step && step.branches || [ step ])
+          steps.push(branch);
+
+      for(let c of steps) {
+        if(!c || !c.func) {
+          warn('An automation step could not be read and was skipped.');
+          continue;
+        }
+        c = Object.assign({}, c, { args: c.args || {} });
+
         if(c.func == 'MOVE_CARDS_BETWEEN_HOLDERS') {
           if((!c.args.from && !c.args.objects) || !c.args.to)
             continue;
+          const args = c.args;
           const moveFlip = c.args.moveFlip && c.args.moveFlip.value;
 
           let quantity = 1;
           if(c.args.quantity) {
             if(c.args.quantity.type == 'reference')
               quantity = '${' + c.args.quantity.questionId + '}';
+            else if(c.args.quantity.counterId && byID[c.args.quantity.counterId])
+              quantity = `\${PROPERTY text OF ${c.args.quantity.counterId}}`;
             else if(c.args.quantity.value == 'all')
               quantity = 0;
             else
@@ -933,6 +1245,26 @@ export default async function convertPCIO(content) {
           }
           if(moveFlip && moveFlip != 'none')
             c.face = moveFlip == 'faceDown' ? 0 : 1;
+
+          const toPosition = (args.toPosition || {}).value;
+          if(toPosition && toPosition != 'top')
+            warn(`Moving objects to "${toPosition}" is not supported - they end up on top of the destination.`);
+          if((args.startingOffset || {}).value)
+            warn('The starting holder offset of a move automation is not supported.');
+
+          // 'auto' (fit to holder) needs no operation: VTT children inherit the
+          // rotation of their holder
+          const changeRotation = (args.changeRotation || {}).value;
+          if(c.func == 'MOVE' && changeRotation && changeRotation != 'none' && changeRotation != 'auto') {
+            const rotate = rotateOperation({
+              holder: c.to,
+              count:  c.count !== undefined ? c.count : (c.fillTo !== undefined ? c.fillTo : 1)
+            }, w.clickRoutine, changeRotation, (args.setRotation || {}).value);
+            if(rotate) {
+              w.clickRoutine.push(c);
+              c = rotate;
+            }
+          }
         }
         if(c.func == 'RECALL_CARDS') {
           if(!c.args.decks)
@@ -1000,14 +1332,16 @@ export default async function convertPCIO(content) {
             c.holder = c.holder[0];
         }
         if(c.func == 'SORT_CARDS') {
-          if(!c.args.sources)
+          const sources = c.args.sources || c.args.holders;
+          const direction = c.args.direction || c.args.sortDirection;
+          if(!sources)
             continue;
-          const holders = c.args.sources.value.map(id=>byID[id].type == 'seat' ? 'hand' : id);
+          const holders = sources.value.map(id=>byID[id] && byID[id].type == 'seat' ? 'hand' : id);
           c = {
             func:   'SORT',
             holder: holders,
             key:    'sortingOrder',
-            reverse: !c.args.direction || c.args.direction.value != 'za'
+            reverse: !direction || direction.value != 'za'
           };
           if(c.holder.length == 1)
             c.holder = c.holder[0];
@@ -1018,7 +1352,8 @@ export default async function convertPCIO(content) {
           if(!c.args.holders && !c.args.objects)
             continue;
           const flipFace = c.args.flipFace;
-
+          if((c.args.reverse || {}).value == 'reverse')
+            warn('Reversing the order of a pile while flipping it is not supported.');
 
           c = importWidgetQuery(w.clickRoutine, c.args, 'holders', 'holder', 'collection', {
             func:   'FLIP',
@@ -1028,8 +1363,12 @@ export default async function convertPCIO(content) {
             c.holder = c.holder[0];
           if(!c.count)
             delete c.count;
-          if(flipFace)
+          if(flipFace && (flipFace.value == 'faceUp' || flipFace.value == 'faceDown'))
             c.face = flipFace.value == 'faceDown' ? 0 : 1;
+          else if(flipFace && flipFace.value == 'random')
+            warn('Randomly flipping objects has no VirtualTabletop equivalent - they are flipped to the other side instead.');
+          else if(flipFace && flipFace.value == 'switch')
+            warn('Flipping all objects to the same side is not supported - each object is flipped individually.');
         }
         if(c.func == 'CHANGE_TIMER_STATE') {
           if(!c.args.timers)
@@ -1078,11 +1417,16 @@ export default async function convertPCIO(content) {
         if(c.func == 'CHANGE_COUNTER') {
           if(!c.args.counters)
             continue;
+          // PCIO used add/subtract before it settled on inc/dec
+          const changeMode = c.args.counterChangeMode || c.args.changeMode;
+          let value = c.args.changeNumber ? c.args.changeNumber.value : 0;
+          if(c.args.changeNumber && c.args.changeNumber.counterId && byID[c.args.changeNumber.counterId])
+            value = `\${PROPERTY text OF ${c.args.changeNumber.counterId}}`;
           c = {
             func: 'LABEL',
             label: c.args.counters.value,
-            mode:  c.args.changeMode ? c.args.changeMode.value : 'set',
-            value: c.args.changeNumber ? c.args.changeNumber.value : 0
+            mode:  { add: 'inc', subtract: 'dec' }[changeMode && changeMode.value] || (changeMode ? changeMode.value : 'set'),
+            value
           };
           if(c.label.length == 1)
             c.label = c.label[0];
@@ -1091,28 +1435,60 @@ export default async function convertPCIO(content) {
           if(c.value === 0)
             delete c.value;
         }
-        if(c.func == 'CHANGE_CHOOSER') {
-          if(!c.args.choosers)
+        if(c.func == 'CHANGE_CHOOSER' || c.func == 'ROLL_DICE') {
+          // "Roll / Change Dice" and "Change Chooser" both cycle the faces of
+          // the widgets they target
+          const isDice = c.func == 'ROLL_DICE';
+          const targets = isDice ? c.args.dice : c.args.choosers;
+          if(!targets)
             continue;
-          c = {
-            func: 'FLIP',
-            collection: c.args.choosers.value,
-            face: c.args.choice ? Object.keys(byID[byID[c.args.choosers.value[0]].deck].cardTypes).indexOf(c.args.choice.value) : null,
-            faceCycle: c.args.changeType == 'prev' ? 'backward' : null
-          };
-          if(c.face === null)
-            delete c.face;
-          if(c.faceCycle === null)
-            delete c.faceCycle;
-        }
-        if(c.func == 'ROLL_DICE') {
-          if(!c.args.dice)
-            continue;
-          c = {
-            note:       'Roll dice',
-            func:       'CLICK',
-            collection: c.args.dice.value
-          };
+          const changeType = (c.args.chooserChangeType || c.args.diceChangeType || c.args.changeType || {}).value;
+          const choice = c.args.chooserChoice || c.args.diceChoice || c.args.choice;
+          const deck = byID[targets.value[0]] && byID[byID[targets.value[0]].deck];
+          const faces = deck && deck.cardTypes ? Object.keys(deck.cardTypes) : [];
+
+          if(isDice && (!changeType || changeType == 'random')) {
+            c = {
+              note:       'Roll dice',
+              func:       'CLICK',
+              collection: targets.value
+            };
+          } else if(isDice) {
+            // dice have no flip(), their face is set directly - out of range
+            // values wrap around so +1/-1 cycles through the faces
+            w.clickRoutine.push({
+              func: 'SELECT',
+              property: 'id',
+              relation: 'in',
+              value: targets.value,
+              type: 'dice'
+            });
+            c = changeType == 'set' && choice && faces.indexOf(choice.value) != -1 ? {
+              note: 'Change dice',
+              func: 'SET',
+              property: 'activeFace',
+              value: faces.indexOf(choice.value)
+            } : {
+              note: 'Cycle dice',
+              func: 'SET',
+              property: 'activeFace',
+              relation: changeType == 'prev' ? '-' : '+',
+              value: 1
+            };
+          } else {
+            c = {
+              func: 'FLIP',
+              collection: targets.value
+            };
+            if(changeType == 'random' && faces.length) {
+              w.clickRoutine.push(`var pcioFace = randInt 0 ${faces.length-1}`);
+              c.face = '${pcioFace}';
+            } else if(changeType == 'set' && choice && faces.indexOf(choice.value) != -1) {
+              c.face = faces.indexOf(choice.value);
+            } else if(changeType == 'prev') {
+              c.faceCycle = 'backward';
+            }
+          }
         }
         if(c.func == 'SPIN_SPINNER') {
           if(!c.args.spinners)
@@ -1122,6 +1498,100 @@ export default async function convertPCIO(content) {
             func:       'CLICK',
             collection: c.args.spinners.value
           };
+        }
+        if(c.func == 'ROTATE_OBJECTS') {
+          const target = importWidgetQuery(w.clickRoutine, c.args, 'objects', 'holder', 'collection', {
+            count: (c.args.rotateMode || {}).value == 'top' ? 1 : 0
+          });
+          const rotate = rotateOperation(target, w.clickRoutine, (c.args.changeRotation || {}).value || 'auto', (c.args.setRotation || {}).value);
+          if(!rotate)
+            continue;
+          c = rotate;
+          if(c.holder && c.holder.length == 1)
+            c.holder = c.holder[0];
+        }
+        if(c.func == 'SHIFT_OBJECTS') {
+          // shift the contents of an ordered list of holders by one position,
+          // optionally wrapping the last one around to the first
+          const holders = c.args.holders ? c.args.holders.value : [];
+          if(holders.length < 2)
+            continue;
+          if(holders.filter(id=>!byID[id] || byID[id].type != 'cardPile').length) {
+            warn('Shifting objects between player seats has no VirtualTabletop equivalent and was skipped.');
+            continue;
+          }
+          const wrap = !c.args.moveMode || c.args.moveMode.value == 'wrap';
+          const order = (c.args.moveDirection || {}).value == 'reverse' ? holders.slice().reverse() : holders;
+          const count = (c.args.objectsMode || {}).value == 'top' ? 1 : 0;
+          const steps = Math.min(+((wrap ? c.args.stepsWrap : c.args.stepsEdge) || {}).value || 1, holders.length);
+          if((c.args.objectsMode || {}).value == 'custom')
+            warn('Shifting only a subset of the objects in a holder is not supported - all objects are shifted.');
+
+          if(wrap) {
+            output.pcioShiftTempHolder = {
+              id: 'pcioShiftTempHolder',
+              type: 'holder',
+              x: -200,
+              y: -300
+            };
+          }
+          for(let step=0; step<steps; ++step) {
+            if(wrap)
+              w.clickRoutine.push({ func: 'MOVE', from: order[order.length-1], to: 'pcioShiftTempHolder', count });
+            for(let i=order.length-2; i>=0; --i)
+              w.clickRoutine.push({ func: 'MOVE', from: order[i], to: order[i+1], count });
+            if(wrap)
+              w.clickRoutine.push({ func: 'MOVE', from: 'pcioShiftTempHolder', to: order[0], count });
+          }
+          continue;
+        }
+        if(c.func == 'STAND_UP_PLAYER') {
+          if(!c.args.seats)
+            continue;
+          w.clickRoutine.push({
+            func: 'SELECT',
+            property: 'id',
+            relation: 'in',
+            value: c.args.seats.value,
+            type: 'seat'
+          });
+          c = {
+            note: 'Stand up players',
+            func: 'SET',
+            property: 'player',
+            value: ''
+          };
+        }
+        if(c.func == 'NEXT_TURN') {
+          c = {
+            func: 'TURN',
+            turnCycle: `\${PROPERTY text OF ${turnDirection()}}`
+          };
+        }
+        if(c.func == 'REVERSE_TURN_DIRECTION') {
+          const direction = (c.args.turnDirection || {}).value;
+          const set = value=>[
+            { func: 'SELECT', property: 'id', value: turnDirection() },
+            { func: 'SET',    property: 'text', value }
+          ];
+          c = direction == 'cw' || direction == 'ccw' ? {
+            note: 'Set turn direction',
+            func: 'IF',
+            condition: true,
+            thenRoutine: set(direction == 'ccw' ? 'backward' : 'forward')
+          } : {
+            note: 'Reverse turn direction',
+            func: 'IF',
+            operand1: `\${PROPERTY text OF ${turnDirection()}}`,
+            operand2: 'forward',
+            thenRoutine: set('backward'),
+            elseRoutine: set('forward')
+          };
+        }
+
+        if(c.args) {
+          warn(`The automation step ${c.func} of "${widget.label || widget.id}" has no VirtualTabletop equivalent and was skipped.`);
+          continue;
         }
         w.clickRoutine.push(c);
       }
@@ -1134,6 +1604,7 @@ export default async function convertPCIO(content) {
         w.value = widget.value;
       addDimensions(w, widget, 110, 110);
     } else {
+      warn(`Widgets of type ${widget.type} cannot be imported.`);
       w.css = 'background: repeating-linear-gradient(45deg, red, red 10px, darkred 10px, darkred 20px);';
     }
 
@@ -1142,5 +1613,17 @@ export default async function convertPCIO(content) {
 
     output[widget.id] = w;
   }
+
+  // whose turn it is - the seats are created after the turn button was read
+  for(const seatID in turnAtSeat)
+    if(output[seatID])
+      output[seatID].turn = true;
+
+  if(warnings.length) {
+    output._meta.info.importerWarnings = warnings;
+    Logging.log(`PCIO import (schema version ${schemaVersion || 'unknown'}): ${warnings.length} warnings: ${warnings.join(' ')}`);
+  }
+  output._meta.info.importerSchemaVersion = schemaVersion;
+
   return output;
 }

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -31,7 +31,8 @@ const pcioFonts = {
 
 export default async function convertPCIO(content) {
   const zip = await JSZip.loadAsync(content);
-  const widgets = JSON.parse(await zip.files['widgets.json'].async('string'));
+  // a null entry in widgets.json must not break the loops that follow
+  const widgets = JSON.parse(await zip.files['widgets.json'].async('string')).filter(widget=>widget && typeof widget == 'object');
 
   // the file format version lives in its own zip member since PCIO schema 3
   let schemaVersion = 0;
@@ -220,7 +221,7 @@ export default async function convertPCIO(content) {
         type: 'card'
       });
       // choosers are cards in VTT but PCIO never includes them in a query
-      const chooserDecks = widgets.filter(w=>w && w.type == 'cardDeck' && w.collectionType == 'choosers').map(w=>w.id);
+      const chooserDecks = widgets.filter(w=>w.type == 'cardDeck' && w.collectionType == 'choosers').map(w=>w.id);
       if(chooserDecks.length) {
         into({
           func: 'SELECT',
@@ -288,8 +289,6 @@ export default async function convertPCIO(content) {
   // and used 'rotation' before it became 'r' - normalize both so that the rest
   // of the importer only has to deal with one spelling
   for(const widget of widgets) {
-    if(!widget || typeof widget != 'object')
-      continue;
     if(widget.type == 'holder')
       widget.type = 'cardPile';
     if(widget.r === undefined && typeof widget.rotation == 'number' && widget.type != 'spinner')
@@ -302,27 +301,39 @@ export default async function convertPCIO(content) {
   const turnAtSeat = {};
 
   // PCIO keeps every counter inside its bounds while a VTT label just counts on,
-  // so a counter with bounds gets them applied wherever its value is changed
+  // so a counter with bounds gets them applied wherever its value is changed. A
+  // counter can be bounded on one side only, which stays unbounded here as well.
   const counterBounds = {};
   for(const widget of widgets) {
-    if(widget && widget.type == 'counter' && (widget.counterMin != null || widget.counterMax != null)) {
-      const min = widget.counterMin != null ? +widget.counterMin : -9999;
-      counterBounds[widget.id] = {
-        min,
-        max: Math.max(widget.counterMax != null ? +widget.counterMax : 9999, min+1)
-      };
-    }
+    if(widget.type != 'counter')
+      continue;
+    const min = isNaN(parseFloat(widget.counterMin)) ? -Infinity : parseFloat(widget.counterMin);
+    const max = isNaN(parseFloat(widget.counterMax)) ?  Infinity : parseFloat(widget.counterMax);
+    if(min == -Infinity && max == Infinity)
+      continue;
+    if(max < min)
+      warn(`Counter ${widget.label || widget.id} has a maximum below its minimum - its value is kept at ${max}.`);
+    counterBounds[widget.id] = { min, max };
+  }
+
+  // how a range of a counter reads in a warning
+  function boundsText(bounds) {
+    if(bounds.min == -Infinity)
+      return `maximum of ${bounds.max}`;
+    if(bounds.max == Infinity)
+      return `minimum of ${bounds.min}`;
+    return `range of ${bounds.min} to ${bounds.max}`;
   }
 
   // the operations that keep a variable within the bounds of a counter
   function clampCounter(id, variable) {
-    const bounds = counterBounds[id];
-    if(!bounds)
-      return [];
-    return [
-      `var ${variable} = max \${${variable}} ${bounds.min}`,
-      `var ${variable} = min \${${variable}} ${bounds.max}`
-    ];
+    const bounds = counterBounds[id] || { min: -Infinity, max: Infinity };
+    const operations = [];
+    if(bounds.min > -Infinity)
+      operations.push(`var ${variable} = max \${${variable}} ${bounds.min}`);
+    if(bounds.max < Infinity)
+      operations.push(`var ${variable} = min \${${variable}} ${bounds.max}`);
+    return operations;
   }
 
   for(const widget of widgets) {
@@ -392,8 +403,6 @@ export default async function convertPCIO(content) {
   }
 
   for(const widget of widgets) {
-    if(!widget || typeof widget != 'object')
-      continue;
     if(!widget.type) {
       // schema 6 files contain records that only carry styling for an attached label
       warn(`Ignored a widget without a type (${widget.id}).`);
@@ -454,7 +463,9 @@ export default async function convertPCIO(content) {
       const deck = byID[widget.deck];
       if(deck && deck.cardTypes) {
         const faces = Object.entries(deck.cardTypes);
-        const pips = faces.every(([ , face ], i)=>String(face.image || '').match(new RegExp(`/img/dice-basic/${i+1}.svg$`)));
+        // only the six standard pip faces are what a VTT dice widget shows by
+        // default - a die with fewer of them needs its faces spelled out
+        const pips = faces.length == 6 && faces.every(([ , face ], i)=>String(face.image || '').match(new RegExp(`/img/dice-basic/${i+1}.svg$`)));
         if(!pips) {
           w.faces = faces.map(function([ , face ]) {
             if(face.image)
@@ -844,7 +855,7 @@ export default async function convertPCIO(content) {
         w.editable = true;
       pcioStyle(widget, w, (widget.mainTextStyle || {}).size ? [] : [ 'font-size: 30px' ]);
       if(bounds && widget.allowPlayerEditValue !== false)
-        warn(`Typing a value into counter ${widget.label || widget.id} is not restricted to its range of ${bounds.min} to ${bounds.max} - its buttons and the automations that change it are.`);
+        warn(`Typing a value into counter ${widget.label || widget.id} is not restricted to its ${boundsText(bounds)} - its buttons and the automations that change it are.`);
 
       const counterStep = Math.abs(+widget.counterStep) || 1;
 
@@ -1191,6 +1202,7 @@ export default async function convertPCIO(content) {
       if(widget.type == 'turnButton')
         widget.height = widget.width = 64;
       addDimensions(w, widget, 80, 80);
+      pcioStyle(widget, w);
 
       w.clickRoutine = [];
 
@@ -1264,9 +1276,9 @@ export default async function convertPCIO(content) {
       function importSteps(steps, routine) {
         for(const step of steps || []) {
           const branches = step && step.branches || [ step ];
-          // a read step with alternatives may not run at all, in which case PCIO
-          // sees its result as empty
-          if(branches.length > 1 && readDefaults[(branches[0] || {}).func] !== undefined)
+          // a read step that only runs under a condition may not run at all, in
+          // which case PCIO sees its result as empty
+          if((branches[0] || {}).condition && readDefaults[branches[0].func] !== undefined)
             routine.push(`var ${readVariable(step.id)} = ${readDefaults[branches[0].func]}`);
           importBranches(branches, routine, step && step.id);
         }
@@ -1319,10 +1331,15 @@ export default async function convertPCIO(content) {
             return `\${${variable}}`;
           }
           const field = (argument.collectionFieldSelectors || [])[0];
-          if(field && field.fieldId && importWidgetQuery(routine, { objects: argument }, '', '', '', {}, { collection: variable })) {
-            // PCIO adds up one field of the card type of everything it finds
-            routine.push({ func: 'GET', collection: variable, property: field.fieldId, aggregation: 'sum', variable, skipMissing: true });
-            return `\${${variable}}`;
+          if(field && field.fieldId) {
+            // PCIO adds up one field of the card type of everything it finds.
+            // The objects may already be a collection of a popup question, in
+            // which case the query selects nothing of its own.
+            const target = importWidgetQuery(routine, { objects: argument }, '', '', 'collection', {}, { collection: variable });
+            if(target) {
+              routine.push({ func: 'GET', collection: target.collection || variable, property: field.fieldId, aggregation: 'sum', variable, skipMissing: true });
+              return `\${${variable}}`;
+            }
           }
         }
         return fallback;
@@ -1458,10 +1475,27 @@ export default async function convertPCIO(content) {
           // destinations, which leaves them in the opposite order of moving the
           // whole pile at once. Only a move out of a holder has an order to keep:
           // a collection is moved in the order it was selected in.
-          if((args.moveMethod || {}).value != 'all' && c.func == 'MOVE' && c.from && !fill && typeof quantity == 'number' && quantity > 1 && quantity <= 100)
-            routine.push({ note: 'Deal one at a time', func: 'FOREACH', range: [ 1, quantity ], loopRoutine: [ Object.assign({}, c, { count: 1 }) ] });
-          else
+          const oneAtATime = (args.moveMethod || {}).value != 'all' && c.func == 'MOVE' && c.from && !fill;
+          const dealLoop = ()=>({ func: 'FOREACH', range: [ 1, quantity ], loopRoutine: [ Object.assign({}, c, { count: 1 }) ] });
+          if(oneAtATime && typeof quantity == 'number' && quantity > 1 && quantity <= 100) {
+            routine.push(Object.assign({ note: 'Deal one at a time' }, dealLoop()));
+          } else if(oneAtATime && typeof quantity == 'string') {
+            // the quantity is only known when the button is clicked and a range
+            // ending below its start would count down, so dealing nothing at all
+            // has to skip the loop
+            routine.push({
+              note: 'Deal one at a time',
+              func: 'IF',
+              operand1: quantity,
+              relation: '>',
+              operand2: 0,
+              thenRoutine: [ dealLoop() ]
+            });
+          } else {
+            if(oneAtATime && typeof quantity == 'number' && quantity > 100)
+              warn(`"${widget.label || widget.id}" moves up to ${quantity} objects in one go instead of one after the other - they can end up in the opposite order.`);
             routine.push(c);
+          }
 
           // 'auto' (fit to holder) needs no operation: VTT children inherit the
           // rotation of their holder
@@ -1598,6 +1632,9 @@ export default async function convertPCIO(content) {
             // flip() rolls a face of its own for every object it is given
             c.faceCycle = 'random';
           } else if(ordered) {
+            // GET leaves the variable alone for an empty pile, which nothing is
+            // flipped in anyway - the default keeps it from becoming NaN
+            routine.push('var pcioFace = 0');
             routine.push({ func: 'GET', collection: c.collection, property: 'activeFace', aggregation: 'last', variable: 'pcioFace' });
             routine.push('var pcioFace = 1 - ${pcioFace}');
             c.face = '${pcioFace}';

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -91,11 +91,22 @@ export default async function convertPCIO(content) {
   if(zip.files['schemaVersion'])
     schemaVersion = +(await zip.files['schemaVersion'].async('string')) || 0;
 
-  // everything that could not be translated ends up in _meta.info.importerWarnings
+  // everything that could not be translated ends up in _meta.info.importerWarnings.
+  // A broken file can have a note per widget, so the report is capped: it is
+  // shown in the interface and stored in the room, which nobody is served by
+  // filling with thousands of lines.
+  const maxWarnings = 100;
   const warnings = [];
+  const warned = new Set();
+  let suppressedWarnings = 0;
   function warn(text) {
-    if(warnings.indexOf(text) == -1)
+    if(warned.has(text))
+      return;
+    warned.add(text);
+    if(warnings.length < maxWarnings)
       warnings.push(text);
+    else
+      ++suppressedWarnings;
   }
 
   // how a widget is called in a warning - the label the user gave it if it has one
@@ -145,7 +156,7 @@ export default async function convertPCIO(content) {
     }
   }
 
-  function mapName(name) {
+  function mapName(name, silent) {
     if(name.match(/^\/img\//)) {
       name = 'https://playingcards.io' + name;
 
@@ -170,7 +181,7 @@ export default async function convertPCIO(content) {
       if(german)
         name = `/i/cards-german/${german[2]}${{acorns:'Acorn',bells:'Bell',hearts:'Heart',leaves:'Leaf'}[german[1]]}.svg`;
 
-      if(name.match(/^https:\/\/playingcards\.io\/img\//))
+      if(!silent && name.match(/^https:\/\/playingcards\.io\/img\//))
         warn(`Images in ${name.replace(/^https:\/\/playingcards\.io|[^/]*$/g, '')} have no VirtualTabletop equivalent and stay linked to playingcards.io.`);
     }
     return nameMap[name] || name;
@@ -290,6 +301,12 @@ export default async function convertPCIO(content) {
     if(objects && objects.type == 'reference') {
       target[collectionParam] = objects.questionId;
       return target;
+    }
+    if(objects && objects.type == 'variable') {
+      // the object a "Find Cards & Pieces" step looked up - VirtualTabletop
+      // automations have nothing to select it by
+      warn(`An automation step works on the object that a "${pcioFuncNames.FIND_CARDS_PIECES}" step looked up, which has no VirtualTabletop equivalent - that step was skipped.`);
+      return null;
     }
     if(objects && objects.type == 'literal' && Array.isArray(objects.value)) {
       into({
@@ -430,6 +447,23 @@ export default async function convertPCIO(content) {
     return `range of ${bounds.min} to ${bounds.max}`;
   }
 
+  // a player can clear a counter or type text into it, which parses to NaN and
+  // would stick forever once it is calculated with - LABEL's own inc/dec mode
+  // falls back to 0 the same way
+  function readCounter(id, variable) {
+    return [
+      `var ${variable} = parseFloat \${PROPERTY text OF ${id}}`,
+      `var ${variable} = \${${variable}} || 0`
+    ];
+  }
+
+  // LABEL rounds an increment to the decimals of the value and the step while
+  // plain float arithmetic turns 0.1+0.2 into 0.30000000000000004
+  function roundCounter(variable, step) {
+    const decimals = typeof step == 'number' ? (String(step).split('.')[1] || '').length : 0;
+    return decimals ? [ `var ${variable} = \${${variable}} toFixed ${decimals}` ] : [];
+  }
+
   // the operations that keep a variable within the bounds of a counter
   function clampCounter(id, variable) {
     const bounds = counterBounds[id] || { min: -Infinity, max: Infinity };
@@ -474,6 +508,22 @@ export default async function convertPCIO(content) {
   const byID = {};
   for(const widget of widgets)
     byID[widget.id] = widget;
+
+  // PCIO backs its dice with a cardDeck. A deck that holds exactly the six
+  // standard pip faces and is only used by dice is rendered by VirtualTabletop's
+  // own dice widget, so those images never reach the table and reporting them as
+  // "stays linked to playingcards.io" would be untrue.
+  function isStandardPipDeck(deck) {
+    const faces = deck && deck.cardTypes ? Object.entries(deck.cardTypes) : [];
+    return faces.length == 6 && faces.every(([ , face ], i)=>String((face || {}).image || '').match(new RegExp(`/img/dice-basic/${i+1}.svg$`)));
+  }
+  const nativeDiceDecks = {};
+  for(const widget of widgets)
+    if(widget.type == 'dice' && isStandardPipDeck(byID[widget.deck]))
+      nativeDiceDecks[widget.deck] = true;
+  for(const widget of widgets)
+    if(widget.type == 'card' || widget.type == 'piece' || widget.type == 'chooser')
+      delete nativeDiceDecks[widget.deck];
 
   const cardsPerCoordinates = {};
   for(const widget of widgets) {
@@ -570,7 +620,7 @@ export default async function convertPCIO(content) {
         const faces = Object.entries(deck.cardTypes);
         // only the six standard pip faces are what a VTT dice widget shows by
         // default - a die with fewer of them needs its faces spelled out
-        const pips = faces.length == 6 && faces.every(([ , face ], i)=>String(face.image || '').match(new RegExp(`/img/dice-basic/${i+1}.svg$`)));
+        const pips = isStandardPipDeck(deck);
         if(!pips) {
           w.faces = faces.map(function([ , face ]) {
             if(face.image)
@@ -915,7 +965,7 @@ export default async function convertPCIO(content) {
       let sortingOrder = 0;
       for(const type in w.cardTypes) {
         for(const key in w.cardTypes[type])
-          w.cardTypes[type][key] = mapName(w.cardTypes[type][key]);
+          w.cardTypes[type][key] = mapName(w.cardTypes[type][key], nativeDiceDecks[widget.id]);
         w.cardTypes[type].sortingOrder = ++sortingOrder;
       }
     } else if(widget.type == 'card' || widget.type == 'piece' || widget.type == 'chooser') {
@@ -996,9 +1046,10 @@ export default async function convertPCIO(content) {
           text,
 
           clickRoutine: bounds ? [
-            `var pcioCounter = parseFloat \${PROPERTY text OF ${widget.id}}`,
+            ...readCounter(widget.id, 'pcioCounter'),
             `var pcioCounter = \${pcioCounter} + ${value}`,
             ...clampCounter(widget.id, 'pcioCounter'),
+            ...roundCounter('pcioCounter', value),
             { func: 'LABEL', label: widget.id, value: '${pcioCounter}' }
           ] : [
             { func: 'LABEL', label: widget.id, mode: 'inc', value }
@@ -1406,13 +1457,24 @@ export default async function convertPCIO(content) {
         return 'pcio' + String(stepID).replace(/[^A-Za-z0-9_]/g, '');
       }
 
+      // an automation can name a widget that is no longer in the file, which
+      // would import as an operation on something that does not exist
+      function knownIDs(ids) {
+        const known = (ids || []).filter(id=>byID[id]);
+        if(known.length < (ids || []).length)
+          warn(`An automation step of ${widgetName(widget)} works on a widget that is not part of the file - that widget was left out.`);
+        return known;
+      }
+
       function importSteps(steps, routine) {
         for(const step of steps || []) {
           const branches = step && step.branches || [ step ];
-          // a read step that only runs under a condition may not run at all, in
-          // which case PCIO sees its result as empty
-          if((branches[0] || {}).condition && readDefaults[branches[0].func] !== undefined)
-            routine.push(`var ${readVariable(step.id)} = ${readDefaults[branches[0].func]}`);
+          // a read step whose alternatives are conditional - or which is only one
+          // of several alternatives - may not run at all, in which case PCIO sees
+          // its result as empty
+          const read = branches.find(branch=>branch && readDefaults[branch.func] !== undefined);
+          if(read && (read !== branches[0] || branches[0].condition))
+            routine.push(`var ${readVariable(step.id)} = ${readDefaults[read.func]}`);
           importBranches(branches, routine, step && step.id);
         }
       }
@@ -1445,17 +1507,20 @@ export default async function convertPCIO(content) {
         routine.push(operation);
       }
 
-      // a number argument is a fixed value, an answer from the popup, the result
-      // of an earlier read step or a query that adds up counters or card fields
+      // a number argument is a fixed value, the value of a counter, an answer
+      // from the popup, the result of an earlier read step or a query that adds
+      // up counters or card fields
       function numberArgument(routine, argument, fallback) {
         if(!argument || typeof argument != 'object')
           return fallback;
+        if(argument.counterId)
+          return byID[argument.counterId] ? `\${PROPERTY text OF ${argument.counterId}}` : unknownNumber(fallback);
         if(argument.type == 'literal')
           return argument.value === null || argument.value === undefined ? fallback : argument.value;
         if(argument.type == 'reference' && argument.questionId)
           return `\${${argument.questionId}}`;
         if(argument.type == 'variable')
-          return readValues[argument.callId] ? `\${${readValues[argument.callId]}}` : fallback;
+          return readValues[argument.callId] ? `\${${readValues[argument.callId]}}` : unknownNumber(fallback);
         if(argument.type == 'query') {
           const counters = (argument.counters || []).filter(id=>byID[id]);
           const variable = `pcioNumber${++temporaries}`;
@@ -1475,6 +1540,13 @@ export default async function convertPCIO(content) {
             }
           }
         }
+        return unknownNumber(fallback);
+      }
+
+      // a number the importer cannot calculate would silently turn into whatever
+      // the fallback is, which can make a comparison always true
+      function unknownNumber(fallback) {
+        warn(`A number an automation step of ${widgetName(widget)} calculates with could not be imported - it uses ${fallback} instead.`);
         return fallback;
       }
 
@@ -1491,6 +1563,7 @@ export default async function convertPCIO(content) {
         if(c.func == 'FIND_CARDS_PIECES') {
           // returns the ID of an object, which none of PCIO's own automations can
           // do anything with - importing the step would have no effect
+          warn(`The automation step "${pcioFuncNames.FIND_CARDS_PIECES}" of ${widgetName(widget)} was skipped - VirtualTabletop automations cannot work with the object it looks up.`);
           return true;
         }
         if(c.func == 'NUMBERS_FROM_COUNTERS') {
@@ -1558,9 +1631,7 @@ export default async function convertPCIO(content) {
           const args = c.args;
           const moveFlip = c.args.moveFlip && c.args.moveFlip.value;
 
-          const quantity = args.quantity && args.quantity.counterId && byID[args.quantity.counterId]
-            ? `\${PROPERTY text OF ${args.quantity.counterId}}`
-            : numberArgument(routine, args.quantity, 1);
+          const quantity = numberArgument(routine, args.quantity, 1);
           const fill = args.fillAdd && args.fillAdd.value == 'fill' && quantity !== 'all';
 
           // PCIO starts dealing at the n-th of its destinations
@@ -1615,10 +1686,17 @@ export default async function convertPCIO(content) {
           // whole pile at once. Only a move out of a holder has an order to keep:
           // a collection is moved in the order it was selected in.
           const oneAtATime = (args.moveMethod || {}).value != 'all' && c.func == 'MOVE' && c.from && !fill;
+          const sources = [].concat(c.from);
           const dealLoop = ()=>({ func: 'FOREACH', range: [ 1, quantity ], loopRoutine: [ Object.assign({}, c, { count: 1 }) ] });
-          if(oneAtATime && typeof quantity == 'number' && quantity > 1 && quantity <= 100) {
+          if(oneAtATime && quantity === 'all' && sources.every(id=>byID[id])) {
+            // "all objects" has no number to count up to, so the loop runs once
+            // per object that is in the source when the button is clicked
+            const collection = `pcioDeal${++temporaries}`;
+            routine.push({ func: 'SELECT', type: 'card', property: 'parent', relation: 'in', value: sources, collection });
+            routine.push({ note: 'Deal one at a time', func: 'FOREACH', collection, loopRoutine: [ Object.assign({}, c, { count: 1 }) ] });
+          } else if(oneAtATime && typeof quantity == 'number' && quantity > 1 && quantity <= 100) {
             routine.push(Object.assign({ note: 'Deal one at a time' }, dealLoop()));
-          } else if(oneAtATime && typeof quantity == 'string') {
+          } else if(oneAtATime && typeof quantity == 'string' && quantity !== 'all') {
             // the quantity is only known when the button is clicked and a range
             // ending below its start would count down, so dealing nothing at all
             // has to skip the loop
@@ -1631,8 +1709,8 @@ export default async function convertPCIO(content) {
               thenRoutine: [ dealLoop() ]
             });
           } else {
-            if(oneAtATime && typeof quantity == 'number' && quantity > 100)
-              warn(`${widgetName(widget)} moves up to ${quantity} objects in one go instead of one after the other - they can end up in the opposite order.`);
+            if(oneAtATime && (quantity === 'all' || typeof quantity == 'number' && quantity > 100))
+              warn(`${widgetName(widget)} moves ${quantity === 'all' ? 'all objects' : `up to ${quantity} objects`} in one go instead of one after the other - they can end up in the opposite order.`);
             routine.push(c);
           }
 
@@ -1655,8 +1733,11 @@ export default async function convertPCIO(content) {
         if(c.func == 'RECALL_CARDS') {
           if(!c.args.decks)
             return;
+          const decks = knownIDs(c.args.decks.value);
+          if(!decks.length)
+            return;
 
-          for(const deckID of c.args.decks.value) {
+          for(const deckID of decks) {
             if(!byID[deckID].parent) {
               output.tempHolderForDeckRecall = {
                 id: 'tempHolderForDeckRecall',
@@ -1683,7 +1764,7 @@ export default async function convertPCIO(content) {
             }
           }
 
-          const holders = c.args.decks.value.map(d=>byID[d].parent).filter(d=>d);
+          const holders = decks.map(d=>byID[d].parent).filter(d=>d);
           const flip = c.args.flip;
           c = {
             func:     'RECALL',
@@ -1709,7 +1790,9 @@ export default async function convertPCIO(content) {
         if(c.func == 'SHUFFLE_CARDS') {
           if(!c.args.holders)
             return;
-          const holders = c.args.holders.value.map(id=>byID[id].type == 'seat' ? 'hand' : id);
+          const holders = knownIDs(c.args.holders.value).map(id=>byID[id].type == 'seat' ? 'hand' : id);
+          if(!holders.length)
+            return;
           c = {
             func:   'SHUFFLE',
             holder: holders
@@ -1798,9 +1881,11 @@ export default async function convertPCIO(content) {
           };
           c = {
             func: 'TIMER',
-            timer: c.args.timers.value,
+            timer: knownIDs(c.args.timers.value),
             mode: mode
           };
+          if(!c.timer.length)
+            return;
 
           if(c.timer.length == 1)
             c.timer = c.timer[0];
@@ -1819,10 +1904,12 @@ export default async function convertPCIO(content) {
           };
           c = {
             func: 'TIMER',
-            timer: c.args.timers.value,
+            timer: knownIDs(c.args.timers.value),
             mode: mode,
             seconds: numberArgument(routine, c.args.seconds, 30)
           };
+          if(!c.timer.length)
+            return;
           if(c.timer.length == 1)
             c.timer = c.timer[0];
           if(c.seconds === undefined)
@@ -1835,20 +1922,23 @@ export default async function convertPCIO(content) {
             return;
           // PCIO used add/subtract before it settled on inc/dec
           const changeMode = c.args.counterChangeMode || c.args.changeMode;
-          const value = c.args.changeNumber && c.args.changeNumber.counterId && byID[c.args.changeNumber.counterId]
-            ? `\${PROPERTY text OF ${c.args.changeNumber.counterId}}`
-            : numberArgument(routine, c.args.changeNumber, 0);
+          const value = numberArgument(routine, c.args.changeNumber, 0);
           const mode = { add: 'inc', subtract: 'dec' }[changeMode && changeMode.value] || (changeMode ? changeMode.value : 'set');
 
           // a counter with bounds is not simply counted on but calculated and
           // clamped for every counter it is applied to
           for(const counter of c.args.counters.value.filter(id=>counterBounds[id])) {
-            routine.push(mode == 'set'
-              ? `var pcioCounter = ${value} + 0`
-              : `var pcioCounter = parseFloat \${PROPERTY text OF ${counter}}`);
-            if(mode != 'set')
+            if(mode == 'set') {
+              routine.push(`var pcioCounter = ${value} + 0`);
+              if(typeof value != 'number')
+                routine.push('var pcioCounter = ${pcioCounter} || 0');
+            } else {
+              routine.push(...readCounter(counter, 'pcioCounter'));
               routine.push(`var pcioCounter = \${pcioCounter} ${mode == 'dec' ? '-' : '+'} ${value}`);
+            }
             routine.push(...clampCounter(counter, 'pcioCounter'));
+            if(mode != 'set')
+              routine.push(...roundCounter('pcioCounter', value));
             routine.push({ func: 'LABEL', label: counter, value: '${pcioCounter}' });
           }
 
@@ -1946,7 +2036,7 @@ export default async function convertPCIO(content) {
         if(c.func == 'SHIFT_OBJECTS') {
           // shift the contents of an ordered list of holders by one position,
           // optionally wrapping the last one around to the first
-          const holders = c.args.holders ? c.args.holders.value : [];
+          const holders = knownIDs(c.args.holders ? c.args.holders.value : []);
           if(holders.length < 2)
             return;
           const reversed = (c.args.moveDirection || {}).value == 'reverse';
@@ -2089,6 +2179,9 @@ export default async function convertPCIO(content) {
 
   for(const group of Object.values(groupedWarnings))
     warn(group.message(widgetNames(group.names), group.names.length));
+
+  if(suppressedWarnings)
+    warnings.push(`${suppressedWarnings} more note${suppressedWarnings > 1 ? 's are' : ' is'} not listed here.`);
 
   if(schemaVersion > knownSchemaVersion)
     warnings.unshift(`This file uses PlayingCards.io format ${schemaVersion} while the importer only knows up to ${knownSchemaVersion} - anything newer than that is missing.`);

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -126,11 +126,13 @@ export default async function convertPCIO(content) {
       css.push(`background: ${background}`);
 
     if(Array.isArray(widget.mainOutlines)) {
-      const outline = widget.mainOutlines.filter(o=>o && o.size && pcioFill(o.fill)).pop();
-      if(outline) {
-        css.push(`border: ${outline.size}px solid ${pcioFill(outline.fill)}`, 'box-sizing: border-box');
-        if(widget.mainOutlines.length > 1)
-          warn('Stacked outlines are not supported and were collapsed into a single border.');
+      // PCIO draws every outline as a ring around the widget at its own offset:
+      // the innermost one becomes the border, the ones around it box-shadows
+      const outlines = widget.mainOutlines.filter(o=>o && o.size && pcioFill(o.fill)).sort((a, b)=>(a.offset || 0) - (b.offset || 0));
+      if(outlines.length) {
+        css.push(`border: ${outlines[0].size}px solid ${pcioFill(outlines[0].fill)}`, 'box-sizing: border-box');
+        if(outlines.length > 1)
+          css.push('box-shadow: ' + outlines.slice(1).map(o=>`0 0 0 ${(o.offset || 0) + o.size}px ${pcioFill(o.fill)}`).join(', '));
       } else if(!(w.classes || '').match(/transparent/)) {
         css.push('border-color: transparent');
       }
@@ -151,8 +153,10 @@ export default async function convertPCIO(content) {
         css.push(`font-family: ${pcioFonts[text.font]}`);
       else if(text.font)
         warn(`Font ${text.font} is not available in VirtualTabletop.`);
-      if(Array.isArray(text.outlines) && text.outlines.length)
-        warn('Outlined text is not supported.');
+      // a stroke painted behind the glyphs is what PCIO's text outline looks like
+      const textOutline = (text.outlines || []).filter(o=>o && o.size && pcioFill(o.fill)).pop();
+      if(textOutline)
+        css.push(`-webkit-text-stroke: ${textOutline.size*2}px ${pcioFill(textOutline.fill)}`, 'paint-order: stroke fill');
     }
 
     if(typeof widget.mainBorderRadius == 'number')
@@ -169,14 +173,20 @@ export default async function convertPCIO(content) {
       w.height = widget.height;
   }
 
-  function importWidgetQuery(routine, args, legacySource, holdersParam, collectionParam, target) {
+  // The objects an automation works on: either a holder parameter on the
+  // operation itself or a SELECT into a collection. Returns null for a query
+  // that matches nothing so that the caller can skip the whole step, which is
+  // what PCIO does with it.
+  function importWidgetQuery(routine, args, legacySource, holdersParam, collectionParam, target, options={}) {
     const objects = args.objects || args.customObjects;
+    const collection = options.collection;
+    const into = ops=>routine.push(Object.assign(ops, collection ? { collection } : {}, options.sortBy ? { sortBy: options.sortBy } : {}));
     if(objects && objects.type == 'reference') {
       target[collectionParam] = objects.questionId;
       return target;
     }
     if(objects && objects.type == 'literal' && Array.isArray(objects.value)) {
-      routine.push({
+      into({
         func: 'SELECT',
         property: 'id',
         relation: 'in',
@@ -187,13 +197,17 @@ export default async function convertPCIO(content) {
     if(objects && objects.type == 'query') {
       const holders = objects.holders || [];
       const collections = objects.collections || [];
-      if(Array.isArray(objects.queryWidgetTypes) && objects.queryWidgetTypes.filter(t=>t != 'card' && t != 'piece').length)
+      // PCIO finds nothing when a query is restricted to neither a holder nor a
+      // deck and nothing when it does not name the widget types it looks for
+      if(!holders.length && !collections.length || !Array.isArray(objects.queryWidgetTypes))
+        return null;
+      if(objects.queryWidgetTypes.filter(t=>t != 'card' && t != 'piece').length)
         warn(`An automation looks for ${objects.queryWidgetTypes.join('/')} but only cards and pieces are selected.`);
-      if(holders.length && !collections.length) {
+      if(holders.length && !collections.length && !collection) {
         target[holdersParam] = holders;
         return target;
       }
-      routine.push(holders.length ? {
+      into(holders.length ? {
         func: 'SELECT',
         property: 'parent',
         relation: 'in',
@@ -208,9 +222,9 @@ export default async function convertPCIO(content) {
       // choosers are cards in VTT but PCIO never includes them in a query
       const chooserDecks = widgets.filter(w=>w && w.type == 'cardDeck' && w.collectionType == 'choosers').map(w=>w.id);
       if(chooserDecks.length) {
-        routine.push({
+        into({
           func: 'SELECT',
-          source: 'DEFAULT',
+          source: collection || 'DEFAULT',
           property: 'deck',
           relation: 'in',
           value: chooserDecks,
@@ -218,9 +232,9 @@ export default async function convertPCIO(content) {
         });
       }
       if(collections.length) {
-        routine.push({
+        into({
           func: 'SELECT',
-          source: 'DEFAULT',
+          source: collection || 'DEFAULT',
           property: 'deck',
           relation: 'in',
           value: collections
@@ -228,9 +242,11 @@ export default async function convertPCIO(content) {
       }
       return target;
     }
-    if(args[legacySource])
+    if(args[legacySource]) {
       target[holdersParam] = args[legacySource].value;
-    return target;
+      return target;
+    }
+    return null;
   }
 
   // ROTATE for one of PCIO's rotation modes, null if it has no equivalent
@@ -243,7 +259,11 @@ export default async function convertPCIO(content) {
       routine.push('var pcioRotation = randRange 0 360 45');
       return Object.assign(target, { func: 'ROTATE', angle: '${pcioRotation}', mode: 'set' });
     }
-    warn(`Rotating objects to "${mode}" (fit to holder) has no VirtualTabletop equivalent.`);
+    // "fit to holder": a widget in a holder is drawn at the rotation of that
+    // holder, so aligning it with its holder means rotating it back to 0
+    if(mode == 'auto')
+      return Object.assign(target, { func: 'ROTATE', angle: 0, mode: 'set' });
+    warn(`Rotating objects to "${mode}" has no VirtualTabletop equivalent.`);
     return null;
   }
 
@@ -280,6 +300,30 @@ export default async function convertPCIO(content) {
   const pileOverlaps = {};
   const pileTransparent = {};
   const turnAtSeat = {};
+
+  // PCIO keeps every counter inside its bounds while a VTT label just counts on,
+  // so a counter with bounds gets them applied wherever its value is changed
+  const counterBounds = {};
+  for(const widget of widgets) {
+    if(widget && widget.type == 'counter' && (widget.counterMin != null || widget.counterMax != null)) {
+      const min = widget.counterMin != null ? +widget.counterMin : -9999;
+      counterBounds[widget.id] = {
+        min,
+        max: Math.max(widget.counterMax != null ? +widget.counterMax : 9999, min+1)
+      };
+    }
+  }
+
+  // the operations that keep a variable within the bounds of a counter
+  function clampCounter(id, variable) {
+    const bounds = counterBounds[id];
+    if(!bounds)
+      return [];
+    return [
+      `var ${variable} = max \${${variable}} ${bounds.min}`,
+      `var ${variable} = min \${${variable}} ${bounds.max}`
+    ];
+  }
 
   for(const widget of widgets) {
     if(widget.type == 'cardDeck' && widget.parent)
@@ -487,8 +531,8 @@ export default async function convertPCIO(content) {
 
         for(const allowed of w.dropTarget) {
           if(byID[allowed.deck]) {
-            dropOffsetX = Math.round(Math.min(dropOffsetX, (widget.width  - (byID[allowed.deck].cardWidth  || 103))/2));
-            dropOffsetY = Math.round(Math.min(dropOffsetY, (widget.height - (byID[allowed.deck].cardHeight || 160))/2));
+            dropOffsetX = Math.round(Math.min(dropOffsetX, ((widget.width  || 111) - (byID[allowed.deck].cardWidth  || 103))/2));
+            dropOffsetY = Math.round(Math.min(dropOffsetY, ((widget.height || 168) - (byID[allowed.deck].cardHeight || 160))/2));
           }
         }
       }
@@ -637,10 +681,10 @@ export default async function convertPCIO(content) {
           object.height = object.h;
           delete object.w;
           delete object.h;
-          if(object.textFont) {
+          if(object.textFont !== undefined) {
             if(pcioFonts[object.textFont])
               object.css = `font-family: ${pcioFonts[object.textFont]}`;
-            else
+            else if(object.textFont)
               warn(`Font ${object.textFont} is not available in VirtualTabletop.`);
             delete object.textFont;
           }
@@ -768,7 +812,8 @@ export default async function convertPCIO(content) {
           delete pile.y;
         pile.width = byID[w.deck].cardWidth || 103;
         pile.height = byID[w.deck].cardHeight || 160;
-        pile.parent = widget.parent;
+        if(widget.parent)
+          pile.parent = widget.parent;
 
         delete w.x;
         delete w.y;
@@ -793,11 +838,13 @@ export default async function convertPCIO(content) {
       w.y += 5;
       w.width = widget.width || 140;
       w.height = widget.height || 44;
-      w.text = widget.counterValue;
-      w.editable = true;
+      const bounds = counterBounds[widget.id];
+      w.text = bounds ? Math.min(Math.max(+widget.counterValue || 0, bounds.min), bounds.max) : widget.counterValue;
+      if(widget.allowPlayerEditValue !== false)
+        w.editable = true;
       pcioStyle(widget, w, (widget.mainTextStyle || {}).size ? [] : [ 'font-size: 30px' ]);
-      if(widget.counterMin !== undefined && widget.counterMin !== null || widget.counterMax !== undefined && widget.counterMax !== null)
-        warn(`Counter ${widget.label || widget.id} has minimum/maximum bounds which are not enforced after the import.`);
+      if(bounds && widget.allowPlayerEditValue !== false)
+        warn(`Typing a value into counter ${widget.label || widget.id} is not restricted to its range of ${bounds.min} to ${bounds.max} - its buttons and the automations that change it are.`);
 
       const counterStep = Math.abs(+widget.counterStep) || 1;
 
@@ -813,15 +860,22 @@ export default async function convertPCIO(content) {
           movableInEdit: false,
           text,
 
-          clickRoutine: [
+          clickRoutine: bounds ? [
+            `var pcioCounter = parseFloat \${PROPERTY text OF ${widget.id}}`,
+            `var pcioCounter = \${pcioCounter} + ${value}`,
+            ...clampCounter(widget.id, 'pcioCounter'),
+            { func: 'LABEL', label: widget.id, value: '${pcioCounter}' }
+          ] : [
             { func: 'LABEL', label: widget.id, mode: 'inc', value }
           ]
         };
         if(x)
           output[widget.id + suffix].x += x;
       }
-      addCounterButton('_decrementButton', 0,                  '-', -counterStep);
-      addCounterButton('_incrementButton', w.width - w.height, '+',  counterStep);
+      if(widget.counterShowButtons !== false) {
+        addCounterButton('_decrementButton', 0,                  '-', -counterStep);
+        addCounterButton('_incrementButton', w.width - w.height, '+',  counterStep);
+      }
 
       if(widget.label) {
         output[widget.id + 'label'] = {
@@ -1192,43 +1246,180 @@ export default async function convertPCIO(content) {
           warn('Players cannot reverse the turn direction by clicking the turn button - use the "Reverse turn direction" button that was added instead.');
       }
 
-      const steps = [];
-      for(const step of widget.clickRoutine ? (widget.clickRoutine.steps || widget.clickRoutine) : [])
-        // PCIO wraps every step into { id, branches: [ { func, args } ] } since schema 6
-        for(const branch of step && step.branches || [ step ])
-          steps.push(branch);
+      // PCIO wraps every step into { id, branches: [ { func, args } ] } since
+      // schema 6. The branches of one step are alternatives of which the first
+      // one whose condition holds runs, so they import as a chain of IFs. The
+      // condition is the result of an earlier step that calls a "read" function;
+      // arguments can reference those results the same way. Every result is kept
+      // in a variable named after the step that produced it.
+      const readValues = {};
+      const numberLists = {};
+      const readDefaults = { COMPARE_NUMBERS: false, IS_EQUAL: false, MATH: 0, RANDOM_NUMBER: 0, SUM_LIST: 0 };
+      let temporaries = 0;
 
-      for(let c of steps) {
+      function readVariable(stepID) {
+        return 'pcio' + String(stepID).replace(/[^A-Za-z0-9_]/g, '');
+      }
+
+      function importSteps(steps, routine) {
+        for(const step of steps || []) {
+          const branches = step && step.branches || [ step ];
+          // a read step with alternatives may not run at all, in which case PCIO
+          // sees its result as empty
+          if(branches.length > 1 && readDefaults[(branches[0] || {}).func] !== undefined)
+            routine.push(`var ${readVariable(step.id)} = ${readDefaults[branches[0].func]}`);
+          importBranches(branches, routine, step && step.id);
+        }
+      }
+
+      function importBranches(branches, routine, stepID) {
+        const branch = branches[0];
+        if(!branch)
+          return;
+        const condition = branch.condition && branch.condition.callId;
+        if(condition && !readValues[condition]) {
+          warn(`The condition of an automation step of "${widget.label || widget.id}" could not be imported - that alternative was skipped.`);
+          importBranches(branches.slice(1), routine, stepID);
+          return;
+        }
+        if(!condition) {
+          // an alternative without a condition always runs: PCIO never looks at
+          // the ones behind it
+          importBranch(branch, routine, stepID);
+          return;
+        }
+        const thenRoutine = [];
+        importBranch(branch, thenRoutine, stepID);
+        const elseRoutine = [];
+        importBranches(branches.slice(1), elseRoutine, stepID);
+        if(!thenRoutine.length && !elseRoutine.length)
+          return;
+        const operation = { func: 'IF', condition: `\${${readValues[condition]}}`, thenRoutine };
+        if(elseRoutine.length)
+          operation.elseRoutine = elseRoutine;
+        routine.push(operation);
+      }
+
+      // a number argument is a fixed value, an answer from the popup, the result
+      // of an earlier read step or a query that adds up counters or card fields
+      function numberArgument(routine, argument, fallback) {
+        if(!argument || typeof argument != 'object')
+          return fallback;
+        if(argument.type == 'literal')
+          return argument.value === null || argument.value === undefined ? fallback : argument.value;
+        if(argument.type == 'reference' && argument.questionId)
+          return `\${${argument.questionId}}`;
+        if(argument.type == 'variable')
+          return readValues[argument.callId] ? `\${${readValues[argument.callId]}}` : fallback;
+        if(argument.type == 'query') {
+          const counters = (argument.counters || []).filter(id=>byID[id]);
+          const variable = `pcioNumber${++temporaries}`;
+          if(counters.length) {
+            routine.push(...addUpCounters(counters, variable));
+            return `\${${variable}}`;
+          }
+          const field = (argument.collectionFieldSelectors || [])[0];
+          if(field && field.fieldId && importWidgetQuery(routine, { objects: argument }, '', '', '', {}, { collection: variable })) {
+            // PCIO adds up one field of the card type of everything it finds
+            routine.push({ func: 'GET', collection: variable, property: field.fieldId, aggregation: 'sum', variable, skipMissing: true });
+            return `\${${variable}}`;
+          }
+        }
+        return fallback;
+      }
+
+      function addUpCounters(counters, variable) {
+        return counters.map((counter, i)=>i
+          ? `var ${variable} = \${${variable}} + \${PROPERTY text OF ${counter}}`
+          : `var ${variable} = parseFloat \${PROPERTY text OF ${counter}}`);
+      }
+
+      // the read functions: their result goes into the variable of their step
+      function importReadStep(c, routine, stepID) {
+        const variable = readVariable(stepID);
+        const args = c.args;
+        if(c.func == 'FIND_CARDS_PIECES') {
+          // returns the ID of an object, which none of PCIO's own automations can
+          // do anything with - importing the step would have no effect
+          return true;
+        }
+        if(c.func == 'NUMBERS_FROM_COUNTERS') {
+          // a list of counter values, which only SUM_LIST consumes
+          numberLists[stepID] = ((args.counters || {}).value || []).filter(id=>byID[id]);
+          return true;
+        }
+        if(c.func == 'SUM_LIST') {
+          const counters = numberLists[(args.list || {}).callId] || [];
+          routine.push(...(counters.length ? addUpCounters(counters, variable) : [ `var ${variable} = 0` ]));
+        } else if(c.func == 'MATH') {
+          const operator = (args.mathOperator || {}).value || 'add';
+          const infix = { add: '+', subtract: '-', multiply: '*', divide: '/', remainder: '%', exponent: '**' }[operator];
+          const prefix = { absolute: 'abs', round: 'round', ceiling: 'ceil', floor: 'floor' }[operator];
+          const a = numberArgument(routine, args.numberA, 1);
+          if(infix)
+            routine.push(`var ${variable} = ${a} ${infix} ${numberArgument(routine, args.numberB, 1)}`);
+          else if(prefix)
+            routine.push(`var ${variable} = ${prefix} ${a}`);
+          else
+            return false;
+        } else if(c.func == 'RANDOM_NUMBER') {
+          const min = numberArgument(routine, args.minimum, 1);
+          const step = numberArgument(routine, args.step, 1);
+          let max = numberArgument(routine, args.maximum, 10);
+          // randRange stops short of its endpoint while PCIO includes the maximum
+          if(typeof max == 'number' && typeof step == 'number') {
+            max += step;
+          } else {
+            const endpoint = `pcioNumber${++temporaries}`;
+            routine.push(`var ${endpoint} = ${max} + ${step}`);
+            max = `\${${endpoint}}`;
+          }
+          routine.push(`var ${variable} = randRange ${min} ${max} ${step}`);
+        } else if(c.func == 'COMPARE_NUMBERS' || c.func == 'IS_EQUAL') {
+          const relation = c.func == 'IS_EQUAL' ? '==' : { eq: '==', gt: '>', lt: '<', gte: '>=', lte: '<=' }[(args.comparisonOperator || {}).value] || '==';
+          const a = numberArgument(routine, args.numberA, 1);
+          routine.push(`var ${variable} = ${a} ${relation} ${numberArgument(routine, args.numberB, 1)}`);
+        } else {
+          return false;
+        }
+        readValues[stepID] = variable;
+        return true;
+      }
+
+      function importBranch(c, routine, stepID) {
         if(!c || !c.func) {
           warn('An automation step could not be read and was skipped.');
-          continue;
+          return;
         }
         c = Object.assign({}, c, { args: c.args || {} });
 
+        if(importReadStep(c, routine, stepID))
+          return;
+
         if(c.func == 'MOVE_CARDS_BETWEEN_HOLDERS') {
           if((!c.args.from && !c.args.objects) || !c.args.to)
-            continue;
+            return;
           const args = c.args;
           const moveFlip = c.args.moveFlip && c.args.moveFlip.value;
 
-          let quantity = 1;
-          if(c.args.quantity) {
-            if(c.args.quantity.type == 'reference')
-              quantity = '${' + c.args.quantity.questionId + '}';
-            else if(c.args.quantity.counterId && byID[c.args.quantity.counterId])
-              quantity = `\${PROPERTY text OF ${c.args.quantity.counterId}}`;
-            else if(c.args.quantity.value == 'all')
-              quantity = 0;
-            else
-              quantity = c.args.quantity.value;
-          }
+          const quantity = args.quantity && args.quantity.counterId && byID[args.quantity.counterId]
+            ? `\${PROPERTY text OF ${args.quantity.counterId}}`
+            : numberArgument(routine, args.quantity, 1);
+          const fill = args.fillAdd && args.fillAdd.value == 'fill' && quantity !== 'all';
 
-          c = importWidgetQuery(w.clickRoutine, c.args, 'from', 'from', 'collection', {
+          // PCIO starts dealing at the n-th of its destinations
+          const destinations = args.to.value.slice();
+          if(destinations.length)
+            destinations.push(...destinations.splice(0, (+(args.startingOffset || {}).value || 0) % destinations.length));
+
+          c = importWidgetQuery(routine, args, 'from', 'from', 'collection', {
             func:  'MOVE',
             count: quantity,
-            to:    c.args.to.value,
-            fillTo: c.args.fillAdd && c.args.fillAdd.value == 'fill' ? quantity : null
+            to:    destinations,
+            fillTo: fill ? quantity : null
           });
+          if(!c)
+            return;
           if(c.from && c.from.length == 1)
             c.from = c.from[0];
           if(c.count == 1)
@@ -1246,11 +1437,31 @@ export default async function convertPCIO(content) {
           if(moveFlip && moveFlip != 'none')
             c.face = moveFlip == 'faceDown' ? 0 : 1;
 
+          // PCIO can put the objects below the ones already in the destination.
+          // VTT always moves onto the top, so the ones that are there are parked
+          // in a hidden holder and put back on top afterwards.
           const toPosition = (args.toPosition || {}).value;
-          if(toPosition && toPosition != 'top')
+          const toBottom = toPosition == 'bottom' && c.func == 'MOVE' && typeof c.to == 'string' && byID[c.to] && byID[c.to].type == 'cardPile';
+          if(toBottom) {
+            output.pcioMoveTempHolder = {
+              id: 'pcioMoveTempHolder',
+              type: 'holder',
+              x: -200,
+              y: -500
+            };
+            routine.push({ func: 'MOVE', from: c.to, to: 'pcioMoveTempHolder', count: 'all' });
+          } else if(toPosition && toPosition != 'top') {
             warn(`Moving objects to "${toPosition}" is not supported - they end up on top of the destination.`);
-          if((args.startingOffset || {}).value)
-            warn('The starting holder offset of a move automation is not supported.');
+          }
+
+          // PCIO hands out one object after the other, going around the
+          // destinations, which leaves them in the opposite order of moving the
+          // whole pile at once. Only a move out of a holder has an order to keep:
+          // a collection is moved in the order it was selected in.
+          if((args.moveMethod || {}).value != 'all' && c.func == 'MOVE' && c.from && !fill && typeof quantity == 'number' && quantity > 1 && quantity <= 100)
+            routine.push({ note: 'Deal one at a time', func: 'FOREACH', range: [ 1, quantity ], loopRoutine: [ Object.assign({}, c, { count: 1 }) ] });
+          else
+            routine.push(c);
 
           // 'auto' (fit to holder) needs no operation: VTT children inherit the
           // rotation of their holder
@@ -1259,16 +1470,18 @@ export default async function convertPCIO(content) {
             const rotate = rotateOperation({
               holder: c.to,
               count:  c.count !== undefined ? c.count : (c.fillTo !== undefined ? c.fillTo : 1)
-            }, w.clickRoutine, changeRotation, (args.setRotation || {}).value);
-            if(rotate) {
-              w.clickRoutine.push(c);
-              c = rotate;
-            }
+            }, routine, changeRotation, (args.setRotation || {}).value);
+            if(rotate)
+              routine.push(rotate);
           }
+
+          if(toBottom)
+            routine.push({ func: 'MOVE', from: 'pcioMoveTempHolder', to: c.to, count: 'all' });
+          return;
         }
         if(c.func == 'RECALL_CARDS') {
           if(!c.args.decks)
-            continue;
+            return;
 
           for(const deckID of c.args.decks.value) {
             if(!byID[deckID].parent) {
@@ -1277,22 +1490,22 @@ export default async function convertPCIO(content) {
                 type: 'holder',
                 x: -200
               };
-              w.clickRoutine.push({
+              routine.push({
                 func: 'SELECT',
                 property: 'deck',
                 value: deckID
               });
-              w.clickRoutine.push({
+              routine.push({
                 func: 'SET',
                 property: 'parent',
                 value: 'tempHolderForDeckRecall'
               });
-              w.clickRoutine.push({
+              routine.push({
                 func: 'MOVEXY',
                 from: 'tempHolderForDeckRecall',
                 x: byID[deckID].x + (86-(byID[deckID].cardWidth ||103))/2,
                 y: byID[deckID].y + (86-(byID[deckID].cardHeight||160))/2,
-                count: 0
+                count: 'all'
               });
             }
           }
@@ -1312,7 +1525,7 @@ export default async function convertPCIO(content) {
           if(c.inHolder)
             delete c.inHolder;
           if(!flip || flip.value != 'none') {
-            w.clickRoutine.push(c);
+            routine.push(c);
             c = {
               func:   'FLIP',
               holder: holders,
@@ -1322,7 +1535,7 @@ export default async function convertPCIO(content) {
         }
         if(c.func == 'SHUFFLE_CARDS') {
           if(!c.args.holders)
-            continue;
+            return;
           const holders = c.args.holders.value.map(id=>byID[id].type == 'seat' ? 'hand' : id);
           c = {
             func:   'SHUFFLE',
@@ -1335,7 +1548,7 @@ export default async function convertPCIO(content) {
           const sources = c.args.sources || c.args.holders;
           const direction = c.args.direction || c.args.sortDirection;
           if(!sources)
-            continue;
+            return;
           const holders = sources.value.map(id=>byID[id] && byID[id].type == 'seat' ? 'hand' : id);
           c = {
             func:   'SORT',
@@ -1350,29 +1563,56 @@ export default async function convertPCIO(content) {
         }
         if(c.func == "FLIP_CARDS") {
           if(!c.args.holders && !c.args.objects)
-            continue;
-          const flipFace = c.args.flipFace;
-          if((c.args.reverse || {}).value == 'reverse')
-            warn('Reversing the order of a pile while flipping it is not supported.');
+            return;
+          const args = c.args;
+          // "switch" is PCIO's default: every object ends up on the side opposite
+          // to the one the object on top currently shows
+          const flipFace = (args.flipFace || {}).value || 'switch';
+          const wholePile = (args.flipMode || {}).value == 'pile';
+          // turning a whole pile over also reverses its order unless that is
+          // switched off - reversing and flipping to the side of the top object
+          // both need the objects in a collection ordered bottom to top
+          const reverse = wholePile && (args.reverse || {}).value != 'none';
+          const ordered = wholePile && (reverse || flipFace == 'switch');
 
-          c = importWidgetQuery(w.clickRoutine, c.args, 'holders', 'holder', 'collection', {
-            func:   'FLIP',
-            count:  !c.args.flipMode || c.args.flipMode.value != 'pile' ? 1 : 0
-          });
+          c = importWidgetQuery(routine, args, 'holders', 'holder', 'collection', {
+            func:  'FLIP',
+            count: wholePile ? 0 : 1
+          }, ordered ? { collection: 'pcioPile', sortBy: 'z' } : {});
+          if(!c)
+            return;
           if(c.holder && c.holder.length == 1)
             c.holder = c.holder[0];
           if(!c.count)
             delete c.count;
-          if(flipFace && (flipFace.value == 'faceUp' || flipFace.value == 'faceDown'))
-            c.face = flipFace.value == 'faceDown' ? 0 : 1;
-          else if(flipFace && flipFace.value == 'random')
-            warn('Randomly flipping objects has no VirtualTabletop equivalent - they are flipped to the other side instead.');
-          else if(flipFace && flipFace.value == 'switch')
-            warn('Flipping all objects to the same side is not supported - each object is flipped individually.');
+          if(ordered) {
+            if(c.holder) {
+              routine.push({ func: 'SELECT', property: 'parent', relation: 'in', value: [].concat(c.holder), type: 'card', collection: 'pcioPile', sortBy: 'z' });
+              delete c.holder;
+            }
+            c.collection = c.collection || 'pcioPile';
+          }
+          if(flipFace == 'faceUp' || flipFace == 'faceDown') {
+            c.face = flipFace == 'faceDown' ? 0 : 1;
+          } else if(flipFace == 'random') {
+            // flip() rolls a face of its own for every object it is given
+            c.faceCycle = 'random';
+          } else if(ordered) {
+            routine.push({ func: 'GET', collection: c.collection, property: 'activeFace', aggregation: 'last', variable: 'pcioFace' });
+            routine.push('var pcioFace = 1 - ${pcioFace}');
+            c.face = '${pcioFace}';
+          } else if(flipFace == 'switch' && (Array.isArray(c.holder) || c.collection)) {
+            // flipping the top object of one pile that way is just flipping it
+            warn('Flipping the top objects of several piles all to the same side is not supported - each of them is flipped to its other side instead.');
+          }
+          if(reverse) {
+            routine.push(c);
+            c = { note: 'Reverse the pile', func: 'SHUFFLE', collection: c.collection, mode: 'reverse' };
+          }
         }
         if(c.func == 'CHANGE_TIMER_STATE') {
           if(!c.args.timers)
-            continue;
+            return;
           if ((c.args.playState && c.args.playState.value)=="switch"){
             var mode = "toggle"
           } else if ((c.args.playState && c.args.playState.value)=="pause"){
@@ -1391,7 +1631,7 @@ export default async function convertPCIO(content) {
         }
         if(c.func == 'CHANGE_TIMER_TIME') {
           if(!c.args.timers)
-            continue;
+            return;
           if ((c.args.changeType && c.args.changeType.value)=='add'){
             var mode = 'inc'
           } else if ((c.args.changeType && c.args.changeType.value)=='subtract'){
@@ -1405,7 +1645,7 @@ export default async function convertPCIO(content) {
             func: 'TIMER',
             timer: c.args.timers.value,
             mode: mode,
-            seconds: c.args.seconds && c.args.seconds.value
+            seconds: numberArgument(routine, c.args.seconds, 30)
           };
           if(c.timer.length == 1)
             c.timer = c.timer[0];
@@ -1416,20 +1656,35 @@ export default async function convertPCIO(content) {
         }
         if(c.func == 'CHANGE_COUNTER') {
           if(!c.args.counters)
-            continue;
+            return;
           // PCIO used add/subtract before it settled on inc/dec
           const changeMode = c.args.counterChangeMode || c.args.changeMode;
-          let value = c.args.changeNumber ? c.args.changeNumber.value : 0;
-          if(c.args.changeNumber && c.args.changeNumber.counterId && byID[c.args.changeNumber.counterId])
-            value = `\${PROPERTY text OF ${c.args.changeNumber.counterId}}`;
+          const value = c.args.changeNumber && c.args.changeNumber.counterId && byID[c.args.changeNumber.counterId]
+            ? `\${PROPERTY text OF ${c.args.changeNumber.counterId}}`
+            : numberArgument(routine, c.args.changeNumber, 0);
+          const mode = { add: 'inc', subtract: 'dec' }[changeMode && changeMode.value] || (changeMode ? changeMode.value : 'set');
+
+          // a counter with bounds is not simply counted on but calculated and
+          // clamped for every counter it is applied to
+          for(const counter of c.args.counters.value.filter(id=>counterBounds[id])) {
+            routine.push(mode == 'set'
+              ? `var pcioCounter = ${value} + 0`
+              : `var pcioCounter = parseFloat \${PROPERTY text OF ${counter}}`);
+            if(mode != 'set')
+              routine.push(`var pcioCounter = \${pcioCounter} ${mode == 'dec' ? '-' : '+'} ${value}`);
+            routine.push(...clampCounter(counter, 'pcioCounter'));
+            routine.push({ func: 'LABEL', label: counter, value: '${pcioCounter}' });
+          }
+
+          const counters = c.args.counters.value.filter(id=>!counterBounds[id]);
+          if(!counters.length)
+            return;
           c = {
             func: 'LABEL',
-            label: c.args.counters.value,
-            mode:  { add: 'inc', subtract: 'dec' }[changeMode && changeMode.value] || (changeMode ? changeMode.value : 'set'),
+            label: counters.length == 1 ? counters[0] : counters,
+            mode,
             value
           };
-          if(c.label.length == 1)
-            c.label = c.label[0];
           if(c.mode == 'set')
             delete c.mode;
           if(c.value === 0)
@@ -1441,7 +1696,7 @@ export default async function convertPCIO(content) {
           const isDice = c.func == 'ROLL_DICE';
           const targets = isDice ? c.args.dice : c.args.choosers;
           if(!targets)
-            continue;
+            return;
           const changeType = (c.args.chooserChangeType || c.args.diceChangeType || c.args.changeType || {}).value;
           const choice = c.args.chooserChoice || c.args.diceChoice || c.args.choice;
           const deck = byID[targets.value[0]] && byID[byID[targets.value[0]].deck];
@@ -1456,7 +1711,7 @@ export default async function convertPCIO(content) {
           } else if(isDice) {
             // dice have no flip(), their face is set directly - out of range
             // values wrap around so +1/-1 cycles through the faces
-            w.clickRoutine.push({
+            routine.push({
               func: 'SELECT',
               property: 'id',
               relation: 'in',
@@ -1481,7 +1736,7 @@ export default async function convertPCIO(content) {
               collection: targets.value
             };
             if(changeType == 'random' && faces.length) {
-              w.clickRoutine.push(`var pcioFace = randInt 0 ${faces.length-1}`);
+              routine.push(`var pcioFace = randInt 0 ${faces.length-1}`);
               c.face = '${pcioFace}';
             } else if(changeType == 'set' && choice && faces.indexOf(choice.value) != -1) {
               c.face = faces.indexOf(choice.value);
@@ -1492,7 +1747,7 @@ export default async function convertPCIO(content) {
         }
         if(c.func == 'SPIN_SPINNER') {
           if(!c.args.spinners)
-            continue;
+            return;
           c = {
             note:       'Spin spinners',
             func:       'CLICK',
@@ -1500,12 +1755,14 @@ export default async function convertPCIO(content) {
           };
         }
         if(c.func == 'ROTATE_OBJECTS') {
-          const target = importWidgetQuery(w.clickRoutine, c.args, 'objects', 'holder', 'collection', {
-            count: (c.args.rotateMode || {}).value == 'top' ? 1 : 0
+          const target = importWidgetQuery(routine, c.args, 'objects', 'holder', 'collection', {
+            count: (c.args.rotateMode || {}).value == 'top' ? 1 : 'all'
           });
-          const rotate = rotateOperation(target, w.clickRoutine, (c.args.changeRotation || {}).value || 'auto', (c.args.setRotation || {}).value);
+          if(!target)
+            return;
+          const rotate = rotateOperation(target, routine, (c.args.changeRotation || {}).value || 'auto', (c.args.setRotation || {}).value);
           if(!rotate)
-            continue;
+            return;
           c = rotate;
           if(c.holder && c.holder.length == 1)
             c.holder = c.holder[0];
@@ -1515,17 +1772,43 @@ export default async function convertPCIO(content) {
           // optionally wrapping the last one around to the first
           const holders = c.args.holders ? c.args.holders.value : [];
           if(holders.length < 2)
-            continue;
-          if(holders.filter(id=>!byID[id] || byID[id].type != 'cardPile').length) {
-            warn('Shifting objects between player seats has no VirtualTabletop equivalent and was skipped.');
-            continue;
-          }
+            return;
+          const reversed = (c.args.moveDirection || {}).value == 'reverse';
           const wrap = !c.args.moveMode || c.args.moveMode.value == 'wrap';
-          const order = (c.args.moveDirection || {}).value == 'reverse' ? holders.slice().reverse() : holders;
-          const count = (c.args.objectsMode || {}).value == 'top' ? 1 : 0;
+          const order = reversed ? holders.slice().reverse() : holders;
+          const count = (c.args.objectsMode || {}).value == 'top' ? 1 : 'all';
           const steps = Math.min(+((wrap ? c.args.stepsWrap : c.args.stepsEdge) || {}).value || 1, holders.length);
           if((c.args.objectsMode || {}).value == 'custom')
             warn('Shifting only a subset of the objects in a holder is not supported - all objects are shifted.');
+
+          const seats = holders.filter(id=>byID[id] && byID[id].type == 'seat');
+          if(seats.length && seats.length < holders.length) {
+            warn('Shifting objects between a mix of holders and player seats has no VirtualTabletop equivalent and was skipped.');
+            return;
+          }
+          if(seats.length) {
+            // a hand is one holder per room in VTT and it is the owner that makes
+            // its cards a player's own, which is exactly what SWAPHANDS shifts
+            if(!wrap)
+              warn('Passing the hands of the players on towards the last seat instead of around the table is not supported - they wrap around.');
+            routine.push({
+              func: 'SELECT',
+              property: 'id',
+              relation: 'in',
+              value: seats,
+              type: 'seat',
+              collection: 'pcioSeats'
+            });
+            routine.push({
+              note: 'Pass the hands on',
+              func: 'SWAPHANDS',
+              source: 'pcioSeats',
+              interval: steps,
+              direction: reversed ? 'backward' : 'forward',
+              keepOrder: true
+            });
+            return;
+          }
 
           if(wrap) {
             output.pcioShiftTempHolder = {
@@ -1537,18 +1820,18 @@ export default async function convertPCIO(content) {
           }
           for(let step=0; step<steps; ++step) {
             if(wrap)
-              w.clickRoutine.push({ func: 'MOVE', from: order[order.length-1], to: 'pcioShiftTempHolder', count });
+              routine.push({ func: 'MOVE', from: order[order.length-1], to: 'pcioShiftTempHolder', count });
             for(let i=order.length-2; i>=0; --i)
-              w.clickRoutine.push({ func: 'MOVE', from: order[i], to: order[i+1], count });
+              routine.push({ func: 'MOVE', from: order[i], to: order[i+1], count });
             if(wrap)
-              w.clickRoutine.push({ func: 'MOVE', from: 'pcioShiftTempHolder', to: order[0], count });
+              routine.push({ func: 'MOVE', from: 'pcioShiftTempHolder', to: order[0], count });
           }
-          continue;
+          return;
         }
         if(c.func == 'STAND_UP_PLAYER') {
           if(!c.args.seats)
-            continue;
-          w.clickRoutine.push({
+            return;
+          routine.push({
             func: 'SELECT',
             property: 'id',
             relation: 'in',
@@ -1591,10 +1874,12 @@ export default async function convertPCIO(content) {
 
         if(c.args) {
           warn(`The automation step ${c.func} of "${widget.label || widget.id}" has no VirtualTabletop equivalent and was skipped.`);
-          continue;
+          return;
         }
-        w.clickRoutine.push(c);
+        routine.push(c);
       }
+
+      importSteps(widget.clickRoutine ? (widget.clickRoutine.steps || widget.clickRoutine) : [], w.clickRoutine);
 
     } else if(widget.type == 'spinner') {
       w.type = widget.type;

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -143,7 +143,9 @@ export default async function convertPCIO(content) {
   } catch(e) {}
 
   for(const filename in zip.files) {
-    if(filename.match(/^\/?userassets/) && zip.files[filename]._data) {
+    // a .pcio carries a folder entry for its assets, which has no content: it
+    // would be written out as an empty "undefined_undefined" asset
+    if(filename.match(/^\/?userassets/) && !zip.files[filename].dir && zip.files[filename]._data) {
       // 10 MiB is the same limit that FileLoader applies to assets in .vtt files
       if(zip.files[filename]._data.uncompressedSize >= 10485760) {
         warn(`Asset ${filename} is bigger than 10 MiB and was not imported.`);

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -29,6 +29,58 @@ const pcioFonts = {
   'westminstergotisch':  'Metamorphous'
 };
 
+// the names PCIO's own editor uses - a warning that says MOVE_CARDS_BETWEEN_HOLDERS
+// or labelText does not help anyone looking for the thing in playingcards.io
+const pcioFuncNames = {
+  CHANGE_CHOOSER:             'Change Chooser',
+  CHANGE_COUNTER:             'Change Counter',
+  CHANGE_TIMER_STATE:         'Start / Pause Timer',
+  CHANGE_TIMER_TIME:          'Change Timer',
+  COMPARE_NUMBERS:            'Compare Numbers',
+  FIND_CARDS_PIECES:          'Find Cards & Pieces',
+  FLIP_CARDS:                 'Flip Objects',
+  IS_EQUAL:                   'Is Equal',
+  MATH:                       'Math',
+  MOVE_CARDS_BETWEEN_HOLDERS: 'Move Objects',
+  NEXT_TURN:                  'Finish Turn',
+  NUMBERS_FROM_COUNTERS:      'Numbers from Counters',
+  RANDOM_NUMBER:              'Random Number',
+  RECALL_CARDS:               'Recall Objects',
+  REVERSE_TURN_DIRECTION:     'Reverse Turn Direction',
+  ROLL_DICE:                  'Roll / Change Dice',
+  ROTATE_OBJECTS:             'Rotate Objects',
+  SHIFT_OBJECTS:              'Shift Objects',
+  SHUFFLE_CARDS:              'Shuffle Objects',
+  SORT_CARDS:                 'Sort Objects',
+  SPIN_SPINNER:               'Spin Spinners',
+  STAND_UP_PLAYER:            'Stand Up Players',
+  SUM_LIST:                   'Sum'
+};
+
+const pcioTypeNames = {
+  automationButton: 'Button',
+  board:            'Board',
+  card:             'Card',
+  cardDeck:         'Collection',
+  cardPile:         'Holder',
+  chooser:          'Chooser',
+  counter:          'Counter',
+  dice:             'Dice',
+  hand:             'Hand',
+  holder:           'Holder',
+  labelText:        'Label Text',
+  piece:            'Piece',
+  seat:             'Player Seat',
+  separator:        'Separator',
+  spinner:          'Spinner',
+  timer:            'Timer',
+  turnButton:       'Turn Button',
+  urlButton:        'URL Button'
+};
+
+// the newest PCIO file format this importer was written against
+const knownSchemaVersion = 8;
+
 export default async function convertPCIO(content) {
   const zip = await JSZip.loadAsync(content);
   // a null entry in widgets.json must not break the loops that follow
@@ -44,6 +96,32 @@ export default async function convertPCIO(content) {
   function warn(text) {
     if(warnings.indexOf(text) == -1)
       warnings.push(text);
+  }
+
+  // how a widget is called in a warning - the label the user gave it if it has one
+  function widgetName(widget) {
+    return `"${(widget || {}).label || (widget || {}).id || 'unnamed'}"`;
+  }
+
+  // a list of widget names, shortened so that a room full of them stays readable
+  function widgetNames(names) {
+    if(names.length > 3)
+      return `${names.slice(0, 3).join(', ')} and ${names.length-3} more`;
+    return names.length > 1 ? `${names.slice(0, -1).join(', ')} and ${names[names.length-1]}` : names[0];
+  }
+
+  // A warning that names the widget it is about would repeat itself once per
+  // widget, so the same problem on several widgets is collected under one key
+  // and turned into a single line listing them once everything was imported.
+  const groupedWarnings = {};
+  function warnAbout(key, widget, message) {
+    const group = groupedWarnings[key] = groupedWarnings[key] || { names: [], message };
+    if(group.names.indexOf(widgetName(widget)) == -1)
+      group.names.push(widgetName(widget));
+  }
+
+  function warnFont(font, widget) {
+    warnAbout(`font ${font}`, widget, (names, count)=>`The font ${font} is not available in VirtualTabletop - ${names} ${count > 1 ? 'use' : 'uses'} the default font instead.`);
   }
 
   const nameMap = {};
@@ -120,8 +198,14 @@ export default async function convertPCIO(content) {
   }
 
   // PCIO applies mainBackground/mainOutlines/mainTextStyle/mainBorderRadius to
-  // holders, buttons, labels, counters and seats alike - translate them to CSS
-  function pcioStyle(widget, w, css=[]) {
+  // holders, buttons, labels, counters and seats alike - translate them to CSS.
+  // Whatever the importer generates inside such a widget (a holder's label and
+  // shuffle button, a counter's caption and +/- buttons) is VirtualTabletop
+  // chrome that PCIO does not style, so it must not inherit the text style:
+  // options.noTextStyle drops it (PCIO ignores it for holders and hands as well)
+  // and options.textSelector keeps it on the element that shows the text.
+  function pcioStyle(widget, w, css=[], options={}) {
+    const textCSS = Object.assign({}, options.text);
     const background = pcioFill((widget.mainBackground || {}).fill);
     if(background && !(w.classes || '').match(/transparent/))
       css.push(`background: ${background}`);
@@ -139,32 +223,53 @@ export default async function convertPCIO(content) {
       }
     }
 
-    const text = widget.mainTextStyle;
+    const text = options.noTextStyle ? null : widget.mainTextStyle;
     if(text && typeof text == 'object') {
       if(text.size)
-        css.push(`font-size: ${Math.round(text.size)}px`);
+        textCSS['font-size'] = `${Math.round(text.size)}px`;
       if(text.size && text.lineHeight)
-        css.push(`line-height: ${Math.round(text.size*text.lineHeight)}px`);
+        textCSS['line-height'] = `${Math.round(text.size*text.lineHeight)}px`;
       if(text.align)
-        css.push(`text-align: ${text.align}`);
+        textCSS['text-align'] = text.align;
       const color = pcioFill(text.mainFill);
       if(color)
-        css.push(`color: ${color}`);
+        textCSS['color'] = color;
       if(text.font && pcioFonts[text.font])
-        css.push(`font-family: ${pcioFonts[text.font]}`);
+        textCSS['font-family'] = pcioFonts[text.font];
       else if(text.font)
-        warn(`Font ${text.font} is not available in VirtualTabletop.`);
-      // a stroke painted behind the glyphs is what PCIO's text outline looks like
+        warnFont(text.font, widget);
+      // a stroke painted behind the glyphs is what PCIO's text outline looks
+      // like - it strokes twice the size so that the fill covers the inner half
       const textOutline = (text.outlines || []).filter(o=>o && o.size && pcioFill(o.fill)).pop();
-      if(textOutline)
-        css.push(`-webkit-text-stroke: ${textOutline.size*2}px ${pcioFill(textOutline.fill)}`, 'paint-order: stroke fill');
+      if(textOutline) {
+        textCSS['-webkit-text-stroke'] = `${textOutline.size*2}px ${pcioFill(textOutline.fill)}`;
+        textCSS['paint-order'] = 'stroke fill';
+      }
     }
 
     if(typeof widget.mainBorderRadius == 'number')
       w.borderRadius = widget.mainBorderRadius;
-    if(css.length)
-      w.css = (w.css ? w.css.replace(/;\s*$/, '') + '; ' : '') + css.join('; ');
+
+    const textDeclarations = Object.entries(textCSS).map(([ property, value ])=>`${property}: ${value}`);
+    if(options.textSelector && textDeclarations.length) {
+      const style = {};
+      if(w.css || css.length)
+        style.default = (w.css ? w.css.replace(/;\s*$/, '') + '; ' : '') + css.join('; ');
+      style[options.textSelector] = textCSS;
+      w.css = style;
+    } else if(css.length || textDeclarations.length) {
+      w.css = (w.css ? w.css.replace(/;\s*$/, '') + '; ' : '') + css.concat(textDeclarations).join('; ');
+    }
     return w;
+  }
+
+  // how far the outlines of a widget reach beyond its width and height - PCIO
+  // paints them outside the widget as well, so whatever the importer puts next
+  // to the widget has to keep that distance to stay readable
+  function outlineExtent(widget) {
+    if(!Array.isArray(widget.mainOutlines))
+      return 0;
+    return widget.mainOutlines.reduce((extent, o)=>Math.max(extent, o && o.size ? (o.offset || 0) + o.size : 0), 0);
   }
 
   function addDimensions(w, widget, defaultWidth=100, defaultHeight=100) {
@@ -264,7 +369,7 @@ export default async function convertPCIO(content) {
     // holder, so aligning it with its holder means rotating it back to 0
     if(mode == 'auto')
       return Object.assign(target, { func: 'ROTATE', angle: 0, mode: 'set' });
-    warn(`Rotating objects to "${mode}" has no VirtualTabletop equivalent.`);
+    warn(`Rotating objects to "${mode}" has no VirtualTabletop equivalent - that step was skipped.`);
     return null;
   }
 
@@ -312,7 +417,7 @@ export default async function convertPCIO(content) {
     if(min == -Infinity && max == Infinity)
       continue;
     if(max < min)
-      warn(`Counter ${widget.label || widget.id} has a maximum below its minimum - its value is kept at ${max}.`);
+      warn(`Counter ${widgetName(widget)} has a maximum below its minimum - its value is kept at ${max}.`);
     counterBounds[widget.id] = { min, max };
   }
 
@@ -477,6 +582,11 @@ export default async function convertPCIO(content) {
         }
         w.width  = deck.cardWidth  || 50;
         w.height = deck.cardHeight || 50;
+        // a face default-prints at almost the size of the die, which only fits a
+        // single character - scale a word down so that it stays on the face
+        const longestFace = (w.faces || []).reduce((longest, face)=>Math.max(longest, String(face.value === undefined ? '' : face.value).length), 0);
+        if(longestFace > 1)
+          w.css = `--fontSize: ${Math.round(Math.min(w.width, w.height)/(0.6*longestFace))}px`;
         const activeFace = faces.findIndex(([ key ])=>key == widget.diceValue);
         if(activeFace > 0)
           w.activeFace = activeFace;
@@ -493,18 +603,22 @@ export default async function convertPCIO(content) {
           {
             func: 'INPUT',
             header: w.text,
+            // a single honest button: nothing here navigates anywhere
+            confirmButtonText: 'Close',
+            cancelButtonText: null,
+            cancelButtonIcon: null,
             fields: [
-              { type: 'text',   text: 'PlayingCards.io opened this link in a new tab:' },
-              { type: 'string', label: 'Link', value: url, variable: 'url' }
+              { type: 'text',   text: 'On PlayingCards.io this button opened a webpage. VirtualTabletop cannot open links, so here is the address:' },
+              { type: 'text',   text: url }
             ]
           }
         ];
       }
       pcioStyle(widget, w);
-      warn('Webpage buttons cannot open a link in VirtualTabletop - they now show the link instead.');
+      warnAbout('urlButton', widget, (names, count)=>`Webpage buttons cannot open a link in VirtualTabletop - the button${count > 1 ? 's' : ''} ${names} now show${count > 1 ? '' : 's'} the address instead.`);
     } else if(widget.type == 'hand') {
       if(widget.enabled === false) {
-        warn('A disabled hand was not imported.');
+        warn(`The disabled hand ${widgetName(widget)} was not imported.`);
         continue;
       }
       w.type = 'holder';
@@ -525,7 +639,7 @@ export default async function convertPCIO(content) {
       w.height = widget.height || 180;
       if(widget.allowedDecks && widget.allowedDecks.length)
         w.dropTarget = widget.allowedDecks.map(d=>({deck:d}));
-      pcioStyle(widget, w);
+      pcioStyle(widget, w, [], { noTextStyle: true });
     } else if(widget.type == 'cardPile') {
       w.type = 'holder';
       if(pileTransparent[w.id])
@@ -554,10 +668,10 @@ export default async function convertPCIO(content) {
       if(widget.layoutType == 'grid') {
         // VTT holders can only spread along one axis
         w.alignChildren = false;
-        warn(`Holder ${widget.label || widget.id} uses PCIO's grid layout which has no VirtualTabletop equivalent - imported as freeform.`);
+        warnAbout('gridLayout', widget, (names, count)=>`PlayingCards.io's grid layout has no VirtualTabletop equivalent - the holder${count > 1 ? 's' : ''} ${names} ${count > 1 ? 'were' : 'was'} imported as freeform.`);
       }
       if(widget.spreadMulti == 'multi' && widget.layoutType == 'spread')
-        warn(`Holder ${widget.label || widget.id} spreads cards into multiple groups which VirtualTabletop cannot do - all cards are in one row.`);
+        warnAbout('spreadMulti', widget, (names, count)=>`Spreading cards into multiple groups is not something VirtualTabletop can do - the cards in the holder${count > 1 ? 's' : ''} ${names} are all in one row.`);
 
       if(widget.layoutType == 'spread') {
         if(widget.spreadDirection == 'down') {
@@ -590,21 +704,22 @@ export default async function convertPCIO(content) {
       if(widget.layoutType != 'spread' && widget.layoutType != 'freeform')
         w.inheritChildZ = true;
 
-      pcioStyle(widget, w);
+      pcioStyle(widget, w, [], { noTextStyle: true });
 
+      const outlines = outlineExtent(widget);
       if(widget.label) {
-        output[widget.id + '_label'] = pcioStyle({ mainTextStyle: widget.mainTextStyle }, {
+        output[widget.id + '_label'] = {
           id: widget.id + '_label',
           parent: widget.id,
           x: -(w.width || 111) * 0.1,
-          y: -40,
+          y: -40 - outlines,
           width: (w.width || 111) * 1.2,
           height: 40,
           type: 'label',
           text: widget.label,
           twoRowBottomAlign: true,
           movableInEdit: false
-        });
+        };
         if(widget.allowPlayerEditLabel)
           output[widget.id + '_label'].editable = true;
       }
@@ -635,11 +750,14 @@ export default async function convertPCIO(content) {
         output[widget.id + '_shuffleButton'] = {
           id: widget.id + '_shuffleButton',
           parent: widget.id,
-          y: 1.02*(w.height || 168),
+          y: 1.02*(w.height || 168) + outlines,
           width: w.width || 111,
           height: 32,
           type: 'button',
-          text: w.width < 70 ? 'R&S' : 'Recall & Shuffle',
+          // PCIO shortens the label the same way below 60px - a smaller font is
+          // what keeps the long one on one line in a holder-wide button
+          text: (w.width || 111) < 60 ? 'R & S' : 'Recall & Shuffle',
+          css: 'font-size: 13px',
           movableInEdit: false,
 
           clickRoutine: recallConfirmation([
@@ -675,9 +793,9 @@ export default async function convertPCIO(content) {
       if(widget.allowPlayerClick === false)
         w.cardDefaults.clickable = false;
       if(Array.isArray(widget.snapAngles) && widget.snapAngles.length > 1)
-        warn('Card rotation snapping (snapAngles) has no VirtualTabletop equivalent.');
+        warnAbout('snapAngles', widget, (names, count)=>`The "Rotation Snapping" of the collection${count > 1 ? 's' : ''} ${names} has no VirtualTabletop equivalent - those objects rotate freely.`);
       if(widget.showUnflipped)
-        warn('"Show unflipped side to owner" has no VirtualTabletop equivalent.');
+        warnAbout('showUnflipped', widget, (names, count)=>`"Show Unflipped Side To Owner" of the collection${count > 1 ? 's' : ''} ${names} has no VirtualTabletop equivalent.`);
 
       for(const face of w.faceTemplates) {
         // includeBorder is a boolean in old files and light/heavy in new ones
@@ -696,7 +814,7 @@ export default async function convertPCIO(content) {
             if(pcioFonts[object.textFont])
               object.css = `font-family: ${pcioFonts[object.textFont]}`;
             else if(object.textFont)
-              warn(`Font ${object.textFont} is not available in VirtualTabletop.`);
+              warnFont(object.textFont, widget);
             delete object.textFont;
           }
         }
@@ -853,9 +971,15 @@ export default async function convertPCIO(content) {
       w.text = bounds ? Math.min(Math.max(+widget.counterValue || 0, bounds.min), bounds.max) : widget.counterValue;
       if(widget.allowPlayerEditValue !== false)
         w.editable = true;
-      pcioStyle(widget, w, (widget.mainTextStyle || {}).size ? [] : [ 'font-size: 30px' ]);
+      // the text style belongs on the value, not on the caption and +/- buttons
+      pcioStyle(widget, w, [], {
+        textSelector: ' > textarea',
+        text: (widget.mainTextStyle || {}).size ? {} : { 'font-size': '30px' }
+      });
+      if(bounds && !isNaN(parseFloat(widget.counterValue)) && w.text != parseFloat(widget.counterValue))
+        warn(`Counter ${widgetName(widget)} was outside its ${boundsText(bounds)} and starts at ${w.text} instead of ${widget.counterValue}.`);
       if(bounds && widget.allowPlayerEditValue !== false)
-        warn(`Typing a value into counter ${widget.label || widget.id} is not restricted to its ${boundsText(bounds)} - its buttons and the automations that change it are.`);
+        warnAbout(`bounds ${boundsText(bounds)}`, widget, (names, count)=>`Typing a value into the counter${count > 1 ? 's' : ''} ${names} is not restricted to ${count > 1 ? 'their' : 'its'} ${boundsText(bounds)} - the buttons and the automations that change ${count > 1 ? 'them' : 'it'} are.`);
 
       const counterStep = Math.abs(+widget.counterStep) || 1;
 
@@ -889,8 +1013,8 @@ export default async function convertPCIO(content) {
       }
 
       if(widget.label) {
-        output[widget.id + 'label'] = {
-          id: widget.id + 'label',
+        output[widget.id + '_label'] = {
+          id: widget.id + '_label',
           parent: widget.id,
           movableInEdit: false,
           y: -28,
@@ -922,9 +1046,14 @@ export default async function convertPCIO(content) {
       if(style.font && pcioFonts[style.font])
         w.css.default['font-family'] = pcioFonts[style.font];
       else if(style.font)
-        warn(`Font ${style.font} is not available in VirtualTabletop.`);
+        warnFont(style.font, widget);
       addDimensions(w, widget, 100, 20);
-      w.height = (size+2) * 3.5;
+      // a PCIO label text is always 60px high and lets longer text overflow it -
+      // VirtualTabletop scrolls instead, so grow the box for text that wraps
+      const lineHeight = style.lineHeight ? Math.round(size*style.lineHeight) : size;
+      const charsPerLine = Math.max(1, Math.floor((w.width || widget.width || 200) / (size*0.55)));
+      const rows = String(w.text || '').split('\n').reduce((sum, line)=>sum + Math.max(1, Math.ceil(line.length/charsPerLine)), 0);
+      w.height = Math.max(60, rows*lineHeight + 6);
     } else if(widget.type == 'separator') {
       w.movable = false;
       w.layer = -1;
@@ -945,7 +1074,7 @@ export default async function convertPCIO(content) {
       if(typeof widget.seatIndex == 'number')
         w.index = widget.seatIndex + 1;
       if(widget.flipTableForSeated)
-        warn('"Flip table for seated player" has no VirtualTabletop equivalent.');
+        warnAbout('flipTable', widget, (names, count)=>`"Flip Table For Seated Player" of the player seat${count > 1 ? 's' : ''} ${names} has no VirtualTabletop equivalent - the table looks the same for everyone.`);
       w.x = (widget.x || 0) + 69;
       w.y = (widget.y || 0) - 38;
       w.height = 42;
@@ -1199,8 +1328,12 @@ export default async function convertPCIO(content) {
       if(widget.label !== '')
         w.text = widget.label;
 
-      if(widget.type == 'turnButton')
-        widget.height = widget.width = 64;
+      // a PCIO turn button cannot be resized - it is always 162x66, which is
+      // also what its label was written for
+      if(widget.type == 'turnButton') {
+        widget.width = 162;
+        widget.height = 66;
+      }
       addDimensions(w, widget, 80, 80);
       pcioStyle(widget, w);
 
@@ -1255,7 +1388,7 @@ export default async function convertPCIO(content) {
         if(widget.currentTurn && byID[widget.currentTurn])
           turnAtSeat[widget.currentTurn] = true;
         if(widget.playersCanReverse)
-          warn('Players cannot reverse the turn direction by clicking the turn button - use the "Reverse turn direction" button that was added instead.');
+          warn('The turn button has no arrows to reverse the turn direction - clicking it always advances in the current direction, which only a "Reverse Turn Direction" automation can turn around.');
       }
 
       // PCIO wraps every step into { id, branches: [ { func, args } ] } since
@@ -1290,7 +1423,7 @@ export default async function convertPCIO(content) {
           return;
         const condition = branch.condition && branch.condition.callId;
         if(condition && !readValues[condition]) {
-          warn(`The condition of an automation step of "${widget.label || widget.id}" could not be imported - that alternative was skipped.`);
+          warn(`The condition of an automation step of ${widgetName(widget)} could not be imported - that alternative was skipped.`);
           importBranches(branches.slice(1), routine, stepID);
           return;
         }
@@ -1405,7 +1538,7 @@ export default async function convertPCIO(content) {
 
       function importBranch(c, routine, stepID) {
         if(!c || !c.func) {
-          warn('An automation step could not be read and was skipped.');
+          warn(`An automation step of ${widgetName(widget)} could not be read and was skipped.`);
           return;
         }
         c = Object.assign({}, c, { args: c.args || {} });
@@ -1468,7 +1601,7 @@ export default async function convertPCIO(content) {
             };
             routine.push({ func: 'MOVE', from: c.to, to: 'pcioMoveTempHolder', count: 'all' });
           } else if(toPosition && toPosition != 'top') {
-            warn(`Moving objects to "${toPosition}" is not supported - they end up on top of the destination.`);
+            warn(`Moving objects to "${toPosition}" is not supported - the objects ${widgetName(widget)} moves end up on top of the destination.`);
           }
 
           // PCIO hands out one object after the other, going around the
@@ -1493,7 +1626,7 @@ export default async function convertPCIO(content) {
             });
           } else {
             if(oneAtATime && typeof quantity == 'number' && quantity > 100)
-              warn(`"${widget.label || widget.id}" moves up to ${quantity} objects in one go instead of one after the other - they can end up in the opposite order.`);
+              warn(`${widgetName(widget)} moves up to ${quantity} objects in one go instead of one after the other - they can end up in the opposite order.`);
             routine.push(c);
           }
 
@@ -1640,7 +1773,7 @@ export default async function convertPCIO(content) {
             c.face = '${pcioFace}';
           } else if(flipFace == 'switch' && (Array.isArray(c.holder) || c.collection)) {
             // flipping the top object of one pile that way is just flipping it
-            warn('Flipping the top objects of several piles all to the same side is not supported - each of them is flipped to its other side instead.');
+            warn(`Flipping the top objects of several piles all to the same side is not supported - ${widgetName(widget)} flips each of them to its other side instead.`);
           }
           if(reverse) {
             routine.push(c);
@@ -1816,18 +1949,18 @@ export default async function convertPCIO(content) {
           const count = (c.args.objectsMode || {}).value == 'top' ? 1 : 'all';
           const steps = Math.min(+((wrap ? c.args.stepsWrap : c.args.stepsEdge) || {}).value || 1, holders.length);
           if((c.args.objectsMode || {}).value == 'custom')
-            warn('Shifting only a subset of the objects in a holder is not supported - all objects are shifted.');
+            warn(`Shifting only a subset of the objects in a holder is not supported - ${widgetName(widget)} shifts all of them.`);
 
           const seats = holders.filter(id=>byID[id] && byID[id].type == 'seat');
           if(seats.length && seats.length < holders.length) {
-            warn('Shifting objects between a mix of holders and player seats has no VirtualTabletop equivalent and was skipped.');
+            warn(`Shifting objects between a mix of holders and player seats has no VirtualTabletop equivalent - the step of ${widgetName(widget)} was skipped.`);
             return;
           }
           if(seats.length) {
             // a hand is one holder per room in VTT and it is the owner that makes
             // its cards a player's own, which is exactly what SWAPHANDS shifts
             if(!wrap)
-              warn('Passing the hands of the players on towards the last seat instead of around the table is not supported - they wrap around.');
+              warn(`Passing the hands of the players on towards the last seat instead of around the table is not supported - ${widgetName(widget)} wraps them around.`);
             routine.push({
               func: 'SELECT',
               property: 'id',
@@ -1910,7 +2043,7 @@ export default async function convertPCIO(content) {
         }
 
         if(c.args) {
-          warn(`The automation step ${c.func} of "${widget.label || widget.id}" has no VirtualTabletop equivalent and was skipped.`);
+          warn(`The automation step "${pcioFuncNames[c.func] || c.func}" of ${widgetName(widget)} has no VirtualTabletop equivalent and was skipped.`);
           return;
         }
         routine.push(c);
@@ -1926,8 +2059,15 @@ export default async function convertPCIO(content) {
         w.value = widget.value;
       addDimensions(w, widget, 110, 110);
     } else {
-      warn(`Widgets of type ${widget.type} cannot be imported.`);
-      w.css = 'background: repeating-linear-gradient(45deg, red, red 10px, darkred 10px, darkred 20px);';
+      // keep the size and say what is missing instead of leaving a nameless
+      // striped block where the widget used to be
+      const typeName = pcioTypeNames[widget.type] || widget.type;
+      w.width = widget.width || 100;
+      w.height = widget.height || 100;
+      w.type = 'label';
+      w.text = `${typeName} not imported`;
+      w.css ='background: repeating-linear-gradient(45deg, red, red 10px, darkred 10px, darkred 20px); color: white; text-shadow: 0 0 4px black;';
+      warn(`Widgets of type "${typeName}" cannot be imported - the striped placeholder at ${Math.round(widget.x || 0)},${Math.round(widget.y || 0)} marks where ${widgetName(widget)} was.`);
     }
 
     if(w.image)
@@ -1940,6 +2080,12 @@ export default async function convertPCIO(content) {
   for(const seatID in turnAtSeat)
     if(output[seatID])
       output[seatID].turn = true;
+
+  for(const group of Object.values(groupedWarnings))
+    warn(group.message(widgetNames(group.names), group.names.length));
+
+  if(schemaVersion > knownSchemaVersion)
+    warnings.unshift(`This file uses PlayingCards.io format ${schemaVersion} while the importer only knows up to ${knownSchemaVersion} - anything newer than that is missing.`);
 
   if(warnings.length) {
     output._meta.info.importerWarnings = warnings;

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -692,8 +692,8 @@ export default async function convertPCIO(content) {
           w.dropOffsetY = dropOffsetY;
 
         if(pileOverlaps[w.id]) {
-          w.x += 4;
-          w.y += 4;
+          w.x = (w.x || 0) + 4;
+          w.y = (w.y || 0) + 4;
           w.width = (w.width || 111) - 8;
           w.height = (w.height || 168) - 8;
           w.dropOffsetX = 0;
@@ -964,7 +964,7 @@ export default async function convertPCIO(content) {
         w.owner = widget.owner;
     } else if(widget.type == 'counter') {
       w.type = 'label';
-      w.y += 5;
+      w.y = (w.y || 0) + 5;
       w.width = widget.width || 140;
       w.height = widget.height || 44;
       const bounds = counterBounds[widget.id];
@@ -1399,7 +1399,7 @@ export default async function convertPCIO(content) {
       // in a variable named after the step that produced it.
       const readValues = {};
       const numberLists = {};
-      const readDefaults = { COMPARE_NUMBERS: false, IS_EQUAL: false, MATH: 0, RANDOM_NUMBER: 0, SUM_LIST: 0 };
+      const readDefaults = { COMPARE_NUMBERS: false, IS_EQUAL: false, MATH: 0, NUMBERS_FROM_COUNTERS: 0, RANDOM_NUMBER: 0, SUM_LIST: 0 };
       let temporaries = 0;
 
       function readVariable(stepID) {
@@ -1494,13 +1494,19 @@ export default async function convertPCIO(content) {
           return true;
         }
         if(c.func == 'NUMBERS_FROM_COUNTERS') {
-          // a list of counter values, which only SUM_LIST consumes
-          numberLists[stepID] = ((args.counters || {}).value || []).filter(id=>byID[id]);
+          // A list of counter values which only SUM_LIST consumes, so the sum is
+          // all that has to survive. PCIO reads the counters when this step runs,
+          // so it is captured here and not where the sum is used - the counters
+          // may well change in between, and a step that runs in one alternative
+          // only must not leak its counters into the others.
+          const counters = ((args.counters || {}).value || []).filter(id=>byID[id]);
+          routine.push(...(counters.length ? addUpCounters(counters, variable) : [ `var ${variable} = 0` ]));
+          numberLists[stepID] = variable;
           return true;
         }
         if(c.func == 'SUM_LIST') {
-          const counters = numberLists[(args.list || {}).callId] || [];
-          routine.push(...(counters.length ? addUpCounters(counters, variable) : [ `var ${variable} = 0` ]));
+          const list = numberLists[(args.list || {}).callId];
+          routine.push(`var ${variable} = ${list ? `\${${list}}` : 0}`);
         } else if(c.func == 'MATH') {
           const operator = (args.mathOperator || {}).value || 'add';
           const infix = { add: '+', subtract: '-', multiply: '*', divide: '/', remainder: '%', exponent: '**' }[operator];

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -189,6 +189,11 @@ export default async function convertPCIO(content) {
     return nameMap[name] || name;
   }
 
+  // text and URLs from the file end up inside a widget's html property
+  function htmlEscape(text) {
+    return String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
   // PCIO fill object (solid colour or gradient) as a CSS background/color value
   function pcioFill(fill) {
     if(!fill || typeof fill != 'object')
@@ -208,6 +213,27 @@ export default async function convertPCIO(content) {
     if(fill.type == 'conicGradient')
       return `conic-gradient(from ${fill.angle || 0}deg, ${stops})`;
     return `linear-gradient(${(fill.angle || 0) + 180}deg, ${stops})`;
+  }
+
+  // A text fill can be a gradient, which CSS only paints as a background - so
+  // put it behind the text and clip it to the glyphs. That works where the text
+  // has an element of its own (the textarea of a label or a counter); where the
+  // widget itself shows the text, clipping would take its background with it.
+  function textFill(fill, ownElement, widget) {
+    const value = pcioFill(fill);
+    if(!value)
+      return {};
+    if(!value.match(/gradient\(/))
+      return { 'color': value };
+    if(ownElement)
+      return {
+        'background-image': value,
+        '-webkit-background-clip': 'text',
+        'background-clip': 'text',
+        '-webkit-text-fill-color': 'transparent'
+      };
+    warnAbout('textGradient', widget, (names, count)=>`The text of ${names} is filled with a gradient, which VirtualTabletop only does for labels and counters - ${count > 1 ? 'they use' : 'it uses'} the default text colour instead.`);
+    return {};
   }
 
   // PCIO applies mainBackground/mainOutlines/mainTextStyle/mainBorderRadius to
@@ -244,9 +270,7 @@ export default async function convertPCIO(content) {
         textCSS['line-height'] = `${Math.round(text.size*text.lineHeight)}px`;
       if(text.align)
         textCSS['text-align'] = text.align;
-      const color = pcioFill(text.mainFill);
-      if(color)
-        textCSS['color'] = color;
+      Object.assign(textCSS, textFill(text.mainFill, !!options.textSelector, widget));
       if(text.font && pcioFonts[text.font])
         textCSS['font-family'] = pcioFonts[text.font];
       else if(text.font)
@@ -645,29 +669,43 @@ export default async function convertPCIO(content) {
       }
       addDimensions(w, widget, w.width || 50, w.height || 50);
     } else if(widget.type == 'urlButton') {
-      // VTT cannot open a link from a button - show it so it can be copied
-      w.type = 'button';
-      w.text = widget.label || 'Open';
+      const label = widget.label || 'Open';
+      const url = String(widget.clickURL || widget.url || '');
       addDimensions(w, widget, 80, 80);
-      const url = widget.clickURL || widget.url;
-      if(url) {
-        w.clickRoutine = [
-          {
-            func: 'INPUT',
-            header: w.text,
-            // a single honest button: nothing here navigates anywhere
-            confirmButtonText: 'Close',
-            cancelButtonText: null,
-            cancelButtonIcon: null,
-            fields: [
-              { type: 'text',   text: 'On PlayingCards.io this button opened a webpage. VirtualTabletop cannot open links, so here is the address:' },
-              { type: 'text',   text: url }
-            ]
-          }
-        ];
+      if(url.match(/^(https?:\/\/|mailto:)/i)) {
+        // a link in the html of a basic widget is a real link: the room page
+        // sets <base target="_blank">, so it opens the page in a new tab just
+        // like the PCIO button does. The button class keeps the look, and the
+        // link fills the widget so that a click anywhere on it counts.
+        w.type = 'basic';
+        w.classes = 'button';
+        w.movable = false;
+        w.layer = -1;
+        w.borderRadius = 800;
+        w.html = `<a href="${htmlEscape(url)}" style="display: flex; width: 100%; height: 100%; align-items: center; justify-content: center; color: inherit; text-decoration: none">${htmlEscape(label)}</a>`;
+      } else {
+        // an address VirtualTabletop would not open as a link - show it instead
+        w.type = 'button';
+        w.text = label;
+        if(url) {
+          w.clickRoutine = [
+            {
+              func: 'INPUT',
+              header: label,
+              // a single honest button: nothing here navigates anywhere
+              confirmButtonText: 'Close',
+              cancelButtonText: null,
+              cancelButtonIcon: null,
+              fields: [
+                { type: 'text',   text: 'On PlayingCards.io this button opened a webpage. VirtualTabletop cannot open this address, so here it is:' },
+                { type: 'text',   text: url }
+              ]
+            }
+          ];
+          warnAbout('urlButton', widget, (names, count)=>`The webpage button${count > 1 ? 's' : ''} ${names} ${count > 1 ? 'open addresses' : 'opens an address'} that VirtualTabletop cannot follow - ${count > 1 ? 'they show them' : 'it shows it'} instead.`);
+        }
       }
       pcioStyle(widget, w);
-      warnAbout('urlButton', widget, (names, count)=>`Webpage buttons cannot open a link in VirtualTabletop - the button${count > 1 ? 's' : ''} ${names} now show${count > 1 ? '' : 's'} the address instead.`);
     } else if(widget.type == 'hand') {
       if(widget.enabled === false) {
         warn(`The disabled hand ${widgetName(widget)} was not imported.`);
@@ -1093,9 +1131,11 @@ export default async function convertPCIO(content) {
           'letter-spacing': '-1px'
         }
       };
-      const color = pcioFill(style.mainFill);
-      if(color)
-        w.css.default.color = color;
+      const fill = textFill(style.mainFill, true, widget);
+      if(fill.color)
+        w.css.default.color = fill.color;
+      else
+        Object.assign(w.css[' textarea'], fill);
       if(style.font && pcioFonts[style.font])
         w.css.default['font-family'] = pcioFonts[style.font];
       else if(style.font)

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -157,6 +157,11 @@ export default class Room {
             this.state._meta.states[stateID].variants[newVariantID] = variantMeta;
           else if(type != 'link' || meta.importerTemp)
             delete this.state._meta.states[stateID].variants[newVariantID].link;
+          // the import report belongs to the game, not to one of its variants
+          if(meta.importerWarnings) {
+            const notes = this.state._meta.states[stateID].importerWarnings || [];
+            this.state._meta.states[stateID].importerWarnings = [ ...new Set(notes.concat(meta.importerWarnings)) ];
+          }
           if(!this.state._meta.states[stateID].attribution)
             this.state._meta.states[stateID].attribution = meta.attribution;
           if(meta.attribution && meta.attribution != this.state._meta.states[stateID].attribution)

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -157,11 +157,12 @@ export default class Room {
             this.state._meta.states[stateID].variants[newVariantID] = variantMeta;
           else if(type != 'link' || meta.importerTemp)
             delete this.state._meta.states[stateID].variants[newVariantID].link;
-          // the import report belongs to the game, not to one of its variants
-          if(meta.importerWarnings) {
-            const notes = this.state._meta.states[stateID].importerWarnings || [];
-            this.state._meta.states[stateID].importerWarnings = [ ...new Set(notes.concat(meta.importerWarnings)) ];
-          }
+          // The import report belongs to the game, not to one of its variants.
+          // stateID comes from the request, so it must not be able to reach
+          // Object.prototype through the states object.
+          const gameMeta = Object.prototype.hasOwnProperty.call(this.state._meta.states, stateID) && this.state._meta.states[stateID];
+          if(gameMeta && meta.importerWarnings)
+            gameMeta.importerWarnings = [ ...new Set((gameMeta.importerWarnings || []).concat(meta.importerWarnings)) ];
           if(!this.state._meta.states[stateID].attribution)
             this.state._meta.states[stateID].attribution = meta.attribution;
           if(meta.attribution && meta.attribution != this.state._meta.states[stateID].attribution)

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -158,11 +158,12 @@ export default class Room {
           else if(type != 'link' || meta.importerTemp)
             delete this.state._meta.states[stateID].variants[newVariantID].link;
           // The import report belongs to the game, not to one of its variants.
-          // stateID comes from the request, so it must not be able to reach
-          // Object.prototype through the states object.
-          const gameMeta = Object.prototype.hasOwnProperty.call(this.state._meta.states, stateID) && this.state._meta.states[stateID];
-          if(gameMeta && meta.importerWarnings)
+          // stateID comes from the request, so writing through it must not be
+          // able to reach Object.prototype.
+          if(meta.importerWarnings && stateID != '__proto__') {
+            const gameMeta = this.state._meta.states[stateID];
             gameMeta.importerWarnings = [ ...new Set((gameMeta.importerWarnings || []).concat(meta.importerWarnings)) ];
+          }
           if(!this.state._meta.states[stateID].attribution)
             this.state._meta.states[stateID].attribution = meta.attribution;
           if(meta.attribution && meta.attribution != this.state._meta.states[stateID].attribution)

--- a/tests/server/pcio-import.test.js
+++ b/tests/server/pcio-import.test.js
@@ -211,7 +211,7 @@ describe('PCIO importer', () => {
       { func: 'LABEL', label: 'counter', value: '${pcioCounter}' }
     ]);
     expect(state._meta.info.importerWarnings).toEqual([
-      'Typing a value into counter counter is not restricted to its maximum of 10 - its buttons and the automations that change it are.'
+      'Typing a value into the counter "counter" is not restricted to its maximum of 10 - the buttons and the automations that change it are.'
     ]);
   });
 
@@ -460,10 +460,122 @@ describe('PCIO importer', () => {
     ], 8);
 
     expect(state._meta.info.importerWarnings).toEqual([
-      'Widgets of type somethingNew cannot be imported.',
+      'Widgets of type "somethingNew" cannot be imported - the striped placeholder at 0,0 marks where "unknown" was.',
       'Ignored a widget without a type (noType).',
-      'The automation step FUTURE_STEP of "Shift" has no VirtualTabletop equivalent and was skipped.'
+      'The automation step "FUTURE_STEP" of "Shift" has no VirtualTabletop equivalent and was skipped.'
     ]);
     expect(state.button.clickRoutine).toEqual([]);
+  });
+
+  it('keeps the size of a widget it cannot import and says what it was', async () => {
+    const state = await importWidgets([
+      { id: 'unknown', type: 'videoPlayer', x: 200, y: 400, width: 180, height: 100 }
+    ], 8);
+
+    expect(state.unknown.width).toBe(180);
+    expect(state.unknown.height).toBe(100);
+    expect(state.unknown.text).toBe('videoPlayer not imported');
+  });
+
+  it('does not put the text style of a holder on the chrome it generates', async () => {
+    const textStyle = { size: 22, font: 'unquiet-spirits', mainFill: { type: 'color', color: '#ffffff' } };
+    const state = await importWidgets([
+      { id: 'holder', type: 'holder', x: 0, y: 0, width: 111, height: 168, label: 'Draw Pile', hasShuffleButton: true,
+        mainTextStyle: textStyle,
+        mainOutlines: [ { size: 2, offset: 0, fill: { type: 'color', color: '#000000' } }, { size: 4, offset: 4, fill: { type: 'color', color: '#ff0000' } } ] },
+      deck
+    ], 8);
+
+    // PCIO renders a holder label at a fixed size and ignores mainTextStyle there
+    expect(state.holder.css).toBe('border: 2px solid #000000; box-sizing: border-box; box-shadow: 0 0 0 8px #ff0000');
+    expect(state.holder_label.css).toBeUndefined();
+    // the outlines reach 8px beyond the holder, so label and button move aside
+    expect(state.holder_label.y).toBe(-48);
+    expect(state.holder_shuffleButton.y).toBe(1.02*168 + 8);
+  });
+
+  it('styles the value of a counter without styling its caption and buttons', async () => {
+    const state = await importWidgets([
+      { id: 'counter', type: 'counter', x: 0, y: 0, label: 'Score', counterValue: 3,
+        mainBackground: { fill: { type: 'color', color: '#dcedc8' } },
+        mainTextStyle: { size: 26, mainFill: { type: 'color', color: '#1b5e20' } } }
+    ], 8);
+
+    expect(state.counter.css).toEqual({
+      default: 'background: #dcedc8',
+      ' > textarea': { 'font-size': '26px', color: '#1b5e20' }
+    });
+    expect(state.counter_label.css).toBeUndefined();
+    expect(state.counter_incrementButton.css).toBeUndefined();
+  });
+
+  it('reports the same problem on several widgets as one line', async () => {
+    const state = await importWidgets([
+      { id: 'a', type: 'holder', x: 0,   y: 0, label: 'One',   layoutType: 'grid' },
+      { id: 'b', type: 'holder', x: 200, y: 0, label: 'Two',   layoutType: 'grid' },
+      { id: 'c', type: 'holder', x: 400, y: 0, label: 'Three', layoutType: 'grid' },
+      { id: 'd', type: 'holder', x: 600, y: 0, label: 'Four',  layoutType: 'grid' }
+    ], 8);
+
+    expect(state._meta.info.importerWarnings).toEqual([
+      `PlayingCards.io's grid layout has no VirtualTabletop equivalent - the holders "One", "Two", "Three" and 1 more were imported as freeform.`
+    ]);
+  });
+
+  it('warns about a file format that is newer than the importer', async () => {
+    const state = await importWidgets([ { id: 'holder', type: 'holder', x: 0, y: 0 } ], 9);
+
+    expect(state._meta.info.importerWarnings[0]).toBe('This file uses PlayingCards.io format 9 while the importer only knows up to 8 - anything newer than that is missing.');
+  });
+
+  it('shows the address of a webpage button without pretending to open it', async () => {
+    const state = await importWidgets([
+      { id: 'link', type: 'urlButton', x: 0, y: 0, label: 'Rules', clickURL: 'https://example.com/rules' }
+    ], 8);
+
+    expect(state.link.clickRoutine).toEqual([ {
+      func: 'INPUT',
+      header: 'Rules',
+      confirmButtonText: 'Close',
+      cancelButtonText: null,
+      cancelButtonIcon: null,
+      fields: [
+        { type: 'text', text: 'On PlayingCards.io this button opened a webpage. VirtualTabletop cannot open links, so here is the address:' },
+        { type: 'text', text: 'https://example.com/rules' }
+      ]
+    } ]);
+  });
+
+  it('gives a label text the height PCIO gives it and grows it for wrapping text', async () => {
+    const state = await importWidgets([
+      { id: 'short', type: 'labelText', x: 0, y: 0,   width: 400, height: 60, labelContent: 'One line',
+        mainTextStyle: { size: 30 } },
+      { id: 'long',  type: 'labelText', x: 0, y: 100, width: 200, height: 60, mainTextStyle: { size: 30 },
+        labelContent: 'A label with quite a lot of text in it that has to wrap several times to fit' }
+    ], 8);
+
+    expect(state.short.height).toBe(60);
+    expect(state.long.height).toBeGreaterThan(60);
+  });
+
+  it('imports a turn button at the size PCIO gives it', async () => {
+    const state = await importWidgets([
+      { id: 'turn', type: 'turnButton', x: 0, y: 0, label: 'End Turn', clickRoutine: { steps: [] } }
+    ], 8);
+
+    expect(state.turn.width).toBe(162);
+    expect(state.turn.height).toBe(66);
+  });
+
+  it('scales a die face down so that a word fits on it', async () => {
+    const state = await importWidgets([
+      { id: 'dd', type: 'cardDeck', x: 0, y: 0, collectionType: 'dice', cardWidth: 50, cardHeight: 50,
+        cardTypes: { one: { label: 'Yes' }, two: { label: 'No' }, three: { label: 'Maybe' } },
+        faceTemplate: { objects: [] } },
+      { id: 'die', type: 'dice', deck: 'dd', x: 0, y: 0 }
+    ], 8);
+
+    expect(state.die.faces).toEqual([ { value: 'Yes' }, { value: 'No' }, { value: 'Maybe' } ]);
+    expect(state.die.css).toBe('--fontSize: 17px');
   });
 });

--- a/tests/server/pcio-import.test.js
+++ b/tests/server/pcio-import.test.js
@@ -607,6 +607,31 @@ describe('PCIO importer', () => {
     expect(state.counter_incrementButton.css).toBeUndefined();
   });
 
+  it('paints a gradient text fill onto the glyphs and reports where it cannot', async () => {
+    const gradient = { fill: { type: 'linearGradient', angle: 0, stops: [ { color: '#ff0000', position: 0 }, { color: '#0000ff', position: 1 } ] } };
+    const state = await importWidgets([
+      { id: 'label',   type: 'labelText', x: 0, y: 0,   labelContent: 'Gradient', mainTextStyle: { size: 30, mainFill: gradient.fill } },
+      { id: 'counter', type: 'counter',   x: 0, y: 100, counterValue: 3,          mainTextStyle: { size: 26, mainFill: gradient.fill } },
+      { id: 'button',  type: 'urlButton', x: 0, y: 200, label: 'Rules', clickURL: 'https://example.com',
+        mainTextStyle: { size: 20, mainFill: gradient.fill } }
+    ], 8);
+
+    const gradientCSS = {
+      'background-image': 'linear-gradient(180deg, #ff0000 0%, #0000ff 100%)',
+      '-webkit-background-clip': 'text',
+      'background-clip': 'text',
+      '-webkit-text-fill-color': 'transparent'
+    };
+    expect(state.label.css[' textarea']).toEqual(Object.assign({ 'letter-spacing': '-1px' }, gradientCSS));
+    expect(state.label.css.default.color).toBeUndefined();
+    expect(state.counter.css[' > textarea']).toEqual(Object.assign({ 'font-size': '26px' }, gradientCSS));
+    // the button paints its own background, which clipping the text would eat
+    expect(state.button.css).toBe('font-size: 20px');
+    expect(state._meta.info.importerWarnings).toEqual([
+      'The text of "Rules" is filled with a gradient, which VirtualTabletop only does for labels and counters - it uses the default text colour instead.'
+    ]);
+  });
+
   it('reports the same problem on several widgets as one line', async () => {
     const state = await importWidgets([
       { id: 'a', type: 'holder', x: 0,   y: 0, label: 'One',   layoutType: 'grid' },
@@ -626,11 +651,27 @@ describe('PCIO importer', () => {
     expect(state._meta.info.importerWarnings[0]).toBe('This file uses PlayingCards.io format 9 while the importer only knows up to 8 - anything newer than that is missing.');
   });
 
-  it('shows the address of a webpage button without pretending to open it', async () => {
+  it('makes a webpage button a real link', async () => {
     const state = await importWidgets([
-      { id: 'link', type: 'urlButton', x: 0, y: 0, label: 'Rules', clickURL: 'https://example.com/rules' }
+      { id: 'link', type: 'urlButton', x: 0, y: 0, label: 'Rules & "tips"', clickURL: 'https://example.com/rules?a=1&b=2' }
     ], 8);
 
+    expect(state.link.type).toBe('basic');
+    expect(state.link.classes).toBe('button');
+    expect(state.link.movable).toBe(false);
+    expect(state.link.clickRoutine).toBe(undefined);
+    expect(state.link.html).toContain('href="https://example.com/rules?a=1&amp;b=2"');
+    expect(state.link.html).toContain('>Rules &amp; &quot;tips&quot;</a>');
+    expect(state._meta.info.importerWarnings).toBe(undefined);
+  });
+
+  it('shows the address of a webpage button it cannot link to', async () => {
+    const state = await importWidgets([
+      { id: 'link', type: 'urlButton', x: 0, y: 0, label: 'Rules', clickURL: 'javascript:alert(1)' }
+    ], 8);
+
+    expect(state.link.type).toBe('button');
+    expect(state.link.html).toBe(undefined);
     expect(state.link.clickRoutine).toEqual([ {
       func: 'INPUT',
       header: 'Rules',
@@ -638,10 +679,11 @@ describe('PCIO importer', () => {
       cancelButtonText: null,
       cancelButtonIcon: null,
       fields: [
-        { type: 'text', text: 'On PlayingCards.io this button opened a webpage. VirtualTabletop cannot open links, so here is the address:' },
-        { type: 'text', text: 'https://example.com/rules' }
+        { type: 'text', text: 'On PlayingCards.io this button opened a webpage. VirtualTabletop cannot open this address, so here it is:' },
+        { type: 'text', text: 'javascript:alert(1)' }
       ]
     } ]);
+    expect(state._meta.info.importerWarnings).toEqual([ 'The webpage button "Rules" opens an address that VirtualTabletop cannot follow - it shows it instead.' ]);
   });
 
   it('gives a label text the height PCIO gives it and grows it for wrapping text', async () => {

--- a/tests/server/pcio-import.test.js
+++ b/tests/server/pcio-import.test.js
@@ -117,6 +117,57 @@ describe('PCIO importer', () => {
     ]);
   });
 
+  it('deals a quantity that is only known when the button is clicked', async () => {
+    const state = await importWidgets([
+      { id: 'source', type: 'holder', x: 0, y: 0 },
+      { id: 'target', type: 'holder', x: 200, y: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Deal', x: 0, y: 300,
+        clickRoutine: {
+          popupMessage: 'How many?',
+          questions: [ { id: 'howMany', type: 'number', label: 'Cards', defaultValue: 5 } ],
+          steps: [ { id: 'a', branches: [ { func: 'MOVE_CARDS_BETWEEN_HOLDERS', args: {
+            from:     { type: 'literal', value: [ 'source' ] },
+            to:       { type: 'literal', value: [ 'target' ] },
+            quantity: { type: 'reference', questionId: 'howMany' }
+          } } ] } ]
+        }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine[1]).toEqual({
+      note: 'Deal one at a time',
+      func: 'IF',
+      operand1: '${howMany}',
+      relation: '>',
+      operand2: 0,
+      thenRoutine: [
+        { func: 'FOREACH', range: [ 1, '${howMany}' ], loopRoutine: [ { func: 'MOVE', from: 'source', to: 'target', count: 1 } ] }
+      ]
+    });
+    expect(state._meta.info.importerWarnings).toBeUndefined();
+  });
+
+  it('reports a quantity too large to deal one at a time', async () => {
+    const state = await importWidgets([
+      { id: 'source', type: 'holder', x: 0, y: 0 },
+      { id: 'target', type: 'holder', x: 200, y: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Deal', x: 0, y: 300,
+        clickRoutine: { steps: [ { id: 'a', branches: [ { func: 'MOVE_CARDS_BETWEEN_HOLDERS', args: {
+          from:     { type: 'literal', value: [ 'source' ] },
+          to:       { type: 'literal', value: [ 'target' ] },
+          quantity: { type: 'literal', value: 200 }
+        } } ] } ] }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine).toEqual([ { func: 'MOVE', from: 'source', to: 'target', count: 200 } ]);
+    expect(state._meta.info.importerWarnings).toEqual([
+      '"Deal" moves up to 200 objects in one go instead of one after the other - they can end up in the opposite order.'
+    ]);
+  });
+
   it('keeps a counter within its bounds wherever it is changed', async () => {
     const state = await importWidgets([
       { id: 'counter', type: 'counter', x: 0, y: 0, counterValue: 9, counterMin: 0, counterMax: 5, counterStep: 2 },
@@ -147,6 +198,23 @@ describe('PCIO importer', () => {
     ]);
   });
 
+  it('only clamps the side a counter is bounded on', async () => {
+    const state = await importWidgets([
+      { id: 'counter', type: 'counter', x: 0, y: 0, counterValue: 3, counterMax: 10 }
+    ], 8);
+
+    expect(state.counter.text).toBe(3);
+    expect(state.counter_incrementButton.clickRoutine).toEqual([
+      'var pcioCounter = parseFloat ${PROPERTY text OF counter}',
+      'var pcioCounter = ${pcioCounter} + 1',
+      'var pcioCounter = min ${pcioCounter} 10',
+      { func: 'LABEL', label: 'counter', value: '${pcioCounter}' }
+    ]);
+    expect(state._meta.info.importerWarnings).toEqual([
+      'Typing a value into counter counter is not restricted to its maximum of 10 - its buttons and the automations that change it are.'
+    ]);
+  });
+
   it('turns a whole pile over: every card to the same side and the order reversed', async () => {
     const state = await importWidgets([
       { id: 'holder', type: 'holder', x: 0, y: 0 },
@@ -163,6 +231,7 @@ describe('PCIO importer', () => {
 
     expect(state.button.clickRoutine).toEqual([
       { func: 'SELECT', property: 'parent', relation: 'in', value: [ 'holder' ], type: 'card', collection: 'pcioPile', sortBy: 'z' },
+      'var pcioFace = 0',
       { func: 'GET', collection: 'pcioPile', property: 'activeFace', aggregation: 'last', variable: 'pcioFace' },
       'var pcioFace = 1 - ${pcioFace}',
       { func: 'FLIP', collection: 'pcioPile', face: '${pcioFace}' },
@@ -189,6 +258,118 @@ describe('PCIO importer', () => {
       { func: 'SELECT', property: 'id', relation: 'in', value: [ 'seat1', 'seat2' ], type: 'seat', collection: 'pcioSeats' },
       { note: 'Pass the hands on', func: 'SWAPHANDS', source: 'pcioSeats', interval: 1, direction: 'forward', keepOrder: true }
     ]);
+  });
+
+  it('shifts the contents of plain holders around through a temporary holder', async () => {
+    const state = await importWidgets([
+      { id: 'a', type: 'holder', x: 0,   y: 0 },
+      { id: 'b', type: 'holder', x: 200, y: 0 },
+      { id: 'c', type: 'holder', x: 400, y: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Shift', x: 0, y: 300,
+        clickRoutine: { steps: [ { id: 'shift', branches: [ { func: 'SHIFT_OBJECTS', args: {
+          holders:   { type: 'literal', value: [ 'a', 'b', 'c' ] },
+          moveMode:  { type: 'literal', value: 'wrap' },
+          stepsWrap: { type: 'literal', value: 1 }
+        } } ] } ] }
+      }
+    ], 8);
+
+    expect(state.pcioShiftTempHolder.type).toBe('holder');
+    expect(state.button.clickRoutine).toEqual([
+      { func: 'MOVE', from: 'c', to: 'pcioShiftTempHolder',   count: 'all' },
+      { func: 'MOVE', from: 'b', to: 'c',                     count: 'all' },
+      { func: 'MOVE', from: 'a', to: 'b',                     count: 'all' },
+      { func: 'MOVE', from: 'pcioShiftTempHolder', to: 'a',   count: 'all' }
+    ]);
+  });
+
+  it('calculates with the operators that have no named function', async () => {
+    const state = await importWidgets([
+      { id: 'counter', type: 'counter', x: 0, y: 0, counterValue: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Math', x: 0, y: 300,
+        clickRoutine: { steps: [
+          { id: 'mod', branches: [ { func: 'MATH', args: {
+            mathOperator: { type: 'literal', value: 'remainder' },
+            numberA:      { type: 'literal', value: 7 },
+            numberB:      { type: 'literal', value: 3 }
+          } } ] },
+          { id: 'pow', branches: [ { func: 'MATH', args: {
+            mathOperator: { type: 'literal', value: 'exponent' },
+            numberA:      { type: 'variable', callId: 'mod' },
+            numberB:      { type: 'literal', value: 3 }
+          } } ] },
+          { id: 'set', branches: [ { func: 'CHANGE_COUNTER', args: {
+            counters:          { type: 'literal', value: [ 'counter' ] },
+            counterChangeMode: { type: 'literal', value: 'set' },
+            changeNumber:      { type: 'variable', callId: 'pow' }
+          } } ] }
+        ] }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine).toEqual([
+      'var pciomod = 7 % 3',
+      'var pciopow = ${pciomod} ** 3',
+      { func: 'LABEL', label: 'counter', value: '${pciopow}' }
+    ]);
+  });
+
+  it('gives a read step that only runs under a condition its empty default', async () => {
+    const state = await importWidgets([
+      { id: 'counter', type: 'counter', x: 0, y: 0, counterValue: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Maybe', x: 0, y: 300,
+        clickRoutine: { steps: [
+          { id: 'ask', branches: [ { func: 'IS_EQUAL', args: {
+            numberA: { type: 'literal', value: 1 },
+            numberB: { type: 'literal', value: 1 }
+          } } ] },
+          { id: 'roll', branches: [ { func: 'RANDOM_NUMBER', condition: { type: 'variable', callId: 'ask' }, args: {
+            minimum: { type: 'literal', value: 1 },
+            maximum: { type: 'literal', value: 6 },
+            step:    { type: 'literal', value: 1 }
+          } } ] },
+          { id: 'set', branches: [ { func: 'CHANGE_COUNTER', args: {
+            counters:          { type: 'literal', value: [ 'counter' ] },
+            counterChangeMode: { type: 'literal', value: 'set' },
+            changeNumber:      { type: 'variable', callId: 'roll' }
+          } } ] }
+        ] }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine).toEqual([
+      'var pcioask = 1 == 1',
+      'var pcioroll = 0',
+      { func: 'IF', condition: '${pcioask}', thenRoutine: [ 'var pcioroll = randRange 1 7 1' ] },
+      { func: 'LABEL', label: 'counter', value: '${pcioroll}' }
+    ]);
+  });
+
+  it('translates the background, outlines and text style of a button', async () => {
+    const state = await importWidgets([
+      {
+        id: 'button', type: 'automationButton', label: 'Styled', x: 0, y: 0, width: 120, height: 60,
+        mainBackground: { fill: { type: 'linearGradient', angle: 90, stops: [ { color: '#ff0000', position: 0 }, { color: '#0000ff', position: 1 } ] } },
+        mainOutlines: [ { size: 2, offset: 0, fill: { type: 'color', color: '#000000' } }, { size: 3, offset: 4, fill: { type: 'color', color: '#ffffff' } } ],
+        mainTextStyle: { size: 20, align: 'left', mainFill: { type: 'color', color: '#123456' } },
+        mainBorderRadius: 12,
+        clickRoutine: { steps: [] }
+      }
+    ], 8);
+
+    expect(state.button.borderRadius).toBe(12);
+    expect(state.button.css).toBe([
+      'background: linear-gradient(270deg, #ff0000 0%, #0000ff 100%)',
+      'border: 2px solid #000000',
+      'box-sizing: border-box',
+      'box-shadow: 0 0 0 7px #ffffff',
+      'font-size: 20px',
+      'text-align: left',
+      'color: #123456'
+    ].join('; '));
   });
 
   it('translates counter and chooser changes including cycling backwards', async () => {
@@ -238,6 +419,34 @@ describe('PCIO importer', () => {
         { image: 'https://playingcards.io/img/dice-d4/2.svg' }
       ]
     });
+  });
+
+  it('spells out the faces of a die that has fewer than six of the standard ones', async () => {
+    const state = await importWidgets([
+      { id: 'd3Deck', type: 'cardDeck', x: 0, y: 0, collectionType: 'dice', cardWidth: 50, cardHeight: 50,
+        cardTypes: { one: { image: '/img/dice-basic/1.svg' }, two: { image: '/img/dice-basic/2.svg' }, three: { image: '/img/dice-basic/3.svg' } },
+        faceTemplate: { objects: [ { type: 'image', x: 0, y: 0, w: 50, h: 50, valueType: 'dynamic', value: 'image' } ] } },
+      { id: 'd3', type: 'dice', deck: 'd3Deck', x: 0, y: 0 }
+    ], 8);
+
+    expect(state.d3.faces).toEqual([
+      { image: 'https://playingcards.io/img/dice-basic/1.svg' },
+      { image: 'https://playingcards.io/img/dice-basic/2.svg' },
+      { image: 'https://playingcards.io/img/dice-basic/3.svg' }
+    ]);
+  });
+
+  it('leaves the faces of a standard six sided die to the dice widget', async () => {
+    const faces = {};
+    for(let i=1; i<=6; ++i)
+      faces['f' + i] = { image: `/img/dice-basic/${i}.svg` };
+    const state = await importWidgets([
+      { id: 'd6Deck', type: 'cardDeck', x: 0, y: 0, collectionType: 'dice', cardWidth: 50, cardHeight: 50, cardTypes: faces,
+        faceTemplate: { objects: [ { type: 'image', x: 0, y: 0, w: 50, h: 50, valueType: 'dynamic', value: 'image' } ] } },
+      { id: 'd6', type: 'dice', deck: 'd6Deck', x: 0, y: 0 }
+    ], 8);
+
+    expect(state.d6.faces).toBeUndefined();
   });
 
   it('reports what it could not translate', async () => {

--- a/tests/server/pcio-import.test.js
+++ b/tests/server/pcio-import.test.js
@@ -2,11 +2,13 @@ import JSZip from 'jszip';
 
 import convertPCIO from '../../server/pcioimport.mjs';
 
-async function importWidgets(widgets, schemaVersion) {
+async function importWidgets(widgets, schemaVersion, files={}) {
   const zip = new JSZip();
   zip.file('widgets.json', JSON.stringify(widgets));
   if(schemaVersion !== undefined)
     zip.file('schemaVersion', String(schemaVersion));
+  for(const [ name, content ] of Object.entries(files))
+    zip.file(name, content);
   return await convertPCIO(await zip.generateAsync({ type: 'nodebuffer' }));
 }
 
@@ -872,6 +874,25 @@ describe('PCIO importer', () => {
 
     expect(state._meta.info.importerWarnings.length).toBe(101);
     expect(state._meta.info.importerWarnings[100]).toBe('50 more notes are not listed here.');
+  });
+
+  it('points an asset at the copy the client already uploaded', async () => {
+    const state = await importWidgets([
+      { id: 'board', type: 'board', x: 0, y: 0, width: 100, height: 100, boardImage: 'package://userassets/board.png' }
+    ], 8, { 'asset-map.json': JSON.stringify({ '1234_5678': 'userassets/board.png' }) });
+
+    expect(state.board.image).toBe('/assets/1234_5678');
+  });
+
+  it('skips an asset that is bigger than the limit for .vtt assets', async () => {
+    const state = await importWidgets([
+      { id: 'board', type: 'board', x: 0, y: 0, width: 100, height: 100, boardImage: 'package://userassets/huge.png' }
+    ], 8, { 'userassets/huge.png': Buffer.alloc(10485760) });
+
+    expect(state.board.image).toBe('package://userassets/huge.png');
+    expect(state._meta.info.importerWarnings).toEqual([
+      'Asset userassets/huge.png is bigger than 10 MiB and was not imported.'
+    ]);
   });
 
   it('imports a file whose schema version is missing or unreadable', async () => {

--- a/tests/server/pcio-import.test.js
+++ b/tests/server/pcio-import.test.js
@@ -1,0 +1,138 @@
+import JSZip from 'jszip';
+
+import convertPCIO from '../../server/pcioimport.mjs';
+
+async function importWidgets(widgets, schemaVersion) {
+  const zip = new JSZip();
+  zip.file('widgets.json', JSON.stringify(widgets));
+  if(schemaVersion !== undefined)
+    zip.file('schemaVersion', String(schemaVersion));
+  return await convertPCIO(await zip.generateAsync({ type: 'nodebuffer' }));
+}
+
+const deck = {
+  id: 'deck', type: 'cardDeck', parent: 'holder', x: 0, y: 0,
+  cardTypes: { a: { label: 'A', image: '/img/cards-french/spades-a.svg' } },
+  faceTemplate: { includeBorder: 'heavy', objects: [ { type: 'image', x: 0, y: 0, w: 103, h: 160, valueType: 'dynamic', value: 'image' } ] }
+};
+
+describe('PCIO importer', () => {
+  it('imports schema 6+ holders which used to be called cardPile', async () => {
+    const state = await importWidgets([
+      { id: 'holder', type: 'holder', x: 10, y: 20, width: 111, height: 168, label: 'Draw', hasShuffleButton: true },
+      deck,
+      { id: 'card', type: 'card', deck: 'deck', cardType: 'a', parent: 'holder', x: 10, y: 20 }
+    ], 8);
+
+    expect(state.holder.type).toBe('holder');
+    expect(state.holder.css).toBeUndefined();
+    expect(state.holder_label.text).toBe('Draw');
+    expect(state.holder_shuffleButton.type).toBe('button');
+    expect(state.card.parent).toBe('holder');
+    expect(state._meta.info.importerSchemaVersion).toBe(8);
+    expect(state._meta.info.importerWarnings).toBeUndefined();
+  });
+
+  it('still imports the old cardPile type', async () => {
+    const state = await importWidgets([
+      { id: 'holder', type: 'cardPile', x: 10, y: 20, layoutType: 'spread', spreadDirection: 'down' }
+    ]);
+    expect(state.holder.type).toBe('holder');
+    expect(state.holder.stackOffsetY).toBe(168);
+    expect(state._meta.info.importerSchemaVersion).toBe(0);
+  });
+
+  it('reads automation steps wrapped in branches and translates their arguments', async () => {
+    const state = await importWidgets([
+      { id: 'source', type: 'holder', x: 0, y: 0 },
+      { id: 'target', type: 'holder', x: 200, y: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Deal', x: 0, y: 300,
+        clickRoutine: { steps: [
+          { id: 'step1', branches: [ { func: 'MOVE_CARDS_BETWEEN_HOLDERS', args: {
+            from:     { type: 'literal', value: [ 'source' ] },
+            to:       { type: 'literal', value: [ 'target' ] },
+            quantity: { type: 'literal', value: 3 },
+            moveFlip: { type: 'literal', value: 'faceUp' }
+          } } ] },
+          { id: 'step2', branches: [ { func: 'SORT_CARDS', args: {
+            holders:       { type: 'literal', value: [ 'target' ] },
+            sortDirection: { type: 'literal', value: 'za' }
+          } } ] }
+        ] }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine).toEqual([
+      { func: 'MOVE', from: 'source', to: 'target', count: 3, face: 1 },
+      { func: 'SORT', holder: 'target', key: 'sortingOrder' }
+    ]);
+  });
+
+  it('translates counter and chooser changes including cycling backwards', async () => {
+    const state = await importWidgets([
+      { id: 'counter', type: 'counter', x: 0, y: 0, counterValue: 0 },
+      { id: 'chooserDeck', type: 'cardDeck', x: 0, y: 0, collectionType: 'choosers',
+        cardTypes: { one: { label: '1' }, two: { label: '2' } },
+        faceTemplate: { objects: [ { type: 'image', x: 0, y: 0, w: 80, h: 40, valueType: 'dynamic', value: 'image' } ] } },
+      { id: 'chooser', type: 'chooser', deck: 'chooserDeck', x: 0, y: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Score', x: 0, y: 300,
+        clickRoutine: { steps: [
+          { id: 'a', branches: [ { func: 'CHANGE_COUNTER', args: {
+            counters:          { type: 'literal', value: [ 'counter' ] },
+            counterChangeMode: { type: 'literal', value: 'inc' },
+            changeNumber:      { type: 'literal', value: 2 }
+          } } ] },
+          { id: 'b', branches: [ { func: 'CHANGE_CHOOSER', args: {
+            choosers:          { type: 'literal', value: [ 'chooser' ] },
+            chooserChangeType: { type: 'literal', value: 'prev' }
+          } } ] }
+        ] }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine).toEqual([
+      { func: 'LABEL', label: 'counter', mode: 'inc', value: 2 },
+      { func: 'FLIP', collection: [ 'chooser' ], faceCycle: 'backward' }
+    ]);
+  });
+
+  it('imports the faces of a deck backed die', async () => {
+    const state = await importWidgets([
+      { id: 'diceDeck', type: 'cardDeck', x: 0, y: 0, collectionType: 'dice', cardWidth: 60, cardHeight: 60,
+        cardTypes: { one: { label: '1', image: '/img/dice-d4/1.svg' }, two: { label: '2', image: '/img/dice-d4/2.svg' } },
+        faceTemplate: { objects: [ { type: 'image', x: 0, y: 0, w: 60, h: 60, valueType: 'dynamic', value: 'image' } ] } },
+      { id: 'die', type: 'dice', deck: 'diceDeck', x: 0, y: 0, diceValue: 'two' }
+    ], 8);
+
+    expect(state.die).toMatchObject({
+      type: 'dice',
+      width: 60,
+      height: 60,
+      activeFace: 1,
+      faces: [
+        { image: 'https://playingcards.io/img/dice-d4/1.svg' },
+        { image: 'https://playingcards.io/img/dice-d4/2.svg' }
+      ]
+    });
+  });
+
+  it('reports what it could not translate', async () => {
+    const state = await importWidgets([
+      { id: 'unknown', type: 'somethingNew', x: 0, y: 0 },
+      { id: 'noType', x: 0, y: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Shift', x: 0, y: 0,
+        clickRoutine: { steps: [ { id: 'a', branches: [ { func: 'FUTURE_STEP', args: {} } ] } ] }
+      }
+    ], 8);
+
+    expect(state._meta.info.importerWarnings).toEqual([
+      'Widgets of type somethingNew cannot be imported.',
+      'Ignored a widget without a type (noType).',
+      'The automation step FUTURE_STEP of "Shift" has no VirtualTabletop equivalent and was skipped.'
+    ]);
+    expect(state.button.clickRoutine).toEqual([]);
+  });
+});

--- a/tests/server/pcio-import.test.js
+++ b/tests/server/pcio-import.test.js
@@ -42,6 +42,14 @@ describe('PCIO importer', () => {
     expect(state._meta.info.importerSchemaVersion).toBe(0);
   });
 
+  it('keeps the position of a counter that sits at the very top of the table', async () => {
+    const state = await importWidgets([
+      { id: 'counter', type: 'counter', x: 0, y: 0, counterValue: 3 }
+    ], 8);
+    expect(state.counter.y).toBe(5);
+    expect(state.counter.x).toBeUndefined();
+  });
+
   it('reads automation steps wrapped in branches and translates their arguments', async () => {
     const state = await importWidgets([
       { id: 'source', type: 'holder', x: 0, y: 0 },
@@ -345,6 +353,91 @@ describe('PCIO importer', () => {
       'var pcioroll = 0',
       { func: 'IF', condition: '${pcioask}', thenRoutine: [ 'var pcioroll = randRange 1 7 1' ] },
       { func: 'LABEL', label: 'counter', value: '${pcioroll}' }
+    ]);
+  });
+
+  it('adds up the counters of a number list when that step runs, not where the sum is used', async () => {
+    const state = await importWidgets([
+      { id: 'a', type: 'counter', x: 0, y: 0, counterValue: 1 },
+      { id: 'b', type: 'counter', x: 100, y: 0, counterValue: 2 },
+      { id: 'total', type: 'counter', x: 200, y: 0, counterValue: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Total', x: 0, y: 300,
+        clickRoutine: { steps: [
+          { id: 'list', branches: [ { func: 'NUMBERS_FROM_COUNTERS', args: {
+            counters: { type: 'literal', value: [ 'a', 'b' ] }
+          } } ] },
+          // PCIO sums the values the list step saw, so this must not change the result
+          { id: 'bump', branches: [ { func: 'CHANGE_COUNTER', args: {
+            counters:          { type: 'literal', value: [ 'a' ] },
+            counterChangeMode: { type: 'literal', value: 'inc' },
+            changeNumber:      { type: 'literal', value: 10 }
+          } } ] },
+          { id: 'sum', branches: [ { func: 'SUM_LIST', args: {
+            list: { type: 'variable', callId: 'list' }
+          } } ] },
+          { id: 'set', branches: [ { func: 'CHANGE_COUNTER', args: {
+            counters:          { type: 'literal', value: [ 'total' ] },
+            counterChangeMode: { type: 'literal', value: 'set' },
+            changeNumber:      { type: 'variable', callId: 'sum' }
+          } } ] }
+        ] }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine).toEqual([
+      'var pciolist = parseFloat ${PROPERTY text OF a}',
+      'var pciolist = ${pciolist} + ${PROPERTY text OF b}',
+      { func: 'LABEL', label: 'a', mode: 'inc', value: 10 },
+      'var pciosum = ${pciolist}',
+      { func: 'LABEL', label: 'total', value: '${pciosum}' }
+    ]);
+  });
+
+  it('picks the counters of the number list alternative that actually runs', async () => {
+    const state = await importWidgets([
+      { id: 'a', type: 'counter', x: 0, y: 0, counterValue: 1 },
+      { id: 'b', type: 'counter', x: 100, y: 0, counterValue: 2 },
+      { id: 'total', type: 'counter', x: 200, y: 0, counterValue: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Total', x: 0, y: 300,
+        clickRoutine: { steps: [
+          { id: 'first', branches: [ { func: 'IS_EQUAL', args: {
+            numberA: { type: 'query', counters: [ 'a' ] },
+            numberB: { type: 'literal', value: 1 }
+          } } ] },
+          { id: 'list', branches: [
+            { func: 'NUMBERS_FROM_COUNTERS', condition: { type: 'variable', callId: 'first' }, args: {
+              counters: { type: 'literal', value: [ 'a' ] }
+            } },
+            { func: 'NUMBERS_FROM_COUNTERS', args: {
+              counters: { type: 'literal', value: [ 'b' ] }
+            } }
+          ] },
+          { id: 'sum', branches: [ { func: 'SUM_LIST', args: {
+            list: { type: 'variable', callId: 'list' }
+          } } ] },
+          { id: 'set', branches: [ { func: 'CHANGE_COUNTER', args: {
+            counters:          { type: 'literal', value: [ 'total' ] },
+            counterChangeMode: { type: 'literal', value: 'set' },
+            changeNumber:      { type: 'variable', callId: 'sum' }
+          } } ] }
+        ] }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine).toEqual([
+      'var pcioNumber1 = parseFloat ${PROPERTY text OF a}',
+      'var pciofirst = ${pcioNumber1} == 1',
+      'var pciolist = 0',
+      {
+        func: 'IF',
+        condition: '${pciofirst}',
+        thenRoutine: [ 'var pciolist = parseFloat ${PROPERTY text OF a}' ],
+        elseRoutine: [ 'var pciolist = parseFloat ${PROPERTY text OF b}' ]
+      },
+      'var pciosum = ${pciolist}',
+      { func: 'LABEL', label: 'total', value: '${pciosum}' }
     ]);
   });
 

--- a/tests/server/pcio-import.test.js
+++ b/tests/server/pcio-import.test.js
@@ -192,6 +192,7 @@ describe('PCIO importer', () => {
     expect(state.counter.text).toBe(5);
     expect(state.counter_incrementButton.clickRoutine).toEqual([
       'var pcioCounter = parseFloat ${PROPERTY text OF counter}',
+      'var pcioCounter = ${pcioCounter} || 0',
       'var pcioCounter = ${pcioCounter} + 2',
       'var pcioCounter = max ${pcioCounter} 0',
       'var pcioCounter = min ${pcioCounter} 5',
@@ -199,6 +200,7 @@ describe('PCIO importer', () => {
     ]);
     expect(state.button.clickRoutine).toEqual([
       'var pcioCounter = parseFloat ${PROPERTY text OF counter}',
+      'var pcioCounter = ${pcioCounter} || 0',
       'var pcioCounter = ${pcioCounter} + 4',
       'var pcioCounter = max ${pcioCounter} 0',
       'var pcioCounter = min ${pcioCounter} 5',
@@ -214,6 +216,7 @@ describe('PCIO importer', () => {
     expect(state.counter.text).toBe(3);
     expect(state.counter_incrementButton.clickRoutine).toEqual([
       'var pcioCounter = parseFloat ${PROPERTY text OF counter}',
+      'var pcioCounter = ${pcioCounter} || 0',
       'var pcioCounter = ${pcioCounter} + 1',
       'var pcioCounter = min ${pcioCounter} 10',
       { func: 'LABEL', label: 'counter', value: '${pcioCounter}' }
@@ -670,5 +673,213 @@ describe('PCIO importer', () => {
 
     expect(state.die.faces).toEqual([ { value: 'Yes' }, { value: 'No' }, { value: 'Maybe' } ]);
     expect(state.die.css).toBe('--fontSize: 17px');
+  });
+
+  it('deals all objects one at a time, once per object that is there', async () => {
+    const state = await importWidgets([
+      { id: 'source', type: 'holder', x: 0, y: 0 },
+      { id: 'target', type: 'holder', x: 200, y: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Recall', x: 0, y: 300,
+        clickRoutine: { steps: [ { id: 'a', branches: [ { func: 'MOVE_CARDS_BETWEEN_HOLDERS', args: {
+          from:     { type: 'literal', value: [ 'source' ] },
+          to:       { type: 'literal', value: [ 'target' ] },
+          quantity: { type: 'literal', value: 'all' }
+        } } ] } ] }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine).toEqual([
+      { func: 'SELECT', type: 'card', property: 'parent', relation: 'in', value: [ 'source' ], collection: 'pcioDeal1' },
+      { note: 'Deal one at a time', func: 'FOREACH', collection: 'pcioDeal1', loopRoutine: [
+        { func: 'MOVE', from: 'source', to: 'target', count: 1 }
+      ] }
+    ]);
+    expect(state._meta.info.importerWarnings).toBeUndefined();
+  });
+
+  it('moves all objects in one go when PCIO does not deal them one by one', async () => {
+    const state = await importWidgets([
+      { id: 'source', type: 'holder', x: 0, y: 0 },
+      { id: 'target', type: 'holder', x: 200, y: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Dump', x: 0, y: 300,
+        clickRoutine: { steps: [ { id: 'a', branches: [ { func: 'MOVE_CARDS_BETWEEN_HOLDERS', args: {
+          from:       { type: 'literal', value: [ 'source' ] },
+          to:         { type: 'literal', value: [ 'target' ] },
+          quantity:   { type: 'literal', value: 'all' },
+          moveMethod: { type: 'literal', value: 'all' }
+        } } ] } ] }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine).toEqual([ { func: 'MOVE', from: 'source', to: 'target', count: 'all' } ]);
+  });
+
+  it('puts objects under the ones a pile already holds, starting at the given destination', async () => {
+    const state = await importWidgets([
+      { id: 'source', type: 'holder', x: 0, y: 0 },
+      { id: 'left',   type: 'holder', x: 200, y: 0 },
+      { id: 'right',  type: 'holder', x: 400, y: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Under', x: 0, y: 300,
+        clickRoutine: { steps: [ { id: 'a', branches: [ { func: 'MOVE_CARDS_BETWEEN_HOLDERS', args: {
+          from:           { type: 'literal', value: [ 'source' ] },
+          to:             { type: 'literal', value: [ 'left', 'right' ] },
+          quantity:       { type: 'literal', value: 1 },
+          startingOffset: { type: 'literal', value: 1 },
+          toPosition:     { type: 'literal', value: 'bottom' }
+        } } ] } ] }
+      }
+    ], 8);
+
+    // a bottom move only works on a single pile, so the two destinations keep it
+    // at the top and are dealt starting at the second one
+    expect(state.button.clickRoutine).toEqual([ { func: 'MOVE', from: 'source', to: [ 'right', 'left' ] } ]);
+    expect(state._meta.info.importerWarnings).toEqual([
+      'Moving objects to "bottom" is not supported - the objects "Under" moves end up on top of the destination.'
+    ]);
+  });
+
+  it('recovers a bounded counter that a player cleared and keeps fractional steps clean', async () => {
+    const state = await importWidgets([
+      { id: 'counter', type: 'counter', x: 0, y: 0, counterValue: 0, counterMin: 0, counterMax: 1, counterStep: 0.1 }
+    ], 8);
+
+    expect(state.counter_incrementButton.clickRoutine).toEqual([
+      'var pcioCounter = parseFloat ${PROPERTY text OF counter}',
+      'var pcioCounter = ${pcioCounter} || 0',
+      'var pcioCounter = ${pcioCounter} + 0.1',
+      'var pcioCounter = max ${pcioCounter} 0',
+      'var pcioCounter = min ${pcioCounter} 1',
+      'var pcioCounter = ${pcioCounter} toFixed 1',
+      { func: 'LABEL', label: 'counter', value: '${pcioCounter}' }
+    ]);
+  });
+
+  it('gives a step its read default when the read function is not its first alternative', async () => {
+    const state = await importWidgets([
+      { id: 'holder', type: 'holder', x: 0, y: 0 },
+      { id: 'counter', type: 'counter', x: 100, y: 0, counterValue: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Mixed', x: 0, y: 300,
+        clickRoutine: { steps: [
+          { id: 'ask', branches: [ { func: 'IS_EQUAL', args: {
+            numberA: { type: 'literal', value: 1 },
+            numberB: { type: 'literal', value: 1 }
+          } } ] },
+          { id: 'mix', branches: [
+            { func: 'SHUFFLE_CARDS', condition: { type: 'variable', callId: 'ask' }, args: {
+              holders: { type: 'literal', value: [ 'holder' ] }
+            } },
+            { func: 'MATH', args: {
+              mathOperator: { type: 'literal', value: 'add' },
+              numberA:      { type: 'literal', value: 2 },
+              numberB:      { type: 'literal', value: 3 }
+            } }
+          ] },
+          { id: 'set', branches: [ { func: 'CHANGE_COUNTER', args: {
+            counters:          { type: 'literal', value: [ 'counter' ] },
+            counterChangeMode: { type: 'literal', value: 'set' },
+            changeNumber:      { type: 'variable', callId: 'mix' }
+          } } ] }
+        ] }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine).toEqual([
+      'var pcioask = 1 == 1',
+      'var pciomix = 0',
+      {
+        func: 'IF',
+        condition: '${pcioask}',
+        thenRoutine: [ { func: 'SHUFFLE', holder: 'holder' } ],
+        elseRoutine: [ 'var pciomix = 2 + 3' ]
+      },
+      { func: 'LABEL', label: 'counter', value: '${pciomix}' }
+    ]);
+  });
+
+  it('reads a counter wherever a number is expected and reports one it cannot', async () => {
+    const state = await importWidgets([
+      { id: 'a', type: 'counter', x: 0, y: 0, counterValue: 2 },
+      { id: 'total', type: 'counter', x: 100, y: 0, counterValue: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Double', x: 0, y: 300,
+        clickRoutine: { steps: [
+          { id: 'calc', branches: [ { func: 'MATH', args: {
+            mathOperator: { type: 'literal', value: 'multiply' },
+            numberA:      { counterId: 'a' },
+            numberB:      { type: 'somethingNew' }
+          } } ] },
+          { id: 'set', branches: [ { func: 'CHANGE_COUNTER', args: {
+            counters:          { type: 'literal', value: [ 'total' ] },
+            counterChangeMode: { type: 'literal', value: 'set' },
+            changeNumber:      { type: 'variable', callId: 'calc' }
+          } } ] }
+        ] }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine).toEqual([
+      'var pciocalc = ${PROPERTY text OF a} * 1',
+      { func: 'LABEL', label: 'total', value: '${pciocalc}' }
+    ]);
+    expect(state._meta.info.importerWarnings).toEqual([
+      'A number an automation step of "Double" calculates with could not be imported - it uses 1 instead.'
+    ]);
+  });
+
+  it('reports an automation that works on a widget which is not in the file', async () => {
+    const state = await importWidgets([
+      { id: 'holder', type: 'holder', x: 0, y: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Shuffle', x: 0, y: 300,
+        clickRoutine: { steps: [
+          { id: 'a', branches: [ { func: 'SHUFFLE_CARDS', args: {
+            holders: { type: 'literal', value: [ 'holder', 'deletedHolder' ] }
+          } } ] },
+          { id: 'b', branches: [ { func: 'RECALL_CARDS', args: {
+            decks: { type: 'literal', value: [ 'deletedDeck' ] }
+          } } ] }
+        ] }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine).toEqual([ { func: 'SHUFFLE', holder: 'holder' } ]);
+    expect(state._meta.info.importerWarnings).toEqual([
+      'An automation step of "Shuffle" works on a widget that is not part of the file - that widget was left out.'
+    ]);
+  });
+
+  it('does not report the images of a die that VirtualTabletop draws itself', async () => {
+    const pips = Object.fromEntries([ 1, 2, 3, 4, 5, 6 ].map(i=>[ String(i), { image: `/img/dice-basic/${i}.svg` } ]));
+    const state = await importWidgets([
+      { id: 'dd', type: 'cardDeck', x: 0, y: 0, collectionType: 'dice', cardWidth: 50, cardHeight: 50,
+        cardTypes: pips, faceTemplate: { objects: [] } },
+      { id: 'die', type: 'dice', deck: 'dd', x: 0, y: 0 }
+    ], 8);
+
+    expect(state.die.faces).toBeUndefined();
+    expect(state._meta.info.importerWarnings).toBeUndefined();
+  });
+
+  it('caps the report instead of storing a note per widget', async () => {
+    const broken = [];
+    for(let i=0; i<150; ++i)
+      broken.push({ id: `v${i}`, type: 'videoPlayer', x: i, y: 0, width: 10, height: 10 });
+    const state = await importWidgets(broken, 8);
+
+    expect(state._meta.info.importerWarnings.length).toBe(101);
+    expect(state._meta.info.importerWarnings[100]).toBe('50 more notes are not listed here.');
+  });
+
+  it('imports a file whose schema version is missing or unreadable', async () => {
+    for(const version of [ undefined, '', 'seven' ]) {
+      const state = await importWidgets([ { id: 'holder', type: 'holder', x: 0, y: 0 } ], version);
+      expect(state.holder.type).toBe('holder');
+      expect(state._meta.info.importerSchemaVersion).toBe(0);
+      expect(state._meta.info.importerWarnings).toBeUndefined();
+    }
   });
 });

--- a/tests/server/pcio-import.test.js
+++ b/tests/server/pcio-import.test.js
@@ -8,7 +8,7 @@ async function importWidgets(widgets, schemaVersion, files={}) {
   if(schemaVersion !== undefined)
     zip.file('schemaVersion', String(schemaVersion));
   for(const [ name, content ] of Object.entries(files))
-    zip.file(name, content);
+    content === null ? zip.folder(name) : zip.file(name, content);
   return await convertPCIO(await zip.generateAsync({ type: 'nodebuffer' }));
 }
 
@@ -882,6 +882,16 @@ describe('PCIO importer', () => {
     ], 8, { 'asset-map.json': JSON.stringify({ '1234_5678': 'userassets/board.png' }) });
 
     expect(state.board.image).toBe('/assets/1234_5678');
+  });
+
+  it('ignores the folder entry that a .pcio carries for its assets', async () => {
+    const state = await importWidgets([
+      { id: 'board', type: 'board', x: 0, y: 0, width: 100, height: 100, boardImage: 'package://userassets/' }
+    ], 8, { 'userassets': null });
+
+    // it has no content, so it used to become an empty "undefined_undefined" asset
+    expect(state.board.image).toBe('package://userassets/');
+    expect(state._meta.info.importerWarnings).toBeUndefined();
   });
 
   it('skips an asset that is bigger than the limit for .vtt assets', async () => {

--- a/tests/server/pcio-import.test.js
+++ b/tests/server/pcio-import.test.js
@@ -64,8 +64,130 @@ describe('PCIO importer', () => {
     ], 8);
 
     expect(state.button.clickRoutine).toEqual([
-      { func: 'MOVE', from: 'source', to: 'target', count: 3, face: 1 },
+      // PCIO deals one card after the other unless it is told to move the pile
+      { note: 'Deal one at a time', func: 'FOREACH', range: [ 1, 3 ], loopRoutine: [
+        { func: 'MOVE', from: 'source', to: 'target', count: 1, face: 1 }
+      ] },
       { func: 'SORT', holder: 'target', key: 'sortingOrder' }
+    ]);
+  });
+
+  it('runs the alternatives of a step as an IF chain over the results of its read steps', async () => {
+    const state = await importWidgets([
+      { id: 'counter', type: 'counter', x: 0, y: 0, counterValue: 1 },
+      {
+        id: 'button', type: 'automationButton', label: 'Coin', x: 0, y: 300,
+        clickRoutine: { steps: [
+          { id: 'roll', branches: [ { func: 'RANDOM_NUMBER', args: {
+            minimum: { type: 'literal', value: 1 },
+            maximum: { type: 'literal', value: 6 },
+            step:    { type: 'literal', value: 1 }
+          } } ] },
+          { id: 'high', branches: [ { func: 'COMPARE_NUMBERS', args: {
+            numberA:            { type: 'variable', callId: 'roll' },
+            comparisonOperator: { type: 'literal', value: 'gt' },
+            numberB:            { type: 'query', counters: [ 'counter' ] }
+          } } ] },
+          { id: 'change', branches: [
+            { func: 'CHANGE_COUNTER', condition: { type: 'variable', callId: 'high' }, args: {
+              counters:          { type: 'literal', value: [ 'counter' ] },
+              counterChangeMode: { type: 'literal', value: 'set' },
+              changeNumber:      { type: 'variable', callId: 'roll' }
+            } },
+            { func: 'CHANGE_COUNTER', args: {
+              counters:          { type: 'literal', value: [ 'counter' ] },
+              counterChangeMode: { type: 'literal', value: 'inc' },
+              changeNumber:      { type: 'literal', value: 1 }
+            } }
+          ] }
+        ] }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine).toEqual([
+      'var pcioroll = randRange 1 7 1',
+      'var pcioNumber1 = parseFloat ${PROPERTY text OF counter}',
+      'var pciohigh = ${pcioroll} > ${pcioNumber1}',
+      {
+        func: 'IF',
+        condition: '${pciohigh}',
+        thenRoutine: [ { func: 'LABEL', label: 'counter', value: '${pcioroll}' } ],
+        elseRoutine: [ { func: 'LABEL', label: 'counter', mode: 'inc', value: 1 } ]
+      }
+    ]);
+  });
+
+  it('keeps a counter within its bounds wherever it is changed', async () => {
+    const state = await importWidgets([
+      { id: 'counter', type: 'counter', x: 0, y: 0, counterValue: 9, counterMin: 0, counterMax: 5, counterStep: 2 },
+      {
+        id: 'button', type: 'automationButton', label: 'Add', x: 0, y: 300,
+        clickRoutine: { steps: [ { id: 'a', branches: [ { func: 'CHANGE_COUNTER', args: {
+          counters:          { type: 'literal', value: [ 'counter' ] },
+          counterChangeMode: { type: 'literal', value: 'inc' },
+          changeNumber:      { type: 'literal', value: 4 }
+        } } ] } ] }
+      }
+    ], 8);
+
+    expect(state.counter.text).toBe(5);
+    expect(state.counter_incrementButton.clickRoutine).toEqual([
+      'var pcioCounter = parseFloat ${PROPERTY text OF counter}',
+      'var pcioCounter = ${pcioCounter} + 2',
+      'var pcioCounter = max ${pcioCounter} 0',
+      'var pcioCounter = min ${pcioCounter} 5',
+      { func: 'LABEL', label: 'counter', value: '${pcioCounter}' }
+    ]);
+    expect(state.button.clickRoutine).toEqual([
+      'var pcioCounter = parseFloat ${PROPERTY text OF counter}',
+      'var pcioCounter = ${pcioCounter} + 4',
+      'var pcioCounter = max ${pcioCounter} 0',
+      'var pcioCounter = min ${pcioCounter} 5',
+      { func: 'LABEL', label: 'counter', value: '${pcioCounter}' }
+    ]);
+  });
+
+  it('turns a whole pile over: every card to the same side and the order reversed', async () => {
+    const state = await importWidgets([
+      { id: 'holder', type: 'holder', x: 0, y: 0 },
+      {
+        id: 'button', type: 'automationButton', label: 'Flip', x: 0, y: 300,
+        clickRoutine: { steps: [ { id: 'a', branches: [ { func: 'FLIP_CARDS', args: {
+          objects:  { type: 'query', queryWidgetTypes: [ 'card', 'piece' ], holders: [ 'holder' ] },
+          flipMode: { type: 'literal', value: 'pile' },
+          flipFace: { type: 'literal', value: 'switch' },
+          reverse:  { type: 'literal', value: 'reverse' }
+        } } ] } ] }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine).toEqual([
+      { func: 'SELECT', property: 'parent', relation: 'in', value: [ 'holder' ], type: 'card', collection: 'pcioPile', sortBy: 'z' },
+      { func: 'GET', collection: 'pcioPile', property: 'activeFace', aggregation: 'last', variable: 'pcioFace' },
+      'var pcioFace = 1 - ${pcioFace}',
+      { func: 'FLIP', collection: 'pcioPile', face: '${pcioFace}' },
+      { note: 'Reverse the pile', func: 'SHUFFLE', collection: 'pcioPile', mode: 'reverse' }
+    ]);
+  });
+
+  it('passes the hands of the players on when objects are shifted between seats', async () => {
+    const state = await importWidgets([
+      { id: 'seat1', type: 'seat', seatIndex: 0, x: 0, y: 0 },
+      { id: 'seat2', type: 'seat', seatIndex: 1, x: 100, y: 0 },
+      { id: 'hand', type: 'hand', x: 0, y: 400 },
+      {
+        id: 'button', type: 'automationButton', label: 'Pass', x: 0, y: 300,
+        clickRoutine: { steps: [ { id: 'a', branches: [ { func: 'SHIFT_OBJECTS', args: {
+          holders:   { type: 'literal', value: [ 'seat1', 'seat2' ] },
+          moveMode:  { type: 'literal', value: 'wrap' },
+          stepsWrap: { type: 'literal', value: 1 }
+        } } ] } ] }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine).toEqual([
+      { func: 'SELECT', property: 'id', relation: 'in', value: [ 'seat1', 'seat2' ], type: 'seat', collection: 'pcioSeats' },
+      { note: 'Pass the hands on', func: 'SWAPHANDS', source: 'pcioSeats', interval: 1, direction: 'forward', keepOrder: true }
     ]);
   });
 

--- a/validator/validate_gamefile.js
+++ b/validator/validate_gamefile.js
@@ -1129,7 +1129,8 @@ function validateGameFile(data, checkMeta) {
                 'name', 'image', 'rules', 'bgg', 'year', 'mode', 'time', 'attribution', 
                 'lastUpdate', 'language', 'showName', 'skill', 'description', 'similarImage', 
                 'similarName', 'similarDesigner', 'similarAwards', 'ruleText', 'helpText', 
-                'players', 'variant', 'variantImage', 'importer', 'importerTime', 'usesAIImagery'
+                'players', 'variant', 'variantImage', 'importer', 'importerTime', 'usesAIImagery',
+                'importerTemp', 'importerWarnings', 'importerSchemaVersion'
             ];
             for (const prop of Object.keys(data._meta.info)) {
                 if (!infoProps.includes(prop)) {


### PR DESCRIPTION
## Why

Every room exported from today's playingcards.io imported broken. PCIO renamed `cardPile` to `holder` in schema version 6 and wrapped every automation step into `{ id, branches: [ { func, args } ] }`; the importer knew neither. The result: **every card zone became a red striped placeholder** (no drop target, no layout, no label, no shuffle button, and every card that referenced it as `parent` orphaned), and **every button imported looking fine and did nothing**, because PCIO's raw step JSON was pushed into the VTT `clickRoutine` unchanged. All of that failed silently.

| before | after |
| --- | --- |
| ![before](https://agent.virtualtabletop.io/reports/pr/1532143734744027338/pcio-chess-before.png) | ![after](https://agent.virtualtabletop.io/reports/pr/1532143734744027338/pcio-chess-after.png) |

PCIO's Chess, imported from a current export ([the PCIO room it came from](https://agent.virtualtabletop.io/reports/pr/1532143734744027338/pcio-chess-original.png)).

## What changed (`server/pcioimport.mjs`)

**Format awareness**
- read the `schemaVersion` zip member (recorded as `_meta.info.importerSchemaVersion`), treat `holder` as the `cardPile` it is, skip records without a `type` instead of turning them into placeholders
- flatten `branches`, and accept both old and new argument names (`sources`/`holders`, `direction`/`sortDirection`, `changeMode`/`counterChangeMode`, `changeType`/`chooserChangeType`/`diceChangeType`)

**Automation steps that had no translation before**
- **Shift Objects** — a chain of `MOVE`s along the ordered holders, with a hidden temp holder for the wrap-around; direction, "towards edge" and the step count are honoured
- **Rotate Objects** — `ROTATE` (cw/ccw/set angle, and "randomize" via `var … = randRange 0 360 45`); Move Objects now applies its rotation-on-arrival too
- **Roll / Change Dice** — roll → `CLICK`; cycle prev/next and "change to face" → `SET activeFace` (VTT dice have no `flip()`, and out-of-range faces wrap, so ±1 cycles)
- **Finish Turn**, **Stand Up Players**, **Reverse Turn Direction** — the last one plus `turnCCW`/`playersCanReverse` needed the room's turn direction to live somewhere, so a hidden `pcioTurnDirection` label holds it, `TURN` reads it as `turnCycle` and the reverse step flips it. `currentTurn` sets `turn` on the seat.

**Fidelity**
- deck-backed **dice** import their faces (art or labels), current value and size; the six standard pip dice become native VTT pips
- PCIO's **styling system** — `mainBackground` (solid plus linear/radial/conic gradients), `mainOutlines`, `mainTextStyle`, `mainBorderRadius`, separator `mainThickness` — becomes widget CSS/`borderRadius` on holders, hands, counters, labels and buttons; its nine fonts map to the closest font VTT ships (also for `textFont` on card-face text)
- carry `allowPlayerMove`/`allowPlayerClick` (dropping them was a rules change), `counterStep`, hand `allowedDecks`, running timers, `includeBorder: light/heavy` weights; map the Spanish and German decks to VTT's built-in art; raise the asset limit from 2 MiB to 10 MiB (what FileLoader allows for `.vtt` assets)
- **webpage buttons** (`urlButton`) import as real links instead of as placeholders: a basic widget whose `html` holds an `<a>` filling the button, which the room page opens in a new tab (`<base target="_blank">`). An address VirtualTabletop would not follow still shows in a popup
- queries: collection-only queries and explicit object lists now produce a working `SELECT`; counter-driven quantities read the counter

**Two defects**
- `CHANGE_CHOOSER` compared the `{type,value}` wrapper to `'prev'`, so "cycle previous" always imported as "cycle next"
- `CHANGE_COUNTER` passed PCIO's `add`/`subtract` straight through as a VTT `LABEL` mode

**Conditional automation** (added after review)
- a step's `branches` are alternatives of which PCIO runs the first one whose `condition` holds — they import as a chain of `IF` / `elseRoutine`
- the read functions **Math**, **Random Number**, **Compare Numbers**, **Is Equal**, **Numbers from Counters** and **Sum** each store their result in a variable named after their step, which the conditions and arguments of later steps reference by `callId`. (`Find Cards & Pieces` returns an object ID that none of PCIO's own automations can consume, so importing it would have no effect either way.)
- number arguments can now come from a popup question, from an earlier read step, or from a query that adds up counters or one card-type field of the objects it finds (`SELECT` + `GET … aggregation: sum`)

**More of the "missing in VTT" list, as small routines**
- **counter minimum/maximum**: the ± buttons and every automation that changes a bounded counter calculate and clamp (`var … = max …` / `min`), and the imported value is clamped too. `counterShowButtons` and `allowPlayerEditValue` are honoured
- **Move to the bottom of a pile**: the objects already there are parked in a hidden holder and put back on top
- **Move "deal one-by-one"** (PCIO's default, and it decides the resulting order) and **`startingOffset`**: a `FOREACH` that hands out one object per destination per round, starting at the n-th destination
- **Rotate "fit to holder"**: `ROTATE mode: set, angle: 0`
- **Flip "all to the same side"** (PCIO's default): the top object's side read with `GET … aggregation: last` over the pile sorted by `z`; **"randomize"**: `faceCycle: random`, which rolls a side per object; **"reverse pile order"** (also a default): `SHUFFLE mode: reverse`
- **Shift objects across player seats**: `SWAPHANDS` over a collection of exactly those seats, with the step count as its `interval`
- **stacked outlines** become `box-shadow` rings around the border, **outlined text** a `-webkit-text-stroke` painted behind the glyphs

**Four more defects**
- "all objects" imported as `MOVE … count: 0`, which moves *nothing* — so "move/shift all" and "recall a parentless deck" silently did nothing
- a query restricted to neither a holder nor a deck selected everything; PCIO finds nothing
- a holder without an explicit width produced `NaN` drop offsets, a face template kept an empty `textFont`, and a pile of parentless cards kept `parent: null` — the three reasons imported games showed validator errors in edit mode

**No more silence** — everything untranslatable lands in `_meta.info.importerWarnings`, in the server log and, since 11616b5b, in the interface: the game details overlay lists the notes under an **"Import notes (n)"** heading and games that carry them get an `info` badge on their library tile. Reported are unknown widget types (whose striped placeholder keeps the size of what it replaced), skipped automation steps, oversized assets, grid/multi-group layouts, `flipTableForSeated`, `snapAngles`, clamped and typed-in counter values, substituted fonts and a file format newer than the importer. The texts use PlayingCards.io's own names for widgets and automation steps, name the widgets they are about, and collect one problem on several widgets into a single line.

## Verification

- 24 rooms exported live from playingcards.io with Playwright (Checkers, Chess, Go, Reversi, Backgammon, Hockey, Dominoes, Mahjong, Mexican Train, Cribbage, Crazy Eights, Go Fish, Hearts, Match Up, Flash Cards, Fridge Word Magnets, 52-card sandbox, Hand and Foot, Push, Carousel, Zap!, Zioncheck and two "kitchen sink" rooms built by adding one of every widget type in PCIO's edit mode) plus 40 `.pcio` files from public repos (schema 0–3, so the old format is covered): every one imported, pushed into a local room and screenshotted against the PCIO original — no crash, no client-side JS error, no placeholder left, and every state still survives `FileUpdater` to version 21.
- **A PCIO test room for the conditional automation**, built on top of a real export of PCIO's "Standard 52 Card Deck" room: [pcio-conditional.pcio](https://agent.virtualtabletop.io/reports/pr/1532143734744027338/pcio-conditional.pcio). It was **loaded back into playingcards.io** ("Import from File"), its buttons clicked there and the room exported again — then the same buttons were clicked in the VTT import. The read/branch buttons leave the counters on the same values in both (10 and 101), the bounded counter stops at the same place, the same cards end up *under* the same cards, and the flipped pile comes out the same way round. Passing hands was checked separately with three seated players: after three passes every hand is back at its own seat.
- A synthetic schema-8 room exercising the steps no real room in the corpus used (Shift, Rotate, Change Dice, Stand Up, Finish Turn, Reverse Turn Direction, gradients, counter step, running timer, webpage button): every imported button clicked in a browser, its effect on the room state checked and the console watched for routine problems. The imported result is loadable as [pcio-feature-test.vtt](https://agent.virtualtabletop.io/reports/pr/1532143734744027338/pcio-feature-test.vtt).
- Every one of the 66 corpus files imported and run through `validator/validate_gamefile.js`: **no unknown property and no invalid routine operation** anywhere in the output (that sweep is what turned up the three defects above).
- `npm test`: 132 passing, including the importer tests (`tests/server/pcio-import.test.js`) covering the holder rename, the old `cardPile`, `branches`, the renamed arguments, deck-backed dice, the warning report, the IF chain over read steps, counter bounds, pile flipping, hand shifting, the style scoping of holders and counters, the placeholder for an unimportable widget, the grouped warnings, the webpage-button link and its popup fallback, and the gradient text fill.
- TestCafe `editor.js` (15) and `publiclibrary-1..4` (18) pass locally — the only client change is the import-notes section in the game details overlay and the library-tile badge, which touch no widget or routine code.

No new widget or routine properties, so no JSON-editor entries are needed; the only validator change is that the importer's own `_meta.info` keys (`importerTemp`, `importerWarnings`, `importerSchemaVersion`) are known to it now. No legacy mode or migration: the importer produces state at `_meta.version: 4` exactly as before, and every corpus file was checked through `FileUpdater`.

## What is still out of reach

Written up in detail, with the reasoning per item: **[PCIO importer gap report](https://agent.virtualtabletop.io/reports/pr/1532143734744027338/pcio-import-report.html)**. What is left is the part that needs engine features rather than routine code: `flipTableForSeated` (PCIO rotates the whole table 180° for the seated player), grid holder layout and multi-group spreads (VTT holders spread along one axis, with no wrapping and no second group), `snapAngles` (no hook for a player rotating a card), Move's "group at start/end" (the same multi-group spread), chooser column layout, and PCIO's own art beyond the card decks and piece sets, which stays hot-linked. A gradient text fill is painted onto the glyphs where the text has an element of its own (a label, a counter) and reported where the widget itself shows its text, because clipping the gradient to the glyphs would take the widget background with it. Two things are imported but not exactly: a bounded counter is not clamped while a value is being *typed* into it (a VTT label commits on every keystroke, so clamping would fight the typist), and dealing reproduces PCIO's order but not its visible one-card-at-a-time animation.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3072/pr-test (or any other room on that server)


