### PR TITLE
Deck wizard: any icon as a suit, more card designs, optional holder and reset button

### DIFF
--- a/client/css/editor/deckeditor.css
+++ b/client/css/editor/deckeditor.css
@@ -707,6 +707,32 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   cursor: pointer;
 }
 
+/* Applies to every mode: what gets added around the new deck. */
+.deckEditorNewDeckOptions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0 0 16px 0;
+  padding-top: 12px;
+  border-top: 1px solid #0002;
+}
+
+.deckEditorNewDeckOptionsLabel {
+  font-size: 11px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  opacity: 0.7;
+}
+
+.deckEditorNewDeckOptions label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
 #deckEditorNewDeckPanel:not(:empty) {
   border-top: 1px solid #0002;
   padding-top: 16px;

--- a/client/css/editor/deckeditor.css
+++ b/client/css/editor/deckeditor.css
@@ -464,6 +464,18 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   z-index: 20;
 }
 
+/* Opening the picker from an icon property inside one of the dialogs above parks it next to that dialog
+   (pickSymbolKeepingOverlay), where the rule above no longer applies and it would render behind #deckEditor
+   (z-index 1). Float it over the whole editor instead: above the sidebar (2), the toolbar (3) and the
+   dialog it was opened from (20). */
+#symbolPickerOverlay.symbolPickerAboveEditor {
+  position: fixed;
+  inset: 0;
+  width: auto;
+  height: auto;
+  z-index: 30;
+}
+
 #deckEditorExportOverlay {
   position: fixed;
   top: var(--editToolbarHeight);
@@ -707,14 +719,16 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   cursor: pointer;
 }
 
-/* Applies to every mode: what gets added around the new deck. */
+/* Applies to every mode, so it is set apart from the mode list above and the picked mode's panel below. */
 .deckEditorNewDeckOptions {
   display: flex;
   flex-direction: column;
   gap: 6px;
   margin: 0 0 16px 0;
-  padding-top: 12px;
-  border-top: 1px solid #0002;
+  padding: 10px 12px;
+  border: 1px solid #0002;
+  border-radius: 8px;
+  background: #0000000a;
 }
 
 .deckEditorNewDeckOptionsLabel {
@@ -731,6 +745,24 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   gap: 8px;
   cursor: pointer;
   font-size: 13px;
+}
+
+/* the reset button needs a holder to recall the cards into, so without one its option is off, not just
+   greyed out while still looking ticked */
+.deckEditorNewDeckOptions label:has(input:disabled) {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* what unticking the holder means, shown only once it is unticked */
+.deckEditorNewDeckOptionsHint {
+  display: none;
+  font-size: 12px;
+  opacity: 0.85;
+}
+
+.deckEditorNewDeckOptions:has(#deckEditorNewDeckHolder:not(:checked)) .deckEditorNewDeckOptionsHint {
+  display: block;
 }
 
 #deckEditorNewDeckPanel:not(:empty) {

--- a/client/css/editor/sidebarModules.css
+++ b/client/css/editor/sidebarModules.css
@@ -118,28 +118,60 @@
 }
 
 
+/* The deck creation flows disable their "Add to game" until something is picked. button[icon].green
+   (specificity 0,2,1) beats the generic button:disabled (0,1,1), so without this the greyed-out state never
+   applies and a button that does nothing still looks clickable. */
+.tune.editorModule button[icon].green:disabled,
+.tune.editorModule button[icon].green:disabled:hover {
+  background-color: #808080;
+  color: #d3d3d3;
+}
+
+
 /* custom deck: one compact row per suit (icon, name, color, ranks, remove) */
 
 .tune.editorModule .deckGeneratorHint {
   margin: 0 0 8px 0;
   font-size: 12px;
+  opacity: 0.85;
+}
+
+/* One grid for the whole list, so the header labels and every row share the same columns. The rows and their
+   pickers are display: contents, i.e. their children are the grid items. */
+.tune.editorModule .deckGeneratorSuits {
+  display: grid;
+  grid-template-columns: auto minmax(60px, 1fr) auto minmax(80px, 2fr) auto;
+  align-items: center;
+  gap: 4px 6px;
+}
+
+.tune.editorModule .deckGeneratorSuitHeader,
+.tune.editorModule .deckGeneratorSuit,
+.tune.editorModule .deckGeneratorSuitPickers {
+  display: contents;
+}
+
+.tune.editorModule .deckGeneratorSuitHeader > span {
+  font-size: 11px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
   opacity: 0.7;
 }
 
