### PR TITLE
Deck editor: multi-select, grouped properties, and a non-modal Edit Widgets panel for decks

### DIFF
--- a/client/css/editor/deckeditor.css
+++ b/client/css/editor/deckeditor.css
@@ -181,6 +181,24 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   flex-shrink: 0;
 }
 
+/* Align / distribute for a multi-selection of face objects, next to the history controls. Icon-only buttons in
+   one block, disabled (not hidden) while fewer objects than they need are selected. */
+#deckEditorAlignToolbar {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+#deckEditorAlignToolbar button {
+  padding: 3px 6px;
+  margin: 0;
+}
+
+#deckEditorAlignToolbar button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 #deckEditorHistoryLabel {
   font-size: 11px;
   font-weight: bold;
@@ -1192,6 +1210,65 @@ body.deckEditorPanning #deckEditorMain * {
   font-style: italic;
   opacity: 0.75;
   margin: 6px 5px 10px;
+}
+
+/* Property groups (Content / Position / Size / Colors / Appearance / Custom), the deck editor's version of the
+   Edit Widget sidebar's collapsible blocks - same shape and behaviour, but inside the tab that owns them. */
+.deckEditorGroup {
+  margin: 6px 0;
+  border: 1px solid var(--backgroundHighlightColor1);
+  border-radius: 5px;
+}
+
+.deckEditorGroupHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  margin: 0;
+  padding: 4px 6px;
+  border: 0;
+  border-radius: 4px;
+  background: var(--backgroundHighlightColor1);
+  color: var(--textColor);
+  text-align: left;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.deckEditorGroupTitle {
+  flex-shrink: 0;
+}
+
+/* What the block holds, so a folded one still says what is inside it. */
+.deckEditorGroupSummary {
+  flex: 1 1 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: right;
+  font-weight: normal;
+  font-size: 11px;
+  opacity: 0.75;
+}
+
+.deckEditorGroupArrow::before {
+  content: 'expand_more';
+  font-family: 'Material Symbols';
+  display: inline-block;
+}
+
+.deckEditorGroup.collapsed .deckEditorGroupArrow::before {
+  content: 'chevron_right';
+}
+
+.deckEditorGroupBody {
+  padding: 6px 6px 0;
+}
+
+.deckEditorGroup.collapsed .deckEditorGroupBody {
+  display: none;
 }
 
 /* Shared style for the small notes under section headers (Dynamic properties intro, HTML-object hint). */

--- a/client/css/editor/deckeditor.css
+++ b/client/css/editor/deckeditor.css
@@ -181,24 +181,6 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   flex-shrink: 0;
 }
 
-/* Align / distribute for a multi-selection of face objects, next to the history controls. Icon-only buttons in
-   one block, disabled (not hidden) while fewer objects than they need are selected. */
-#deckEditorAlignToolbar {
-  display: flex;
-  gap: 2px;
-  flex-shrink: 0;
-}
-
-#deckEditorAlignToolbar button {
-  padding: 3px 6px;
-  margin: 0;
-}
-
-#deckEditorAlignToolbar button:disabled {
-  opacity: 0.4;
-  cursor: default;
-}
-
 #deckEditorHistoryLabel {
   font-size: 11px;
   font-weight: bold;
@@ -1074,6 +1056,32 @@ body.deckEditorPanning #deckEditorMain * {
   cursor: default;
 }
 
+/* Align / distribute for a multi-selection of face objects: the Object tab's second toolbar row, right where
+   the selection is made. Icon-only buttons, disabled (not hidden) while fewer objects than they need are
+   selected - each in a wrapper that carries the tooltip, since a disabled button gets no pointer events. */
+.deckEditorAlignToolbar {
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 2px;
+}
+
+.deckEditorAlignButton {
+  display: flex;
+}
+
+.deckEditorAlignLabel {
+  font-size: 11px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  opacity: 0.7;
+  margin-right: 4px;
+}
+
+.deckEditorAlignToolbar button {
+  padding: 3px 6px;
+}
+
 /* Holds the shared "Add to: All Cards / Card Type" submenu while the Object tab's "+" has it open. */
 .deckEditorSidebarAddHost:not(:empty) {
   display: block;
@@ -1236,6 +1244,12 @@ body.deckEditorPanning #deckEditorMain * {
   cursor: pointer;
 }
 
+/* Focus ring like the Edit Widget sidebar's collapsible headers (propertyInputs.css), which this mirrors. */
+.deckEditorGroupHeader:focus-visible {
+  outline: 2px solid var(--VTTblue);
+  outline-offset: -2px;
+}
+
 .deckEditorGroupTitle {
   flex-shrink: 0;
 }
@@ -1264,7 +1278,7 @@ body.deckEditorPanning #deckEditorMain * {
 }
 
 .deckEditorGroupBody {
-  padding: 6px 6px 0;
+  padding: 4px 6px;
 }
 
 .deckEditorGroup.collapsed .deckEditorGroupBody {
@@ -1341,6 +1355,25 @@ body.deckEditorPanning #deckEditorMain * {
 
 #deckEditorSidebar .deckEditorProperties .genericInput label {
   flex-shrink: 0;
+}
+
+/* The property name in front of the field. A fixed column so every field starts at the same x - but a
+   game-defined name can be longer than it, so it ends in an ellipsis (and its full text in the tooltip)
+   instead of being cut mid-word right against the field. */
+.deckEditorPropertyLabel {
+  display: inline-block;
+  width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* "(mixed)" stands in for a value the selected objects disagree about, so it must not read as a value someone
+   typed - which the color alone doesn't manage in dark mode, where placeholders are drawn in the same white
+   as real text (layout.css). */
+.deckEditorMixedValue::placeholder {
+  font-style: italic;
+  opacity: 0.6;
 }
 
 /* Property rows: a small red trash to delete the property. The glyph size lives on ::before (button[icon]

--- a/client/css/editor/toolbar.css
+++ b/client/css/editor/toolbar.css
@@ -51,6 +51,11 @@
   display: block;
 }
 
+/* A hover tooltip must never intercept a click meant for whatever is underneath it. */
+#editorToolbar button span, #editorDragToolbar button span {
+  pointer-events: none;
+}
+
 #editorToolbar .divider, #editorDragToolbar .divider {
   border-left: 1px solid #fff8;
   margin: 5px;

--- a/client/editor.html
+++ b/client/editor.html
@@ -290,6 +290,7 @@
           <div id="deckEditorBreadcrumb" title="Your edits this session — click a step to jump back or forward to it."></div>
           <span class="deckEditorHistoryDivider"></span>
           <button icon="crop_portrait" id="deckEditorCardView" class="active">Card view</button>
+          <button icon="close" id="deckEditorClose" title="Close the deck editor.">Close</button>
         </div>
         <div id="deckEditorContent">
           <div id="deckEditorMainCol">

--- a/client/editor.html
+++ b/client/editor.html
@@ -289,6 +289,17 @@
           <span id="deckEditorHistoryLabel">History:</span>
           <div id="deckEditorBreadcrumb" title="Your edits this session — click a step to jump back or forward to it."></div>
           <span class="deckEditorHistoryDivider"></span>
+          <div id="deckEditorAlignToolbar" title="Ctrl+click (or Shift+click) face objects to select more than one, then line them up here.">
+            <button id="deckEditorAlignLeft" icon="align_horizontal_left" title="Align the selected face objects to the left"></button>
+            <button id="deckEditorAlignCenter" icon="align_horizontal_center" title="Align the selected face objects to the center"></button>
+            <button id="deckEditorAlignRight" icon="align_horizontal_right" title="Align the selected face objects to the right"></button>
+            <button id="deckEditorAlignTop" icon="align_vertical_top" title="Align the selected face objects to the top"></button>
+            <button id="deckEditorAlignMiddle" icon="align_vertical_center" title="Align the selected face objects to the middle"></button>
+            <button id="deckEditorAlignBottom" icon="align_vertical_bottom" title="Align the selected face objects to the bottom"></button>
+            <button id="deckEditorDistributeH" class="deckEditorDistributeButton" icon="horizontal_distribute" title="Equalize the horizontal spacing between the selected face objects"></button>
+            <button id="deckEditorDistributeV" class="deckEditorDistributeButton" icon="vertical_distribute" title="Equalize the vertical spacing between the selected face objects"></button>
+          </div>
+          <span class="deckEditorHistoryDivider"></span>
           <button icon="crop_portrait" id="deckEditorCardView" class="active">Card view</button>
         </div>
         <div id="deckEditorContent">

--- a/client/editor.html
+++ b/client/editor.html
@@ -289,17 +289,6 @@
           <span id="deckEditorHistoryLabel">History:</span>
           <div id="deckEditorBreadcrumb" title="Your edits this session — click a step to jump back or forward to it."></div>
           <span class="deckEditorHistoryDivider"></span>
-          <div id="deckEditorAlignToolbar" title="Ctrl+click (or Shift+click) face objects to select more than one, then line them up here.">
-            <button id="deckEditorAlignLeft" icon="align_horizontal_left" title="Align the selected face objects to the left"></button>
-            <button id="deckEditorAlignCenter" icon="align_horizontal_center" title="Align the selected face objects to the center"></button>
-            <button id="deckEditorAlignRight" icon="align_horizontal_right" title="Align the selected face objects to the right"></button>
-            <button id="deckEditorAlignTop" icon="align_vertical_top" title="Align the selected face objects to the top"></button>
-            <button id="deckEditorAlignMiddle" icon="align_vertical_center" title="Align the selected face objects to the middle"></button>
-            <button id="deckEditorAlignBottom" icon="align_vertical_bottom" title="Align the selected face objects to the bottom"></button>
-            <button id="deckEditorDistributeH" class="deckEditorDistributeButton" icon="horizontal_distribute" title="Equalize the horizontal spacing between the selected face objects"></button>
-            <button id="deckEditorDistributeV" class="deckEditorDistributeButton" icon="vertical_distribute" title="Equalize the vertical spacing between the selected face objects"></button>
-          </div>
-          <span class="deckEditorHistoryDivider"></span>
           <button icon="crop_portrait" id="deckEditorCardView" class="active">Card view</button>
         </div>
         <div id="deckEditorContent">

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -1698,10 +1698,12 @@ class DeckEditor {
   }
 
   async alignObjects(property, lowerBound, upperBound, factor) {
+    // Flush first, measure afterwards: besides not absorbing a pending typed edit into this action, flushing
+    // can run a queued field edit that moves an object - the rects below have to describe the result of that.
+    await this.flushPendingCommits();
     const items = this.alignItems();
     if(items.length < 2)
       return;
-    await this.flushPendingCommits(); // don't absorb a pending typed edit into this action
     const lower = Math.min(...items.map(item=>item.rect[lowerBound]));
     const target = lower + (Math.max(...items.map(item=>item.rect[upperBound])) - lower) * factor;
     for(const { object, rect } of items) {
@@ -1712,10 +1714,10 @@ class DeckEditor {
   }
 
   async distributeObjects(property, lowerBound, upperBound) {
+    await this.flushPendingCommits(); // flush before measuring, see alignObjects
     const items = this.alignItems();
     if(items.length < 3)
       return;
-    await this.flushPendingCommits(); // don't absorb a pending typed edit into this action
     const sorted = [...items].sort((a,b)=>a.rect[lowerBound] - b.rect[lowerBound]);
     const start = sorted[0].rect[lowerBound];
     const span = Math.max(...items.map(item=>item.rect[upperBound])) - start;
@@ -1820,7 +1822,7 @@ class DeckEditor {
       // A disabled button receives no pointer events, so its own tooltip never opens - which is exactly the
       // state in which it needs to explain itself. The tooltip therefore sits on a wrapper around it instead.
       const wrapper = div(bar, 'deckEditorAlignButton');
-      wrapper.title = `${title}. Needs ${minSelected} or more selected: ctrl+click objects on the card or in the list, or ctrl+A to take the whole face.`;
+      wrapper.title = `${title}. Needs ${minSelected} or more visible objects selected: ctrl+click objects on the card or in the list, or ctrl+A to take the whole face.`;
       const button = document.createElement('button');
       button.id = id;
       button.setAttribute('icon', icon);
@@ -1832,10 +1834,16 @@ class DeckEditor {
     this.updateAlignToolbar();
   }
 
+  // Enabled from what align/distribute can actually act on, not from the raw selection: alignItems() leaves out
+  // objects without a visible box ("display: false"), so counting the selection would leave a button clickable
+  // that then does nothing - e.g. one visible object plus a hidden one.
   updateAlignToolbar() {
-    const selected = this._selectedObjects.length;
-    for(const button of $a('.deckEditorAlignToolbar button'))
-      button.disabled = selected < +button.dataset.minSelected;
+    const buttons = $a('.deckEditorAlignToolbar button');
+    if(!buttons.length)
+      return;
+    const usable = this.alignItems().length;
+    for(const button of buttons)
+      button.disabled = usable < +button.dataset.minSelected;
   }
 
   updateDragToolbar() {
@@ -2754,12 +2762,21 @@ class DeckEditor {
     input.disabled = !editable;
     input.title = bound ? `Text for card type "${this.cardType}" (property "${bound}")` : 'Text on every card';
     // Clicking/dragging inside the field must not start a row drag, but should still select this field's
-    // face object (and switch to its face) if it isn't already the selection.
-    input.onmousedown = e=>e.stopPropagation();
+    // face object (and switch to its face) if it isn't already the selection. The browser focuses the field on
+    // mousedown, so whether the user was already typing in it has to be remembered from before that.
+    let wasFocused = false;
+    input.onmousedown = e=>{
+      wasFocused = document.activeElement == input;
+      e.stopPropagation();
+    };
     input.onclick = e=>{
       e.stopPropagation();
       // The field covers most of its row, so it has to offer the row's Ctrl/Shift multi-select too - otherwise
-      // text objects could only ever be selected one at a time.
+      // text objects could only ever be selected one at a time. Inside the field the user is currently typing
+      // in, though, those clicks belong to the text: shift+click extends the caret selection there, and taking
+      // it over would rebuild the tree (afterSelectionChanged) and destroy the field mid-edit.
+      if(wasFocused && (e.shiftKey || e.ctrlKey || e.metaKey))
+        return;
       if(e.shiftKey)
         return this.extendObjectSelection(index, faceIndex, e.ctrlKey || e.metaKey);
       if(e.ctrlKey || e.metaKey)
@@ -2793,8 +2810,10 @@ class DeckEditor {
     box.append(input);
   }
 
-  // Copies every selected object, appending the copies after the last one so a copied group stays a group -
-  // and selects the copies, so the next drag moves them off their originals.
+  // Copies every selected object, putting the copies together right after the last one - so they stay a block
+  // that the next drag (they are the new selection) moves off the originals as a whole. A non-contiguous
+  // selection therefore comes back contiguous: the copies are drawn next to each other rather than each one
+  // right on top of its original.
   async copySelectedObject() {
     const face = this.faceTemplates[this.face];
     const indices = this.selectedObjectIndices();
@@ -2820,10 +2839,17 @@ class DeckEditor {
     if(!face || !Array.isArray(face.objects) || from === to || to < 0 || to >= face.objects.length)
       return;
     await this.flushPendingCommits(); // don't absorb a pending typed edit into this action
-    const wasSelected = this.selectedObject === from;
     const [ object ] = face.objects.splice(from, 1);
     face.objects.splice(to, 0, object);
-    this.selectedObject = wasSelected ? to : null; // keep the dragged object selected if it was
+    // The whole selection follows the splice, so reordering one row doesn't drop objects that were picked up
+    // with ctrl+click: the dragged object lands on "to", everything it moved past shifts by one, the rest stays.
+    this._selectedObjects = this._selectedObjects.map(i=>{
+      if(i === from)
+        return to;
+      if(from < to)
+        return i > from && i <= to ? i-1 : i;
+      return i >= to && i < from ? i+1 : i;
+    });
     this.refreshMainCardFaces();
     await this.commit('faceTemplates', `${getPlayerDetails().playerName} reordered a face object of deck ${this.deckID} in deck editor`);
     this.render();
@@ -3034,7 +3060,9 @@ class DeckEditor {
       input.oninput = input.onchange = _=>{
         if(fieldType == 'number') {
           if(input.value.trim() === '') {
-            if(emptyIsZero) // face object properties: an erased number reads as 0
+            // Face object properties: an erased number reads as 0 - except in a "(mixed)" field, where empty is
+            // the state it started in, so clearing it again is "never mind" and must not write 0 to everything.
+            if(emptyIsZero && !mixed)
               onValueChanged(0);
             return; // otherwise a momentarily-empty field shouldn't commit 0 over the real value
           }

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -1521,10 +1521,10 @@ class DeckEditor {
         e.preventDefault();
         // Ctrl/Cmd or Shift picks up a second object instead of replacing the selection - and only changes the
         // selection, so a modifier click can't drag the objects around by accident.
+        if(e.shiftKey)
+          return this.extendObjectSelection(index, undefined, e.ctrlKey || e.metaKey);
         if(e.ctrlKey || e.metaKey)
           return this.toggleObjectSelection(index);
-        if(e.shiftKey)
-          return this.extendObjectSelection(index);
         if(!this.isObjectSelected(index))
           this.selectObject(index);
         this.startObjectDrag(name, e, index);
@@ -1615,14 +1615,17 @@ class DeckEditor {
     this.afterSelectionChanged();
   }
 
-  // Shift+click selects everything between the primary object and the clicked one, like a file list.
-  extendObjectSelection(index, face) {
+  // Shift+click selects everything between the primary object and the clicked one, like a file list: the range
+  // becomes the whole selection, so objects picked up earlier and left outside it are dropped. Ctrl+Shift+click
+  // is the additive version - it adds the range to what is already selected.
+  extendObjectSelection(index, face, additive) {
     if((face !== undefined && face !== this.face) || this.selectedObject === null)
       return this.selectObject(index, face);
     const range = [];
     for(let i=Math.min(this.selectedObject, index); i<=Math.max(this.selectedObject, index); ++i)
       range.push(i);
-    this._selectedObjects = [ ...this._selectedObjects.filter(i=>range.indexOf(i) == -1), ...range.filter(i=>i != index), index ];
+    const kept = additive ? this._selectedObjects.filter(i=>range.indexOf(i) == -1) : [];
+    this._selectedObjects = [ ...kept, ...range.filter(i=>i != index), index ]; // clicked object last = primary
     this.afterSelectionChanged();
   }
 
@@ -2044,7 +2047,7 @@ class DeckEditor {
       'deckEditorScopeEveryCard', 'Same on every card type');
     // Note below (not part of) the header, in the same style as the Dynamic properties note.
     if(multi)
-      div(sidebar, 'deckEditorSectionNote').textContent = 'Every row below changes all selected objects at once. A property the selected objects do not agree on shows as "(mixed)" until a new value is typed. Ctrl+click adds or removes an object, ctrl+A selects the whole face.';
+      div(sidebar, 'deckEditorSectionNote').textContent = 'Every row below changes all selected objects at once. A property the selected objects do not agree on shows as "(mixed)" until a new value is typed. Ctrl+click adds or removes an object, shift+click selects a range of them, ctrl+A the whole face.';
     else if(object.type == 'html')
       div(sidebar, 'deckEditorSectionNote').textContent = 'The JSON Editor should be used for editing HTML face objects.';
 
@@ -2533,10 +2536,10 @@ class DeckEditor {
     this.treeObjectPreviews.push({ box: previewBox, index, face });
     this.renderObjectPreview(previewBox, index, face);
     row.onclick = e=>{
+      if(e.shiftKey)
+        return this.extendObjectSelection(index, face, e.ctrlKey || e.metaKey);
       if(e.ctrlKey || e.metaKey)
         return this.toggleObjectSelection(index, face);
-      if(e.shiftKey)
-        return this.extendObjectSelection(index, face);
       this.selectObject(index, face);
     };
     // Drag-and-drop reordering, only within the current face (objects of other expanded faces are read-only here).
@@ -2757,10 +2760,10 @@ class DeckEditor {
       e.stopPropagation();
       // The field covers most of its row, so it has to offer the row's Ctrl/Shift multi-select too - otherwise
       // text objects could only ever be selected one at a time.
+      if(e.shiftKey)
+        return this.extendObjectSelection(index, faceIndex, e.ctrlKey || e.metaKey);
       if(e.ctrlKey || e.metaKey)
         return this.toggleObjectSelection(index, faceIndex);
-      if(e.shiftKey)
-        return this.extendObjectSelection(index, faceIndex);
       if(this.selectedObject !== index || this.face !== faceIndex)
         this.selectObject(index, faceIndex);
     };

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -262,9 +262,14 @@ class DeckEditor {
     return [...this._selectedObjects].sort((a,b)=>a-b);
   }
 
-  selectedObjectTemplates() {
+  // The shown face's object array, or an empty one while there is no face (yet).
+  faceObjects() {
     const face = this.faceTemplates[this.face];
-    const objects = face && Array.isArray(face.objects) ? face.objects : [];
+    return face && Array.isArray(face.objects) ? face.objects : [];
+  }
+
+  selectedObjectTemplates() {
+    const objects = this.faceObjects();
     return this.selectedObjectIndices().map(index=>objects[index]).filter(object=>object);
   }
 
@@ -870,7 +875,9 @@ class DeckEditor {
         return this.redo();
       }
       // Ctrl/Cmd+A selects every face object of the shown face, ready for a shared property edit or an alignment.
-      if(key == 'a' && [ 'TEXTAREA', 'INPUT', 'SELECT' ].indexOf(e.target.tagName) == -1 && !e.target.isContentEditable) {
+      // Not while one of the editor's overlays (export, import, new deck, ...) is up though: there the browser's
+      // own "select all" is what the user means.
+      if(key == 'a' && !isOverlayActive() && [ 'TEXTAREA', 'INPUT', 'SELECT' ].indexOf(e.target.tagName) == -1 && !e.target.isContentEditable) {
         e.preventDefault();
         return this.selectAllObjects();
       }
@@ -1547,6 +1554,7 @@ class DeckEditor {
 
     // Dragging one object of a multi-selection moves the whole selection, so a group keeps its arrangement.
     const dragged = this.startPositions(this.faceTemplates[this.face].objects[index]);
+    const collapseOnClick = this._selectedObjects.length > 1; // see up() below
     const startCoords = eventCoords(name, e);
     let moved = false;
 
@@ -1574,6 +1582,11 @@ class DeckEditor {
       if(moved) {
         await this.commit('faceTemplates', this.objectActionCause('moved', dragged.length));
         this.renderSidebar();
+      } else if(collapseOnClick) {
+        // A plain click on a member of a multi-selection keeps the group while the mouse is down (so it can
+        // drag the whole group) but falls back to just this object when it turns out to be a click - the same
+        // as clicking its row in the tree, and what keeps the next property edit from hitting all of them.
+        this.selectObject(index);
       }
     };
     for(const event of [ 'mousemove', 'touchmove' ])
@@ -1667,22 +1680,31 @@ class DeckEditor {
     return faceDiv ? faceDiv.children[this.selectedObject] : null;
   }
 
-  // The rendered nodes of the selected objects, in the same order as selectedObjectTemplates/dragObjects.
+  // The rendered nodes of the selected objects, in the same order as selectedObjectTemplates/dragObjects - so
+  // the same indices are dropped here as there and entry i always belongs to object i.
   selectedObjectDivs() {
+    const objects = this.faceObjects();
     const faceDiv = this.mainCard ? $a('.cardFace', this.mainCard.domElement)[this.face] : null;
     if(!faceDiv)
       return [];
-    return this.selectedObjectIndices().map(index=>faceDiv.children[index] || null);
+    return this.selectedObjectIndices().filter(index=>objects[index]).map(index=>faceDiv.children[index] || null);
   }
 
   // Align / distribute work on what is actually drawn (getBoundingClientRect, so rotated objects and auto-sized
   // icons line up by their visible box) and write the result back in the card's own coordinates - the same
   // approach the room editor's align toolbar takes with widgets.
+  // Each object is paired with its own rendered node by index (not by position in two separately filtered
+  // lists), and objects without a visible box are left out: a "display: false" object renders as display:none,
+  // whose rect is all zeros, so aligning to it would teleport it by the card's offset on screen.
   alignItems() {
-    const divs = this.selectedObjectDivs();
-    return this.selectedObjectTemplates()
-      .map((object, i)=>({ object, rect: divs[i] ? divs[i].getBoundingClientRect() : null }))
-      .filter(item=>item.rect);
+    const objects = this.faceObjects();
+    const faceDiv = this.mainCard ? $a('.cardFace', this.mainCard.domElement)[this.face] : null;
+    if(!faceDiv)
+      return [];
+    return this.selectedObjectIndices()
+      .filter(index=>objects[index] && faceDiv.children[index])
+      .map(index=>({ object: objects[index], rect: faceDiv.children[index].getBoundingClientRect() }))
+      .filter(item=>item.rect.width || item.rect.height);
   }
 
   async alignObjects(property, lowerBound, upperBound, factor) {
@@ -1714,7 +1736,7 @@ class DeckEditor {
       object[property] = Math.round((object[property] || 0) - (rect[lowerBound] - start - offset)/this.cardScale);
       offset += gap + rect[upperBound] - rect[lowerBound];
     }
-    await this.finishAlignment(items.length, 'evenly spaced');
+    await this.finishAlignment(items.length, 'distributed');
   }
 
   async finishAlignment(count, verb) {
@@ -1731,9 +1753,15 @@ class DeckEditor {
   // isn't drawn at all. For that case this puts a replacement rectangle into the card wrapper, outside the clip,
   // at the object's box clamped to the card - i.e. just inside the card's outer edge - and turns the object's
   // own outline off so only one rectangle is drawn.
+  // Only the primary object can carry that replacement rectangle, so every other object gets the class taken
+  // off again first - ctrl+clicking a second object makes it the new primary, and the old one would otherwise
+  // keep an outline that is turned off with no rectangle standing in for it.
   updateSelectionOutline() {
     const objectDiv = this.selectedObjectDiv();
     const outline = this.selectionOutline;
+    for(const clipped of $a('.deckEditorClippedObject', this.mainCard && this.mainCard.domElement))
+      if(clipped != objectDiv)
+        clipped.classList.remove('deckEditorClippedObject');
     if(!this.cardWrapper || !objectDiv) {
       if(outline)
         outline.style.display = 'none';
@@ -2014,9 +2042,11 @@ class DeckEditor {
       if(property == 'type')
         return this.renderObjectTypeRow(objectProps, objects, objectFieldArgs('type'));
       // Known object properties get a fixed field type (number or text) with no type selector; the value's
-      // JS type decides for anything custom.
-      const fieldType = this.objectFieldType(property);
+      // JS type decides for anything custom. A "(mixed)" row has no value to read that type from, so it is
+      // taken from the first object that has the property set - otherwise a mixed checkbox/JSON row would
+      // fall back to a text field and write a string ("false") where a boolean belongs.
       const common = this.commonPropertyValue(objects, property);
+      const fieldType = this.objectFieldType(property) || this.valueFieldType(common.sample);
       const onValueChanged = v=>this.queueFieldEdit(async _=>{
         await this.flushPendingCommitForOtherField('faceTemplates', objectFieldArgs(property)[1]);
         for(const selected of objects)
@@ -2831,11 +2861,14 @@ class DeckEditor {
 
   // The value a property has across the selected objects: the shared one, or mixed = true as soon as they
   // disagree - the row then shows an empty "(mixed)" field that only writes once something is typed into it.
+  // A mixed row still needs a field type though (a checkbox has to stay a checkbox), and value is blank in that
+  // case, so sample carries the first value actually set - what the row's type is then read from.
   commonPropertyValue(objects, property) {
     const key = value=>JSON.stringify(value === undefined ? null : value);
     const first = objects.length ? objects[0][property] : undefined;
     const mixed = objects.some(object=>key(object[property]) !== key(first));
-    return { value: mixed ? undefined : first, mixed };
+    const set = objects.find(object=>object[property] !== undefined);
+    return { value: mixed ? undefined : first, mixed, sample: set ? set[property] : undefined };
   }
 
   // The blocks the sidebar sorts property rows into, mirroring the Edit Widget sidebar so both read the same
@@ -2865,8 +2898,11 @@ class DeckEditor {
       for(const property of inGroup)
         remaining.splice(remaining.indexOf(property), 1);
 
+      // Position/Size start folded only for a face object, where x/y/width/height are usually changed by
+      // dragging the object around. On the other tabs those same names are the point of the tab (All Cards is
+      // mostly width/height) or an arbitrary game-defined property, so there they start open.
       const key = `${stateKey}:${group.id}`;
-      const collapsed = this.groupCollapsed[key] !== undefined ? this.groupCollapsed[key] : !!group.collapsed;
+      const collapsed = this.groupCollapsed[key] !== undefined ? this.groupCollapsed[key] : (stateKey == 'object' && !!group.collapsed);
       const wrap = div(target, `deckEditorGroup${collapsed ? ' collapsed' : ''}`);
       const header = document.createElement('button');
       header.type = 'button';
@@ -2898,17 +2934,25 @@ class DeckEditor {
     return undefined;
   }
 
+  // The field a value asks for when nothing forces a type: numbers get a number field, booleans a checkbox,
+  // arrays/objects a JSON textarea, everything else a text field.
+  valueFieldType(value) {
+    if(typeof value === 'number')
+      return 'number';
+    if(typeof value === 'boolean')
+      return 'boolean';
+    if(value !== null && typeof value === 'object')
+      return 'object';
+    return 'text';
+  }
+
   // A property row with a fixed input type and NO type selector — matches addInput's return shape ({ dom }) so
   // the make-dynamic / delete buttons attach the same way. fieldType may be forced (number/text/boolean/object)
   // or left undefined to follow the value's JS type. mixed marks a row whose selected objects disagree about
   // the value: the field starts empty and says so, and only writes to them once something is entered.
   addTypedInput(label, value, onValueChanged, target, fieldType, emptyIsZero, mixed) {
-    if(!fieldType) {
-      if(typeof value === 'number') fieldType = 'number';
-      else if(typeof value === 'boolean') fieldType = 'boolean';
-      else if(value !== null && typeof value === 'object') fieldType = 'object';
-      else fieldType = 'text';
-    }
+    if(!fieldType)
+      fieldType = this.valueFieldType(value);
     const wrapper = div(target, 'genericInput deckEditorTypedInput');
     const labelEl = document.createElement('label');
     labelEl.style.cssText = 'display:inline-block;width:100px';

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -340,6 +340,7 @@ class DeckEditor {
     $('#deckEditorRedo').onclick = _=>this.redo();
     $('#deckEditorCardView').onclick = _=>this.setRoomVisible(!this.roomVisible);
     this.setRoomVisible(false); // sets the toggle's initial tooltip
+    $('#deckEditorClose').onclick = _=>this.close();
     $('#deckEditorShowAll').onclick = _=>{
       this.showAllAreas = !this.showAllAreas;
       $('#deckEditorShowAll').classList.toggle('active', this.showAllAreas);

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -79,25 +79,27 @@ class DeckEditorMoveButton extends DeckEditorDragButton {
   }
 
   async dragStart() {
-    const object = deckEditor.selectedObjectTemplate();
-    this.startX = object.x || 0;
-    this.startY = object.y || 0;
+    this.starts = deckEditor.startPositions();
   }
 
   async dragMove(dx, dy) {
-    const object = deckEditor.selectedObjectTemplate();
-    object.x = Math.round(this.startX + dx);
-    object.y = Math.round(this.startY + dy);
+    for(const start of this.starts) {
+      start.object.x = Math.round(start.x + dx);
+      start.object.y = Math.round(start.y + dy);
+    }
     deckEditor.refreshMainCardFaces();
 
-    return `
+    // With several objects moving together the feedback follows the primary one - they all move by the same
+    // amount, so one pair of coordinates describes the whole drag.
+    const object = deckEditor.selectedObjectTemplate();
+    return object ? `
       X: <i>${object.x}</i><br>
       Y: <i>${object.y}</i>
-    `;
+    ` : null;
   }
 
   async dragEnd() {
-    await deckEditor.commit('faceTemplates', `${getPlayerDetails().playerName} moved a face object of deck ${deckEditor.deckID} in deck editor`);
+    await deckEditor.commit('faceTemplates', deckEditor.objectActionCause('moved', this.starts.length));
     deckEditor.renderSidebar();
   }
 }
@@ -111,36 +113,48 @@ class DeckEditorResizeButton extends DeckEditorDragButton {
     this.keepAspectRatio = keepAspectRatio;
   }
 
+  // Every selected object is resized by the same number of card pixels, each starting from its own size - so a
+  // group of objects keeps its size differences instead of being flattened to one size.
   async dragStart() {
-    const object = deckEditor.selectedObjectTemplate();
-    const objectDiv = deckEditor.selectedObjectDiv();
-    this.resizeIconSize = object.type == 'icon' && object.width === undefined;
-    this.startSize   = object.size !== undefined ? object.size : (objectDiv ? objectDiv.offsetWidth : 0);
-    this.startWidth  = object.width  !== undefined ? object.width  : (objectDiv ? objectDiv.offsetWidth  : 0);
-    this.startHeight = object.height !== undefined ? object.height : (objectDiv ? objectDiv.offsetHeight : 0);
+    const divs = deckEditor.selectedObjectDivs();
+    this.starts = deckEditor.dragObjects().map((object, i)=>{
+      const objectDiv = divs[i];
+      return {
+        object,
+        iconSize:    object.type == 'icon' && object.width === undefined,
+        startSize:   object.size   !== undefined ? object.size   : (objectDiv ? objectDiv.offsetWidth  : 0),
+        startWidth:  object.width  !== undefined ? object.width  : (objectDiv ? objectDiv.offsetWidth  : 0),
+        startHeight: object.height !== undefined ? object.height : (objectDiv ? objectDiv.offsetHeight : 0)
+      };
+    });
   }
 
   async dragMove(dx, dy) {
-    const object = deckEditor.selectedObjectTemplate();
+    for(const start of this.starts) {
+      const object = start.object;
+      if(start.iconSize) {
+        object.size = Math.max(1, Math.round(start.startSize + Math.max(dx, dy)));
+        continue;
+      }
 
-    if(this.resizeIconSize) {
-      object.size = Math.max(1, Math.round(this.startSize + Math.max(dx, dy)));
-      deckEditor.refreshMainCardFaces();
-      return `Size: <i>${object.size}</i>`;
+      let resizeDx = dx;
+      let resizeDy = dy;
+      if(this.keepAspectRatio && start.startWidth && start.startHeight) {
+        if(resizeDx > resizeDy)
+          resizeDy = resizeDx * start.startHeight / start.startWidth;
+        else
+          resizeDx = resizeDy * start.startWidth / start.startHeight;
+      }
+      object.width  = Math.max(1, Math.round(start.startWidth  + resizeDx));
+      object.height = Math.max(1, Math.round(start.startHeight + resizeDy));
     }
-
-    let resizeDx = dx;
-    let resizeDy = dy;
-    if(this.keepAspectRatio && this.startWidth && this.startHeight) {
-      if(resizeDx > resizeDy)
-        resizeDy = resizeDx * this.startHeight / this.startWidth;
-      else
-        resizeDx = resizeDy * this.startWidth / this.startHeight;
-    }
-    object.width  = Math.max(1, Math.round(this.startWidth  + resizeDx));
-    object.height = Math.max(1, Math.round(this.startHeight + resizeDy));
     deckEditor.refreshMainCardFaces();
 
+    const object = deckEditor.selectedObjectTemplate();
+    if(!object)
+      return null;
+    if(object.type == 'icon' && object.width === undefined)
+      return `Size: <i>${object.size}</i>`;
     return `
       Width: <i>${object.width}</i><br>
       Height: <i>${object.height}</i>
@@ -148,7 +162,7 @@ class DeckEditorResizeButton extends DeckEditorDragButton {
   }
 
   async dragEnd() {
-    await deckEditor.commit('faceTemplates', `${getPlayerDetails().playerName} resized a face object of deck ${deckEditor.deckID} in deck editor`);
+    await deckEditor.commit('faceTemplates', deckEditor.objectActionCause('resized', this.starts.length));
     deckEditor.renderSidebar();
   }
 }
@@ -159,19 +173,20 @@ class DeckEditorRotateButton extends DeckEditorDragButton {
   }
 
   async dragStart() {
-    this.startRotation = deckEditor.selectedObjectTemplate().rotation || 0;
+    this.starts = deckEditor.dragObjects().map(object=>({ object, rotation: object.rotation || 0 }));
   }
 
   async dragMove(dx, dy) {
-    const object = deckEditor.selectedObjectTemplate();
-    object.rotation = Math.floor(this.startRotation + (dx+dy)/2);
+    for(const start of this.starts)
+      start.object.rotation = Math.floor(start.rotation + (dx+dy)/2);
     deckEditor.refreshMainCardFaces();
 
-    return `Rotation: <i>${object.rotation}°</i>`;
+    const object = deckEditor.selectedObjectTemplate();
+    return object ? `Rotation: <i>${object.rotation}°</i>` : null;
   }
 
   async dragEnd() {
-    await deckEditor.commit('faceTemplates', `${getPlayerDetails().playerName} rotated a face object of deck ${deckEditor.deckID} in deck editor`);
+    await deckEditor.commit('faceTemplates', deckEditor.objectActionCause('rotated', this.starts.length));
     deckEditor.renderSidebar();
   }
 }
@@ -181,7 +196,7 @@ class DeckEditor {
     this.deckID = null;
     this.cardType = null;
     this.face = 0;
-    this.selectedObject = null;
+    this._selectedObjects = []; // the selected face objects, in click order - see the selectedObject accessor
     this.cardScale = 1;   // effective scale = fitScale * userZoom (drag math divides by this)
     this.fitScale = 1;    // scale that fits the card in the main area
     this.userZoom = 1;    // extra zoom from scroll wheel / pinch
@@ -223,6 +238,56 @@ class DeckEditor {
     this.applyingHistory = false;
     this.maxHistory = 60;
     this.actionSeq = 0;
+
+    this.groupCollapsed = {}; // which sidebar property groups the user folded away, keyed "tab:group"
+  }
+
+  // Several face objects can be selected at once (Ctrl/Shift+click), which is what makes editing a property of
+  // all of them - or aligning them - possible. The selection lives in _selectedObjects in click order, so its
+  // LAST entry is the primary one: the object whose properties headline the sidebar and whose box the drag
+  // toolbar hangs off. selectedObject reads exactly that, and assigning to it collapses the selection back to a
+  // single object - which is what every structural change (adding, deleting, reordering, restoring a remembered
+  // selection, ...) means when it sets one, so all those paths keep working unchanged.
+  get selectedObject() {
+    return this._selectedObjects.length ? this._selectedObjects[this._selectedObjects.length-1] : null;
+  }
+
+  set selectedObject(index) {
+    this._selectedObjects = index === null || index === undefined ? [] : [ index ];
+  }
+
+  // The selection in the order the objects sit on the face (not the order they were clicked), which is what the
+  // sidebar rows, align/distribute and multi-delete want.
+  selectedObjectIndices() {
+    return [...this._selectedObjects].sort((a,b)=>a-b);
+  }
+
+  selectedObjectTemplates() {
+    const face = this.faceTemplates[this.face];
+    const objects = face && Array.isArray(face.objects) ? face.objects : [];
+    return this.selectedObjectIndices().map(index=>objects[index]).filter(object=>object);
+  }
+
+  isObjectSelected(index) {
+    return this._selectedObjects.indexOf(index) != -1;
+  }
+
+  // The objects a drag acts on: the whole selection, falling back to the single object the drag started on.
+  dragObjects(fallbackObject) {
+    const objects = this.selectedObjectTemplates();
+    if(objects.length)
+      return objects;
+    return fallbackObject ? [ fallbackObject ] : [];
+  }
+
+  startPositions(fallbackObject) {
+    return this.dragObjects(fallbackObject).map(object=>({ object, x: object.x || 0, y: object.y || 0 }));
+  }
+
+  // Causes of the drag/align actions, phrased for one object or for a group so the breadcrumb (and the room's
+  // undo history) says which of the two happened.
+  objectActionCause(verb, count) {
+    return `${getPlayerDetails().playerName} ${verb} ${count > 1 ? `${count} face objects` : 'a face object'} of deck ${this.deckID} in deck editor`;
   }
 
   addInput(labelText, value, onValueChanged, target) {
@@ -275,6 +340,20 @@ class DeckEditor {
       $('#deckEditorShowAll').classList.toggle('active', this.showAllAreas);
       $('#deckEditorMain').classList.toggle('deckEditorShowAllAreas', this.showAllAreas);
     };
+    // Align / distribute the selected face objects (top bar). They need a multi-selection, which
+    // updateAlignToolbar enables them for.
+    for(const [ id, run ] of [
+      [ 'deckEditorAlignLeft',   _=>this.alignObjects('x', 'left', 'right', 0) ],
+      [ 'deckEditorAlignCenter', _=>this.alignObjects('x', 'left', 'right', 0.5) ],
+      [ 'deckEditorAlignRight',  _=>this.alignObjects('x', 'left', 'right', 1) ],
+      [ 'deckEditorAlignTop',    _=>this.alignObjects('y', 'top', 'bottom', 0) ],
+      [ 'deckEditorAlignMiddle', _=>this.alignObjects('y', 'top', 'bottom', 0.5) ],
+      [ 'deckEditorAlignBottom', _=>this.alignObjects('y', 'top', 'bottom', 1) ],
+      [ 'deckEditorDistributeH', _=>this.distributeObjects('x', 'left', 'right') ],
+      [ 'deckEditorDistributeV', _=>this.distributeObjects('y', 'top', 'bottom') ]
+    ])
+      $(`#${id}`).onclick = run;
+
     $('#deckEditorExport').onclick = _=>this.openExportOverlay();
     $('#deckEditorExportClose').onclick = _=>this.closeExportOverlay();
     for(const control of $a('#deckEditorExportDialog input, #deckEditorExportDialog select')) {
@@ -790,6 +869,11 @@ class DeckEditor {
         e.preventDefault();
         return this.redo();
       }
+      // Ctrl/Cmd+A selects every face object of the shown face, ready for a shared property edit or an alignment.
+      if(key == 'a' && [ 'TEXTAREA', 'INPUT', 'SELECT' ].indexOf(e.target.tagName) == -1 && !e.target.isContentEditable) {
+        e.preventDefault();
+        return this.selectAllObjects();
+      }
     }
 
     if([ 'TEXTAREA', 'INPUT', 'SELECT' ].indexOf(e.target.tagName) != -1 || e.target.isContentEditable)
@@ -1061,8 +1145,8 @@ class DeckEditor {
     if(this.face >= this.faceTemplates.length)
       this.face = Math.max(0, this.faceTemplates.length-1);
     const face = this.faceTemplates[this.face];
-    if(this.selectedObject !== null && (!face || !Array.isArray(face.objects) || this.selectedObject >= face.objects.length))
-      this.selectedObject = null;
+    const objectCount = face && Array.isArray(face.objects) ? face.objects.length : 0;
+    this._selectedObjects = this._selectedObjects.filter(index=>index < objectCount); // drop indices that vanished
     // A reload only happens for genuine external changes (see matchesWorkingCopy guard), so record it as its
     // own breadcrumb step (no actionId => never merges) rather than swapping the working copy out silently.
     this.recordHistory('__external__', null);
@@ -1205,7 +1289,10 @@ class DeckEditor {
 
     cause = cause.replace(/ \(#\d+\)$/, ''); // per-action suffix that keeps room-undo entries separate
 
-    let match = cause.match(/ updated "(.+?)" of face object (\d+) /);
+    let match = cause.match(/ updated "(.+?)" of (\d+) face objects /);
+    if(match)
+      return `Edited ${match[1]} of ${match[2]} objects`;
+    match = cause.match(/ updated "(.+?)" of face object (\d+) /);
     if(match)
       return `Edited ${match[1]} of object ${match[2]}`;
     match = cause.match(/ updated "(.+?)" of card type "(.+?)" /);
@@ -1434,11 +1521,17 @@ class DeckEditor {
       return;
 
     [...faceDiv.children].forEach((objectDiv, index)=>{
-      objectDiv.classList.toggle('deckEditorSelectedObject', index === this.selectedObject);
+      objectDiv.classList.toggle('deckEditorSelectedObject', this.isObjectSelected(index));
       const pointerDown = (name, e)=>{
         e.stopPropagation();
         e.preventDefault();
-        if(this.selectedObject !== index)
+        // Ctrl/Cmd or Shift picks up a second object instead of replacing the selection - and only changes the
+        // selection, so a modifier click can't drag the objects around by accident.
+        if(e.ctrlKey || e.metaKey)
+          return this.toggleObjectSelection(index);
+        if(e.shiftKey)
+          return this.extendObjectSelection(index);
+        if(!this.isObjectSelected(index))
           this.selectObject(index);
         this.startObjectDrag(name, e, index);
       };
@@ -1452,10 +1545,9 @@ class DeckEditor {
     // into the drag's commit. commit() snapshots synchronously, so not awaiting this here is safe.
     this.flushPendingCommits();
 
-    const object = this.faceTemplates[this.face].objects[index];
+    // Dragging one object of a multi-selection moves the whole selection, so a group keeps its arrangement.
+    const dragged = this.startPositions(this.faceTemplates[this.face].objects[index]);
     const startCoords = eventCoords(name, e);
-    const startX = object.x || 0;
-    const startY = object.y || 0;
     let moved = false;
 
     const move = ev=>{
@@ -1467,8 +1559,10 @@ class DeckEditor {
         moved = true;
       if(!moved)
         return;
-      object.x = Math.round(startX + dx);
-      object.y = Math.round(startY + dy);
+      for(const start of dragged) {
+        start.object.x = Math.round(start.x + dx);
+        start.object.y = Math.round(start.y + dy);
+      }
       this.refreshMainCardFaces();
       this.updateDragToolbar();
     };
@@ -1478,7 +1572,7 @@ class DeckEditor {
       for(const event of [ 'mouseup', 'touchend', 'touchcancel' ])
         document.removeEventListener(event, up);
       if(moved) {
-        await this.commit('faceTemplates', `${getPlayerDetails().playerName} moved a face object of deck ${this.deckID} in deck editor`);
+        await this.commit('faceTemplates', this.objectActionCause('moved', dragged.length));
         this.renderSidebar();
       }
     };
@@ -1491,9 +1585,6 @@ class DeckEditor {
   selectObject(index, face) {
     if(index !== null)
       this.activeArea = 'tree';
-    // Follow the selection with the sidebar tab: picking an object shows its properties, dropping the
-    // selection falls back to the face the object lives on.
-    this.sidebarTab = index !== null ? 'object' : 'face';
     // Clicking an object of another (expanded) face makes that face current first.
     if(index !== null && face !== undefined && face !== this.face) {
       if(this.deckID)
@@ -1502,14 +1593,60 @@ class DeckEditor {
       this.selectedObject = index;
       this.deckSymbolSelected = false;
       this.treeLevel = 'object';
+      this.sidebarTab = 'object';
       this.render();
       return;
     }
     this.selectedObject = index;
-    if(index !== null) {
+    this.afterSelectionChanged();
+  }
+
+  // Ctrl/Cmd+click adds or removes one face object, so a property (or an alignment) can be applied to several of
+  // them at once. Objects of another face can only be selected on their own - the working copy the sidebar edits
+  // is always the shown face.
+  toggleObjectSelection(index, face) {
+    if(face !== undefined && face !== this.face)
+      return this.selectObject(index, face);
+    const at = this._selectedObjects.indexOf(index);
+    if(at != -1)
+      this._selectedObjects.splice(at, 1);
+    else
+      this._selectedObjects.push(index); // last = primary
+    this.afterSelectionChanged();
+  }
+
+  // Shift+click selects everything between the primary object and the clicked one, like a file list.
+  extendObjectSelection(index, face) {
+    if((face !== undefined && face !== this.face) || this.selectedObject === null)
+      return this.selectObject(index, face);
+    const range = [];
+    for(let i=Math.min(this.selectedObject, index); i<=Math.max(this.selectedObject, index); ++i)
+      range.push(i);
+    this._selectedObjects = [ ...this._selectedObjects.filter(i=>range.indexOf(i) == -1), ...range.filter(i=>i != index), index ];
+    this.afterSelectionChanged();
+  }
+
+  selectAllObjects() {
+    const face = this.faceTemplates[this.face];
+    if(!face || !Array.isArray(face.objects) || !face.objects.length)
+      return;
+    this._selectedObjects = face.objects.map((_, index)=>index);
+    this.afterSelectionChanged();
+  }
+
+  // Everything that has to follow a changed selection, however it was changed. The sidebar tab follows too:
+  // picking an object shows its properties, dropping the selection falls back to the face the object lives on.
+  afterSelectionChanged() {
+    if(this.selectedObject !== null) {
+      this.activeArea = 'tree';
       this.deckSymbolSelected = false; // selecting a face object leaves the card-defaults view
       this.treeLevel = 'object';
     }
+    this.sidebarTab = this.selectedObject !== null ? 'object' : 'face';
+    // Picking an object out of the tree while the card-defaults view was showing has to bring the card back:
+    // the selection outline, the drag toolbar and align/distribute all work off the rendered card.
+    if(this.selectedObject !== null && !this.mainCard)
+      this.renderMain();
     this.attachObjectHandlers();
     this.renderLeftSidebar(); // keep the left face-object list's highlight in sync with the main card
     this.renderSidebar();
@@ -1528,6 +1665,63 @@ class DeckEditor {
       return null;
     const faceDiv = $a('.cardFace', this.mainCard.domElement)[this.face];
     return faceDiv ? faceDiv.children[this.selectedObject] : null;
+  }
+
+  // The rendered nodes of the selected objects, in the same order as selectedObjectTemplates/dragObjects.
+  selectedObjectDivs() {
+    const faceDiv = this.mainCard ? $a('.cardFace', this.mainCard.domElement)[this.face] : null;
+    if(!faceDiv)
+      return [];
+    return this.selectedObjectIndices().map(index=>faceDiv.children[index] || null);
+  }
+
+  // Align / distribute work on what is actually drawn (getBoundingClientRect, so rotated objects and auto-sized
+  // icons line up by their visible box) and write the result back in the card's own coordinates - the same
+  // approach the room editor's align toolbar takes with widgets.
+  alignItems() {
+    const divs = this.selectedObjectDivs();
+    return this.selectedObjectTemplates()
+      .map((object, i)=>({ object, rect: divs[i] ? divs[i].getBoundingClientRect() : null }))
+      .filter(item=>item.rect);
+  }
+
+  async alignObjects(property, lowerBound, upperBound, factor) {
+    const items = this.alignItems();
+    if(items.length < 2)
+      return;
+    await this.flushPendingCommits(); // don't absorb a pending typed edit into this action
+    const lower = Math.min(...items.map(item=>item.rect[lowerBound]));
+    const target = lower + (Math.max(...items.map(item=>item.rect[upperBound])) - lower) * factor;
+    for(const { object, rect } of items) {
+      const own = rect[lowerBound] + (rect[upperBound] - rect[lowerBound]) * factor;
+      object[property] = Math.round((object[property] || 0) - (own - target)/this.cardScale);
+    }
+    await this.finishAlignment(items.length, 'aligned');
+  }
+
+  async distributeObjects(property, lowerBound, upperBound) {
+    const items = this.alignItems();
+    if(items.length < 3)
+      return;
+    await this.flushPendingCommits(); // don't absorb a pending typed edit into this action
+    const sorted = [...items].sort((a,b)=>a.rect[lowerBound] - b.rect[lowerBound]);
+    const start = sorted[0].rect[lowerBound];
+    const span = Math.max(...items.map(item=>item.rect[upperBound])) - start;
+    const used = items.reduce((sum, item)=>sum + item.rect[upperBound] - item.rect[lowerBound], 0);
+    const gap = (span - used) / (items.length - 1);
+    let offset = 0;
+    for(const { object, rect } of sorted) {
+      object[property] = Math.round((object[property] || 0) - (rect[lowerBound] - start - offset)/this.cardScale);
+      offset += gap + rect[upperBound] - rect[lowerBound];
+    }
+    await this.finishAlignment(items.length, 'evenly spaced');
+  }
+
+  async finishAlignment(count, verb) {
+    this.refreshMainCardFaces();
+    await this.commit('faceTemplates', this.objectActionCause(verb, count));
+    this.renderSidebar();
+    this.updateDragToolbar();
   }
 
   // The selected object's orange rectangle. While the object stays well inside the card that rectangle is a CSS
@@ -1583,8 +1777,17 @@ class DeckEditor {
     this.selectionOutline.style.height = height + 'px';
   }
 
+  // Aligning needs two objects, spreading them out evenly needs three. The buttons stay visible below that (and
+  // say what they would do) instead of appearing and disappearing with the selection.
+  updateAlignToolbar() {
+    const selected = this._selectedObjects.length;
+    for(const button of $a('#deckEditorAlignToolbar button'))
+      button.disabled = selected < (button.classList.contains('deckEditorDistributeButton') ? 3 : 2);
+  }
+
   updateDragToolbar() {
     this.updateSelectionOutline();
+    this.updateAlignToolbar();
     const toolbar = $('#deckEditorDragToolbar');
     const objectDiv = this.selectedObjectDiv();
     if(!objectDiv) {
@@ -1718,8 +1921,8 @@ class DeckEditor {
     if(!deck)
       return;
 
-    // A <header> (not a div) so the test selector `.deckEditorProperties:first-of-type` keeps matching the
-    // first properties div. scopeClass carries the topbar's blue/amber accent into the sidebar sections.
+    // A <header> element, so a tab reads as titled sections rather than a stack of divs. scopeClass carries
+    // the topbar's blue/amber accent into the sidebar sections.
     const addHeader = (text, scopeClass, caption)=>{
       const header = document.createElement('header');
       header.className = `deckEditorSidebarHeader ${scopeClass}`;
@@ -1771,7 +1974,6 @@ class DeckEditor {
 
     // The object tab stays clickable without a selection, so a face object can be added straight from here.
     if(!object) {
-      // A <p> (not a div) so the test selector `.deckEditorProperties:first-of-type` keeps matching.
       const note = document.createElement('p');
       note.className = 'deckEditorSectionNote';
       note.textContent = 'No face object is selected. Add one with the + above, or click an object on the card or in the list to the left to edit it.';
@@ -1780,44 +1982,54 @@ class DeckEditor {
       return;
     }
 
-    // The caption spells out what the rows below do, so the contrast with the amber "different per card
-    // type" Dynamic properties section further down is stated, not just colored.
-    addHeader(`Face object ${this.selectedObject+1} (${object.type || 'text'})`, 'deckEditorScopeEveryCard', 'Same on every card type');
+    // With more than one object selected every row edits all of them at once, so the header counts them instead
+    // of naming one. The caption spells out what the rows below do, so the contrast with the amber "different
+    // per card type" Dynamic properties section further down is stated, not just colored.
+    const objects = this.selectedObjectTemplates();
+    const multi = objects.length > 1;
+    addHeader(multi ? `${objects.length} face objects selected` : `Face object ${this.selectedObject+1} (${object.type || 'text'})`,
+      'deckEditorScopeEveryCard', 'Same on every card type');
     // Note below (not part of) the header, in the same style as the Dynamic properties note.
-    if(object.type == 'html')
+    if(multi)
+      div(sidebar, 'deckEditorSectionNote').textContent = 'Every row below changes all selected objects at once. A property the selected objects do not agree on shows as "(mixed)" until a new value is typed.';
+    else if(object.type == 'html')
       div(sidebar, 'deckEditorSectionNote').textContent = 'The JSON Editor should be used for editing HTML face objects.';
 
     // One cause/actionId per edited field: a typing burst on one property of one object stays one
     // breadcrumb/undo step, but edits to another property or object become their own step.
-    const objectFieldArgs = property=>[
+    const objectFieldArgs = property=>multi ? [
+      `${getPlayerDetails().playerName} updated "${property}" of ${objects.length} face objects on face ${this.face} of deck ${this.deckID} in deck editor`,
+      `field:faceTemplates:${this.face}:${this.selectedObjectIndices().join('+')}:${property}`
+    ] : [
       `${getPlayerDetails().playerName} updated "${property}" of face object ${this.selectedObject+1} on face ${this.face} of deck ${this.deckID} in deck editor`,
       `field:faceTemplates:${this.face}:${this.selectedObject}:${property}`
     ];
-    const objectProps = div(sidebar, 'deckEditorProperties deckEditorObjectProperties');
-    for(const property of Object.keys(object)) {
-      if(property == 'dynamicProperties')
-        continue;
+    // Grouped into the same blocks the Edit Widget sidebar uses (see renderPropertyGroups); a property only one
+    // of the selected objects has still gets a row, so it can be given to all of them in one go.
+    const objectProperties = [...new Set(objects.flatMap(o=>Object.keys(o)))].filter(property=>property != 'dynamicProperties');
+    const commonType = this.commonPropertyValue(objects, 'type');
+    this.renderPropertyGroups(sidebar, objectProperties, 'object', (property, objectProps)=>{
       // The object's structural "type" is a dropdown of the valid types (not a free-typed field that could
       // be broken by a typo) and can't be deleted.
-      if(property == 'type') {
-        this.renderObjectTypeRow(objectProps, object);
-        continue;
-      }
+      if(property == 'type')
+        return this.renderObjectTypeRow(objectProps, objects, objectFieldArgs('type'));
       // Known object properties get a fixed field type (number or text) with no type selector; the value's
       // JS type decides for anything custom.
       const fieldType = this.objectFieldType(property);
+      const common = this.commonPropertyValue(objects, property);
       const onValueChanged = v=>this.queueFieldEdit(async _=>{
         await this.flushPendingCommitForOtherField('faceTemplates', objectFieldArgs(property)[1]);
-        object[property] = v;
+        for(const selected of objects)
+          selected[property] = v;
         this.refreshMainCardFaces();
         this.updateDragToolbar();
         this.scheduleCommit('faceTemplates', ...objectFieldArgs(property));
       });
-      const row = this.addTypedInput(property, object[property], onValueChanged, objectProps, fieldType, true);
+      const row = this.addTypedInput(property, common.value, onValueChanged, objectProps, fieldType, true, common.mixed);
       // The object's own value is an image/icon: a picker button opens the same chip picker the Edit
       // Widgets tab uses for a basic widget's Content section, right below this row.
-      if(property == 'value' && (object.type == 'image' || object.type == 'icon'))
-        this.addAssetPickerToRow(row, objectProps, object.type, ()=>object[property], onValueChanged);
+      if(property == 'value' && !commonType.mixed && (commonType.value == 'image' || commonType.value == 'icon'))
+        this.addAssetPickerToRow(row, objectProps, commonType.value, _=>this.commonPropertyValue(objects, property).value, onValueChanged);
       // A color-named property (color, strokeColor, …) or a color-looking value gets a swatch + color picker.
       else
         this.addColorPickerToRow(row, objectProps, property, onValueChanged);
@@ -1825,22 +2037,29 @@ class DeckEditor {
       // Dynamic properties section's Link control below. Only the delete (trash) button stays on the row.
       this.addPropertyDeleteButton(row, property, async _=>{
         await this.flushPendingCommits();
-        delete object[property];
+        for(const selected of objects)
+          delete selected[property];
         this.refreshMainCardFaces();
-        await this.commit('faceTemplates', `${getPlayerDetails().playerName} deleted property "${property}" of a face object of deck ${this.deckID} in deck editor`);
+        const from = multi ? `${objects.length} face objects` : 'a face object';
+        await this.commit('faceTemplates', `${getPlayerDetails().playerName} deleted property "${property}" of ${from} of deck ${this.deckID} in deck editor`);
         this.renderSidebar();
       });
-    }
+    }, 'deckEditorObjectProperties');
     addPropertyRow(sidebar, (property, type)=>this.queueFieldEdit(async _=>{
-      if(property == 'dynamicProperties' || object[property] !== undefined)
+      if(property == 'dynamicProperties' || objects.every(selected=>selected[property] !== undefined))
         return;
       await this.flushPendingCommitForOtherField('faceTemplates', objectFieldArgs(property)[1]);
-      object[property] = this.initialValueForType(type);
+      for(const selected of objects)
+        if(selected[property] === undefined)
+          selected[property] = this.initialValueForType(type);
       this.scheduleCommit('faceTemplates', ...objectFieldArgs(property));
       this.renderSidebar();
     }));
 
-    this.renderDynamicProperties(sidebar, object);
+    // Bindings are per object (they name the card type property each one reads), so they stay a single-object
+    // affair - with several objects selected the section would have nothing meaningful to show.
+    if(!multi)
+      this.renderDynamicProperties(sidebar, object);
 
     // No "Delete object" button here — objects are deleted from the left face-object list (or Delete key).
     this.renderObjectHint();
@@ -1864,7 +2083,8 @@ class DeckEditor {
       // Selecting an object is not required to open this tab: without one it still offers the + that adds a
       // face object, so an empty face can be filled without going through the tree.
       { id: 'object', label: 'Object', icon: 'category', scope: 'deckEditorScopeEveryCard', available: !!face,
-        title: object ? `Face object ${this.selectedObject+1} of ${this.faceLabel(this.face).toLowerCase()}`
+        title: this._selectedObjects.length > 1 ? `${this._selectedObjects.length} face objects of ${this.faceLabel(this.face).toLowerCase()} - every property here is set on all of them`
+             : object ? `Face object ${this.selectedObject+1} of ${this.faceLabel(this.face).toLowerCase()}`
                       : 'Add a face object, or click one on the card or in the list to the left to edit it' }
     ];
   }
@@ -1878,6 +2098,7 @@ class DeckEditor {
     const hasFace = !!this.faceTemplates[this.face];
     const hasType = this.cardType !== null;
     const hasObject = !!this.selectedObjectTemplate();
+    const objectNoun = this._selectedObjects.length > 1 ? 'objects' : 'object';
     const actions = {
       defaults: [
         [ 'Add a new deck to the game', true, _=>this.openNewDeckOverlay() ],
@@ -1896,15 +2117,14 @@ class DeckEditor {
       ],
       object: [
         [ 'Add a face object to this face', hasFace, null ], // wired to the submenu below
-        [ 'Copy the selected face object', hasObject, _=>this.copySelectedObject() ],
-        [ 'Delete the selected face object', hasObject, _=>this.deleteSelectedObject() ]
+        [ `Copy the selected face ${objectNoun}`, hasObject, _=>this.copySelectedObject() ],
+        [ `Delete the selected face ${objectNoun}`, hasObject, _=>this.deleteSelectedObject() ]
       ]
     }[this.sidebarTab];
     if(!actions)
       return;
 
-    // A <menu> (not a div) so the test selector `.deckEditorProperties:first-of-type` keeps matching the first
-    // properties div of the panel below.
+    // A <menu>: this is a list of actions, not one more block of properties.
     const bar = document.createElement('menu');
     bar.className = 'deckEditorSidebarToolbar';
     sidebar.append(bar);
@@ -1951,8 +2171,7 @@ class DeckEditor {
   }
 
   renderSidebarTabs(sidebar, tabs) {
-    // A <nav> (not a div) so the test selector `.deckEditorProperties:first-of-type` keeps matching the first
-    // properties div of the panel below.
+    // A <nav>: the tab bar navigates between scopes, it does not edit anything.
     const nav = document.createElement('nav');
     nav.id = 'deckEditorTabs';
     sidebar.append(nav);
@@ -2004,7 +2223,6 @@ class DeckEditor {
       `${getPlayerDetails().playerName} updated "${property}" of card type "${this.cardType}" of deck ${this.deckID} in deck editor`,
       `field:cardTypes:${this.cardType}:${property}`
     ];
-    const typeProps = div(sidebar, 'deckEditorProperties');
     // Properties a face object binds to are structural: the object reads them, so their row must stay even
     // when blank. Only free-standing properties get a trash (which removes the whole row + JSON); to remove a
     // bound one, remove the object's binding.
@@ -2013,7 +2231,7 @@ class DeckEditor {
       for(const object of face.objects || [])
         for(const property of Object.values(object.dynamicProperties || {}))
           boundProperties.add(property);
-    const addTypeInput = property=>{
+    const addTypeInput = (property, typeProps)=>{
       const onValueChanged = v=>this.queueFieldEdit(async _=>{
         await this.flushPendingCommitForOtherField('cardTypes', typeFieldArgs(property)[1]);
         typeProperties[property] = v;
@@ -2038,11 +2256,11 @@ class DeckEditor {
           this.renderSidebar();
         });
     };
-    for(const property of Object.keys(typeProperties))
-      addTypeInput(property);
+    const typePropertyNames = [ ...Object.keys(typeProperties) ];
     for(const property of boundProperties)
       if(typeof typeProperties[property] === 'undefined' && [ 'cardType', 'id' ].indexOf(property) == -1)
-        addTypeInput(property);
+        typePropertyNames.push(property);
+    this.renderPropertyGroups(sidebar, typePropertyNames, 'cardType', addTypeInput);
     addPropertyRow(sidebar, (property, type)=>this.queueFieldEdit(async _=>{
       if(typeProperties[property] !== undefined)
         return;
@@ -2245,14 +2463,20 @@ class DeckEditor {
   renderTreeObjectRow(tree, object, index, face = this.face) {
     const typeIcon = { text: 'format_size', image: 'image', icon: 'add_reaction', html: 'code' }[object.type || 'text'] || 'category';
     const row = div(tree, 'deckEditorTreeNode deckEditorObjectRow', `<span class=deckEditorObjectNum>${index+1}</span><span class=deckEditorTreeIcon icon=${typeIcon}></span><div class=deckEditorObjectPreview></div>`);
-    const objSel = face === this.face && index === this.selectedObject;
+    const objSel = face === this.face && this.isObjectSelected(index);
     row.classList.toggle('selected', objSel && this.activeArea == 'tree');
     row.classList.toggle('selectedInactive', objSel && this.activeArea != 'tree');
-    row.title = `Face object ${index+1} (${object.type || 'text'})`;
+    row.title = `Face object ${index+1} (${object.type || 'text'}) — Ctrl+click to select several at once`;
     const previewBox = $('.deckEditorObjectPreview', row);
     this.treeObjectPreviews.push({ box: previewBox, index, face });
     this.renderObjectPreview(previewBox, index, face);
-    row.onclick = _=>this.selectObject(index, face);
+    row.onclick = e=>{
+      if(e.ctrlKey || e.metaKey)
+        return this.toggleObjectSelection(index, face);
+      if(e.shiftKey)
+        return this.extendObjectSelection(index, face);
+      this.selectObject(index, face);
+    };
     // Drag-and-drop reordering, only within the current face (objects of other expanded faces are read-only here).
     row.draggable = face === this.face;
     row.ondragstart = e=>{
@@ -2291,7 +2515,7 @@ class DeckEditor {
   updateTreeToolbar() {
     const hasDeck = !!this.deck();
     const level = this.treeLevel;
-    const noun = level == 'object' ? 'object' : level;
+    const noun = level == 'object' ? (this._selectedObjects.length > 1 ? 'objects' : 'object') : level;
     const add = $('#deckEditorTreeAdd'), copy = $('#deckEditorTreeCopy'), del = $('#deckEditorTreeDelete'), show = $('#deckEditorShowAll');
     if(add) {
       add.disabled = !hasDeck;
@@ -2469,6 +2693,12 @@ class DeckEditor {
     input.onmousedown = e=>e.stopPropagation();
     input.onclick = e=>{
       e.stopPropagation();
+      // The field covers most of its row, so it has to offer the row's Ctrl/Shift multi-select too - otherwise
+      // text objects could only ever be selected one at a time.
+      if(e.ctrlKey || e.metaKey)
+        return this.toggleObjectSelection(index, faceIndex);
+      if(e.shiftKey)
+        return this.extendObjectSelection(index, faceIndex);
       if(this.selectedObject !== index || this.face !== faceIndex)
         this.selectObject(index, faceIndex);
     };
@@ -2498,19 +2728,25 @@ class DeckEditor {
     box.append(input);
   }
 
+  // Copies every selected object, appending the copies after the last one so a copied group stays a group -
+  // and selects the copies, so the next drag moves them off their originals.
   async copySelectedObject() {
     const face = this.faceTemplates[this.face];
-    if(!face || this.selectedObject === null || !Array.isArray(face.objects))
+    const indices = this.selectedObjectIndices();
+    if(!face || !indices.length || !Array.isArray(face.objects))
       return;
     await this.flushPendingCommits(); // don't absorb a pending typed edit into this action
-    const copy = JSON.parse(JSON.stringify(face.objects[this.selectedObject]));
-    copy.x = (copy.x || 0) + 10; // offset so the copy is visible on top of the original
-    copy.y = (copy.y || 0) + 10;
-    const insertAt = this.selectedObject + 1;
-    face.objects.splice(insertAt, 0, copy);
-    this.selectedObject = insertAt;
+    const insertAt = indices[indices.length-1] + 1;
+    const copies = indices.map(index=>{
+      const copy = JSON.parse(JSON.stringify(face.objects[index]));
+      copy.x = (copy.x || 0) + 10; // offset so the copy is visible on top of the original
+      copy.y = (copy.y || 0) + 10;
+      return copy;
+    });
+    face.objects.splice(insertAt, 0, ...copies);
+    this._selectedObjects = copies.map((_, i)=>insertAt + i);
     this.refreshMainCardFaces();
-    await this.commit('faceTemplates', `${getPlayerDetails().playerName} copied a face object of deck ${this.deckID} in deck editor`);
+    await this.commit('faceTemplates', this.objectActionCause('copied', copies.length));
     this.render();
   }
 
@@ -2558,31 +2794,100 @@ class DeckEditor {
   }
 
   // The object's "type" as a dropdown of valid values (text/image/icon/html); changing it re-renders because
-  // the header and the image-only upload button depend on it. It has no make-dynamic or delete control.
-  renderObjectTypeRow(target, object) {
+  // the header and the image-only upload button depend on it. It has no make-dynamic or delete control. With
+  // several objects selected it sets the type of all of them, and shows "(mixed)" while they differ.
+  renderObjectTypeRow(target, objects, args) {
+    const common = this.commonPropertyValue(objects, 'type');
     const row = div(target, 'genericInput deckEditorTypedInput');
     const labelEl = document.createElement('label');
     labelEl.style.cssText = 'display:inline-block;width:100px';
     labelEl.textContent = 'type';
     const select = document.createElement('select');
+    if(common.mixed) {
+      const mixedOption = document.createElement('option');
+      mixedOption.value = '';
+      mixedOption.textContent = '(mixed)';
+      mixedOption.selected = true;
+      select.append(mixedOption);
+    }
     for(const t of [ 'text', 'image', 'icon', 'html' ]) {
       const opt = document.createElement('option');
       opt.value = opt.textContent = t;
-      opt.selected = (object.type || 'text') == t;
+      opt.selected = !common.mixed && (common.value || 'text') == t;
       select.append(opt);
     }
     select.onchange = _=>this.queueFieldEdit(async _=>{
-      const args = [
-        `${getPlayerDetails().playerName} changed the type of face object ${this.selectedObject+1} on face ${this.face} of deck ${this.deckID} in deck editor`,
-        `field:faceTemplates:${this.face}:${this.selectedObject}:type`
-      ];
+      if(!select.value)
+        return;
       await this.flushPendingCommitForOtherField('faceTemplates', args[1]);
-      object.type = select.value;
+      for(const object of objects)
+        object.type = select.value;
       this.refreshMainCardFaces();
       this.scheduleCommit('faceTemplates', ...args);
       this.renderSidebar();
     });
     row.append(labelEl, select);
+  }
+
+  // The value a property has across the selected objects: the shared one, or mixed = true as soon as they
+  // disagree - the row then shows an empty "(mixed)" field that only writes once something is typed into it.
+  commonPropertyValue(objects, property) {
+    const key = value=>JSON.stringify(value === undefined ? null : value);
+    const first = objects.length ? objects[0][property] : undefined;
+    const mixed = objects.some(object=>key(object[property]) !== key(first));
+    return { value: mixed ? undefined : first, mixed };
+  }
+
+  // The blocks the sidebar sorts property rows into, mirroring the Edit Widget sidebar so both read the same
+  // way: known properties land in Content / Position / Size / Colors / Appearance, and everything the engine
+  // doesn't know - the bespoke properties a game defines for itself - gets its own area at the bottom.
+  propertyGroups() {
+    return [
+      { id: 'content',    title: 'Content',    properties: [ 'type', 'value', 'text', 'name' ] },
+      { id: 'position',   title: 'Position',   properties: [ 'x', 'y', 'rotation' ], collapsed: true },
+      { id: 'size',       title: 'Size',       properties: [ 'width', 'height', 'size', 'scale' ], collapsed: true },
+      { id: 'colors',     title: 'Colors',     properties: [ 'color', 'strokeColor', 'hoverColor', 'hoverStrokeColor' ] },
+      { id: 'appearance', title: 'Appearance', properties: [ 'fontSize', 'textAlign', 'strokeWidth', 'hoverStrokeWidth', 'opacity', 'hoverOpacity', 'offsetX', 'offsetY', 'flip', 'display', 'classes', 'css', 'svgReplaces', 'border', 'radius', 'note' ] },
+      { id: 'custom',     title: 'Custom',     properties: null } // everything else, in the order it is stored
+    ];
+  }
+
+  // Draws one collapsible block per non-empty group and lets renderRow(property, container) fill it. The block's
+  // properties div keeps the deckEditorProperties class (and any extra one the caller needs), so rows, pickers
+  // and their CSS work exactly as they do in an ungrouped list. Which blocks are folded away is remembered per
+  // tab for the session, so a scope the user works in stays open while switching objects.
+  renderPropertyGroups(target, properties, stateKey, renderRow, extraClass = '') {
+    const remaining = properties.slice();
+    for(const group of this.propertyGroups()) {
+      const inGroup = group.properties ? group.properties.filter(property=>remaining.indexOf(property) != -1) : remaining.slice();
+      if(!inGroup.length)
+        continue;
+      for(const property of inGroup)
+        remaining.splice(remaining.indexOf(property), 1);
+
+      const key = `${stateKey}:${group.id}`;
+      const collapsed = this.groupCollapsed[key] !== undefined ? this.groupCollapsed[key] : !!group.collapsed;
+      const wrap = div(target, `deckEditorGroup${collapsed ? ' collapsed' : ''}`);
+      const header = document.createElement('button');
+      header.type = 'button';
+      header.className = 'deckEditorGroupHeader';
+      header.setAttribute('aria-expanded', String(!collapsed));
+      header.title = `Show or hide the ${group.title.toLowerCase()} properties`;
+      // The summary lists what is inside, so a folded block still says what it holds - the same idea as the
+      // Edit Widget sidebar's "x, y" summaries, but working for arbitrary property names.
+      header.innerHTML = `<span class=deckEditorGroupArrow></span><span class=deckEditorGroupTitle>${html(group.title)}</span><span class=deckEditorGroupSummary>${html(inGroup.join(', '))}</span>`;
+      header.onclick = _=>{
+        const nowCollapsed = !wrap.classList.contains('collapsed');
+        wrap.classList.toggle('collapsed', nowCollapsed);
+        header.setAttribute('aria-expanded', String(!nowCollapsed));
+        this.groupCollapsed[key] = nowCollapsed;
+      };
+      wrap.append(header);
+
+      const body = div(wrap, `deckEditorProperties deckEditorGroupBody ${extraClass}`.trim());
+      for(const property of inGroup)
+        renderRow(property, body);
+    }
   }
 
   objectFieldType(property) {
@@ -2595,8 +2900,9 @@ class DeckEditor {
 
   // A property row with a fixed input type and NO type selector — matches addInput's return shape ({ dom }) so
   // the make-dynamic / delete buttons attach the same way. fieldType may be forced (number/text/boolean/object)
-  // or left undefined to follow the value's JS type.
-  addTypedInput(label, value, onValueChanged, target, fieldType, emptyIsZero) {
+  // or left undefined to follow the value's JS type. mixed marks a row whose selected objects disagree about
+  // the value: the field starts empty and says so, and only writes to them once something is entered.
+  addTypedInput(label, value, onValueChanged, target, fieldType, emptyIsZero, mixed) {
     if(!fieldType) {
       if(typeof value === 'number') fieldType = 'number';
       else if(typeof value === 'boolean') fieldType = 'boolean';
@@ -2613,10 +2919,11 @@ class DeckEditor {
       input = document.createElement('input');
       input.type = 'checkbox';
       input.checked = !!value;
+      input.indeterminate = !!mixed;
       input.onchange = _=>onValueChanged(input.checked);
     } else if(fieldType == 'object') {
       input = document.createElement('textarea');
-      input.value = value !== undefined && value !== null ? JSON.stringify(value, null, '  ') : '{}';
+      input.value = mixed ? '' : (value !== undefined && value !== null ? JSON.stringify(value, null, '  ') : '{}');
       input.oninput = input.onchange = _=>{
         try { onValueChanged(JSON.parse(input.value)); input.classList.remove('inputError'); }
         catch(e) { input.classList.add('inputError'); }
@@ -2640,6 +2947,8 @@ class DeckEditor {
         }
       };
     }
+    if(mixed && input.type != 'checkbox')
+      input.placeholder = '(mixed)';
     wrapper.append(input);
     return { dom: wrapper };
   }
@@ -2836,8 +3145,7 @@ class DeckEditor {
       `${getPlayerDetails().playerName} updated "${property}" of card defaults of deck ${this.deckID} in deck editor`,
       `field:cardDefaults:${property}`
     ];
-    const defaultsProps = div(sidebar, 'deckEditorProperties');
-    const addDefaultsInput = property=>{
+    const addDefaultsInput = (property, defaultsProps)=>{
       const forced = (property == 'width' || property == 'height') ? 'number' : undefined;
       const onValueChanged = v=>this.queueFieldEdit(async _=>{
         await this.flushPendingCommitForOtherField('cardDefaults', defaultsFieldArgs(property)[1]);
@@ -2858,11 +3166,11 @@ class DeckEditor {
         });
       }
     };
-    for(const property of Object.keys(this.cardDefaults))
-      addDefaultsInput(property);
+    const defaultsPropertyNames = [ ...Object.keys(this.cardDefaults) ];
     for(const property of [ 'width', 'height' ]) // the most common defaults are always offered
       if(this.cardDefaults[property] === undefined)
-        addDefaultsInput(property);
+        defaultsPropertyNames.push(property);
+    this.renderPropertyGroups(sidebar, defaultsPropertyNames, 'defaults', addDefaultsInput);
     addPropertyRow(sidebar, (property, type)=>this.queueFieldEdit(async _=>{
       if(this.cardDefaults[property] !== undefined)
         return;
@@ -3101,15 +3409,18 @@ class DeckEditor {
 
   async deleteSelectedObject() {
     const face = this.faceTemplates[this.face];
-    if(!face || this.selectedObject === null)
+    const indices = this.selectedObjectIndices();
+    if(!face || !indices.length)
       return;
     await this.flushPendingCommits(); // don't absorb a pending typed edit into this action
-    face.objects.splice(this.selectedObject, 1);
+    for(const index of [...indices].reverse()) // back to front, so the indices still to come stay valid
+      face.objects.splice(index, 1);
     this.selectedObject = null;
     this.refreshMainCardFaces();
     // Only the face template changes: card type properties this object referenced are deliberately kept, since
     // routines / SELECT / CSS can use them independently of any face object (deleting them could break a game).
-    await this.commit('faceTemplates', `${getPlayerDetails().playerName} deleted a face object from deck ${this.deckID} in deck editor`);
+    const what = indices.length > 1 ? `${indices.length} face objects` : 'a face object';
+    await this.commit('faceTemplates', `${getPlayerDetails().playerName} deleted ${what} from deck ${this.deckID} in deck editor`);
     this.renderLeftSidebar(); // drop the deleted row from the left list right away
     this.renderSidebar();
     this.updateDragToolbar();

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -345,19 +345,6 @@ class DeckEditor {
       $('#deckEditorShowAll').classList.toggle('active', this.showAllAreas);
       $('#deckEditorMain').classList.toggle('deckEditorShowAllAreas', this.showAllAreas);
     };
-    // Align / distribute the selected face objects (top bar). They need a multi-selection, which
-    // updateAlignToolbar enables them for.
-    for(const [ id, run ] of [
-      [ 'deckEditorAlignLeft',   _=>this.alignObjects('x', 'left', 'right', 0) ],
-      [ 'deckEditorAlignCenter', _=>this.alignObjects('x', 'left', 'right', 0.5) ],
-      [ 'deckEditorAlignRight',  _=>this.alignObjects('x', 'left', 'right', 1) ],
-      [ 'deckEditorAlignTop',    _=>this.alignObjects('y', 'top', 'bottom', 0) ],
-      [ 'deckEditorAlignMiddle', _=>this.alignObjects('y', 'top', 'bottom', 0.5) ],
-      [ 'deckEditorAlignBottom', _=>this.alignObjects('y', 'top', 'bottom', 1) ],
-      [ 'deckEditorDistributeH', _=>this.distributeObjects('x', 'left', 'right') ],
-      [ 'deckEditorDistributeV', _=>this.distributeObjects('y', 'top', 'bottom') ]
-    ])
-      $(`#${id}`).onclick = run;
 
     $('#deckEditorExport').onclick = _=>this.openExportOverlay();
     $('#deckEditorExportClose').onclick = _=>this.closeExportOverlay();
@@ -1805,12 +1792,47 @@ class DeckEditor {
     this.selectionOutline.style.height = height + 'px';
   }
 
-  // Aligning needs two objects, spreading them out evenly needs three. The buttons stay visible below that (and
-  // say what they would do) instead of appearing and disappearing with the selection.
+  // What the Object tab's align row offers, with the number of selected objects each one needs: aligning takes
+  // two, spreading them out evenly takes three.
+  alignActions() {
+    return [
+      [ 'deckEditorAlignLeft',   'align_horizontal_left',   'Align the selected face objects to the left',   2, _=>this.alignObjects('x', 'left', 'right', 0) ],
+      [ 'deckEditorAlignCenter', 'align_horizontal_center', 'Align the selected face objects to the center', 2, _=>this.alignObjects('x', 'left', 'right', 0.5) ],
+      [ 'deckEditorAlignRight',  'align_horizontal_right',  'Align the selected face objects to the right',  2, _=>this.alignObjects('x', 'left', 'right', 1) ],
+      [ 'deckEditorAlignTop',    'align_vertical_top',      'Align the selected face objects to the top',    2, _=>this.alignObjects('y', 'top', 'bottom', 0) ],
+      [ 'deckEditorAlignMiddle', 'align_vertical_center',   'Align the selected face objects to the middle', 2, _=>this.alignObjects('y', 'top', 'bottom', 0.5) ],
+      [ 'deckEditorAlignBottom', 'align_vertical_bottom',   'Align the selected face objects to the bottom', 2, _=>this.alignObjects('y', 'top', 'bottom', 1) ],
+      [ 'deckEditorDistributeH', 'horizontal_distribute',   'Equalize the horizontal spacing between the selected face objects', 3, _=>this.distributeObjects('x', 'left', 'right') ],
+      [ 'deckEditorDistributeV', 'vertical_distribute',     'Equalize the vertical spacing between the selected face objects',   3, _=>this.distributeObjects('y', 'top', 'bottom') ]
+    ];
+  }
+
+  // The align row of the Object tab's toolbar, right above the selection it acts on. It stays visible with too
+  // few objects selected (disabled, and saying what it would do) instead of appearing and disappearing.
+  renderAlignToolbar(sidebar) {
+    const bar = document.createElement('menu');
+    bar.className = 'deckEditorSidebarToolbar deckEditorAlignToolbar';
+    div(bar, 'deckEditorAlignLabel').textContent = 'Align:';
+    for(const [ id, icon, title, minSelected, run ] of this.alignActions()) {
+      // A disabled button receives no pointer events, so its own tooltip never opens - which is exactly the
+      // state in which it needs to explain itself. The tooltip therefore sits on a wrapper around it instead.
+      const wrapper = div(bar, 'deckEditorAlignButton');
+      wrapper.title = `${title}. Needs ${minSelected} or more selected: ctrl+click objects on the card or in the list, or ctrl+A to take the whole face.`;
+      const button = document.createElement('button');
+      button.id = id;
+      button.setAttribute('icon', icon);
+      button.dataset.minSelected = minSelected;
+      button.onclick = run;
+      wrapper.append(button);
+    }
+    sidebar.append(bar);
+    this.updateAlignToolbar();
+  }
+
   updateAlignToolbar() {
     const selected = this._selectedObjects.length;
-    for(const button of $a('#deckEditorAlignToolbar button'))
-      button.disabled = selected < (button.classList.contains('deckEditorDistributeButton') ? 3 : 2);
+    for(const button of $a('.deckEditorAlignToolbar button'))
+      button.disabled = selected < +button.dataset.minSelected;
   }
 
   updateDragToolbar() {
@@ -2004,22 +2026,25 @@ class DeckEditor {
     if(!object) {
       const note = document.createElement('p');
       note.className = 'deckEditorSectionNote';
-      note.textContent = 'No face object is selected. Add one with the + above, or click an object on the card or in the list to the left to edit it.';
+      note.textContent = 'No face object is selected. Add one with the + above, or click an object on the card or in the list to the left to edit it. Ctrl+click picks several at once (ctrl+A takes the whole face) to edit or align them together.';
       sidebar.append(note);
       this.renderObjectHint();
       return;
     }
 
     // With more than one object selected every row edits all of them at once, so the header counts them instead
-    // of naming one. The caption spells out what the rows below do, so the contrast with the amber "different
-    // per card type" Dynamic properties section further down is stated, not just colored.
+    // of naming one - but it still lists which ones (as the tree numbers them), so the selection can be checked
+    // without looking away. The caption spells out what the rows below do, so the contrast with the amber
+    // "different per card type" Dynamic properties section further down is stated, not just colored.
     const objects = this.selectedObjectTemplates();
     const multi = objects.length > 1;
-    addHeader(multi ? `${objects.length} face objects selected` : `Face object ${this.selectedObject+1} (${object.type || 'text'})`,
+    const numbers = this.selectedObjectIndices().map(index=>index+1);
+    const listed = numbers.length > 8 ? `${numbers.slice(0, 8).join(', ')}, …` : numbers.join(', ');
+    addHeader(multi ? `${objects.length} face objects selected (${listed})` : `Face object ${this.selectedObject+1} (${object.type || 'text'})`,
       'deckEditorScopeEveryCard', 'Same on every card type');
     // Note below (not part of) the header, in the same style as the Dynamic properties note.
     if(multi)
-      div(sidebar, 'deckEditorSectionNote').textContent = 'Every row below changes all selected objects at once. A property the selected objects do not agree on shows as "(mixed)" until a new value is typed.';
+      div(sidebar, 'deckEditorSectionNote').textContent = 'Every row below changes all selected objects at once. A property the selected objects do not agree on shows as "(mixed)" until a new value is typed. Ctrl+click adds or removes an object, ctrl+A selects the whole face.';
     else if(object.type == 'html')
       div(sidebar, 'deckEditorSectionNote').textContent = 'The JSON Editor should be used for editing HTML face objects.';
 
@@ -2087,9 +2112,9 @@ class DeckEditor {
     }));
 
     // Bindings are per object (they name the card type property each one reads), so they stay a single-object
-    // affair - with several objects selected the section would have nothing meaningful to show.
-    if(!multi)
-      this.renderDynamicProperties(sidebar, object);
+    // affair. The section keeps its header with several objects selected and says so, instead of silently
+    // disappearing - a whole panel vanishing on a ctrl+click reads as a bug.
+    this.renderDynamicProperties(sidebar, multi ? null : object);
 
     // No "Delete object" button here — objects are deleted from the left face-object list (or Delete key).
     this.renderObjectHint();
@@ -2113,7 +2138,7 @@ class DeckEditor {
       // Selecting an object is not required to open this tab: without one it still offers the + that adds a
       // face object, so an empty face can be filled without going through the tree.
       { id: 'object', label: 'Object', icon: 'category', scope: 'deckEditorScopeEveryCard', available: !!face,
-        title: this._selectedObjects.length > 1 ? `${this._selectedObjects.length} face objects of ${this.faceLabel(this.face).toLowerCase()} - every property here is set on all of them`
+        title: this._selectedObjects.length > 1 ? `${this._selectedObjects.length} face objects of ${this.faceLabel(this.face).toLowerCase()} — every property here is set on all of them`
              : object ? `Face object ${this.selectedObject+1} of ${this.faceLabel(this.face).toLowerCase()}`
                       : 'Add a face object, or click one on the card or in the list to the left to edit it' }
     ];
@@ -2178,6 +2203,9 @@ class DeckEditor {
       buttons[0].onclick = _=>this.openAddSectionIn(host, 'sidebar');
       if(this.addSectionOpen && this.addSectionHost == 'sidebar')
         host.append($('#deckEditorAddSection')); // it was open here before this rebuild: put it back
+      // Align / distribute act on the face-object selection, so they live with the selection's other actions
+      // here rather than in the top bar, which is about the deck as a whole.
+      this.renderAlignToolbar(sidebar);
     } else if(this.addSectionHost == 'sidebar') {
       this.addSectionOpen = false; // the submenu belongs to the Object tab only
       this.addSectionHost = 'tree';
@@ -2290,7 +2318,11 @@ class DeckEditor {
     for(const property of boundProperties)
       if(typeof typeProperties[property] === 'undefined' && [ 'cardType', 'id' ].indexOf(property) == -1)
         typePropertyNames.push(property);
-    this.renderPropertyGroups(sidebar, typePropertyNames, 'cardType', addTypeInput);
+    // No property groups here: every property of a card type is defined by the game, so sorting them by the
+    // engine's names would put "name" under Content and "cost" under Custom purely by coincidence of naming.
+    const typeProps = div(sidebar, 'deckEditorProperties');
+    for(const property of typePropertyNames)
+      addTypeInput(property, typeProps);
     addPropertyRow(sidebar, (property, type)=>this.queueFieldEdit(async _=>{
       if(typeProperties[property] !== undefined)
         return;
@@ -2830,7 +2862,7 @@ class DeckEditor {
     const common = this.commonPropertyValue(objects, 'type');
     const row = div(target, 'genericInput deckEditorTypedInput');
     const labelEl = document.createElement('label');
-    labelEl.style.cssText = 'display:inline-block;width:100px';
+    labelEl.className = 'deckEditorPropertyLabel';
     labelEl.textContent = 'type';
     const select = document.createElement('select');
     if(common.mixed) {
@@ -2891,16 +2923,29 @@ class DeckEditor {
   // tab for the session, so a scope the user works in stays open while switching objects.
   renderPropertyGroups(target, properties, stateKey, renderRow, extraClass = '') {
     const remaining = properties.slice();
+    const groups = [];
     for(const group of this.propertyGroups()) {
       const inGroup = group.properties ? group.properties.filter(property=>remaining.indexOf(property) != -1) : remaining.slice();
       if(!inGroup.length)
         continue;
       for(const property of inGroup)
         remaining.splice(remaining.indexOf(property), 1);
+      groups.push({ group, inGroup });
+    }
 
+    // A single block is pure chrome: its header would just repeat the rows below it, and there is nothing to
+    // tell them apart from. Such a list is drawn ungrouped, the way it was before there were groups.
+    if(groups.length < 2) {
+      const body = div(target, `deckEditorProperties ${extraClass}`.trim());
+      for(const property of groups.length ? groups[0].inGroup : [])
+        renderRow(property, body);
+      return;
+    }
+
+    for(const { group, inGroup } of groups) {
       // Position/Size start folded only for a face object, where x/y/width/height are usually changed by
-      // dragging the object around. On the other tabs those same names are the point of the tab (All Cards is
-      // mostly width/height) or an arbitrary game-defined property, so there they start open.
+      // dragging the object around. On the All Cards tab width/height are the point of the tab, so there
+      // every block starts open.
       const key = `${stateKey}:${group.id}`;
       const collapsed = this.groupCollapsed[key] !== undefined ? this.groupCollapsed[key] : (stateKey == 'object' && !!group.collapsed);
       const wrap = div(target, `deckEditorGroup${collapsed ? ' collapsed' : ''}`);
@@ -2955,8 +3000,9 @@ class DeckEditor {
       fieldType = this.valueFieldType(value);
     const wrapper = div(target, 'genericInput deckEditorTypedInput');
     const labelEl = document.createElement('label');
-    labelEl.style.cssText = 'display:inline-block;width:100px';
+    labelEl.className = 'deckEditorPropertyLabel';
     labelEl.textContent = label;
+    labelEl.title = label; // game-defined names can be longer than the label column, which cuts them
     wrapper.append(labelEl);
     let input;
     if(fieldType == 'boolean') {
@@ -2964,6 +3010,10 @@ class DeckEditor {
       input.type = 'checkbox';
       input.checked = !!value;
       input.indeterminate = !!mixed;
+      // A checkbox has no placeholder to put "(mixed)" into: the dash in the box is all it can show, so what
+      // that dash means - and what ticking it does to the other objects - is said in the tooltip.
+      if(mixed)
+        input.title = 'Mixed — the selected objects disagree about this. Clicking sets one value on all of them.';
       input.onchange = _=>onValueChanged(input.checked);
     } else if(fieldType == 'object') {
       input = document.createElement('textarea');
@@ -2991,8 +3041,10 @@ class DeckEditor {
         }
       };
     }
-    if(mixed && input.type != 'checkbox')
+    if(mixed && input.type != 'checkbox') {
       input.placeholder = '(mixed)';
+      input.classList.add('deckEditorMixedValue'); // italic, so it can't be read as a value someone typed
+    }
     wrapper.append(input);
     return { dom: wrapper };
   }
@@ -3321,6 +3373,11 @@ class DeckEditor {
     sidebar.append(header);
 
     const container = div(sidebar, 'deckEditorDynamicProperties deckEditorScopeThisType');
+    // object == null: several objects are selected, and each one's bindings name its own card type properties.
+    if(!object) {
+      div(container, 'deckEditorSectionNote').textContent = 'Dynamic properties are per object. Select a single object to edit them.';
+      return;
+    }
     div(container, 'deckEditorSectionNote').textContent = 'These specify a different face object for each card type.';
 
     // The already-active bindings: each row is a live "object property ← card type property" with a red trash.

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -4826,10 +4826,13 @@ class PropertiesModule extends SidebarModule {
   }
 
   renderForDeck(widget) {
-    // Selecting a deck in the Properties module now opens the full deck editor directly instead of the old
-    // minimalist deck view that used to live here. The guard avoids re-opening while it is already up.
-    if(!deckEditor.isOpen())
-      deckEditor.open(widget.id);
+    this.renderTypeHeader(widget);
+    const deckEditorButton = div(this.moduleDOM, 'cardDeckButton', `
+      <button id="propertiesOpenDeckEditor" icon=style>Open deck editor</button>
+    `);
+    $('button', deckEditorButton).onclick = _=>deckEditor.open(widget.id);
+    this.renderBasicSection(widget);
+    this.renderOtherPropertiesSection(widget, [ 'cardDefaults', 'cardTypes', 'faceTemplates' ]);
   }
 
   renderForDice(widget) {

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -339,7 +339,7 @@ test('Deck editor: breadcrumb undo and redo', async t => {
   const deckID = await getDeckID();
 
   const editTextAndUndoImmediately = ClientFunction(() => {
-    const rows = document.querySelectorAll('#deckEditorSidebar > .deckEditorProperties:first-of-type .genericInput');
+    const rows = document.querySelectorAll('#deckEditorSidebar .deckEditorObjectProperties .genericInput');
     let input = null;
     for(let i=0; i<rows.length; ++i)
       if(rows[i].querySelector('label').textContent == 'value')
@@ -394,7 +394,7 @@ test('Deck editor: remote update preserves an unrelated pending edit', async t =
   });
   const deckID = await getDeckID();
   const editAndReceiveRemoteChange = ClientFunction(deckID => {
-    const rows = document.querySelectorAll('#deckEditorSidebar > .deckEditorProperties:first-of-type .genericInput');
+    const rows = document.querySelectorAll('#deckEditorSidebar .deckEditorObjectProperties .genericInput');
     let input = null;
     for(let i=0; i<rows.length; ++i)
       if(rows[i].querySelector('label').textContent == 'value')
@@ -454,7 +454,7 @@ test('Deck editor: rapid cross-field edits stay separate undo steps', async t =>
 
   const rapidEditsThenAddFace = ClientFunction(() => new Promise(resolve => {
     const setField = (label, value) => {
-      const rows = document.querySelectorAll('#deckEditorSidebar > .deckEditorProperties:first-of-type .genericInput');
+      const rows = document.querySelectorAll('#deckEditorSidebar .deckEditorObjectProperties .genericInput');
       for(const row of rows) {
         if(row.querySelector('label').textContent == label) {
           const input = row.querySelector('input');
@@ -752,6 +752,78 @@ test('Deck editor: toolbar button opens an empty editor when the game has none',
     .expect(deckCount()).eql(0)      // ...but no deck is auto-created
     .pressKey('esc')
     .expect(Selector('body').hasClass('deckEditorActive')).notOk();
+});
+
+// Several face objects can be selected at once (Ctrl/Shift+click on the card or in the tree). A property row
+// then writes to all of them - showing "(mixed)" while they disagree - and the top bar's align/distribute
+// buttons line them up. The properties themselves are grouped into the collapsible blocks the Edit Widget
+// sidebar uses, which is what the group/summary expectations below check.
+test('Deck editor: multi-selected face objects share property edits and alignment', async t => {
+  await setRoomState({
+    multiDeck: {
+      id: 'multiDeck', type: 'deck', x: 20, y: 20,
+      cardTypes: { plain: {} },
+      faceTemplates: [ { objects: [
+        { type: 'text', x: 4,  y: 10,  width: 40, height: 20, fontSize: 14, value: 'one',   color: '#000000' },
+        { type: 'text', x: 30, y: 60,  width: 60, height: 20, fontSize: 14, value: 'two',   color: '#000000' },
+        { type: 'text', x: 12, y: 120, width: 50, height: 20, fontSize: 14, value: 'three', color: '#333333' }
+      ] } ]
+    },
+    multiCard: { id: 'multiCard', type: 'card', deck: 'multiDeck', cardType: 'plain', x: 300, y: 100 }
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  const objectRow = Selector('#deckEditorTree .deckEditorObjectRow');
+  const groupTitles = ClientFunction(() => {
+    const titles = [];
+    const groups = document.querySelectorAll('#deckEditorSidebar .deckEditorGroupTitle');
+    for(let i = 0; i < groups.length; ++i)
+      titles.push(groups[i].textContent);
+    return titles;
+  });
+  const setSharedField = ClientFunction((label, value) => {
+    const rows = document.querySelectorAll('#deckEditorSidebar .deckEditorObjectProperties .genericInput');
+    for(let i = 0; i < rows.length; ++i) {
+      if(rows[i].querySelector('label').textContent == label) {
+        const input = rows[i].querySelector('input');
+        const placeholder = input.placeholder;
+        input.value = value;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        return placeholder;
+      }
+    }
+    return null;
+  });
+
+  await t
+    .click('#editButton')
+    .click('#editorSidebar [icon=tune]')
+    .click('#w_multiDeck') // selecting the deck opens the deck editor on it
+    .click(objectRow.nth(0));
+  // one object: the properties are sorted into the same blocks the Edit Widget sidebar uses
+  await t
+    .expect(groupTitles()).eql([ 'Content', 'Position', 'Size', 'Colors', 'Appearance' ])
+    .expect(Selector('#deckEditorAlignLeft').hasAttribute('disabled')).ok(); // needs a second object
+
+  await t
+    .click(objectRow.nth(1), { modifiers: { ctrl: true } })
+    .click(objectRow.nth(2), { modifiers: { ctrl: true } })
+    .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(3)
+    .expect(Selector('#deckEditorMain .deckEditorSelectedObject').count).eql(3)
+    .expect(Selector('#deckEditorSidebar header h2').innerText).eql('3 face objects selected')
+    .expect(Selector('#deckEditorAlignLeft').hasAttribute('disabled')).notOk()
+    .expect(Selector('#deckEditorDistributeV').hasAttribute('disabled')).notOk();
+
+  // the three objects disagree about their color, so the row says so - and typing gives all of them the value
+  await t.expect(setSharedField('color', '#cc0000')).eql('(mixed)');
+  await t.wait(700); // let the debounced faceTemplates commit fire
+  await t
+    .click('#deckEditorAlignLeft')
+    .click('#deckEditorDistributeV')
+    .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(3) // the selection survives
+    .pressKey('esc');
+  await compareState(t, 'fd906b0fb1237f2c7ecca4657535fbb3');
 });
 
 test('Line widget in edit mode', async t => {

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -796,6 +796,15 @@ test('Deck editor: multi-selected face objects share property edits and alignmen
     }
     return null;
   });
+  // A shift+click on the text field of a row that is already being typed in - focused first, so the click sees
+  // the field the way it does mid-edit. Returns whether the field kept the focus.
+  const shiftClickFocusedField = ClientFunction(row => {
+    const input = document.querySelectorAll('#deckEditorTree .deckEditorObjectRow')[row].querySelector('.deckEditorPreviewText');
+    input.focus();
+    input.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, shiftKey: true }));
+    input.dispatchEvent(new MouseEvent('click', { bubbles: true, shiftKey: true }));
+    return document.activeElement == input;
+  });
   const setSharedField = ClientFunction((label, value) => {
     const rows = document.querySelectorAll('#deckEditorSidebar .deckEditorObjectProperties .genericInput');
     for(let i = 0; i < rows.length; ++i) {
@@ -835,14 +844,32 @@ test('Deck editor: multi-selected face objects share property edits and alignmen
   await t
     .click('#deckEditorAlignLeft')
     .click('#deckEditorDistributeV')
-    .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(3) // the selection survives
-    .pressKey('ctrl+a') // ...and Ctrl+A picks up the whole face, including the hidden object
+    .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(3); // the selection survives
+  await t.wait(700); // let the alignment's commit reach the server
+  const aligned = JSON.parse(await faceObjects());
+  await t
+    .expect(aligned[0].x).eql(aligned[1].x) // aligned left: one x for all three
+    .expect(aligned[1].x).eql(aligned[2].x)
+    // distributed vertically: equal gaps, i.e. equal steps since the three are equally tall (±1 for rounding)
+    .expect(Math.abs((aligned[1].y - aligned[0].y) - (aligned[2].y - aligned[1].y)) <= 1).ok()
+    .pressKey('ctrl+a') // Ctrl+A picks up the whole face, including the hidden object
     .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(4);
 
   // a hidden object has no box on screen, so aligning must leave it where it is instead of moving it to where
   // its zero-sized rectangle appears to be
   await t.click('#deckEditorAlignLeft');
   await t.expect(JSON.parse(await faceObjects())[3].x).eql(200);
+
+  // ...and with nothing but that hidden object next to a single visible one there is nothing to align at all,
+  // so the button has to be disabled instead of being clickable and doing nothing
+  await t
+    .click(objectRow.nth(0))
+    .click(objectRow.nth(3), { modifiers: { ctrl: true } })
+    .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(2)
+    .expect(Selector('#deckEditorAlignLeft').hasAttribute('disabled')).ok()
+    .click(objectRow.nth(1), { modifiers: { ctrl: true } }) // back to the whole face for the rows below
+    .click(objectRow.nth(2), { modifiers: { ctrl: true } })
+    .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(4);
 
   // display is set on the hidden object only, so its row is a "(mixed)" checkbox - not a text field, which
   // would write the string "false"/"true" into every object
@@ -865,9 +892,25 @@ test('Deck editor: multi-selected face objects share property edits and alignmen
     .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(3)
     .expect(objectRow.nth(0).hasClass('selected')).notOk()
     .click(objectRow.nth(0), { modifiers: { ctrl: true, shift: true } })
-    .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(4)
+    .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(4);
+
+  // Inside the text field that is currently being typed in, shift+click is the field's own "extend the caret
+  // selection" gesture: it must leave the object selection (and the focus) alone instead of rebuilding the tree.
+  await t
+    .click(objectRow.nth(1))
+    .click(objectRow.nth(2), { modifiers: { ctrl: true } })
+    .click(objectRow.nth(3), { modifiers: { ctrl: true } })
+    .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(3)
+    .expect(shiftClickFocusedField(3)).ok() // the field keeps the focus...
+    .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(3); // ...and the selection stands
+
+  // dragging one of the rows to a new position reorders the objects and carries the whole selection along
+  // instead of dropping it
+  await t
+    .dragToElement(objectRow.nth(3), objectRow.nth(0))
+    .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(3)
     .pressKey('esc');
-  await compareState(t, '5dee75f5433a4bf336dc282d3ebb30cc');
+  await compareState(t, '101012d22e8e8d136d73d75bc4d4a5f7');
 });
 
 test('Line widget in edit mode', async t => {

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -250,7 +250,8 @@ test('Deck editor: add card type, dynamic object, delete face, undo', async t =>
 
   const deckNode = Selector('#deckEditorTree .deckEditorTreeDeck');
   await t
-    .click(`#w_${deckID}`) // selecting the deck opens the deck editor directly (no separate "edit" button)
+    .click(`#w_${deckID}`) // selects the deck, showing the abbreviated Basic/Other properties panel
+    .click('#propertiesOpenDeckEditor') // opens the full deck editor
     .click('#deckEditorStripAdd')                     // add a card type
     .click(deckNode)                                  // select the deck
     .click('#deckEditorTreeAdd')                      // deck "+" adds a new (empty) face, now selected
@@ -359,7 +360,8 @@ test('Deck editor: breadcrumb undo and redo', async t => {
 
   const deckNode = Selector('#deckEditorTree .deckEditorTreeDeck');
   await t
-    .click(`#w_${deckID}`) // selecting the deck opens the deck editor directly (no separate "edit" button)
+    .click(`#w_${deckID}`) // selects the deck, showing the abbreviated Basic/Other properties panel
+    .click('#propertiesOpenDeckEditor') // opens the full deck editor
     .click('#deckEditorStripAdd')  // step 1
     .click(deckNode)                         // select the deck
     .click('#deckEditorTreeAdd')             // step 2: deck "+" adds a face (now empty, selected)
@@ -418,7 +420,8 @@ test('Deck editor: remote update preserves an unrelated pending edit', async t =
 
   const deckNode = Selector('#deckEditorTree .deckEditorTreeDeck');
   await t
-    .click(`#w_${deckID}`) // selecting the deck opens the deck editor directly (no separate "edit" button)
+    .click(`#w_${deckID}`) // selects the deck, showing the abbreviated Basic/Other properties panel
+    .click('#propertiesOpenDeckEditor') // opens the full deck editor
     .click('#deckEditorStripAdd')
     .click(deckNode)
     .click('#deckEditorTreeAdd')
@@ -484,7 +487,8 @@ test('Deck editor: rapid cross-field edits stay separate undo steps', async t =>
   const getFaceCount = ClientFunction(deckID => widgets.get(deckID).get('faceTemplates').length);
 
   await t
-    .click(`#w_${deckID}`) // selecting the deck opens the deck editor directly (no separate "edit" button)
+    .click(`#w_${deckID}`) // selects the deck, showing the abbreviated Basic/Other properties panel
+    .click('#propertiesOpenDeckEditor') // opens the full deck editor
     .click('#deckEditorStripAdd')
     .click(Selector('#deckEditorTree .deckEditorObjectRow').nth(0)) // select the existing object
     .click('#deckEditorTreeAdd')                                    // reveal the add-object controls
@@ -523,7 +527,8 @@ test('Deck editor: switching games while editing does not crash', async t => {
   const deckID = await getDeckID();
 
   await t
-    .click(`#w_${deckID}`) // selecting the deck opens the deck editor directly (no separate "edit" button)
+    .click(`#w_${deckID}`) // selects the deck, showing the abbreviated Basic/Other properties panel
+    .click('#propertiesOpenDeckEditor') // opens the full deck editor
     .click('#deckEditorStripAdd'); // make a change, leaving the deck editor open
 
   // Simulate switching to another game: replace the whole room state. The deck being edited disappears.
@@ -702,7 +707,7 @@ test('Deck editor: toolbar button toggles the editor and stays in sync with Esca
   await t.click('#editorToolbar [icon=style]');
   await t.expect(Selector('body').hasClass('deckEditorActive')).ok();
   await t.expect(toolbarButton.hasClass('active')).ok();
-  await t.expect(Selector('#deckEditorClose').exists).notOk(); // the old Close button is gone
+  await t.expect(Selector('#deckEditorClose').exists).ok(); // the Close button next to Card view
 
   // close via the same button
   await t.click('#editorToolbar [icon=style]');
@@ -727,6 +732,13 @@ test('Deck editor: toolbar button toggles the editor and stays in sync with Esca
 
   // close with Escape -> the button must deactivate too
   await t.pressKey('esc');
+  await t.expect(Selector('body').hasClass('deckEditorActive')).notOk();
+  await t.expect(toolbarButton.hasClass('active')).notOk();
+
+  // close via the Close button next to Card view -> the toolbar button must deactivate too
+  await t.click('#editorToolbar [icon=style]');
+  await t.expect(Selector('body').hasClass('deckEditorActive')).ok();
+  await t.click('#deckEditorClose');
   await t.expect(Selector('body').hasClass('deckEditorActive')).notOk();
   await t.expect(toolbarButton.hasClass('active')).notOk();
 });
@@ -822,7 +834,8 @@ test('Deck editor: multi-selected face objects share property edits and alignmen
   await t
     .click('#editButton')
     .click('#editorSidebar [icon=tune]')
-    .click('#w_multiDeck') // selecting the deck opens the deck editor on it
+    .click('#w_multiDeck') // selects the deck, showing the abbreviated Basic/Other properties panel
+    .click('#propertiesOpenDeckEditor') // opens the full deck editor on it
     .click(objectRow.nth(0));
   // one object: the properties are sorted into the same blocks the Edit Widget sidebar uses
   await t

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -854,7 +854,18 @@ test('Deck editor: multi-selected face objects share property edits and alignmen
   const objects = JSON.parse(await faceObjects());
   await t
     .expect(objects.every(object => object.display === true)).ok() // booleans, not strings
-    .expect(fieldOf('display')).eql('checkbox:common')
+    .expect(fieldOf('display')).eql('checkbox:common');
+
+  // Shift+click makes the range the whole selection: an object picked up with ctrl before, but outside the
+  // range, is dropped. Ctrl+shift+click is the additive version that keeps it.
+  await t
+    .click(objectRow.nth(0))
+    .click(objectRow.nth(3), { modifiers: { ctrl: true } })
+    .click(objectRow.nth(1), { modifiers: { shift: true } }) // range 2-4, so object 1 goes away
+    .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(3)
+    .expect(objectRow.nth(0).hasClass('selected')).notOk()
+    .click(objectRow.nth(0), { modifiers: { ctrl: true, shift: true } })
+    .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(4)
     .pressKey('esc');
   await compareState(t, '5dee75f5433a4bf336dc282d3ebb30cc');
 });

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -764,9 +764,10 @@ test('Deck editor: multi-selected face objects share property edits and alignmen
       id: 'multiDeck', type: 'deck', x: 20, y: 20,
       cardTypes: { plain: {} },
       faceTemplates: [ { objects: [
-        { type: 'text', x: 4,  y: 10,  width: 40, height: 20, fontSize: 14, value: 'one',   color: '#000000' },
-        { type: 'text', x: 30, y: 60,  width: 60, height: 20, fontSize: 14, value: 'two',   color: '#000000' },
-        { type: 'text', x: 12, y: 120, width: 50, height: 20, fontSize: 14, value: 'three', color: '#333333' }
+        { type: 'text', x: 4,   y: 10,  width: 40, height: 20, fontSize: 14, value: 'one',    color: '#000000' },
+        { type: 'text', x: 30,  y: 60,  width: 60, height: 20, fontSize: 14, value: 'two',    color: '#000000' },
+        { type: 'text', x: 12,  y: 120, width: 50, height: 20, fontSize: 14, value: 'three',  color: '#333333' },
+        { type: 'text', x: 200, y: 200, width: 50, height: 20, fontSize: 14, value: 'hidden', color: '#333333', display: false }
       ] } ]
     },
     multiCard: { id: 'multiCard', type: 'card', deck: 'multiDeck', cardType: 'plain', x: 300, y: 100 }
@@ -781,6 +782,19 @@ test('Deck editor: multi-selected face objects share property edits and alignmen
     for(let i = 0; i < groups.length; ++i)
       titles.push(groups[i].textContent);
     return titles;
+  });
+  const faceObjects = ClientFunction(() => JSON.stringify(widgets.get('multiDeck').get('faceTemplates')[0].objects));
+  // What kind of field a property row got, and whether it says the objects disagree - a "(mixed)" row has to
+  // keep the type of the property (a checkbox stays a checkbox) instead of falling back to a text field.
+  const fieldOf = ClientFunction(label => {
+    const rows = document.querySelectorAll('#deckEditorSidebar .deckEditorObjectProperties .genericInput');
+    for(let i = 0; i < rows.length; ++i) {
+      if(rows[i].querySelector('label').textContent == label) {
+        const input = rows[i].querySelector('input, textarea');
+        return `${input.type || input.tagName.toLowerCase()}:${input.indeterminate || input.placeholder == '(mixed)' ? 'mixed' : 'common'}`;
+      }
+    }
+    return null;
   });
   const setSharedField = ClientFunction((label, value) => {
     const rows = document.querySelectorAll('#deckEditorSidebar .deckEditorObjectProperties .genericInput');
@@ -822,8 +836,27 @@ test('Deck editor: multi-selected face objects share property edits and alignmen
     .click('#deckEditorAlignLeft')
     .click('#deckEditorDistributeV')
     .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(3) // the selection survives
+    .pressKey('ctrl+a') // ...and Ctrl+A picks up the whole face, including the hidden object
+    .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(4);
+
+  // a hidden object has no box on screen, so aligning must leave it where it is instead of moving it to where
+  // its zero-sized rectangle appears to be
+  await t.click('#deckEditorAlignLeft');
+  await t.expect(JSON.parse(await faceObjects())[3].x).eql(200);
+
+  // display is set on the hidden object only, so its row is a "(mixed)" checkbox - not a text field, which
+  // would write the string "false"/"true" into every object
+  await t.expect(fieldOf('display')).eql('checkbox:mixed');
+  const displayRow = Selector('#deckEditorSidebar .deckEditorObjectProperties .genericInput')
+    .filter(node => node.querySelector('label').textContent == 'display');
+  await t.click(displayRow.find('input'));
+  await t.wait(700); // let the debounced faceTemplates commit fire
+  const objects = JSON.parse(await faceObjects());
+  await t
+    .expect(objects.every(object => object.display === true)).ok() // booleans, not strings
+    .expect(fieldOf('display')).eql('checkbox:common')
     .pressKey('esc');
-  await compareState(t, 'fd906b0fb1237f2c7ecca4657535fbb3');
+  await compareState(t, '5dee75f5433a4bf336dc282d3ebb30cc');
 });
 
 test('Line widget in edit mode', async t => {

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -755,7 +755,7 @@ test('Deck editor: toolbar button opens an empty editor when the game has none',
 });
 
 // Several face objects can be selected at once (Ctrl/Shift+click on the card or in the tree). A property row
-// then writes to all of them - showing "(mixed)" while they disagree - and the top bar's align/distribute
+// then writes to all of them - showing "(mixed)" while they disagree - and the Object tab's align/distribute
 // buttons line them up. The properties themselves are grouped into the collapsible blocks the Edit Widget
 // sidebar uses, which is what the group/summary expectations below check.
 test('Deck editor: multi-selected face objects share property edits and alignment', async t => {
@@ -825,7 +825,7 @@ test('Deck editor: multi-selected face objects share property edits and alignmen
     .click(objectRow.nth(2), { modifiers: { ctrl: true } })
     .expect(Selector('#deckEditorTree .deckEditorObjectRow.selected').count).eql(3)
     .expect(Selector('#deckEditorMain .deckEditorSelectedObject').count).eql(3)
-    .expect(Selector('#deckEditorSidebar header h2').innerText).eql('3 face objects selected')
+    .expect(Selector('#deckEditorSidebar header h2').innerText).eql('3 face objects selected (1, 2, 3)')
     .expect(Selector('#deckEditorAlignLeft').hasAttribute('disabled')).notOk()
     .expect(Selector('#deckEditorDistributeV').hasAttribute('disabled')).notOk();
 


### PR DESCRIPTION
Three deck-editor enhancements that work together: being able to select more than one face object, a properties sidebar that is organized the way the Edit Widget sidebar is, and selecting a deck widget no longer jumping straight into the deck editor.

## Multi-select of face objects

- **Ctrl/Cmd+click** on an object — on the card or in the left tree — adds it to (or removes it from) the selection; **Shift+click** selects the range from the current object to the clicked one, like a file list — the range becomes the whole selection, while **Ctrl+Shift+click** adds it to what is already selected; **Ctrl+A** selects every object of the shown face. A plain click still selects exactly one, as before. Every selected object gets the orange outline and its tree row is highlighted.
- The **Object tab** then edits all of them at once: each property row writes its value to every selected object, and a row the selected objects disagree about shows an empty `(mixed)` field until a new value is typed (so nothing is overwritten by accident). A property only some of them have still gets a row, so it can be handed to the whole group in one go. `type` works the same way. Bindings (Dynamic properties) stay a single-object affair — they name a per-object card-type property, so with several objects selected the section says so instead of editing anything.
- **Dragging** one object of a selection moves the whole group (keeping its arrangement), and the drag toolbar's **move / resize / rotate** apply to all of them — resize offsets each object from its own size, so size differences are preserved. **Copy** and **Delete** (button or Delete key) act on the whole selection too.
- **New align/distribute buttons in the Object tab's toolbar**, right above the selection they act on: align left / center / right / top / middle / bottom and equalize horizontal / vertical spacing. They use the objects' rendered boxes and write the result back in card coordinates — the same approach `client/js/editor/toolbar/align.js` takes for widgets, so rotated and auto-sized objects line up by what is actually drawn. Aligning needs two selected objects, distributing needs three; below that the buttons are disabled rather than hidden, and their tooltip says how to select more.

## Grouped properties in the sidebar

The property rows of the **Object** and **All Cards** tabs are no longer one flat list. They are sorted into the same collapsible blocks the Edit Widget sidebar uses — **Content, Position, Size, Colors, Appearance** — with everything the engine doesn't know (a game's own bespoke properties) collected in a **Custom** block of its own. Each block's header carries a summary of what is inside it, so a folded block still says what it holds, and Position/Size start folded on the Object tab (they are usually changed by dragging). Which blocks are folded is remembered per tab for the session. A list that would end up in a single block is drawn ungrouped, since such a header only repeats the rows below it.

The **Card Type** tab stays flat: every property of a card type is defined by the game, so sorting them by the engine's property names would be a coincidence of naming rather than a real distinction.

Everything stays nested inside the deck editor and under the existing tabs — the tab bar, the per-tab add/copy/delete toolbar and the scope colors are unchanged.

Also fixed along the way: selecting an object in the tree while the card-defaults view was showing left the card area on its placeholder text, so the selection outline, drag toolbar and the new alignment buttons had nothing to work with. It now renders the card again.

## Selecting a deck widget no longer opens the deck editor directly

Requested by @96LawDawg:

> Clicking on a deck widget while the Edit Mode tab is "Edit Widgets", or when already clicked on a deck and switching from some other tab to "Edit Widgets" should not immediately open the deck editor. Instead it should open a very abbreviated UI that looks like the UI for other widgets at the top and have the "Basic" section:
>
> However, for a deck, above the basic section, add a button to open in the deck editor. The only other section in the UI should be "Other properties" that lists anything not in the Basic section and anything not covered by the deck editor in card defaults, face templates, etc.
>
> Finally, next to the "Card View" button in the upper right, (so it will be right next to "Edit Widgets", add a button to close the deck editor.

Selecting a deck in the Edit Widgets tab now shows the same abbreviated sidebar as every other widget type: a type header, an **Open deck editor** button above everything else, the **Basic** section (Position/Size/Generic, same as any other widget), and an **Other properties** section for anything not in Basic and not owned by the deck editor (`cardDefaults`, `cardTypes` and `faceTemplates` are excluded, since those are edited inside the deck editor itself).

A **Close** button now sits next to **Card view** in the deck editor's upper-right corner, alongside the existing ways to close it (the toolbar's Deck editor toggle button and Escape).

Along the way this surfaced an unrelated bug: the main editor toolbar's hover tooltips had no `pointer-events: none`, so a tooltip could silently swallow a click aimed at whatever sat beneath it — including, at some window widths, the deck editor's own Card view/Close buttons. Fixed by making those tooltips click-through, like tooltips elsewhere in the app already are.

## Screenshots

Three text objects selected at once, with the grouped properties and the alignment row above them:

![multi-selected face objects](https://agent.virtualtabletop.io/reports/pr/1532415754513682593/pr3076-fixed.png)

After aligning them left and equalizing their vertical spacing (note the breadcrumb):

![aligned and evenly spaced](https://agent.virtualtabletop.io/reports/pr/1532415754513682593/pr3076-fixed-aligned.png)

Selecting a deck in Edit Widgets now shows the abbreviated Basic/Other properties panel instead of opening the deck editor:

![abbreviated deck panel](https://agent.virtualtabletop.io/reports/pr/1532415754513682593/deck-abbreviated-panel.png)

The deck editor open, with the new Close button next to Card view:

![deck editor with close button](https://agent.virtualtabletop.io/reports/pr/1532415754513682593/deck-editor-open-with-close.png)

## Notes

- No widget/routine properties were added, renamed or removed, so `validator/` and the JSON editor's `jeCommands` need no update. Saved games are untouched — this is editor UI only.
- Tests: `npm test` (jest) passes; the full TestCafe `editor.js` suite passes locally with **unchanged state hashes**. A new test — *"Deck editor: multi-selected face objects share property edits and alignment"* — covers Ctrl+click multi-selection, the grouped blocks, the `(mixed)` shared edit and align/distribute. Three existing test helpers switched from `#deckEditorSidebar > .deckEditorProperties:first-of-type` to `.deckEditorObjectProperties`, since the object rows now live inside their group blocks. The five existing tests that used to select a deck to open its editor directly now click the new "Open deck editor" button first; the toolbar-toggle test now also covers the new Close button.
- Creator-facing behavior change worth a wiki note: the deck editor's Ctrl/Shift+click multi-selection and the alignment buttons, and that selecting a deck widget no longer opens the deck editor by itself.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3076/pr-test (or any other room on that server)