-.tune.editorModule .deckGeneratorSuit {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 4px;
+/* An open picker sits right below the row it belongs to and spans the full width; a closed one is display:
+   none and takes no grid row at all. */
+.tune.editorModule .deckGeneratorSuitPickers > .propertyPicker {
+  grid-column: 1 / -1;
+  margin-bottom: 0;
 }
 
 .tune.editorModule .deckGeneratorSuit > .propertyInput {
-  flex: 0 0 auto;
   margin: 0;
 }
 
-/* the row's icon in the suit's color (see showIconInSuitColor): the icon masks the color */
-.tune.editorModule .deckGeneratorSuit .deckGeneratorSuitTint {
+/* an icon chip in a suit color (see tintIconChip): the icon masks the color */
+.tune.editorModule .deckGeneratorSuitTint {
   width: 100%;
   height: 100%;
   background: currentColor;
@@ -147,14 +179,24 @@
   mask: var(--mask) center / contain no-repeat;
 }
 
-.tune.editorModule .deckGeneratorSuitName {
-  flex: 1 1 80px;
-  min-width: 60px;
+.tune.editorModule .deckGeneratorSuitName,
+.tune.editorModule .deckGeneratorSuitRanks {
+  width: 100%;
+  min-width: 0;
 }
 
-.tune.editorModule .deckGeneratorSuitRanks {
-  flex: 2 1 130px;
-  min-width: 80px;
+/* the name this suit's card types actually get differs from what is typed (see showResolvedSuitNames) */
+.tune.editorModule .deckGeneratorSuitName.deckGeneratorSuitRenamed {
+  border-color: var(--VTTred, #c0392b);
+}
+
+/* destructive, so red rather than the accent color the rest of the row uses */
+.tune.editorModule .deckGeneratorSuitRemove:not(:disabled) {
+  background: var(--VTTred, #c0392b);
+}
+
+.tune.editorModule .deckGeneratorSuitRemove:hover:not(:disabled) {
+  background: #922b21;
 }
 
 .tune.editorModule .deckGeneratorSuitAdd {
@@ -170,8 +212,10 @@
   opacity: 0.7;
 }
 
+/* these are suit shortcuts, not transparency swatches, so no checkerboard behind them */
 .tune.editorModule .deckGeneratorSuitAdd .propertyValueChip {
   cursor: pointer;
+  background: #fff;
 }
 
 .tune.editorModule .deckGeneratorSuitAdd .propertyValueChip:hover {
@@ -182,7 +226,37 @@
   display: flex;
   align-items: center;
   gap: 6px;
+  margin-top: 8px;
   font-size: 12px;
+}
+
+/* Card design gallery: one tile per design, filling the dialog in as many columns as fit so no design ends up
+   cut off or alone on a row. The name goes below the preview instead of on top of the artwork. */
+.tune.editorModule .deckGeneratorDesigns {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(156px, 1fr));
+  gap: 10px 6px;
+  margin-bottom: 12px;
+}
+
+.tune.editorModule .deckDesignTile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+/* a card design is not a transparency preview, so a flat neutral reads better than the checkerboard */
+.tune.editorModule .deckDesignButton {
+  margin: 0;
+  background: #ededed;
+}
+
+.tune.editorModule .deckDesignLabel {
+  font-size: 12px;
+  font-weight: bold;
+  text-align: center;
+  line-height: 1.2;
 }
 
 
@@ -232,9 +306,8 @@
   min-width: 0;
 }
 
-/* caption bar of a preview tile: the card count of a TTS deck, the name of a card design */
-.tune.editorModule .ttsDeckButton .deckCardCount,
-.tune.editorModule .deckDesignButton .deckDesignLabel {
+/* caption bar of a preview tile: the card count of a TTS deck */
+.tune.editorModule .ttsDeckButton .deckCardCount {
   position: absolute;
   bottom: 0;
   left: 0;

--- a/client/css/editor/sidebarModules.css
+++ b/client/css/editor/sidebarModules.css
@@ -118,21 +118,71 @@
 }
 
 
-.tune.editorModule .suitProperties {
-  height: 160px;
+/* custom deck: one compact row per suit (icon, name, color, ranks, remove) */
+
+.tune.editorModule .deckGeneratorHint {
+  margin: 0 0 8px 0;
+  font-size: 12px;
+  opacity: 0.7;
 }
 
-.tune.editorModule .suitProperties > button.widgetSelectionButton {
-  position: absolute;
+.tune.editorModule .deckGeneratorSuit {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
 }
 
-.tune.editorModule .suitProperties > div {
-  margin-left: 170px;
+.tune.editorModule .deckGeneratorSuit > .propertyInput {
+  flex: 0 0 auto;
+  margin: 0;
 }
 
-.tune.editorModule .suitProperties label {
-  display: inline-block;
-  width: 60px;
+/* the row's icon in the suit's color (see showIconInSuitColor): the icon masks the color */
+.tune.editorModule .deckGeneratorSuit .deckGeneratorSuitTint {
+  width: 100%;
+  height: 100%;
+  background: currentColor;
+  -webkit-mask: var(--mask) center / contain no-repeat;
+  mask: var(--mask) center / contain no-repeat;
+}
+
+.tune.editorModule .deckGeneratorSuitName {
+  flex: 1 1 80px;
+  min-width: 60px;
+}
+
+.tune.editorModule .deckGeneratorSuitRanks {
+  flex: 2 1 130px;
+  min-width: 80px;
+}
+
+.tune.editorModule .deckGeneratorSuitAdd {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  margin: 8px 0;
+}
+
+.tune.editorModule .deckGeneratorSuitAddLabel {
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+.tune.editorModule .deckGeneratorSuitAdd .propertyValueChip {
+  cursor: pointer;
+}
+
+.tune.editorModule .deckGeneratorSuitAdd .propertyValueChip:hover {
+  outline: 2px solid var(--VTTblue);
+}
+
+.tune.editorModule .deckGeneratorLinkedRanks {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
 }
 
 
@@ -182,7 +232,9 @@
   min-width: 0;
 }
 
-.tune.editorModule .ttsDeckButton .deckCardCount {
+/* caption bar of a preview tile: the card count of a TTS deck, the name of a card design */
+.tune.editorModule .ttsDeckButton .deckCardCount,
+.tune.editorModule .deckDesignButton .deckDesignLabel {
   position: absolute;
   bottom: 0;
   left: 0;

--- a/client/editor.html
+++ b/client/editor.html
@@ -239,6 +239,11 @@
         <label><input type="radio" name="deckEditorNewDeckMode" value="images">Upload one image per card or tiled images</label>
         <label><input type="radio" name="deckEditorNewDeckMode" value="tts">Import from Tabletop Simulator</label>
       </div>
+      <div class="deckEditorNewDeckOptions">
+        <span class="deckEditorNewDeckOptionsLabel">Add along with the deck</span>
+        <label title="A holder in the middle of the table that the deck and all its cards are put into."><input type="checkbox" id="deckEditorNewDeckHolder" checked>Holder for the deck, with the cards in it</label>
+        <label title="A button below the holder that recalls all cards into it, flips them to their back and shuffles them."><input type="checkbox" id="deckEditorNewDeckResetButton" checked>Reset button that recalls, flips to back and shuffles</label>
+      </div>
       <div id="deckEditorNewDeckPanel"></div>
     </div>
   </div>

--- a/client/editor.html
+++ b/client/editor.html
@@ -240,9 +240,10 @@
         <label><input type="radio" name="deckEditorNewDeckMode" value="tts">Import from Tabletop Simulator</label>
       </div>
       <div class="deckEditorNewDeckOptions">
-        <span class="deckEditorNewDeckOptionsLabel">Add along with the deck</span>
-        <label title="A holder in the middle of the table that the deck and all its cards are put into."><input type="checkbox" id="deckEditorNewDeckHolder" checked>Holder for the deck, with the cards in it</label>
-        <label title="A button below the holder that recalls all cards into it, flips them to their back and shuffles them."><input type="checkbox" id="deckEditorNewDeckResetButton" checked>Reset button that recalls, flips to back and shuffles</label>
+        <span class="deckEditorNewDeckOptionsLabel">Added to the table with every new deck</span>
+        <label title="A holder in the middle of the table that the deck and all its cards are put into. Without it, the cards go into a pile in the middle of the table instead."><input type="checkbox" id="deckEditorNewDeckHolder" checked>Card holder on the table, holding all the cards</label>
+        <label title="A button below the holder that gathers all cards back into it, turns them face-down and shuffles them."><input type="checkbox" id="deckEditorNewDeckResetButton" checked>Reset button that gathers all cards back, turns them face-down and shuffles</label>
+        <span class="deckEditorNewDeckOptionsHint">Without a holder, the cards go into a pile in the middle of the table.</span>
       </div>
       <div id="deckEditorNewDeckPanel"></div>
     </div>

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -2,23 +2,7 @@
 function generateCardDeckWidgets(id, x, y, addCards) {
   const widgets = [
     { type:'holder', id, x, y, dropTarget: { type: 'card' } },
-    {
-      id: id+'B',
-      parent: id,
-      fixedParent: true,
-      y: 171.36,
-      width: 111,
-      height: 40,
-      type: 'button',
-      text: 'Recall & Shuffle',
-      movableInEdit: false,
-
-      clickRoutine: [
-        { func: 'RECALL',  holder: '${PROPERTY parent}' },
-        { func: 'FLIP',    holder: '${PROPERTY parent}', face: 0 },
-        { func: 'SHUFFLE', holder: '${PROPERTY parent}' }
-      ]
-    }
+    deckResetButton(id, 111, 171.36)
   ];
 
   const types = {};
@@ -1299,6 +1283,7 @@ function populateAddWidgetOverlay() {
 let libraryDecksIndex = null;
 let libraryDecksObserver = null;
 let libraryDeckPreviewCounter = 0;
+let libraryDecksPlacement = null; // set by openLibraryDecksOverlay for the deck a click adds
 const libraryDeckDetailsCache = {};
 
 function getLibraryDeckDetails(entry) {
@@ -1317,7 +1302,10 @@ function getLibraryDeckDetails(entry) {
   return libraryDeckDetailsCache[key];
 }
 
-async function openLibraryDecksOverlay() {
+// placement: what to add around a picked deck, when the browser was opened from the "Add New Deck" dialog (which
+// is hidden while browsing). Opened from anywhere else, a picked deck gets the holder and button it always got.
+async function openLibraryDecksOverlay(placement) {
+  libraryDecksPlacement = placement || deckPlacementDefault;
   showOverlay('libraryDecksOverlay');
   if(libraryDecksIndex == 'loading')
     return;
@@ -1461,6 +1449,7 @@ async function renderLibraryDeckPreview(entry, container) {
 
 // adds the deck like the "add deck" entry of the add widget overlay does:
 // a holder containing the deck, a pile with all its cards and a shuffle button
+// (holder and button are optional when the browser was opened from the "Add New Deck" dialog)
 async function addLibraryDeckToGame(entry) {
   let details;
   try {
@@ -1470,6 +1459,7 @@ async function addLibraryDeckToGame(entry) {
     return;
   }
 
+  const placement = libraryDecksPlacement || deckPlacementDefault;
   batchStart();
   setDeltaCause(`${getPlayerDetails().playerName} added deck ${entry.deck} from public library game ${entry.gameName} in editor`);
 
@@ -1481,47 +1471,40 @@ async function addLibraryDeckToGame(entry) {
 
   const holderWidth  = entry.cardWidth  + 8;
   const holderHeight = entry.cardHeight + 11;
-  await addWidgetLocal({
-    type: 'holder',
-    id,
-    x: Math.round(800 - holderWidth/2),
-    y: Math.round(500 - holderHeight/2),
-    width: holderWidth,
-    height: holderHeight,
-    dropTarget: { type: 'card' }
-  });
-  await addWidgetLocal({
-    id: id+'B',
-    parent: id,
-    fixedParent: true,
-    y: holderHeight,
-    width: holderWidth,
-    height: 40,
-    type: 'button',
-    text: 'Recall & Shuffle',
-    movableInEdit: false,
-
-    clickRoutine: [
-      { func: 'RECALL',  holder: '${PROPERTY parent}' },
-      { func: 'FLIP',    holder: '${PROPERTY parent}', face: 0 },
-      { func: 'SHUFFLE', holder: '${PROPERTY parent}' }
-    ]
-  });
+  if(placement.holder) {
+    await addWidgetLocal({
+      type: 'holder',
+      id,
+      x: Math.round(800 - holderWidth/2),
+      y: Math.round(500 - holderHeight/2),
+      width: holderWidth,
+      height: holderHeight,
+      dropTarget: { type: 'card' }
+    });
+    if(placement.resetButton)
+      await addWidgetLocal(deckResetButton(id, holderWidth, holderHeight));
+  }
 
   const deckWidth  = details.deck.width  || 86;
   const deckHeight = details.deck.height || 86;
-  await addWidgetLocal(Object.assign({}, details.deck, {
-    id: id+'D',
+  // Without a holder the cards still go into a pile in the middle of the table, and the deck widget (which is
+  // invisible outside edit mode) is placed next to it instead of below it.
+  await addWidgetLocal(Object.assign({}, details.deck, { id: id+'D' }, placement.holder ? {
     parent: id,
     x: Math.round((holderWidth -deckWidth )/2),
     y: Math.round((holderHeight-deckHeight)/2)
+  } : {
+    x: Math.round(800 - entry.cardWidth/2 - deckWidth - 10),
+    y: Math.round(500 - deckHeight/2)
   }));
-  await addWidgetLocal({ type: 'pile', id: id+'P', parent: id, width: entry.cardWidth, height: entry.cardHeight });
+  await addWidgetLocal(placement.holder
+    ? { type: 'pile', id: id+'P', parent: id, width: entry.cardWidth, height: entry.cardHeight }
+    : { type: 'pile', id: id+'P', x: Math.round(800 - entry.cardWidth/2), y: Math.round(500 - entry.cardHeight/2), width: entry.cardWidth, height: entry.cardHeight });
 
   for(const [ i, card ] of details.cards.entries())
     await addWidgetLocal(Object.assign({}, card, { id: `${id}C${i+1}`, parent: id+'P', deck: id+'D' }));
 
-  overlayDone(id);
+  overlayDone(placement.holder ? id : id+'P');
   batchEnd();
 }
 
@@ -1765,7 +1748,7 @@ export function initializeEditMode(currentMetaData) {
     overlayDone(await addWidgetLocal(hand));
   });
 
-  on('#browseLibraryDecks', 'click', openLibraryDecksOverlay);
+  on('#browseLibraryDecks', 'click', _=>openLibraryDecksOverlay());
   on('#libraryDecksFilter', 'input', renderLibraryDecksList);
   on('#libraryDecksSort', 'change', renderLibraryDecksList);
   on('#libraryDecksClose', 'click', _=>showOverlay());

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -266,6 +266,8 @@ class DeckEditor {
     $('#deckEditorNewDeckClose').onclick = _=>this.closeNewDeckOverlay();
     for(const radio of $a('#deckEditorNewDeckOverlay input[name=deckEditorNewDeckMode]'))
       radio.onchange = _=>this.renderNewDeckPanel(radio.value);
+    // A reset button recalls the cards into the holder, so it is only offered together with one.
+    $('#deckEditorNewDeckHolder').onchange = _=>$('#deckEditorNewDeckResetButton').disabled = !$('#deckEditorNewDeckHolder').checked;
     $('#deckEditorUndo').onclick = _=>this.undo();
     $('#deckEditorRedo').onclick = _=>this.redo();
     $('#deckEditorCardView').onclick = _=>this.setRoomVisible(!this.roomVisible);
@@ -3159,13 +3161,13 @@ class DeckEditor {
     this.render();
   }
 
-  async addDeck(deckID, size) {
+  async addDeck(deckID, size, placement) {
     if(deckID && widgets.has(deckID)) {
       alert(`A widget with the id "${deckID}" already exists. Please choose a different deck id.`);
       return;
     }
     await this.flushPendingCommits(); // don't absorb a pending typed edit into this action
-    await this.open(await createStarterDeck(deckID, size));
+    await this.open(await createStarterDeck(deckID, size, placement));
     this.treeLevel = 'deck';
     this.render();
   }
@@ -3174,11 +3176,18 @@ class DeckEditor {
   // reinventing those flows, we reuse the ones the properties sidebar already implements (traditional,
   // custom, image upload, TTS import) by rendering them, and the public-library and empty-deck flows.
   openNewDeckOverlay() {
-    if(!this.deckCreator)
+    if(!this.deckCreator) {
       this.deckCreator = new PropertiesModule();
-    // Always start on the "empty deck" default so the submenu is predictable each time it opens.
+      // The flows this instance renders are the dialog's, so they follow its placement checkboxes.
+      this.deckCreator.newDeckPlacement = newDeckPlacement;
+    }
+    // Always start on the "empty deck" default with both placement options on, so the submenu is predictable
+    // each time it opens.
     const empty = $('#deckEditorNewDeckOverlay input[value=empty]');
     empty.checked = true;
+    $('#deckEditorNewDeckHolder').checked = true;
+    $('#deckEditorNewDeckResetButton').checked = true;
+    $('#deckEditorNewDeckResetButton').disabled = false;
     this.renderNewDeckPanel('empty');
     showOverlay('deckEditorNewDeckOverlay');
   }
@@ -3213,14 +3222,16 @@ class DeckEditor {
           return;
         }
         const picked = $('input[name=deckEditorNewDeckSize]:checked', sizes);
+        const placement = newDeckPlacement(); // read before closing the dialog the checkboxes live in
         this.closeNewDeckOverlay();
-        this.addDeck(id || undefined, deckEditorCardSizes[picked ? +picked.value : 0]);
+        this.addDeck(id || undefined, deckEditorCardSizes[picked ? +picked.value : 0], placement);
       };
     } else if(mode == 'library') {
       // Keep the deck editor open: the library overlay is moved into #editor (see initializeDOM) so it shows
-      // above the editor, and pendingNewDeck makes the picked deck open in the editor once it is added.
+      // above the editor, and pendingNewDeck makes the picked deck open in the editor once it is added. The
+      // dialog is hidden while browsing, so the placement options are read now rather than at the click.
       const bar = div(panel, 'deckEditorNewDeckButtonBar', '<button icon=style class=green>Browse the public library</button>');
-      $('button', bar).onclick = _=>openLibraryDecksOverlay();
+      $('button', bar).onclick = _=>openLibraryDecksOverlay(newDeckPlacement());
     } else {
       // Render the existing PropertiesModule deck-creation flow inside a container carrying the same classes
       // the sidebar uses ("tune editorModule"), so its scoped CSS (preview tiles, suit editors, TTS input)
@@ -3571,36 +3582,15 @@ const deckEditorCardSizes = [
   { label: 'Token',       width:  50, height:  50 }
 ];
 
-// Creates a minimal deck to start designing from scratch (holder + deck with one card type, a colored back
-// and a white front, plus one card) and returns the deck's id. Shared by the toolbar button (when the game
-// has no deck yet) and the properties module's "Design a deck in the deck editor" option.
-// deckID: optional id for the deck widget itself (from the "Add New Deck" dialog); the holder and button
-// still get generated ids. Defaults to the holder id + 'D' when not given.
-// size: one of deckEditorCardSizes; the cards, the holder and its button are all built at that size.
-async function createStarterDeck(deckID, size) {
-  batchStart();
-  const id = generateUniqueWidgetID();
-  const dID = deckID || id+'D';
-  const cardWidth = size && size.width || 103;
-  const cardHeight = size && size.height || 160;
-  const holderWidth = cardWidth + 8;   // the holder has always been 8 larger than the card it holds
-  const holderHeight = cardHeight + 8;
-  setDeltaCause(`${getPlayerDetails().playerName} created deck ${dID} for the deck editor`);
-  const holder = { type: 'holder', id, x: 748, y: 400, dropTarget: { type: 'card' } };
-  // Spelled out only when they differ from the holder's own defaults, so a default-sized starter deck is
-  // still exactly the deck this has always created.
-  if(holderWidth != 111 || holderHeight != 168) {
-    holder.width = holderWidth;
-    holder.height = holderHeight;
-  }
-  await addWidgetLocal(holder);
-  // Recall & Shuffle button on the holder, matching the add-widget overlay's deck composite.
-  await addWidgetLocal({
-    id: id+'B',
-    parent: id,
+// The "Recall & Shuffle" button all deck creation flows put below their holder: it recalls the deck's cards,
+// flips them to their back and shuffles them. Offered as an option by the "Add New Deck" wizard.
+function deckResetButton(holderID, width, y) {
+  return {
+    id: holderID+'B',
+    parent: holderID,
     fixedParent: true,
-    y: holderHeight + 3.36,
-    width: holderWidth,
+    y,
+    width,
     height: 40,
     type: 'button',
     text: 'Recall & Shuffle',
@@ -3610,21 +3600,66 @@ async function createStarterDeck(deckID, size) {
       { func: 'FLIP',    holder: '${PROPERTY parent}', face: 0 },
       { func: 'SHUFFLE', holder: '${PROPERTY parent}' }
     ]
-  });
-  await addWidgetLocal({
+  };
+}
+
+// The two options of the "Add New Deck" dialog: whether the new deck gets a holder to put its cards in, and a
+// reset button on that holder. The creation flows the dialog reuses live in three different modules, so it hands
+// each of them this reader (the boxes stay togglable while a flow is on screen). Everywhere else - the properties
+// sidebar, the add widget overlay's library deck browser - deckPlacementDefault applies, which is what those
+// flows have always done.
+function newDeckPlacement() {
+  const holder = $('#deckEditorNewDeckHolder').checked;
+  return { holder, resetButton: holder && $('#deckEditorNewDeckResetButton').checked };
+}
+
+const deckPlacementDefault = { holder: true, resetButton: true };
+
+// Creates a minimal deck to start designing from scratch (holder + deck with one card type, a colored back
+// and a white front, plus one card) and returns the deck's id. Used by the "Empty deck" option of the
+// "Add New Deck" dialog.
+// deckID: optional id for the deck widget itself (from the dialog); the holder and button still get generated
+// ids. Defaults to the holder id + 'D' when not given.
+// size: one of deckEditorCardSizes; the cards, the holder and its button are all built at that size.
+// placement: what to add besides the deck itself, read from the dialog before it closes (see
+// newDeckPlacement); holder and reset button when not given.
+async function createStarterDeck(deckID, size, placement) {
+  placement = placement || deckPlacementDefault;
+  batchStart();
+  const id = generateUniqueWidgetID();
+  const dID = deckID || id+'D';
+  const cardWidth = size && size.width || 103;
+  const cardHeight = size && size.height || 160;
+  const holderWidth = cardWidth + 8;   // the holder has always been 8 larger than the card it holds
+  const holderHeight = cardHeight + 8;
+  setDeltaCause(`${getPlayerDetails().playerName} created deck ${dID} for the deck editor`);
+  if(placement.holder) {
+    const holder = { type: 'holder', id, x: 748, y: 400, dropTarget: { type: 'card' } };
+    // Spelled out only when they differ from the holder's own defaults, so a default-sized starter deck is
+    // still exactly the deck this has always created.
+    if(holderWidth != 111 || holderHeight != 168) {
+      holder.width = holderWidth;
+      holder.height = holderHeight;
+    }
+    await addWidgetLocal(holder);
+    if(placement.resetButton)
+      await addWidgetLocal(deckResetButton(id, holderWidth, holderHeight + 3.36));
+  }
+  // Without a holder the card is placed where the holder would have been and the deck widget (invisible outside
+  // edit mode) next to it, so both are reachable.
+  await addWidgetLocal(Object.assign({
     type: 'deck',
-    id: dID,
-    parent: id,
-    x: 12,
-    y: 41,
+    id: dID
+  }, placement.holder ? { parent: id, x: 12, y: 41 } : { x: 748 - 96, y: 400 }, {
     cardDefaults: { width: cardWidth, height: cardHeight },
     cardTypes: { 'type 1': {} },
     faceTemplates: [
       { objects: [ { type: 'image', x: 0, y: 0, width: cardWidth, height: cardHeight, color: VTTblue } ] },
       { objects: [ { type: 'image', x: 0, y: 0, width: cardWidth, height: cardHeight, color: '#ffffff' } ] }
     ]
-  });
-  await addWidgetLocal({ type: 'card', deck: dID, cardType: 'type 1', parent: id, activeFace: 1 });
+  }));
+  await addWidgetLocal(Object.assign({ type: 'card', deck: dID, cardType: 'type 1' },
+    placement.holder ? { parent: id } : { x: 752, y: 404 }, { activeFace: 1 }));
   batchEnd();
   return dID;
 }

--- a/client/js/editor/propertyInputs.js
+++ b/client/js/editor/propertyInputs.js
@@ -148,6 +148,25 @@ function iconTypeEnabled(value, enabledTypes) {
   return !type || enabledTypes.has(type);
 }
 
+// The full symbol picker is an overlay of its own, so opening it from a picker that sits inside another overlay
+// (e.g. the deck editor's "Add New Deck" dialog) hides that one. Bring that overlay - the one the given element
+// lives in - back afterwards, instead of leaving the user without the dialog they were working in.
+async function pickSymbolKeepingOverlay(element, type='all') {
+  const hostOverlay = element.closest('.overlay');
+  if(!hostOverlay)
+    return await pickSymbol(type);
+
+  // The deck editor parks the symbol picker inside its card view (see DeckEditor.open), which is not where a
+  // dialog floating above the editor wants it: show it where the dialog is and put it back afterwards.
+  const picker = $('#symbolPickerOverlay');
+  const pickerParent = picker.parentNode;
+  hostOverlay.parentNode.appendChild(picker);
+  const symbol = await pickSymbol(type, true, false);
+  pickerParent.appendChild(picker);
+  showOverlay(hostOverlay.id);
+  return symbol;
+}
+
 // Renders a small preview for an icon property value (same formats as getIconDetails).
 function renderIconChip(value, target) {
   const chip = div(target, 'propertyValueChip');
@@ -984,7 +1003,7 @@ class IconInput extends PickerInput {
     showAll.setAttribute('icon', 'apps');
     showAll.textContent = 'Show all';
     showAll.onclick = async _=>{
-      const symbol = await pickSymbol();
+      const symbol = await pickSymbolKeepingOverlay(showAll);
       if(symbol)
         this.setValue(symbol.symbol);
     };
@@ -1045,7 +1064,7 @@ class ImageInput extends PickerInput {
     showAll.setAttribute('icon', 'apps');
     showAll.textContent = 'Show all';
     showAll.onclick = async _=>{
-      const symbol = await pickSymbol('images');
+      const symbol = await pickSymbolKeepingOverlay(showAll, 'images');
       if(symbol)
         this.setValue(symbol.url);
     };

--- a/client/js/editor/propertyInputs.js
+++ b/client/js/editor/propertyInputs.js
@@ -161,10 +161,14 @@ async function pickSymbolKeepingOverlay(element, type='all') {
   const picker = $('#symbolPickerOverlay');
   const pickerParent = picker.parentNode;
   hostOverlay.parentNode.appendChild(picker);
+  // Where it lands has no stacking rule of its own, so it would end up behind the deck editor: the class
+  // floats it over the whole editor (see deckeditor.css) for as long as it is parked here.
+  picker.classList.add('symbolPickerAboveEditor');
   try {
     // even when the picker fails to open (loadSymbolPicker fetches), the user must get their dialog back
     return await pickSymbol(type, true, false);
   } finally {
+    picker.classList.remove('symbolPickerAboveEditor');
     pickerParent.appendChild(picker);
     showOverlay(hostOverlay.id);
   }

--- a/client/js/editor/propertyInputs.js
+++ b/client/js/editor/propertyInputs.js
@@ -164,14 +164,29 @@ async function pickSymbolKeepingOverlay(element, type='all') {
   // Where it lands has no stacking rule of its own, so it would end up behind the deck editor: the class
   // floats it over the whole editor (see deckeditor.css) for as long as it is parked here.
   picker.classList.add('symbolPickerAboveEditor');
+
+  // Whatever happens, the user must get their dialog back: the picker's symbol list is fetched, so it can also
+  // fail to open. Keep that failure here - unhandled it would reach the global error handler, which replaces
+  // the dialog with the client error overlay.
+  let symbol = null;
+  let error = null;
   try {
-    // even when the picker fails to open (loadSymbolPicker fetches), the user must get their dialog back
-    return await pickSymbol(type, true, false);
-  } finally {
-    picker.classList.remove('symbolPickerAboveEditor');
-    pickerParent.appendChild(picker);
-    showOverlay(hostOverlay.id);
+    symbol = await pickSymbol(type, true, false);
+  } catch(e) {
+    error = e;
   }
+
+  picker.classList.remove('symbolPickerAboveEditor');
+  pickerParent.appendChild(picker);
+  // showOverlay toggles, so it would hide the dialog that is still up when the picker never opened at all:
+  // only bring the dialog back when the picker actually took its place.
+  if(hostOverlay.style.display == 'none')
+    showOverlay(hostOverlay.id);
+  if(error) {
+    console.error(error);
+    alert('The symbol picker could not be loaded. Please try again.');
+  }
+  return symbol;
 }
 
 // Renders a small preview for an icon property value (same formats as getIconDetails).

--- a/client/js/editor/propertyInputs.js
+++ b/client/js/editor/propertyInputs.js
@@ -161,10 +161,13 @@ async function pickSymbolKeepingOverlay(element, type='all') {
   const picker = $('#symbolPickerOverlay');
   const pickerParent = picker.parentNode;
   hostOverlay.parentNode.appendChild(picker);
-  const symbol = await pickSymbol(type, true, false);
-  pickerParent.appendChild(picker);
-  showOverlay(hostOverlay.id);
-  return symbol;
+  try {
+    // even when the picker fails to open (loadSymbolPicker fetches), the user must get their dialog back
+    return await pickSymbol(type, true, false);
+  } finally {
+    pickerParent.appendChild(picker);
+    showOverlay(hostOverlay.id);
+  }
 }
 
 // Renders a small preview for an icon property value (same formats as getIconDetails).

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -5,7 +5,7 @@ function positionElementsInArc(elements, radius, arcAngle, container) {
   const middleIndex = Math.floor(n / 2);
 
   for (let i = 0; i < n; i++) {
-    const angle = (arcAngle / (n - 1)) * (i - middleIndex);
+    const angle = n > 1 ? (arcAngle / (n - 1)) * (i - middleIndex) : 0;
     const radians = (Math.PI / 180) * angle;
     const x = container.clientWidth / 2 + radius * Math.sin(radians) - elements[i].offsetWidth / 2;
     const y = container.clientHeight / 2 + (radius - elements[i].offsetHeight / 2) * (1 - Math.cos(radians));
@@ -602,6 +602,20 @@ function courtSuitLetter(icon, suitIndex) {
 // hearts and purple hearts) results in two visibly different suits without having to pick a color first.
 const DECK_GENERATOR_SUIT_COLORS = [ '#e50932', '#000000', '#0062ff', '#00a651', '#8b00ff', '#ff8c00', '#00a8a8', '#a8006c' ];
 
+// Shows an icon chip in a suit color: the previews the icon picker renders are generic, but the color is what
+// tells two suits with the same icon apart. Game icons are single-color silhouettes, so their image is turned
+// into a mask over the color; font icons and emoji just take it as their text color.
+function tintIconChip(chip, icon, color) {
+  if(!chip)
+    return;
+  chip.style.color = color;
+  const image = $('img', chip);
+  if(image && iconValueType(icon) == 'game-icons') {
+    div(chip, 'deckGeneratorSuitTint').style.setProperty('--mask', `url("${image.src}")`);
+    image.remove();
+  }
+}
+
 // Name a suit gets as long as the user does not type one: the readable part of its icon value ("skoll/hearts"
 // becomes "hearts"). Uploaded images and links have no readable name, so those suits get a generic one.
 function defaultSuitName(icon) {
@@ -1009,15 +1023,15 @@ class PropertiesModule extends SidebarModule {
   // the playing-card design needs the pip layout (suit-P.../suit-S...) and the court card pictures.
   deckGenerator(target) {
     const designs = [
-      { label: 'Playing cards', build: deck=>this.deckTemplate_standard(deck), pips: true, rankPictures: true },
-      { label: 'Rainbow',       build: deck=>this.deckTemplate_colors(deck)      },
-      { label: 'Bold color',    build: deck=>this.deckTemplate_simple(deck)      },
-      { label: 'Skinny',        build: deck=>this.deckTemplate_skinny(deck)      },
-      { label: 'Icon shape',    build: deck=>this.deckTemplate_transparent(deck) },
-      { label: 'Minimal',       build: deck=>this.deckTemplate_minimal(deck)     },
-      { label: 'Corner index',  build: deck=>this.deckTemplate_corners(deck)     },
-      { label: 'Round token',   build: deck=>this.deckTemplate_token(deck)       },
-      { label: 'Square tile',   build: deck=>this.deckTemplate_tile(deck)        }
+      { label: 'Playing cards', description: 'The classic look: pips in the middle, a picture for J, Q and K.',      build: deck=>this.deckTemplate_standard(deck), pips: true, rankPictures: true },
+      { label: 'Rainbow',       description: 'Card in the suit color, suit icon in a white circle, rank in two corners.', build: deck=>this.deckTemplate_colors(deck)      },
+      { label: 'Bold color',    description: 'Card in the suit color with a big white rank and a faint suit icon.',  build: deck=>this.deckTemplate_simple(deck)      },
+      { label: 'Skinny',        description: 'Narrow 80 wide card: rank on top, suit icon below.',                   build: deck=>this.deckTemplate_skinny(deck)      },
+      { label: 'Icon shape',    description: 'No card frame - the suit icon itself is the card, rank on top.',       build: deck=>this.deckTemplate_transparent(deck) },
+      { label: 'Minimal',       description: 'Plain white card with the rank on top and the suit icon below.',       build: deck=>this.deckTemplate_minimal(deck)     },
+      { label: 'Corner index',  description: 'Rank and suit in two corners, works with any rank names.',             build: deck=>this.deckTemplate_corners(deck)     },
+      { label: 'Round token',   description: 'Round chip in the suit color with the rank on it, for counters.',      build: deck=>this.deckTemplate_token(deck)       },
+      { label: 'Square tile',   description: 'Square tile framed in the suit color, rank top left, suit bottom right.', build: deck=>this.deckTemplate_tile(deck)        }
     ];
 
     // One entry per suit: { icon, color, name, ranks }. A list rather than a map from icon to properties, so the
@@ -1028,15 +1042,12 @@ class PropertiesModule extends SidebarModule {
     const suitInputWidget = new BasicWidget();
 
     this.addSubHeader('Suits', target);
-    div(target, 'deckGeneratorHint', 'Every suit has its own icon, name, color and ranks. Card types are named after the suit name ("7 of hearts"), so the same icon can be used for several suits.');
+    div(target, 'deckGeneratorHint', 'Every suit has its own icon, name, color and ranks. Ranks are separated by commas, and "2-10" is short for the whole range. The deck gets one card per suit and rank, named after both ("7 of hearts").');
 
     const suitList = div(target, 'deckGeneratorSuits');
-    // The icon and color pickers expand below the list instead of inside the row, so opening one does not push
-    // the other suits around; sharing one group keeps only one of them open at a time.
-    const pickerGroup = { target: div(target, 'deckGeneratorSuitPickers'), current: null };
-
-    const addBar = div(target, 'deckGeneratorSuitAdd');
-    div(addBar, 'deckGeneratorSuitAddLabel', 'Add a suit:');
+    // Each row's icon and color picker expands right below that row (see rowPickers), so it is always obvious
+    // which suit is being edited; sharing one group keeps only one of them open at a time.
+    const pickerGroup = { current: null };
 
     const linkedRanksLabel = document.createElement('label');
     linkedRanksLabel.className = 'deckGeneratorLinkedRanks';
@@ -1054,6 +1065,9 @@ class PropertiesModule extends SidebarModule {
     };
     linkedRanksLabel.append(linkedRanksToggle, 'Same ranks for each suit');
     target.append(linkedRanksLabel);
+
+    const addBar = div(target, 'deckGeneratorSuitAdd');
+    div(addBar, 'deckGeneratorSuitAddLabel', 'Add a suit:');
 
     // A new suit gets the traditional color of its icon; if that icon already exists in that color, the first
     // unused color of the palette is used instead so the two suits can be told apart right away.
@@ -1081,32 +1095,41 @@ class PropertiesModule extends SidebarModule {
     // rows are in the same order as the suits.
     const rankInputs = new Map();
 
+    // Suits left at the same name are numbered apart in the card type names ("7 of hearts 2"). Show that on the
+    // rows it affects, so the numbering is not a surprise once the cards are on the table.
+    const nameInputs = new Map();
+    const showResolvedSuitNames = _=>{
+      const names = uniqueSuitNames();
+      for(const [ index, suit ] of suits.entries()) {
+        const input = nameInputs.get(suit);
+        const typed = suit.name.trim();
+        input.placeholder = names[index];
+        input.classList.toggle('deckGeneratorSuitRenamed', !!typed && typed != names[index]);
+        input.title = typed && typed != names[index]
+          ? `Another suit is already called "${typed}", so this one's cards are named "7 of ${names[index]}".`
+          : `Name of this suit: its cards are named "7 of ${names[index]}".`;
+      }
+    };
+
     const renderSuits = _=>{
       suitList.innerHTML = '';
-      pickerGroup.target.innerHTML = '';
       pickerGroup.current = null;
       rankInputs.clear();
+      nameInputs.clear();
+
+      if(suits.length)
+        div(suitList, 'deckGeneratorSuitHeader', '<span>Icon</span><span>Name</span><span>Color</span><span>Ranks</span><span></span>');
 
       for(const suit of suits) {
         const row = div(suitList, 'deckGeneratorSuit');
+        // The pickers of this row render here rather than inside the row, so opening one does not push the
+        // row's own inputs around - but still right below the suit they belong to.
+        const rowPickers = div(suitList, 'deckGeneratorSuitPickers');
 
-        // The picker's preview is generic, so show it in the suit color here: with the same icon used for more
-        // than one suit, that is what tells the rows apart. Game icons are single-color silhouettes, so their
-        // image is turned into a mask over the color; font icons and emoji just take it as their text color.
-        const showIconInSuitColor = _=>{
-          const chip = $('.propertyValueChip', iconInput.dom);
-          if(!chip)
-            return;
-          chip.style.color = suit.color;
-          const image = $('img', chip);
-          if(image && iconValueType(suit.icon) == 'game-icons') {
-            div(chip, 'deckGeneratorSuitTint').style.setProperty('--mask', `url("${image.src}")`);
-            image.remove();
-          }
-        };
+        const showIconInSuitColor = _=>tintIconChip($('.propertyValueChip', iconInput.dom), suit.icon, suit.color);
 
         const iconInput = new IconInput(this, suitInputWidget, null, {
-          listenTo: [], clearable: false, pickerGroup,
+          listenTo: [], clearable: false, pickerGroup, pickerTarget: rowPickers,
           getValue: _=>suit.icon,
           setValue: value=>{
             if(!propertyInputValueSet(value))
@@ -1126,14 +1149,16 @@ class PropertiesModule extends SidebarModule {
 
         const nameInput = document.createElement('input');
         nameInput.className = 'deckGeneratorSuitName';
-        nameInput.placeholder = 'Suit name';
-        nameInput.title = 'Name of this suit, used to name its card types.';
         nameInput.value = suit.name;
-        nameInput.oninput = _=>suit.name = nameInput.value;
+        nameInputs.set(suit, nameInput);
+        nameInput.oninput = _=>{
+          suit.name = nameInput.value;
+          showResolvedSuitNames();
+        };
         row.append(nameInput);
 
         const colorInput = new ColorInput(this, suitInputWidget, null, {
-          listenTo: [], clearable: false, pickerGroup,
+          listenTo: [], clearable: false, pickerGroup, pickerTarget: rowPickers,
           getValue: _=>suit.color,
           setValue: value=>{
             if(!propertyInputValueSet(value))
@@ -1150,7 +1175,7 @@ class PropertiesModule extends SidebarModule {
         const ranksInput = document.createElement('input');
         ranksInput.className = 'deckGeneratorSuitRanks';
         ranksInput.placeholder = '2-10,J,Q,K,A';
-        ranksInput.title = 'Ranks of this suit: single ranks and number ranges, separated by commas.';
+        ranksInput.title = 'Ranks of this suit, separated by commas. "2-10" is short for the range 2,3,4,5,6,7,8,9,10.';
         ranksInput.value = suit.ranks;
         rankInputs.set(suit, ranksInput);
         ranksInput.oninput = _=>{
@@ -1165,6 +1190,7 @@ class PropertiesModule extends SidebarModule {
         row.append(ranksInput);
 
         const removeButton = document.createElement('button');
+        removeButton.className = 'deckGeneratorSuitRemove';
         removeButton.setAttribute('icon', 'delete');
         removeButton.title = 'Remove this suit';
         removeButton.onclick = _=>{
@@ -1174,9 +1200,26 @@ class PropertiesModule extends SidebarModule {
         };
         row.append(removeButton);
       }
+      showResolvedSuitNames();
+      renderAddBarChips();
     };
 
-    const designSelectionDiv = document.createElement('div');
+    // The chips are shown in the color the suit they add would get, so the shortcut does not look like it adds
+    // a black hearts suit. That color depends on which suits exist, hence a refresh per render.
+    const renderAddBarChips = _=>{
+      for(const chip of $a('.propertyValueChip', addBar))
+        chip.remove();
+      for(const icon of DECK_GENERATOR_SUIT_ICONS) {
+        const chip = renderIconChip(icon, addBar);
+        chip.title = `Add a ${defaultSuitName(icon)} suit in this color`;
+        tintIconChip(chip, icon, colorForNewSuit(icon));
+        chip.onclick = _=>addSuit(icon);
+      }
+    };
+
+    const designHint = document.createElement('div');
+    designHint.className = 'deckGeneratorHint';
+    const designSelectionDiv = div(null, 'deckGeneratorDesigns');
     const updateDesignPreview = _=>{
       const oldScrollTop = this.moduleDOM.scrollTop;
       const oldSelectedButton = $('.selected.deckDesignButton', designSelectionDiv);
@@ -1184,6 +1227,7 @@ class PropertiesModule extends SidebarModule {
       designSelectionDiv.innerHTML = '';
 
       if(!suits.length) {
+        designHint.textContent = 'Add at least one suit above to see the card designs.';
         createButton.disabled = true;
         return;
       }
@@ -1191,24 +1235,30 @@ class PropertiesModule extends SidebarModule {
       // Designs that need the same card type properties share one set of card types (the design only adds faces
       // and card defaults around them), so a preview refresh builds them once instead of nine times.
       const cardTypesByProperties = {};
+      let cardCount = 0;
       for(const [ index, design ] of designs.entries()) {
         const key = `${design.pips ? 'pips' : ''} ${design.rankPictures ? 'pictures' : ''}`;
         const cardTypes = cardTypesByProperties[key] = cardTypesByProperties[key] || getCardTypes(design);
+        cardCount = Object.keys(cardTypes).length; // the same for every design; only the properties differ
         const deck = design.build({ type: 'deck', id: generateUniqueWidgetID(), cardTypes });
-        const designButton = this.renderWidgetButton(new Deck(deck.id), deck, designSelectionDiv);
+        const tile = div(designSelectionDiv, 'deckDesignTile');
+        // One card per tile - the same one in every design, so they can actually be compared - instead of a
+        // fan of five, which at this size is a pile of overlapping slivers.
+        const designButton = this.renderWidgetButton(new Deck(deck.id), deck, tile, [ previewCardType(cardTypes) ]);
         designButton.classList.add('deckDesignButton');
         designButton.dataset.index = index;
-        designButton.title = design.label;
-        div(designButton, 'deckDesignLabel', html(design.label));
+        designButton.title = `${design.label} - ${design.description}`;
+        div(tile, 'deckDesignLabel', html(design.label));
         designButton.classList.toggle('selected', oldSelectedButtonIndex == index);
+        // Single choice like the mode radios above, so clicking the selected design does not silently
+        // deselect it and re-disable the Add button.
         designButton.onclick = e=>{
           for(const button of $a('.deckDesignButton', designSelectionDiv))
-            if(button != designButton)
-              button.classList.remove('selected');
-          designButton.classList.toggle('selected');
-          createButton.disabled = !$a('.selected.deckDesignButton', designSelectionDiv).length;
+            button.classList.toggle('selected', button == designButton);
+          createButton.disabled = false;
         };
       }
+      designHint.textContent =`${cardCount} card${cardCount == 1 ? '' : 's'} from ${suits.length} suit${suits.length == 1 ? '' : 's'}. Pick how they look:`;
       createButton.disabled = !$a('.selected.deckDesignButton', designSelectionDiv).length;
       this.moduleDOM.scrollTop = oldScrollTop;
     };
@@ -1286,6 +1336,13 @@ class PropertiesModule extends SidebarModule {
       return cardTypes;
     };
 
+    // The one card every design tile previews. A numeric rank shows the playing-card design's pip layout, so
+    // prefer one over a court card or a word rank - but any deck has at least a first card type.
+    const previewCardType = cardTypes=>{
+      const keys = Object.keys(cardTypes);
+      return keys.find(key=>String(cardTypes[key].rank).match(/^([5-9]|10)$/)) || keys[0];
+    };
+
     const createButton = document.createElement('button');
     createButton.innerText = 'Add to game';
     createButton.className = 'green';
@@ -1294,23 +1351,19 @@ class PropertiesModule extends SidebarModule {
     createButton.onclick = async e=>{
       const design = designs[+$('.selected.deckDesignButton', designSelectionDiv).dataset.index];
       const deck = design.build({ type: 'deck', id: generateUniqueWidgetID(), cardTypes: getCardTypes(design) });
-      createButton.disabled = true; // adding a card at a time takes a moment; a second click would add a 2nd deck
+      // Adding a card at a time takes a moment: say so, and make a second click impossible while it runs.
+      createButton.disabled = true;
+      createButton.innerText = 'Adding…';
       try {
         await this.addDeckWithCards(deck, 'custom');
       } finally {
+        createButton.innerText = 'Add to game';
         createButton.disabled = false;
       }
     };
 
-    for(const icon of DECK_GENERATOR_SUIT_ICONS) {
-      const chip = renderIconChip(icon, addBar);
-      chip.title = `Add a suit with the ${defaultSuitName(icon)} icon`;
-      chip.onclick = _=>addSuit(icon);
-    }
-
     this.addSubHeader('Card design', target);
-    target.append(designSelectionDiv);
-    target.append(createButton);
+    target.append(designHint, designSelectionDiv, createButton);
 
     for(const icon of DECK_GENERATOR_SUIT_ICONS.slice(0, 4))
       addSuit(icon, false); // one render pass for the four suits a custom deck starts with
@@ -6723,7 +6776,9 @@ class PropertiesModule extends SidebarModule {
     }
   }
 
-  renderWidgetButton(widget, state, target) {
+  // sampleCardTypes: which card types a deck preview fans out. Defaults to five random ones; pass a single one
+  // to get a preview of just that card, big enough to actually read (the card design gallery does that).
+  renderWidgetButton(widget, state, target, sampleCardTypes) {
     const button = document.createElement('button');
     button.className = 'widgetSelectionButton';
     target.appendChild(button);
@@ -6739,7 +6794,7 @@ class PropertiesModule extends SidebarModule {
       // must come back out even when rendering a card throws (the faces can come straight from user input).
       widgets.set(widget.id, widget);
       try {
-        for(const cardType of shuffleArray(Object.keys(widget.get('cardTypes'))).slice(0, 5)) {
+        for(const cardType of sampleCardTypes || shuffleArray(Object.keys(widget.get('cardTypes'))).slice(0, 5)) {
           new Card().renderReadonlyCopyRaw(Object.assign({
             deck: widget.id,
             cardType,

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -60,7 +60,9 @@ function centerElementInClientRect(element, boundingClientRect) {
 
 function parseRankRange(rankRange) {
   const rankArray = [];
-  const rankElements = rankRange.split(',');
+  // Ranks are typed as a comma separated list, so spaces around them are the user separating the list, not part
+  // of a rank ("2-10, J, Q" must not produce a rank called " J").
+  const rankElements = rankRange.split(',').map(rankElement=>rankElement.trim());
 
   rankElements.forEach(rankElement => {
     if(rankElement.match(/-?[0-9]+--?[0-9]+/)) {
@@ -569,6 +571,34 @@ const SEAT_PRESET_FIXED = {
   }
 };
 
+// Suit icons offered as one-click chips in the custom deck dialog. Any other icon can be chosen per suit with
+// the icon picker, so this is just a shortcut for the ones decks use most often.
+const DECK_GENERATOR_SUIT_ICONS = [
+  'skoll/diamonds', 'skoll/hearts', 'skoll/clubs', 'skoll/spades',
+  'delapouite/round-star', 'delapouite/flower-emblem', 'delapouite/plain-circle', 'lorc/biohazard', 'lorc/fluffy-trefoil'
+];
+
+// The four suits a custom deck starts with, and the letter of the court card pictures (/i/cards-default) that
+// belong to them. Suits with any other icon fall back to these pictures in the order they are listed here.
+const DECK_GENERATOR_COURT_SUITS = {
+  'skoll/diamonds': 'D',
+  'skoll/hearts':   'H',
+  'skoll/clubs':    'C',
+  'skoll/spades':   'S'
+};
+
+// Colors offered to a suit whose icon+color combination is already taken, so adding the same icon twice (red
+// hearts and purple hearts) results in two visibly different suits without having to pick a color first.
+const DECK_GENERATOR_SUIT_COLORS = [ '#e50932', '#000000', '#0062ff', '#00a651', '#8b00ff', '#ff8c00', '#00a8a8', '#a8006c' ];
+
+// Name a suit gets as long as the user does not type one: the readable part of its icon value ("skoll/hearts"
+// becomes "hearts"). Uploaded images and links have no readable name, so those suits get a generic one.
+function defaultSuitName(icon) {
+  if(typeof icon != 'string' || icon.match(/^\/assets\/|^https?:\/\//))
+    return '';
+  return icon.replace(/^.*\//, '').replace(/\.svg$/, '').replace(/^[[(]|[\])]$/g, '');
+}
+
 class PropertiesModule extends SidebarModule {
   constructor() {
     super('tune', 'Edit Widgets', 'Edit widget properties.');
@@ -963,188 +993,282 @@ class PropertiesModule extends SidebarModule {
     target.append(createButton);
   }
 
+  // Custom deck: the user defines the suits (any icon, any color, any name, any set of ranks) and picks a card
+  // design. A design declares which card type properties it actually reads, so a deck only carries those: only
+  // the playing-card design needs the pip layout (suit-P.../suit-S...) and the court card pictures.
   deckGenerator(target) {
-    const deckTemplates = [ this.deckTemplate_standard, this.deckTemplate_colors, this.deckTemplate_simple, this.deckTemplate_skinny, this.deckTemplate_transparent ];
+    const designs = [
+      { label: 'Playing cards', build: deck=>this.deckTemplate_standard(deck), pips: true, rankPictures: true },
+      { label: 'Rainbow',       build: deck=>this.deckTemplate_colors(deck)      },
+      { label: 'Bold color',    build: deck=>this.deckTemplate_simple(deck)      },
+      { label: 'Skinny',        build: deck=>this.deckTemplate_skinny(deck)      },
+      { label: 'Icon shape',    build: deck=>this.deckTemplate_transparent(deck) },
+      { label: 'Minimal',       build: deck=>this.deckTemplate_minimal(deck)     },
+      { label: 'Corner index',  build: deck=>this.deckTemplate_corners(deck)     },
+      { label: 'Round token',   build: deck=>this.deckTemplate_token(deck)       },
+      { label: 'Square tile',   build: deck=>this.deckTemplate_tile(deck)        }
+    ];
 
-    const defaultRanks = [ 'skoll/diamonds', 'skoll/hearts', 'skoll/clubs', 'skoll/spades' ];
+    // One entry per suit: { icon, color, name, ranks }. A list rather than a map from icon to properties, so the
+    // same icon can be used for more than one suit (e.g. red hearts and purple hearts).
+    const suits = [];
+    // Dummy widget for the reused icon and color property inputs: both read and write the suit through their
+    // getValue/setValue options, so the widget itself is never touched.
+    const suitInputWidget = new BasicWidget();
 
-    const suitDivs = {};
-    const colors = {};
-    const ranks = {};
+    this.addSubHeader('Suits', target);
+    div(target, 'deckGeneratorHint', 'Every suit has its own icon, name, color and ranks. Card types are named after the suit name ("7 of hearts"), so the same icon can be used for several suits.');
 
-    this.addSubHeader('Suit symbols', target);
+    const suitList = div(target, 'deckGeneratorSuits');
+    // The icon and color pickers expand below the list instead of inside the row, so opening one does not push
+    // the other suits around; sharing one group keeps only one of them open at a time.
+    const pickerGroup = { target: div(target, 'deckGeneratorSuitPickers'), current: null };
 
-    const suitCustomizeDiv = document.createElement('div');
-    this.addSubHeader('Suit properties', suitCustomizeDiv);
+    const addBar = div(target, 'deckGeneratorSuitAdd');
+    div(addBar, 'deckGeneratorSuitAddLabel', 'Add a suit:');
 
-    const linkedRanksToggleDiv = document.createElement('div');
     const linkedRanksLabel = document.createElement('label');
-    linkedRanksLabel.textContent = 'Same ranks for each suit:';
+    linkedRanksLabel.className = 'deckGeneratorLinkedRanks';
     const linkedRanksToggle = document.createElement('input');
     linkedRanksToggle.type = 'checkbox';
     linkedRanksToggle.checked = true;
-    linkedRanksLabel.htmlFor = linkedRanksToggle.id = 'sameRanksToggle';
-
-    linkedRanksToggleDiv.appendChild(linkedRanksLabel);
-    linkedRanksToggleDiv.appendChild(linkedRanksToggle);
-    suitCustomizeDiv.append(linkedRanksToggleDiv);
-
-    const updateLinkedRanks = (symbol, newRanks) => {
-      for(const otherSymbol in ranks)
-        if(linkedRanksToggle.checked && otherSymbol !== symbol)
-          $('.ranks input', suitDivs[otherSymbol]).value = ranks[otherSymbol] = newRanks;
+    // Ticking the box again unifies what is there now, so it never claims ranks are shared while they differ.
+    linkedRanksToggle.onchange = _=>{
+      if(!linkedRanksToggle.checked || !suits.length)
+        return;
+      for(const suit of suits)
+        suit.ranks = suits[0].ranks;
+      renderSuits();
+      updateDesignPreview();
     };
+    linkedRanksLabel.append(linkedRanksToggle, 'Same ranks for each suit');
+    target.append(linkedRanksLabel);
+
+    // A new suit gets the traditional color of its icon; if that icon already exists in that color, the first
+    // unused color of the palette is used instead so the two suits can be told apart right away.
+    const colorForNewSuit = icon=>{
+      const traditional = [ 'skoll/diamonds', 'skoll/hearts' ].includes(icon) ? '#e50932' : '#000000';
+      if(!suits.some(suit=>suit.icon == icon && suit.color == traditional))
+        return traditional;
+      return DECK_GENERATOR_SUIT_COLORS.find(color=>!suits.some(suit=>suit.icon == icon && suit.color == color)) || traditional;
+    };
+
+    const addSuit = (icon, render=true)=>{
+      suits.push({
+        icon,
+        color: colorForNewSuit(icon),
+        name: defaultSuitName(icon),
+        ranks: suits.length && linkedRanksToggle.checked ? suits[0].ranks : '2-10,J,Q,K,A'
+      });
+      if(render) {
+        renderSuits();
+        updateDesignPreview();
+      }
+    };
+
+    // Each suit's ranks input, so the "same ranks" option can write into the others without assuming that the
+    // rows are in the same order as the suits.
+    const rankInputs = new Map();
+
+    const renderSuits = _=>{
+      suitList.innerHTML = '';
+      pickerGroup.target.innerHTML = '';
+      pickerGroup.current = null;
+      rankInputs.clear();
+
+      for(const suit of suits) {
+        const row = div(suitList, 'deckGeneratorSuit');
+
+        // The picker's preview is generic, so show it in the suit color here: with the same icon used for more
+        // than one suit, that is what tells the rows apart. Game icons are single-color silhouettes, so their
+        // image is turned into a mask over the color; font icons and emoji just take it as their text color.
+        const showIconInSuitColor = _=>{
+          const chip = $('.propertyPreviewButton .propertyValueChip', row);
+          if(!chip)
+            return;
+          chip.style.color = suit.color;
+          const image = $('img', chip);
+          if(image && iconValueType(suit.icon) == 'game-icons') {
+            div(chip, 'deckGeneratorSuitTint').style.setProperty('--mask', `url("${image.src}")`);
+            image.remove();
+          }
+        };
+
+        const iconInput = new IconInput(this, suitInputWidget, null, {
+          listenTo: [], clearable: false, pickerGroup,
+          getValue: _=>suit.icon,
+          setValue: value=>{
+            if(!propertyInputValueSet(value))
+              return;
+            // A name the user did not type stays in sync with the icon.
+            if(suit.name == defaultSuitName(suit.icon))
+              $('.deckGeneratorSuitName', row).value = suit.name = defaultSuitName(value);
+            suit.icon = value;
+            iconInput.update();
+            showIconInSuitColor();
+            updateDesignPreview();
+          }
+        });
+        iconInput.render(row);
+        iconInput.update();
+        showIconInSuitColor();
+
+        const nameInput = document.createElement('input');
+        nameInput.className = 'deckGeneratorSuitName';
+        nameInput.placeholder = 'Suit name';
+        nameInput.title = 'Name of this suit, used to name its card types.';
+        nameInput.value = suit.name;
+        nameInput.oninput = _=>suit.name = nameInput.value;
+        row.append(nameInput);
+
+        const colorInput = new ColorInput(this, suitInputWidget, null, {
+          listenTo: [], clearable: false, pickerGroup,
+          getValue: _=>suit.color,
+          setValue: value=>{
+            if(!propertyInputValueSet(value))
+              return;
+            suit.color = value;
+            colorInput.update();
+            showIconInSuitColor();
+            updateDesignPreviewSoon(); // the native color picker fires this per pointer move
+          }
+        });
+        colorInput.render(row);
+        colorInput.update();
+
+        const ranksInput = document.createElement('input');
+        ranksInput.className = 'deckGeneratorSuitRanks';
+        ranksInput.placeholder = '2-10,J,Q,K,A';
+        ranksInput.title = 'Ranks of this suit: single ranks and number ranges, separated by commas.';
+        ranksInput.value = suit.ranks;
+        rankInputs.set(suit, ranksInput);
+        ranksInput.oninput = _=>{
+          for(const other of linkedRanksToggle.checked ? suits : [ suit ]) {
+            other.ranks = ranksInput.value;
+            const input = rankInputs.get(other);
+            if(input && input != ranksInput)
+              input.value = ranksInput.value;
+          }
+          updateDesignPreviewSoon();
+        };
+        row.append(ranksInput);
+
+        const removeButton = document.createElement('button');
+        removeButton.setAttribute('icon', 'delete');
+        removeButton.title = 'Remove this suit';
+        removeButton.onclick = _=>{
+          suits.splice(suits.indexOf(suit), 1);
+          renderSuits();
+          updateDesignPreview();
+        };
+        row.append(removeButton);
+      }
+    };
+
     const designSelectionDiv = document.createElement('div');
     const updateDesignPreview = _=>{
       const oldScrollTop = this.moduleDOM.scrollTop;
-      const oldSelectedButton = $('.selected.deckTemplateButton', target);
+      const oldSelectedButton = $('.selected.deckDesignButton', designSelectionDiv);
       const oldSelectedButtonIndex = oldSelectedButton ? oldSelectedButton.dataset.index : -1;
-      for(const button of $a('.deckTemplateButton', target))
-        button.remove();
+      designSelectionDiv.innerHTML = '';
 
-      if(Object.keys(colors).length == 0) {
+      if(!suits.length) {
         createButton.disabled = true;
         return;
       }
 
-      const deck = getDeckDefinition(true);
-      for(const [ index, deckTemplate ] of Object.entries(deckTemplates)) {
-        const templateButton = this.renderWidgetButton(new Deck(deck.id), deckTemplate(deck), designSelectionDiv);
-        templateButton.classList.add('deckTemplateButton');
-        templateButton.dataset.index = index;
-        templateButton.classList.toggle('selected', oldSelectedButtonIndex == index);
-        templateButton.onclick = e=>{
-          for(const button of $a('.deckTemplateButton', target))
-            if(button != templateButton)
+      // Designs that need the same card type properties share one set of card types (the design only adds faces
+      // and card defaults around them), so a preview refresh builds them once instead of nine times.
+      const cardTypesByProperties = {};
+      for(const [ index, design ] of designs.entries()) {
+        const key = `${design.pips ? 'pips' : ''} ${design.rankPictures ? 'pictures' : ''}`;
+        const cardTypes = cardTypesByProperties[key] = cardTypesByProperties[key] || getCardTypes(design);
+        const deck = design.build({ type: 'deck', id: generateUniqueWidgetID(), cardTypes });
+        const designButton = this.renderWidgetButton(new Deck(deck.id), deck, designSelectionDiv);
+        designButton.classList.add('deckDesignButton');
+        designButton.dataset.index = index;
+        designButton.title = design.label;
+        div(designButton, 'deckDesignLabel', html(design.label));
+        designButton.classList.toggle('selected', oldSelectedButtonIndex == index);
+        designButton.onclick = e=>{
+          for(const button of $a('.deckDesignButton', designSelectionDiv))
+            if(button != designButton)
               button.classList.remove('selected');
-          templateButton.classList.toggle('selected');
-          createButton.disabled = !$a('.selected.deckTemplateButton', target).length;
+          designButton.classList.toggle('selected');
+          createButton.disabled = !$a('.selected.deckDesignButton', designSelectionDiv).length;
         };
-        deck.id = generateUniqueWidgetID();
       }
+      createButton.disabled = !$a('.selected.deckDesignButton', designSelectionDiv).length;
       this.moduleDOM.scrollTop = oldScrollTop;
     };
 
-    for(const symbol of [ 'skoll/diamonds', 'skoll/hearts', 'skoll/clubs', 'skoll/spades', 'delapouite/round-star', 'delapouite/flower-emblem', 'delapouite/plain-circle', 'lorc/biohazard', 'lorc/fluffy-trefoil' ]) {
-      const symbolButton = this.renderWidgetButton(new BasicWidget(), {
-        image: `/i/game-icons.net/${symbol}.svg`,
-        color: '#000',
-        svgReplaces: { '#000': 'color' }
-      }, target);
-      symbolButton.dataset.symbol = symbol;
-      symbolButton.classList.add('deckGeneratorSymbol');
-      symbolButton.onclick = async e=>{
-        symbolButton.classList.toggle('selected');
-        if(symbolButton.classList.contains('selected')) {
-          colors[symbol] = [ 'skoll/diamonds', 'skoll/hearts' ].includes(symbol) ? '#e50932' : '#000000';
-          ranks[symbol] = '2-10,J,Q,K,A';
+    // Rebuilding the previews renders real cards, so coalesce the events that fire while typing a rank list or
+    // dragging a color picker into one refresh.
+    let previewTimer = null;
+    const updateDesignPreviewSoon = _=>{
+      clearTimeout(previewTimer);
+      // ... and skip it entirely when the panel was replaced in the meantime (another dialog mode was picked).
+      previewTimer = setTimeout(_=>designSelectionDiv.isConnected && updateDesignPreview(), 250);
+    };
 
-          suitDivs[symbol] = document.createElement('div');
-          suitDivs[symbol].classList.add('suitProperties');
-          const suitWidget = new BasicWidget();
-          this.renderWidgetButton(suitWidget, {
-            image: `/i/game-icons.net/${symbol}.svg`,
-            color: colors[symbol],
-            svgReplaces: { '#000': 'color' }
-          }, suitDivs[symbol]);
+    // Suits left at the same name get a number appended, so every card type of the deck stays unique.
+    const uniqueSuitNames = _=>{
+      const used = new Set();
+      return suits.map((suit, index)=>{
+        const base = suit.name.trim() || defaultSuitName(suit.icon) || `suit ${index+1}`;
+        let name = base;
+        for(let i = 2; used.has(name); ++i)
+          name = `${base} ${i}`;
+        used.add(name);
+        return name;
+      });
+    };
 
-          const colorPickerDiv = document.createElement('div');
-          const colorPickerLabel = document.createElement('label');
-          colorPickerLabel.textContent = 'Color:';
-          const colorPicker = document.createElement('input');
-          colorPicker.type = 'color';
-          colorPicker.value = colors[symbol];
-          colorPicker.onchange = e=>{
-            colors[symbol] = colorPicker.value;
-            suitWidget.applyDelta({ color: colorPicker.value });
-            updateDesignPreview();
-          };
-          colorPickerDiv.appendChild(colorPickerLabel);
-          colorPickerDiv.appendChild(colorPicker);
-          suitDivs[symbol].append(colorPickerDiv);
-
-          const rankInputDiv = document.createElement('div');
-          const rankInputLabel = document.createElement('label');
-          rankInputDiv.classList.add('ranks');
-          rankInputLabel.textContent = 'Ranks:';
-          const rankInput = document.createElement('input');
-          rankInput.value = ranks[symbol];
-
-          rankInput.onkeyup = e => {
-            updateLinkedRanks(symbol, ranks[symbol] = rankInput.value);
-            updateDesignPreview();
-          };
-
-          rankInputDiv.appendChild(rankInputLabel);
-          rankInputDiv.appendChild(rankInput);
-          suitDivs[symbol].append(rankInputDiv);
-
-          suitCustomizeDiv.append(suitDivs[symbol]);
-        } else {
-          suitDivs[symbol].remove();
-          delete suitDivs[symbol];
-          delete colors[symbol];
-          delete ranks[symbol];
-        }
-        updateDesignPreview();
-      };
-
-      if(defaultRanks.includes(symbol))
-        symbolButton.click();
-    }
-    target.append(suitCustomizeDiv);
-
-    function getDeckDefinition(standardDeck) {
-      const id = generateUniqueWidgetID();
+    // The card types of all suits, with the properties the given design reads: suit, suitColor and rank always,
+    // plus the pip layout and the middle pictures for the playing-card design.
+    const getCardTypes = design=>{
       const cardTypes = {};
-      let suitIndex = 0;
+      const suitNames = uniqueSuitNames();
 
-      for(const [ suitSymbol, suitColor ] of Object.entries(colors)) {
-        const suitURL = suitSymbol;
-        for(const rank of parseRankRange(ranks[suitSymbol])) {
-          const cT = `${rank} of ${suitSymbol.replace(/.*\//, '')}`;
+      for(const [ suitIndex, suit ] of suits.entries()) {
+        for(const rank of parseRankRange(suit.ranks)) {
+          const cT = `${rank} of ${suitNames[suitIndex]}`;
           cardTypes[cT] = {
-            suit: suitURL,
-            suitColor,
+            suit: suit.icon,
+            suitColor: suit.color,
             rank
           };
-          const setCardTypes = (conditions, cardTypesKeys) => {
+
+          const hasPipLayout = String(rank).match(/^[0-9]+$/) && rank <= 21;
+          const setPips = (conditions, cardTypesKeys) => {
             if(conditions)
               for(const key of cardTypesKeys)
-                if(standardDeck)
-                  cardTypes[cT][`suit-${key}`] = suitURL;
+                cardTypes[cT][`suit-${key}`] = suit.icon;
           };
-          if(String(rank).match(/^[0-9]+$/) && rank <= 21) {
-            setCardTypes(rank     >=  4,                           ['P11', 'P13', 'P51', 'P53']);
-            setCardTypes(rank     >= 12 || rank == 2 || rank == 3, ['P12', 'P52']);
-            setCardTypes(rank     ==  7 || rank == 8,              ['P22']);
-            setCardTypes(rank     >= 16 || rank >= 6 && rank <= 8, ['P31', 'P33']);
-            setCardTypes(rank % 2 ==  1 && rank != 7,              ['P32']);
-            setCardTypes(rank     ==  8,                           ['P42']);
+          if(design.pips && hasPipLayout) {
+            setPips(rank     >=  4,                           ['P11', 'P13', 'P51', 'P53']);
+            setPips(rank     >= 12 || rank == 2 || rank == 3, ['P12', 'P52']);
+            setPips(rank     ==  7 || rank == 8,              ['P22']);
+            setPips(rank     >= 16 || rank >= 6 && rank <= 8, ['P31', 'P33']);
+            setPips(rank % 2 ==  1 && rank != 7,              ['P32']);
+            setPips(rank     ==  8,                           ['P42']);
 
-            setCardTypes(rank >= 9,                                                          ['S21', 'S23', 'S31', 'S33']);
-            setCardTypes(rank >= 20 || rank == 10 || rank == 11 || rank >= 14 && rank <= 17, ['S12', 'S42']);
-            setCardTypes(rank >= 12,                                                         ['S22', 'S32']);
-            setCardTypes(rank >= 18,                                                         ['S11', 'S13', 'S41', 'S43']);
+            setPips(rank >= 9,                                                          ['S21', 'S23', 'S31', 'S33']);
+            setPips(rank >= 20 || rank == 10 || rank == 11 || rank >= 14 && rank <= 17, ['S12', 'S42']);
+            setPips(rank >= 12,                                                         ['S22', 'S32']);
+            setPips(rank >= 18,                                                         ['S11', 'S13', 'S41', 'S43']);
           }
-          if('JQK'.includes(rank)) {
-            let defaultRanksuit = defaultRanks[suitIndex % 4].substr(6, 1).toUpperCase();
-            if(defaultRanks.includes(suitSymbol))
-              defaultRanksuit = suitSymbol.substr(6, 1).toUpperCase();
-            cardTypes[cT].rankImage = `/i/cards-default/${rank}${defaultRanksuit}-face.svg`;
-          } else if(!String(rank).match(/^[0-9]+$/) || rank > 21) {
-            cardTypes[cT].rankImage = `/i/game-icons.net/${suitSymbol}.svg`;
-          }
+          // Middle picture of the playing-card design: the court cards use the matching face image, ranks
+          // without a pip layout (jokers, tarot trumps, words, ...) use the suit icon.
+          if(design.rankPictures && rank && 'JQK'.includes(rank))
+            cardTypes[cT].rankImage = `/i/cards-default/${rank}${DECK_GENERATOR_COURT_SUITS[suit.icon] || 'DHCS'[suitIndex % 4]}-face.svg`;
+          else if(design.rankPictures && !hasPipLayout)
+            cardTypes[cT].rankIcon = suit.icon;
         }
-        suitIndex += 1;
       }
 
-      return {
-        type: 'deck',
-        id,
-        cardTypes
-      };
-    }
+      return cardTypes;
+    };
 
     const createButton = document.createElement('button');
     createButton.innerText = 'Add to game';
@@ -1152,67 +1276,30 @@ class PropertiesModule extends SidebarModule {
     createButton.disabled = true;
     createButton.setAttribute('icon', 'add');
     createButton.onclick = async e=>{
-      let standardDeck = false;
-      const deckTemplateButton = document.querySelectorAll('.deckTemplateButton')[0];
-      if (deckTemplateButton && deckTemplateButton.classList.contains('selected'))
-        standardDeck = true
-      batchStart();
-      const deck = getDeckDefinition(standardDeck);
-      setDeltaCause(`${getPlayerDetails().playerName} added custom deck "${deck.id}" in editor`);
-      const finalDeck = deckTemplates[$('.selected.deckTemplateButton', target).dataset.index](deck);
-
-      // Same holder/button/pile structure as addDeckWithCards, so custom decks aren't spread out either.
-      const cardWidth  = finalDeck.cardDefaults && finalDeck.cardDefaults.width  || finalDeck.width  || 103;
-      const cardHeight = finalDeck.cardDefaults && finalDeck.cardDefaults.height || finalDeck.height || 160;
-      const deckWidth  = finalDeck.width  || cardWidth;
-      const deckHeight = finalDeck.height || cardHeight;
-      const holderWidth  = cardWidth  + 8;
-      const holderHeight = cardHeight + 11;
-      const holderID = generateUniqueWidgetID();
-      await addWidgetLocal({
-        type: 'holder', id: holderID,
-        x: Math.round(800 - holderWidth/2), y: Math.round(500 - holderHeight/2),
-        width: holderWidth, height: holderHeight, dropTarget: { type: 'card' }
-      });
-      await addWidgetLocal({
-        id: holderID+'B', parent: holderID, fixedParent: true, y: holderHeight,
-        width: holderWidth, height: 40, type: 'button', text: 'Recall & Shuffle', movableInEdit: false,
-        clickRoutine: [
-          { func: 'RECALL',  holder: '${PROPERTY parent}' },
-          { func: 'FLIP',    holder: '${PROPERTY parent}', face: 0 },
-          { func: 'SHUFFLE', holder: '${PROPERTY parent}' }
-        ]
-      });
-      await addWidgetLocal(Object.assign({}, finalDeck, {
-        parent: holderID,
-        x: Math.round((holderWidth -deckWidth )/2),
-        y: Math.round((holderHeight-deckHeight)/2)
-      }));
-      await addWidgetLocal({ type: 'pile', id: holderID+'P', parent: holderID, width: cardWidth, height: cardHeight });
-
-      for(const [ suitSymbol, suitColor ] of Object.entries(colors)) {
-        for(const rank of parseRankRange(ranks[suitSymbol])) {
-          const cT = `${rank} of ${suitSymbol.replace(/.*\//, '')}`;
-          await addWidgetLocal({
-            type: 'card',
-            id: `${deck.id} ${cT}`,
-            deck: deck.id,
-            cardType: cT,
-            parent: holderID+'P',
-            activeFace: 1
-          });
-        }
+      const design = designs[+$('.selected.deckDesignButton', designSelectionDiv).dataset.index];
+      const deck = design.build({ type: 'deck', id: generateUniqueWidgetID(), cardTypes: getCardTypes(design) });
+      createButton.disabled = true; // adding a card at a time takes a moment; a second click would add a 2nd deck
+      try {
+        await this.addDeckWithCards(deck, 'custom');
+      } finally {
+        createButton.disabled = false;
       }
-
-      batchEnd();
     };
 
-    target.append(suitCustomizeDiv);
+    for(const icon of DECK_GENERATOR_SUIT_ICONS) {
+      const chip = renderIconChip(icon, addBar);
+      chip.title = `Add a suit with the ${defaultSuitName(icon)} icon`;
+      chip.onclick = _=>addSuit(icon);
+    }
 
     this.addSubHeader('Card design', target);
     target.append(designSelectionDiv);
-    updateDesignPreview();
     target.append(createButton);
+
+    for(const icon of DECK_GENERATOR_SUIT_ICONS.slice(0, 4))
+      addSuit(icon, false); // one render pass for the four suits a custom deck starts with
+    renderSuits();
+    updateDesignPreview();
   }
 
   deckImages(target) {
@@ -1423,6 +1510,7 @@ class PropertiesModule extends SidebarModule {
 
     addButton.onclick = async _=>{
       addButton.disabled = true;
+      const placement = this.deckPlacement(); // one import adds every selected deck the same way
       try {
         for(const { button, deck, cardCounts } of foundDecks) {
           if(!button.classList.contains('selected'))
@@ -1433,7 +1521,7 @@ class PropertiesModule extends SidebarModule {
           delete newDeck.y;
           delete newDeck.z;
           newDeck.id = generateUniqueWidgetID();
-          await this.addDeckWithCards(newDeck, 'TTS', cardCounts);
+          await this.addDeckWithCards(newDeck, 'TTS', cardCounts, placement);
           button.classList.remove('selected');
         }
       } catch(e) {
@@ -1444,7 +1532,14 @@ class PropertiesModule extends SidebarModule {
     };
   }
 
-  async addDeckWithCards(deck, type, counts) {
+  // What to add around a new deck. The "Add New Deck" dialog sets newDeckPlacement on the module instance it
+  // renders these flows into (see openNewDeckOverlay), so they follow its checkboxes; the properties sidebar's
+  // own instance has none, so its decks come with a holder and a reset button as they always did.
+  deckPlacement() {
+    return this.newDeckPlacement ? this.newDeckPlacement() : deckPlacementDefault;
+  }
+
+  async addDeckWithCards(deck, type, counts, placement=this.deckPlacement()) {
     batchStart();
     setDeltaCause(`${getPlayerDetails().playerName} added ${type} deck "${deck.id}" in editor`);
 
@@ -1456,39 +1551,40 @@ class PropertiesModule extends SidebarModule {
     const deckHeight = deck.height || cardHeight;
     const holderWidth  = cardWidth  + 8;
     const holderHeight = cardHeight + 11;
-    const holderID = generateUniqueWidgetID();
+    // Without a holder that id is never added, so it does not reserve the pile's id: check for that one too,
+    // like the public-library flow does for all of its suffixes.
+    let holderID = null;
+    do {
+      holderID = generateUniqueWidgetID();
+    } while(widgets.has(holderID+'P'));
+    const pileID = holderID+'P';
 
-    await addWidgetLocal({
-      type: 'holder',
-      id: holderID,
-      x: Math.round(800 - holderWidth/2),
-      y: Math.round(500 - holderHeight/2),
-      width: holderWidth,
-      height: holderHeight,
-      dropTarget: { type: 'card' }
-    });
-    await addWidgetLocal({
-      id: holderID+'B',
-      parent: holderID,
-      fixedParent: true,
-      y: holderHeight,
-      width: holderWidth,
-      height: 40,
-      type: 'button',
-      text: 'Recall & Shuffle',
-      movableInEdit: false,
-      clickRoutine: [
-        { func: 'RECALL',  holder: '${PROPERTY parent}' },
-        { func: 'FLIP',    holder: '${PROPERTY parent}', face: 0 },
-        { func: 'SHUFFLE', holder: '${PROPERTY parent}' }
-      ]
-    });
-    await addWidgetLocal(Object.assign({}, deck, {
+    if(placement.holder) {
+      await addWidgetLocal({
+        type: 'holder',
+        id: holderID,
+        x: Math.round(800 - holderWidth/2),
+        y: Math.round(500 - holderHeight/2),
+        width: holderWidth,
+        height: holderHeight,
+        dropTarget: { type: 'card' }
+      });
+      if(placement.resetButton)
+        await addWidgetLocal(deckResetButton(holderID, holderWidth, holderHeight));
+    }
+    // Without a holder the cards still go into a pile in the middle of the table, and the deck widget (which is
+    // invisible outside edit mode) is placed next to it instead of below it.
+    await addWidgetLocal(Object.assign({}, deck, placement.holder ? {
       parent: holderID,
       x: Math.round((holderWidth -deckWidth )/2),
       y: Math.round((holderHeight-deckHeight)/2)
+    } : {
+      x: Math.round(800 - cardWidth/2 - deckWidth - 10),
+      y: Math.round(500 - deckHeight/2)
     }));
-    await addWidgetLocal({ type: 'pile', id: holderID+'P', parent: holderID, width: cardWidth, height: cardHeight });
+    await addWidgetLocal(placement.holder
+      ? { type: 'pile', id: pileID, parent: holderID, width: cardWidth, height: cardHeight }
+      : { type: 'pile', id: pileID, x: Math.round(800 - cardWidth/2), y: Math.round(500 - cardHeight/2), width: cardWidth, height: cardHeight });
 
     for(const cardType in deck.cardTypes) {
       const count = counts ? counts[cardType] || 0 : 1;
@@ -1498,7 +1594,7 @@ class PropertiesModule extends SidebarModule {
           id: `${deck.id} ${cardType}${count > 1 ? ' '+i : ''}`,
           deck: deck.id,
           cardType: cardType,
-          parent: holderID+'P',
+          parent: pileID,
           activeFace: 1
         });
     }
@@ -1506,9 +1602,304 @@ class PropertiesModule extends SidebarModule {
     batchEnd();
   }
 
-  deckTemplate_colors(deck) {
+  // Adapted from the simple suit/rank decks of the public library (Feta, Escrime): a white card with the rank on
+  // top in the suit color and the suit icon below it.
+  deckTemplate_minimal(deck) {
+    deck.faceTemplates = [
+      {
+        "radius": 10,
+        "objects": [
+          {
+            "type": "image",
+            "width": 103,
+            "height": 160,
+            "color": "transparent",
+            "value": "/i/cards-plastic/1B.svg"
+          }
+        ],
+        "border": 1
+      },
+      {
+        "radius": 10,
+        "objects": [
+          {
+            "type": "image",
+            "width": 103,
+            "height": 160,
+            "color": "white"
+          },
+          {
+            "type": "text",
+            "y": 12,
+            "fontSize": 44,
+            "textAlign": "center",
+            "width": 103,
+            "dynamicProperties": {
+              "value": "rank",
+              "color": "suitColor"
+            }
+          },
+          {
+            "type": "icon",
+            "x": 21.5,
+            "y": 75,
+            "size": 60,
+            "dynamicProperties": {
+              "value": "suit",
+              "color": "suitColor"
+            }
+          }
+        ],
+        "border": 1
+      }
+    ];
+    return deck;
+  }
+
+  // Playing card look without the pip layout: rank and suit in two opposite corners and one big suit icon in the
+  // middle, so it works for any set of ranks (words, high numbers, ...) and any icon.
+  deckTemplate_corners(deck) {
+    deck.faceTemplates = [
+      {
+        "objects": [
+          {
+            "type": "image",
+            "width": 103,
+            "height": 160,
+            "color": "transparent",
+            "value": "/i/cards-default/2B.svg"
+          }
+        ]
+      },
+      {
+        "border": 1,
+        "radius": 6,
+        "objects": [
+          {
+            "type": "image",
+            "width": 103,
+            "height": 160,
+            "color": "white"
+          },
+          {
+            "type": "icon",
+            "x": 21.5,
+            "y": 50,
+            "size": 60,
+            "opacity": 0.85,
+            "dynamicProperties": {
+              "value": "suit",
+              "color": "suitColor"
+            }
+          },
+          {
+            "type": "text",
+            "x": -3,
+            "y": -2,
+            "fontSize": 30,
+            "textAlign": "center",
+            "width": 25,
+            "dynamicProperties": {
+              "value": "rank",
+              "color": "suitColor"
+            },
+            "css": {
+              "letter-spacing": "-6px"
+            }
+          },
+          {
+            "type": "icon",
+            "x": 1,
+            "y": 28,
+            "size": 23,
+            "dynamicProperties": {
+              "value": "suit",
+              "color": "suitColor"
+            }
+          },
+          {
+            "type": "text",
+            "x": 81,
+            "y": 127,
+            "fontSize": 30,
+            "textAlign": "center",
+            "width": 25,
+            "rotation": 180,
+            "dynamicProperties": {
+              "value": "rank",
+              "color": "suitColor"
+            },
+            "css": {
+              "letter-spacing": "-6px"
+            }
+          },
+          {
+            "type": "icon",
+            "x": 79,
+            "y": 110,
+            "size": 23,
+            "rotation": 180,
+            "dynamicProperties": {
+              "value": "suit",
+              "color": "suitColor"
+            }
+          }
+        ]
+      }
+    ];
+    return deck;
+  }
+
+  // Adapted from the round decks of the public library (CONTEST, District Development): a colored disc with the
+  // suit as a watermark and the rank on top.
+  deckTemplate_token(deck) {
     deck.cardDefaults = {
+      width: 100,
+      height: 100
     };
+    deck.faceTemplates = [
+      {
+        "radius": 50,
+        "objects": [
+          {
+            "type": "image",
+            "width": 100,
+            "height": 100,
+            "color": "#333333"
+          },
+          {
+            "type": "image",
+            "x": 18,
+            "y": 18,
+            "width": 64,
+            "height": 64,
+            "color": "#ffffff22",
+            "css": {
+              "border-radius": "50%"
+            }
+          }
+        ],
+        "border": 1
+      },
+      {
+        "radius": 50,
+        "objects": [
+          {
+            "type": "image",
+            "width": 100,
+            "height": 100,
+            "dynamicProperties": {
+              "color": "suitColor"
+            }
+          },
+          {
+            "type": "icon",
+            "x": 20,
+            "y": 35,
+            "size": 60,
+            "color": "#ffffff55",
+            "dynamicProperties": {
+              "value": "suit"
+            }
+          },
+          {
+            "type": "text",
+            "y": 22,
+            "fontSize": 46,
+            "textAlign": "center",
+            "color": "white",
+            "width": 100,
+            "dynamicProperties": {
+              "value": "rank"
+            }
+          }
+        ],
+        "border": 1
+      }
+    ];
+    return deck;
+  }
+
+  // Adapted from the square tile decks of the public library (Scotland Hills): a tile framed in the suit color,
+  // with the rank in the top left and a small suit icon in the bottom right.
+  deckTemplate_tile(deck) {
+    deck.cardDefaults = {
+      width: 80,
+      height: 80
+    };
+    deck.faceTemplates = [
+      {
+        "radius": 16,
+        "objects": [
+          {
+            "type": "image",
+            "width": 80,
+            "height": 80,
+            "color": "#ffffff"
+          },
+          {
+            "type": "image",
+            "x": 8,
+            "y": 8,
+            "width": 64,
+            "height": 64,
+            "color": "transparent",
+            "value": "/i/game-icons.net/viscious-speed/abstract-111.svg"
+          }
+        ],
+        "border": 1
+      },
+      {
+        "radius": 16,
+        "objects": [
+          {
+            "type": "image",
+            "width": 80,
+            "height": 80,
+            "dynamicProperties": {
+              "color": "suitColor"
+            }
+          },
+          {
+            "type": "image",
+            "x": 5,
+            "y": 5,
+            "width": 70,
+            "height": 70,
+            "color": "#ffffff",
+            "css": {
+              "border-radius": "12px"
+            }
+          },
+          {
+            "type": "text",
+            "x": 6,
+            "y": 2,
+            "fontSize": 34,
+            "textAlign": "left",
+            "width": 48,
+            "dynamicProperties": {
+              "value": "rank",
+              "color": "suitColor"
+            }
+          },
+          {
+            "type": "icon",
+            "x": 46,
+            "y": 42,
+            "size": 28,
+            "dynamicProperties": {
+              "value": "suit",
+              "color": "suitColor"
+            }
+          }
+        ]
+      }
+    ];
+    return deck;
+  }
+
+  deckTemplate_colors(deck) {
     deck.faceTemplates = [
       {
         "radius": 10,
@@ -1609,8 +2000,6 @@ class PropertiesModule extends SidebarModule {
   }
 
   deckTemplate_simple(deck) {
-    deck.cardDefaults = {
-    };
     deck.faceTemplates = [
       {
         "objects": [
@@ -1798,6 +2187,16 @@ class PropertiesModule extends SidebarModule {
             },
             "css": {
               "background-size": "100% 100%"
+            }
+          },
+          {
+            "type": "icon",
+            "x": 25,
+            "y": 53,
+            "size": 53,
+            "dynamicProperties": {
+              "value": "rankIcon",
+              "color": "suitColor"
             }
           },
           {
@@ -6320,15 +6719,20 @@ class PropertiesModule extends SidebarModule {
     if(widget.get('type') == 'deck') {
       const parent = new BasicWidget().renderReadonlyCopyRaw({}, button).domElement;
       const faceTemplates = widget.get('faceTemplates');
+      // The preview deck has to be in the widget map for its sample cards to find it. It is a throwaway, so it
+      // must come back out even when rendering a card throws (the faces can come straight from user input).
       widgets.set(widget.id, widget);
-      for(const cardType of shuffleArray(Object.keys(widget.get('cardTypes'))).slice(0, 5)) {
-        new Card().renderReadonlyCopyRaw(Object.assign({
-          deck: widget.id,
-          cardType,
-          activeFace: Array.isArray(faceTemplates) && faceTemplates.length > 1 ? 1 : 0
-        }, state), parent);
+      try {
+        for(const cardType of shuffleArray(Object.keys(widget.get('cardTypes'))).slice(0, 5)) {
+          new Card().renderReadonlyCopyRaw(Object.assign({
+            deck: widget.id,
+            cardType,
+            activeFace: Array.isArray(faceTemplates) && faceTemplates.length > 1 ? 1 : 0
+          }, state), parent);
+        }
+      } finally {
+        widgets.delete(widget.id);
       }
-      widgets.delete(widget.id, widget);
       if (parent.children[0]) 
         positionElementsInArc(parent.children, parent.children[0].clientHeight, 45, parent);
     } else {

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -58,6 +58,11 @@ function centerElementInClientRect(element, boundingClientRect) {
   element.style.transform = `translate(${translateX}px, ${translateY}px) ${element.style.transform}`;
 }
 
+// A range is expanded rank by rank and every rank becomes a card type, on every keystroke of the ranks field -
+// so a mistyped "2-100000" would build 100000 ranks per suit and freeze the tab. Stop at a deck size that is
+// still a deck; the hint above the design gallery says when a list was cut off here.
+const DECK_GENERATOR_MAX_RANKS = 200;
+
 function parseRankRange(rankRange) {
   const rankArray = [];
   // Ranks are typed as a comma separated list, so spaces around them are the user separating the list, not part
@@ -66,12 +71,14 @@ function parseRankRange(rankRange) {
   const rankElements = rankRange.split(',').map(rankElement=>rankElement.trim()).filter(rankElement=>rankElement !== '');
 
   rankElements.forEach(rankElement => {
+    if(rankArray.length >= DECK_GENERATOR_MAX_RANKS)
+      return;
     // A range is the whole entry, and splitting it on '-' would cut a negative bound in half ("-3--1"), so read
     // both bounds from the match instead. Anything else - "J", "Sun", "2b" - is a rank of its own.
     const range = rankElement.match(/^(-?[0-9]+)-(-?[0-9]+)$/);
     if(range) {
       const [ start, end ] = range.slice(1).map(Number);
-      for(let i = start; i <= end; i++)
+      for(let i = start; i <= end && rankArray.length < DECK_GENERATOR_MAX_RANKS; i++)
         rankArray.push(i);
     } else {
       rankArray.push(rankElement);
@@ -84,12 +91,13 @@ function parseRankRange(rankRange) {
 // The line above the card design gallery. A suit list without suits or without any rank is a normal state while
 // the deck is being typed, but it has no cards to show designs of - and a design tile renders a real card, which
 // throws without a card type. Say what is missing instead, so the gallery can be skipped.
-function deckGeneratorDesignHint(suitCount, cardCount) {
+function deckGeneratorDesignHint(suitCount, cardCount, ranksCapped) {
   if(!suitCount)
     return 'Add at least one suit above to see the card designs.';
   if(!cardCount)
     return 'Add at least one rank above to see the card designs.';
-  return `${cardCount} card${cardCount == 1 ? '' : 's'} from ${suitCount} suit${suitCount == 1 ? '' : 's'}. Pick how they look:`;
+  const capped = ranksCapped ? ` Only the first ${DECK_GENERATOR_MAX_RANKS} ranks of a suit are used.` : '';
+  return `${cardCount} card${cardCount == 1 ? '' : 's'} from ${suitCount} suit${suitCount == 1 ? '' : 's'}.${capped} Pick how they look:`;
 }
 
 async function setCardCount(deck, cardType, count) {
@@ -1231,10 +1239,14 @@ class PropertiesModule extends SidebarModule {
     const designHint = document.createElement('div');
     designHint.className = 'deckGeneratorHint deckGeneratorDesignHint';
     const designSelectionDiv = div(null, 'deckGeneratorDesigns');
+    // The picked design is remembered here instead of being read back off the tiles: the gallery is emptied
+    // whenever the suits have no card to preview (a ranks field being retyped), and a selection that lives only
+    // in the DOM would be forgotten with it. The design list itself never changes, so the index stays valid.
+    let selectedDesign = -1;
+    // Nothing can be added without a design, and there is no design to add while the gallery is empty.
+    const updateCreateButton = _=>createButton.disabled = selectedDesign < 0 || !designSelectionDiv.children.length;
     const updateDesignPreview = _=>{
       const oldScrollTop = this.moduleDOM.scrollTop;
-      const oldSelectedButton = $('.selected.deckDesignButton', designSelectionDiv);
-      const oldSelectedButtonIndex = oldSelectedButton ? oldSelectedButton.dataset.index : -1;
       designSelectionDiv.innerHTML = '';
 
       // Designs that need the same card type properties share one set of card types (the design only adds faces
@@ -1247,9 +1259,10 @@ class PropertiesModule extends SidebarModule {
 
       // The card count is the same for every design; only the properties differ.
       const cardCount = suits.length ? Object.keys(cardTypesFor(designs[0])).length : 0;
-      designHint.textContent = deckGeneratorDesignHint(suits.length, cardCount);
+      const ranksCapped = suits.some(suit=>parseRankRange(suit.ranks).length >= DECK_GENERATOR_MAX_RANKS);
+      designHint.textContent = deckGeneratorDesignHint(suits.length, cardCount, ranksCapped);
       if(!cardCount) {
-        createButton.disabled = true;
+        updateCreateButton();
         return;
       }
 
@@ -1261,19 +1274,19 @@ class PropertiesModule extends SidebarModule {
         // fan of five, which at this size is a pile of overlapping slivers.
         const designButton = this.renderWidgetButton(new Deck(deck.id), deck, tile, [ previewCardType(cardTypes) ]);
         designButton.classList.add('deckDesignButton');
-        designButton.dataset.index = index;
         designButton.title = `${design.label} - ${design.description}`;
         div(tile, 'deckDesignLabel', html(design.label));
-        designButton.classList.toggle('selected', oldSelectedButtonIndex == index);
+        designButton.classList.toggle('selected', selectedDesign == index);
         // Single choice like the mode radios above, so clicking the selected design does not silently
         // deselect it and re-disable the Add button.
         designButton.onclick = e=>{
+          selectedDesign = index;
           for(const button of $a('.deckDesignButton', designSelectionDiv))
             button.classList.toggle('selected', button == designButton);
-          createButton.disabled = false;
+          updateCreateButton();
         };
       }
-      createButton.disabled = !$a('.selected.deckDesignButton', designSelectionDiv).length;
+      updateCreateButton();
       this.moduleDOM.scrollTop = oldScrollTop;
     };
 
@@ -1363,7 +1376,7 @@ class PropertiesModule extends SidebarModule {
     createButton.disabled = true;
     createButton.setAttribute('icon', 'add');
     createButton.onclick = async e=>{
-      const design = designs[+$('.selected.deckDesignButton', designSelectionDiv).dataset.index];
+      const design = designs[selectedDesign];
       const deck = design.build({ type: 'deck', id: generateUniqueWidgetID(), cardTypes: getCardTypes(design) });
       // Adding a card at a time takes a moment: say so, and make a second click impossible while it runs.
       createButton.disabled = true;
@@ -1372,7 +1385,9 @@ class PropertiesModule extends SidebarModule {
         await this.addDeckWithCards(deck, 'custom');
       } finally {
         createButton.innerText = 'Add to game';
-        createButton.disabled = false;
+        // The ranks can have been cleared while the cards were added, which empties the gallery: re-enabling
+        // the button unconditionally would offer to add a deck that no longer has a design or a card.
+        updateCreateButton();
       }
     };
 
@@ -1634,12 +1649,12 @@ class PropertiesModule extends SidebarModule {
     const deckHeight = deck.height || cardHeight;
     const holderWidth  = cardWidth  + 8;
     const holderHeight = cardHeight + 11;
-    // Without a holder that id is never added, so it does not reserve the pile's id: check for that one too,
-    // like the public-library flow does for all of its suffixes.
+    // generateUniqueWidgetID only guarantees the holder id itself is free, while the reset button and the pile
+    // are derived from it: check for those too, like the public-library flow does for all of its suffixes.
     let holderID = null;
     do {
       holderID = generateUniqueWidgetID();
-    } while(widgets.has(holderID+'P'));
+    } while([ 'B', 'P' ].some(suffix=>widgets.has(holderID+suffix)));
     const pileID = holderID+'P';
 
     if(placement.holder) {

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -81,6 +81,17 @@ function parseRankRange(rankRange) {
   return rankArray;
 }
 
+// The line above the card design gallery. A suit list without suits or without any rank is a normal state while
+// the deck is being typed, but it has no cards to show designs of - and a design tile renders a real card, which
+// throws without a card type. Say what is missing instead, so the gallery can be skipped.
+function deckGeneratorDesignHint(suitCount, cardCount) {
+  if(!suitCount)
+    return 'Add at least one suit above to see the card designs.';
+  if(!cardCount)
+    return 'Add at least one rank above to see the card designs.';
+  return `${cardCount} card${cardCount == 1 ? '' : 's'} from ${suitCount} suit${suitCount == 1 ? '' : 's'}. Pick how they look:`;
+}
+
 async function setCardCount(deck, cardType, count) {
     batchStart();
     setDeltaCause(`${getPlayerDetails().playerName} updated card count of deck ${deck.id} (card type ${cardType}) in editor`);
@@ -1218,7 +1229,7 @@ class PropertiesModule extends SidebarModule {
     };
 
     const designHint = document.createElement('div');
-    designHint.className = 'deckGeneratorHint';
+    designHint.className = 'deckGeneratorHint deckGeneratorDesignHint';
     const designSelectionDiv = div(null, 'deckGeneratorDesigns');
     const updateDesignPreview = _=>{
       const oldScrollTop = this.moduleDOM.scrollTop;
@@ -1226,20 +1237,24 @@ class PropertiesModule extends SidebarModule {
       const oldSelectedButtonIndex = oldSelectedButton ? oldSelectedButton.dataset.index : -1;
       designSelectionDiv.innerHTML = '';
 
-      if(!suits.length) {
-        designHint.textContent = 'Add at least one suit above to see the card designs.';
+      // Designs that need the same card type properties share one set of card types (the design only adds faces
+      // and card defaults around them), so a preview refresh builds them once instead of nine times.
+      const cardTypesByProperties = {};
+      const cardTypesFor = design=>{
+        const key = `${design.pips ? 'pips' : ''} ${design.rankPictures ? 'pictures' : ''}`;
+        return cardTypesByProperties[key] = cardTypesByProperties[key] || getCardTypes(design);
+      };
+
+      // The card count is the same for every design; only the properties differ.
+      const cardCount = suits.length ? Object.keys(cardTypesFor(designs[0])).length : 0;
+      designHint.textContent = deckGeneratorDesignHint(suits.length, cardCount);
+      if(!cardCount) {
         createButton.disabled = true;
         return;
       }
 
-      // Designs that need the same card type properties share one set of card types (the design only adds faces
-      // and card defaults around them), so a preview refresh builds them once instead of nine times.
-      const cardTypesByProperties = {};
-      let cardCount = 0;
       for(const [ index, design ] of designs.entries()) {
-        const key = `${design.pips ? 'pips' : ''} ${design.rankPictures ? 'pictures' : ''}`;
-        const cardTypes = cardTypesByProperties[key] = cardTypesByProperties[key] || getCardTypes(design);
-        cardCount = Object.keys(cardTypes).length; // the same for every design; only the properties differ
+        const cardTypes = cardTypesFor(design);
         const deck = design.build({ type: 'deck', id: generateUniqueWidgetID(), cardTypes });
         const tile = div(designSelectionDiv, 'deckDesignTile');
         // One card per tile - the same one in every design, so they can actually be compared - instead of a
@@ -1258,7 +1273,6 @@ class PropertiesModule extends SidebarModule {
           createButton.disabled = false;
         };
       }
-      designHint.textContent =`${cardCount} card${cardCount == 1 ? '' : 's'} from ${suits.length} suit${suits.length == 1 ? '' : 's'}. Pick how they look:`;
       createButton.disabled = !$a('.selected.deckDesignButton', designSelectionDiv).length;
       this.moduleDOM.scrollTop = oldScrollTop;
     };

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -61,12 +61,16 @@ function centerElementInClientRect(element, boundingClientRect) {
 function parseRankRange(rankRange) {
   const rankArray = [];
   // Ranks are typed as a comma separated list, so spaces around them are the user separating the list, not part
-  // of a rank ("2-10, J, Q" must not produce a rank called " J").
-  const rankElements = rankRange.split(',').map(rankElement=>rankElement.trim());
+  // of a rank ("2-10, J, Q" must not produce a rank called " J"). Empty entries are a comma the user has not
+  // typed a rank behind yet ("2-10,J,") and would otherwise become a card type called " of hearts".
+  const rankElements = rankRange.split(',').map(rankElement=>rankElement.trim()).filter(rankElement=>rankElement !== '');
 
   rankElements.forEach(rankElement => {
-    if(rankElement.match(/-?[0-9]+--?[0-9]+/)) {
-      const [start, end] = rankElement.split('-').map(Number);
+    // A range is the whole entry, and splitting it on '-' would cut a negative bound in half ("-3--1"), so read
+    // both bounds from the match instead. Anything else - "J", "Sun", "2b" - is a rank of its own.
+    const range = rankElement.match(/^(-?[0-9]+)-(-?[0-9]+)$/);
+    if(range) {
+      const [ start, end ] = range.slice(1).map(Number);
       for(let i = start; i <= end; i++)
         rankArray.push(i);
     } else {
@@ -587,6 +591,13 @@ const DECK_GENERATOR_COURT_SUITS = {
   'skoll/spades':   'S'
 };
 
+// A plain lookup would also find inherited members ("constructor" as an icon value), so only own entries count.
+function courtSuitLetter(icon, suitIndex) {
+  if(Object.prototype.hasOwnProperty.call(DECK_GENERATOR_COURT_SUITS, icon))
+    return DECK_GENERATOR_COURT_SUITS[icon];
+  return 'DHCS'[suitIndex % 4];
+}
+
 // Colors offered to a suit whose icon+color combination is already taken, so adding the same icon twice (red
 // hearts and purple hearts) results in two visibly different suits without having to pick a color first.
 const DECK_GENERATOR_SUIT_COLORS = [ '#e50932', '#000000', '#0062ff', '#00a651', '#8b00ff', '#ff8c00', '#00a8a8', '#a8006c' ];
@@ -1083,7 +1094,7 @@ class PropertiesModule extends SidebarModule {
         // than one suit, that is what tells the rows apart. Game icons are single-color silhouettes, so their
         // image is turned into a mask over the color; font icons and emoji just take it as their text color.
         const showIconInSuitColor = _=>{
-          const chip = $('.propertyPreviewButton .propertyValueChip', row);
+          const chip = $('.propertyValueChip', iconInput.dom);
           if(!chip)
             return;
           chip.style.color = suit.color;
@@ -1232,7 +1243,11 @@ class PropertiesModule extends SidebarModule {
 
       for(const [ suitIndex, suit ] of suits.entries()) {
         for(const rank of parseRankRange(suit.ranks)) {
-          const cT = `${rank} of ${suitNames[suitIndex]}`;
+          // A rank listed twice in the same suit ("2-10,10") would overwrite its own card type: number the
+          // repeats, the same way suits left at the same name are numbered above.
+          let cT = `${rank} of ${suitNames[suitIndex]}`;
+          for(let i = 2; cardTypes[cT]; ++i)
+            cT = `${rank} of ${suitNames[suitIndex]} ${i}`;
           cardTypes[cT] = {
             suit: suit.icon,
             suitColor: suit.color,
@@ -1259,9 +1274,10 @@ class PropertiesModule extends SidebarModule {
             setPips(rank >= 18,                                                         ['S11', 'S13', 'S41', 'S43']);
           }
           // Middle picture of the playing-card design: the court cards use the matching face image, ranks
-          // without a pip layout (jokers, tarot trumps, words, ...) use the suit icon.
-          if(design.rankPictures && rank && 'JQK'.includes(rank))
-            cardTypes[cT].rankImage = `/i/cards-default/${rank}${DECK_GENERATOR_COURT_SUITS[suit.icon] || 'DHCS'[suitIndex % 4]}-face.svg`;
+          // without a pip layout (jokers, tarot trumps, words, ...) use the suit icon. Only the single letters
+          // J, Q and K have a face image - a multi-letter rank like "JQ" would ask for one that does not exist.
+          if(design.rankPictures && String(rank).length == 1 && 'JQK'.includes(rank))
+            cardTypes[cT].rankImage = `/i/cards-default/${rank}${courtSuitLetter(suit.icon, suitIndex)}-face.svg`;
           else if(design.rankPictures && !hasPipLayout)
             cardTypes[cT].rankIcon = suit.icon;
         }

--- a/client/js/symbols.js
+++ b/client/js/symbols.js
@@ -62,7 +62,12 @@ let symbolData = null;
 export async function loadSymbolPicker() {
   if(symbolData === null) {
     symbolData = 'loading';
-    symbolData = await (await fetch('i/fonts/symbols.json')).json();
+    try {
+      symbolData = await (await fetch('i/fonts/symbols.json')).json();
+    } catch(e) {
+      symbolData = null; // a failed fetch must not leave the picker stuck in 'loading' for the whole session
+      throw e;
+    }
     let list = '';
     for(const [ category, symbols ] of Object.entries(symbolData)) {
       if(category == 'Emoji - Flags')

--- a/tests/client/property-inputs.test.js
+++ b/tests/client/property-inputs.test.js
@@ -57,7 +57,10 @@ const cssHelpers = new Function('SidebarModule', 'widgets', propertiesSource + `
     dicePreviewRotation,
     dicePreviewActiveFace,
     textSymbolClass,
-    textValueFromSymbol
+    textValueFromSymbol,
+    parseRankRange,
+    defaultSuitName,
+    courtSuitLetter
   };
 `)(class {}, testWidgets);
 
@@ -208,6 +211,42 @@ describe('timer time helpers', () => {
   test('formatTimerMs and parseTimerInput round-trip', () => {
     for(const ms of [ 0, 1000, 61000, 5500, 3600000, -90000 ])
       expect(cssHelpers.parseTimerInput(cssHelpers.formatTimerMs(ms))).toBe(ms);
+  });
+});
+
+describe('deck generator helpers', () => {
+  test('parseRankRange expands ranges and ignores list whitespace', () => {
+    expect(cssHelpers.parseRankRange('2-10,J,Q,K,A')).toEqual([ 2, 3, 4, 5, 6, 7, 8, 9, 10, 'J', 'Q', 'K', 'A' ]);
+    expect(cssHelpers.parseRankRange('2-10, J, Q')).toEqual([ 2, 3, 4, 5, 6, 7, 8, 9, 10, 'J', 'Q' ]);
+    expect(cssHelpers.parseRankRange('-3--1')).toEqual([ -3, -2, -1 ]);
+    expect(cssHelpers.parseRankRange('Sun,Moon')).toEqual([ 'Sun', 'Moon' ]);
+  });
+
+  test('parseRankRange drops the empty entries of a half-typed list', () => {
+    // a trailing comma would otherwise produce a card type called " of hearts"
+    expect(cssHelpers.parseRankRange('2-4,J,')).toEqual([ 2, 3, 4, 'J' ]);
+    expect(cssHelpers.parseRankRange('A, ,K')).toEqual([ 'A', 'K' ]);
+    expect(cssHelpers.parseRankRange('')).toEqual([]);
+    expect(cssHelpers.parseRankRange(',')).toEqual([]);
+  });
+
+  test('defaultSuitName uses the readable part of an icon value', () => {
+    expect(cssHelpers.defaultSuitName('skoll/hearts')).toBe('hearts');
+    expect(cssHelpers.defaultSuitName('casino')).toBe('casino');
+    expect(cssHelpers.defaultSuitName('[die_face_6]')).toBe('die_face_6');
+    expect(cssHelpers.defaultSuitName('(🎲)')).toBe('🎲');
+    expect(cssHelpers.defaultSuitName('/i/game-icons.net/lorc/star.svg')).toBe('star');
+    // uploads and links have no readable name, so those suits fall back to a generic one
+    expect(cssHelpers.defaultSuitName('/assets/-1234567890')).toBe('');
+    expect(cssHelpers.defaultSuitName('https://example.com/hearts.svg')).toBe('');
+    expect(cssHelpers.defaultSuitName(null)).toBe('');
+  });
+
+  test('court card pictures fall back by suit position, ignoring inherited names', () => {
+    expect(cssHelpers.courtSuitLetter('skoll/hearts', 3)).toBe('H');
+    expect(cssHelpers.courtSuitLetter('lorc/biohazard', 0)).toBe('D');
+    expect(cssHelpers.courtSuitLetter('lorc/biohazard', 5)).toBe('H');
+    expect(cssHelpers.courtSuitLetter('constructor', 2)).toBe('C');
   });
 });
 

--- a/tests/client/property-inputs.test.js
+++ b/tests/client/property-inputs.test.js
@@ -231,6 +231,17 @@ describe('deck generator helpers', () => {
     expect(cssHelpers.parseRankRange(',')).toEqual([]);
   });
 
+  test('parseRankRange stops expanding a range that would freeze the editor', () => {
+    // a mistyped "2-100000" would otherwise build 100000 ranks per suit on every keystroke
+    const huge = cssHelpers.parseRankRange('2-100000');
+    expect(huge.length).toBe(200);
+    expect(huge[0]).toBe(2);
+    expect(huge[199]).toBe(201);
+    // the cap is on the whole list, not on the single range
+    expect(cssHelpers.parseRankRange('2-201,J').length).toBe(200);
+    expect(cssHelpers.parseRankRange('2-201,J')).not.toContain('J');
+  });
+
   test('defaultSuitName uses the readable part of an icon value', () => {
     expect(cssHelpers.defaultSuitName('skoll/hearts')).toBe('hearts');
     expect(cssHelpers.defaultSuitName('casino')).toBe('casino');
@@ -256,6 +267,8 @@ describe('deck generator helpers', () => {
     expect(cssHelpers.deckGeneratorDesignHint(4, 0)).toBe('Add at least one rank above to see the card designs.');
     expect(cssHelpers.deckGeneratorDesignHint(4, 52)).toBe('52 cards from 4 suits. Pick how they look:');
     expect(cssHelpers.deckGeneratorDesignHint(1, 1)).toBe('1 card from 1 suit. Pick how they look:');
+    // and it says so when a rank list hit the cap, so the missing ranks are not a surprise
+    expect(cssHelpers.deckGeneratorDesignHint(1, 200, true)).toBe('200 cards from 1 suit. Only the first 200 ranks of a suit are used. Pick how they look:');
   });
 });
 

--- a/tests/client/property-inputs.test.js
+++ b/tests/client/property-inputs.test.js
@@ -60,7 +60,8 @@ const cssHelpers = new Function('SidebarModule', 'widgets', propertiesSource + `
     textValueFromSymbol,
     parseRankRange,
     defaultSuitName,
-    courtSuitLetter
+    courtSuitLetter,
+    deckGeneratorDesignHint
   };
 `)(class {}, testWidgets);
 
@@ -248,6 +249,14 @@ describe('deck generator helpers', () => {
     expect(cssHelpers.courtSuitLetter('lorc/biohazard', 5)).toBe('H');
     expect(cssHelpers.courtSuitLetter('constructor', 2)).toBe('C');
   });
+
+  test('the design gallery names what is missing instead of previewing zero cards', () => {
+    // a design tile renders a real card, which needs a card type: with no suit or no rank there is none
+    expect(cssHelpers.deckGeneratorDesignHint(0, 0)).toBe('Add at least one suit above to see the card designs.');
+    expect(cssHelpers.deckGeneratorDesignHint(4, 0)).toBe('Add at least one rank above to see the card designs.');
+    expect(cssHelpers.deckGeneratorDesignHint(4, 52)).toBe('52 cards from 4 suits. Pick how they look:');
+    expect(cssHelpers.deckGeneratorDesignHint(1, 1)).toBe('1 card from 1 suit. Pick how they look:');
+  });
 });
 
 describe('property input helpers', () => {
@@ -347,5 +356,64 @@ describe('property input helpers', () => {
 
     expect(inputHelpers.searchIconIndex('icon')).toHaveLength(100);
     expect(inputHelpers.searchImageIndex('icon')).toHaveLength(100);
+  });
+});
+
+// pickSymbolKeepingOverlay moves the symbol picker next to the dialog it was opened from and reaches for a few
+// room globals doing so: build it with a tiny fake DOM, so both outcomes - a picked symbol and a picker that
+// fails to load - can be exercised.
+function symbolPickerFixture(pickSymbolBehavior) {
+  const editor = { children: [] };
+  const pickerParent = { children: [] };
+  for(const parent of [ editor, pickerParent ])
+    parent.appendChild = child => { child.parentNode = parent; parent.children.push(child); };
+
+  const picker = { id: 'symbolPickerOverlay', style: { display: 'none' }, classes: new Set() };
+  picker.classList = { add: c => picker.classes.add(c), remove: c => picker.classes.delete(c) };
+  pickerParent.appendChild(picker);
+
+  const hostOverlay = { id: 'hostOverlay', style: { display: 'flex' }, parentNode: editor };
+  const overlays = { symbolPickerOverlay: picker, hostOverlay };
+  // the real one (client/js/main.js) toggles: showing an overlay that is already visible hides it
+  const showOverlay = id => {
+    for(const [ key, overlay ] of Object.entries(overlays))
+      if(key != id)
+        overlay.style.display = 'none';
+    overlays[id].style.display = overlays[id].style.display !== 'none' ? 'none' : 'flex';
+  };
+
+  const alerts = [];
+  const pickSymbolKeepingOverlay = new Function('$', 'showOverlay', 'pickSymbol', 'alert', 'console', inputsSource + `;
+    return pickSymbolKeepingOverlay;
+  `)(_ => picker, showOverlay, _ => pickSymbolBehavior(showOverlay), message => alerts.push(message), { error: _ => null });
+
+  return { picker, pickerParent, hostOverlay, alerts, call: _ => pickSymbolKeepingOverlay({ closest: _ => hostOverlay }) };
+}
+
+describe('the symbol picker opened from a dialog', () => {
+  test('is parked next to the dialog and gives the dialog back afterwards', async () => {
+    const fixture = symbolPickerFixture(showOverlay => {
+      expect(fixture.picker.parentNode).not.toBe(fixture.pickerParent);
+      expect(fixture.picker.classes.has('symbolPickerAboveEditor')).toBe(true);
+      showOverlay('symbolPickerOverlay'); // what pickSymbol does once the picker is loaded - hides the dialog
+      return Promise.resolve({ symbol: 'casino' });
+    });
+
+    await expect(fixture.call()).resolves.toEqual({ symbol: 'casino' });
+    expect(fixture.hostOverlay.style.display).toBe('flex');
+    expect(fixture.picker.parentNode).toBe(fixture.pickerParent);
+    expect(fixture.picker.classes.size).toBe(0);
+  });
+
+  test('leaves the dialog open and says so when it fails to load', async () => {
+    // loadSymbolPicker fetches, so pickSymbol can reject before it ever hides the dialog: reopening it then
+    // would toggle the still visible dialog off and leave an empty editor behind
+    const fixture = symbolPickerFixture(_ => Promise.reject(new Error('fetch failed')));
+
+    await expect(fixture.call()).resolves.toBe(null); // nothing picked, and no error to the global handler
+    expect(fixture.alerts).toEqual([ 'The symbol picker could not be loaded. Please try again.' ]);
+    expect(fixture.hostOverlay.style.display).toBe('flex');
+    expect(fixture.picker.parentNode).toBe(fixture.pickerParent);
+    expect(fixture.picker.classes.size).toBe(0);
   });
 });

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -754,6 +754,48 @@ test('Deck editor: toolbar button opens an empty editor when the game has none',
     .expect(Selector('body').hasClass('deckEditorActive')).notOk();
 });
 
+// A rank list is empty while it is being retyped: the design gallery has no card to show then and must say so
+// instead of rendering a card without a card type (which throws and leaves the Add button as it was).
+test('Deck editor: the custom deck wizard survives an empty rank list', async t => {
+  await t.resizeWindow(1280, 900);
+  await setRoomState();
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  // typed into the shared ranks field, which "Same ranks for each suit" copies to every suit
+  const setSharedRanks = ClientFunction(ranks => {
+    const input = document.querySelector('.deckGeneratorSuitRanks');
+    input.value = ranks;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  const designs = Selector('.deckDesignButton');
+  const hint = Selector('.deckGeneratorDesignHint');
+  const addToGame = Selector('#deckEditorNewDeckPanel button.green');
+
+  await t
+    .click('#editButton')
+    .click('#editorToolbar [icon=style]')
+    .click('#deckEditorAddDeck')
+    .click('#deckEditorNewDeckOverlay input[value=custom]')
+    .expect(designs.count).gt(0)
+    .expect(hint.textContent).eql('52 cards from 4 suits. Pick how they look:')
+    .click(designs.nth(0))
+    .expect(addToGame.hasAttribute('disabled')).notOk();
+
+  await setSharedRanks('');
+  await t
+    .expect(hint.textContent).eql('Add at least one rank above to see the card designs.')
+    .expect(designs.count).eql(0)
+    .expect(addToGame.hasAttribute('disabled')).ok();
+
+  // and it comes back once there is a rank again
+  await setSharedRanks('A');
+  await t
+    .expect(hint.textContent).eql('4 cards from 4 suits. Pick how they look:')
+    .expect(designs.count).gt(0)
+    .pressKey('esc');
+});
+
 test('Line widget in edit mode', async t => {
   await t.resizeWindow(1280, 800);
   await setRoomState();

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -788,11 +788,19 @@ test('Deck editor: the custom deck wizard survives an empty rank list', async t 
     .expect(designs.count).eql(0)
     .expect(addToGame.hasAttribute('disabled')).ok();
 
-  // and it comes back once there is a rank again
+  // and it comes back once there is a rank again - with the design that was picked before still picked, so the
+  // deck can be added without noticing that the gallery was rebuilt in between
   await setSharedRanks('A');
   await t
     .expect(hint.textContent).eql('4 cards from 4 suits. Pick how they look:')
     .expect(designs.count).gt(0)
+    .expect(designs.nth(0).hasClass('selected')).ok()
+    .expect(addToGame.hasAttribute('disabled')).notOk();
+
+  // a range that would build a card type per rank on every keystroke is cut off, and the hint says so
+  await setSharedRanks('2-100000');
+  await t
+    .expect(hint.textContent).eql('800 cards from 4 suits. Only the first 200 ranks of a suit are used. Pick how they look:')
     .pressKey('esc');
 });
 


### PR DESCRIPTION
## Problem

The "Add New Deck" wizard's **Custom deck of cards (define suits and ranks)** flow was quite limited:

- suits could only be one of **nine hard-coded icons**, and because the suits were a map keyed by that icon, **each icon could only be used once** — no red *and* purple hearts.
- only **five card designs** were offered.
- every generated deck carried card type properties **only one design reads**: `rankImage` was written for all designs, and two designs added an empty `cardDefaults` object. The playing-card design additionally needs the pip layout (`suit-P…`/`suit-S…`), which is why that one "uses way more properties than the others" — even where the properties did nothing.
- the middle picture of the playing-card design was built as `/i/game-icons.net/<suit>.svg`, so ranks without a pip layout (jokers, tarot trumps, words) only worked for game-icons suits.

And for **every** mode of the wizard, a holder, a pile and a "Recall & Shuffle" button were added unconditionally — there was no way to get just the deck and its cards.

## Fix

**Suits (custom deck)**

- One compact row per suit: **icon picker**, name, color, ranks, remove. The icon picker is the properties sidebar's existing `IconInput`, so **any icon works as a suit** — game-icons.net, Material Symbols, emoji, VTT symbols, uploaded images — with search, library filters and the full symbol picker behind "Show all". The nine icons that used to be the only choice stay one click away as "Add a suit:" chips. Each row shows its icon in the suit's color.
- Suits are now a **list**, so **the same icon can be used for several suits**. Each suit has its own name (what its card types are named after, e.g. `7 of purple hearts`); duplicate names get numbered so card types stay unique. A new suit whose icon+color combination already exists picks the next unused palette color, so a second hearts suit is visibly different right away.

**Card designs**

- Four more designs, adapted from simple decks in the public library: **Minimal** (Feta, Escrime), **Corner index** (playing cards without the pip layout, so it works for any rank set), **Round token** (CONTEST, District Development) and **Square tile** (Scotland Hills). Their backs are suit-independent, so face-down cards stay indistinguishable.
- Each design tile now carries the design's name.
- A design **declares which card type properties it reads**, and the generator only writes those: the pip layout and the court card pictures are exclusive to *Playing cards*; every other design gets just `suit`, `suitColor` and `rank`. The empty `cardDefaults` objects are gone too.
- *Playing cards* draws the middle of a card that has no pip layout from a new `rankIcon` card type property as an **icon** instead of a stretched game-icons URL, so jokers/trumps/words also work for Material Symbols and emoji suits.

**Whole wizard: what gets added around the deck**

Two options, both on by default (exactly what the flows did before), applying to all six modes — empty deck, public library, traditional, custom, images and TTS import:

- **Holder for the deck, with the cards in it**
- **Reset button that recalls, flips to back and shuffles** (a reset button recalls *into* a holder, so it follows the holder option)

Without a holder, the deck widget and a pile holding all the cards are placed on the table instead.

**Cleanups that fall out of this**

- The custom flow's copy of the holder/button/deck/pile code is gone; it uses `addDeckWithCards` like the other flows, and all five deck-creation flows build the Recall & Shuffle button through one `deckResetButton()`.
- Rank lists tolerate spaces after the commas (`2-10, J, Q, K, A` used to produce a rank called `" J"`), and re-ticking "Same ranks for each suit" now unifies the ranks it claims are shared.
- `IconInput`/`ImageInput`'s "Show all" reopens the overlay it was invoked from (and shows the symbol picker full size above the deck editor instead of squeezed into its card column).
- Preview refreshes are coalesced and the card types shared between designs, so the nine previews are not rebuilt per keystroke of a rank list.

No widget property or routine parameter was added or renamed (`rankIcon` is a free-form card type property of a deck, which the validator accepts as `any`), so `validator/` and the JSON editor's `jeCommands` need no update.

## Testing

- `npm test` (jest) passes.
- TestCafe `tests/testcafe/editor.js` passes in headless Chromium (15/15), including the deck editor state-hash tests — **the default output of the wizard is unchanged**, byte for byte.
- Drove every mode in a real browser with the options on and off: custom (all designs, plus a Material Symbols suit and hearts twice in two colors), empty deck, traditional, and the public library both from the wizard (options apply) and from the add-widget overlay (unchanged: holder + button).
- Ran `node validator/validate_gamefile_node.js` on a game built with the new designs — no problems reported for the decks.

Playable demo (five decks, one per design, five suits with hearts twice in different colors):
[custom-decks-demo.vtt](https://agent.virtualtabletop.io/reports/pr/1532171279962996877/custom-decks-demo.vtt)

| the dialog | the designs, and a Material Symbols suit |
| --- | --- |
| ![dialog](https://agent.virtualtabletop.io/reports/pr/1532171279962996877/custom-deck-dialog.png) | ![designs](https://agent.virtualtabletop.io/reports/pr/1532171279962996877/card-designs.png) |


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3073/pr-test (or any other room on that server)