### PR TITLE
Rename seat properties (seatedText/emptyText/emptyColor/seatedColor) and make the generic 'display' work on seats

### DIFF
--- a/client/css/editor/propertyInputs.css
+++ b/client/css/editor/propertyInputs.css
@@ -773,6 +773,15 @@
   padding-right: 0;
 }
 
+.editorModule .compactStyledText .placeholderChipRow {
+  display: flex;
+  gap: 6px;
+  /* full row below the input, indented to the width of the label column so the
+     text/color/size controls above stay aligned with the placeholder-less rows */
+  flex: 1 0 100%;
+  margin-left: 138px;
+}
+
 .editorModule .compactStyledText .placeholderChip {
   font-family: monospace;
   font-size: 11px;
@@ -934,4 +943,18 @@ body.editorWidgetPicking, body.editorWidgetPicking .widget {
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
+}
+
+.editorModule .seatPresetCell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* the preset name below the preview instead of inside the sample seat, where
+   longer names wrapped and crowded the box */
+.editorModule .seatPresetCell .seatPresetLabel {
+  font-size: 12px;
+  text-align: center;
+  max-width: 156px;
 }

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -4596,9 +4596,9 @@ class PropertiesModule extends SidebarModule {
       return;
     }
     const seatedColor = widget.get('seatedColor');
-    const { activePlayers, activeColors } = getPlayerDetails();
+    // playerColors covers players who are no longer connected but still seated
     const color = !seatedColor || seatedColor == 'playerColor'
-      ? activeColors[activePlayers.indexOf(player)] : seatedColor;
+      ? getPlayerDetails().playerColors[player] : seatedColor;
     if(color)
       this.inputValueUpdated(widget, 'color', color);
   }

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -4541,7 +4541,10 @@ class PropertiesModule extends SidebarModule {
       button.title = label;
 
       // the presets differ in more than just css now, so compare every key they touch
-      const signature = state => JSON.stringify(Array.from(styleKeys).sort().map(k => state(k) ?? null));
+      const signature = state => JSON.stringify(Array.from(styleKeys).sort().map(k => {
+        const value = state(k);
+        return value === undefined ? null : value;
+      }));
       // a key the preset does not set is reset to null, i.e. back to the widget default
       const presetSignature = signature(k => k in preset ? preset[k] : widget.defaults[k]);
       const update = () => button.classList.toggle('selected', signature(k => widget.get(k)) === presetSignature);
@@ -4553,9 +4556,25 @@ class PropertiesModule extends SidebarModule {
         setDeltaCause(`${getPlayerDetails().playerName} applied the ${label} seat preset to ${widget.id} in editor`);
         for(const key of styleKeys)
           await widget.set(key, key in preset ? preset[key] : null);
+        this.applySeatedColor(widget);
         batchEnd();
       };
     }
+  }
+
+  // A seat's color is written when a player sits down, so changing seatedColor
+  // while somebody is already sitting there would otherwise only show up the
+  // next time the seat is taken.
+  applySeatedColor(widget) {
+    const player = widget.get('player');
+    if(!player)
+      return;
+    const seatedColor = widget.get('seatedColor');
+    const { activePlayers, activeColors } = getPlayerDetails();
+    const color = !seatedColor || seatedColor == 'playerColor'
+      ? activeColors[activePlayers.indexOf(player)] : seatedColor;
+    if(color)
+      this.inputValueUpdated(widget, 'color', color);
   }
 
   // "Use player color" toggle: it edits the seatedColor property, whose special
@@ -4568,10 +4587,11 @@ class PropertiesModule extends SidebarModule {
     };
     const usesPlayerColor = () => readColor() === null;
     const write = value => {
+      batchStart();
+      setDeltaCause(`${getPlayerDetails().playerName} changed the seated color of ${widget.id} in editor`);
       this.inputValueUpdated(widget, 'seatedColor', value === null ? 'playerColor' : value);
-      // a fixed color applies right away to a seat that is already occupied
-      if(value !== null && widget.get('player'))
-        this.inputValueUpdated(widget, 'color', value);
+      this.applySeatedColor(widget);
+      batchEnd();
     };
 
     new CheckboxInput(this, widget, 'Use player color', {

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -390,7 +390,7 @@ const editorPropertyHints = {
   firstColWidth: 'Fixed width of the first scoreboard column when autosizing is off.',
   player: 'The player currently seated here. Setting it also stores their color.',
   index: 'Seat order used by turn and scoreboard logic.',
-  display: 'The seat property whose value is displayed as the seat text.',
+  display: 'Whether the widget is shown at all. A hidden widget stays in the game and can be brought back by a routine.',
   hand: 'ID of the holder used as this seat\'s private hand.',
   turn: 'Marks this seat as currently taking its turn.',
   skipTurn: 'Skip this seat when routines advance turns.',
@@ -545,11 +545,13 @@ const SEAT_PRESET_BACKGROUND = {
   }
 };
 
+// the empty color stays neutral so a free seat is still recognizable as free -
+// with the same red on both sides, taken and free seats look identical
 const SEAT_PRESET_FIXED = {
   "width": 172,
   "height": 48,
   "borderRadius": 8,
-  "emptyColor": "#ff0000",
+  "emptyColor": "#999999",
   "seatedColor": "#ff0000",
   "css": {
     "default": {
@@ -1938,7 +1940,7 @@ class PropertiesModule extends SidebarModule {
   }
 
   basicPropertyExcludeList(extra = []) {
-    return [ 'x', 'y', 'z', 'layer', 'rotation', 'movable', 'movableInEdit', 'width', 'height', 'clickable', 'enlarge', 'ignoreZoom', 'fixedParent', 'linkedToSeat', 'onlyVisibleForSeat', 'inheritFrom' ].concat(extra);
+    return [ 'x', 'y', 'z', 'layer', 'rotation', 'movable', 'movableInEdit', 'width', 'height', 'clickable', 'display', 'enlarge', 'ignoreZoom', 'fixedParent', 'linkedToSeat', 'onlyVisibleForSeat', 'inheritFrom' ].concat(extra);
   }
 
   isSizeRatioLockEnabled(widget) {
@@ -3097,6 +3099,7 @@ class PropertiesModule extends SidebarModule {
     });
 
     this.renderCollapsibleSection('Generic', true, body=>{
+      this.renderCheckbox(widget, 'Visible', 'display', body, editorPropertyHints.display);
       this.renderCheckbox(widget, 'Clickable', 'clickable', body);
       this.renderNumberWithSlider(widget, 'enlarge', 'Enlarge', body, { min: 0, step: 1, slider: false });
       this.renderCheckbox(widget, 'Ignore zoom', 'ignoreZoom', body);
@@ -4497,7 +4500,17 @@ class PropertiesModule extends SidebarModule {
 
     this.addAppearanceSubTitle('When empty');
     this.renderCompactStyledTextInput(widget, 'Text', 'emptyText', 'default');
-    new ColorInput(this, widget, 'Inactive color', { property: 'emptyColor', hint: 'The border color while no player sits here.' }).render(this.moduleDOM);
+    new ColorInput(this, widget, 'Color', {
+      property: 'emptyColor',
+      hint: 'The seat\'s color while nobody sits here.',
+      setValue: value => {
+        batchStart();
+        setDeltaCause(`${getPlayerDetails().playerName} changed the empty color of ${widget.id} in editor`);
+        this.inputValueUpdated(widget, 'emptyColor', value);
+        this.applySeatColor(widget);
+        batchEnd();
+      }
+    }).render(this.moduleDOM);
     new CheckboxInput(this, widget, 'Hide when unused', { property: 'hideWhenUnused', hint: editorPropertyHints.hideWhenUnused }).render(this.moduleDOM);
 
     this.addAppearanceSubTitle('When seated');
@@ -4528,6 +4541,13 @@ class PropertiesModule extends SidebarModule {
     for(const { preset } of Object.values(presets))
       Object.keys(preset).forEach(k => styleKeys.add(k));
 
+    // the colors are edited right below the preset row and are meant to be
+    // customized, so the highlight compares the structural keys exactly and
+    // reduces seatedColor to what actually tells the presets apart: the seated
+    // player's color vs a fixed one
+    const structuralKeys = Array.from(styleKeys).filter(k => k != 'emptyColor' && k != 'seatedColor').sort();
+    const usesPlayerColor = value => !value || value == 'playerColor';
+
     const row = div(this.moduleDOM, 'seatPresetRow');
     for(const [ presetKey, { label, preset } ] of Object.entries(presets)) {
       // a unique id per preview keeps each seat's scoped css (#w_<id>.seated ...)
@@ -4535,16 +4555,18 @@ class PropertiesModule extends SidebarModule {
       // the state - renderReadonlyCopyRaw deletes state.id)
       const previewSeat = new Seat(`seatPreview_${widget.id}_${presetKey}`);
       // a sample color so "Background color" shows a colored seat; "Fixed color"
-      // overrides it with its own seatedColor
-      const previewColor = preset.seatedColor && preset.seatedColor != 'playerColor' ? preset.seatedColor : '#1e88e5';
-      const button = this.renderWidgetButton(previewSeat, Object.assign({ type: 'seat', player: label, color: previewColor, width: 150, height: 44 }, preset), row);
+      // overrides it with its own seatedColor. The size is forced after the
+      // preset so a wider preset still fits the preview button.
+      const previewColor = usesPlayerColor(preset.seatedColor) ? '#1e88e5' : preset.seatedColor;
+      const cell = div(row, 'seatPresetCell');
+      const button = this.renderWidgetButton(previewSeat, Object.assign({ type: 'seat' }, preset, { player: 'Player', color: previewColor, width: 150, height: 44 }), cell);
       button.title = label;
+      div(cell, 'seatPresetLabel').textContent = label;
 
-      // the presets differ in more than just css now, so compare every key they touch
-      const signature = state => JSON.stringify(Array.from(styleKeys).sort().map(k => {
+      const signature = state => JSON.stringify(structuralKeys.map(k => {
         const value = state(k);
         return value === undefined ? null : value;
-      }));
+      }).concat(usesPlayerColor(state('seatedColor'))));
       // a key the preset does not set is reset to null, i.e. back to the widget default
       const presetSignature = signature(k => k in preset ? preset[k] : widget.defaults[k]);
       const update = () => button.classList.toggle('selected', signature(k => widget.get(k)) === presetSignature);
@@ -4556,19 +4578,23 @@ class PropertiesModule extends SidebarModule {
         setDeltaCause(`${getPlayerDetails().playerName} applied the ${label} seat preset to ${widget.id} in editor`);
         for(const key of styleKeys)
           await widget.set(key, key in preset ? preset[key] : null);
-        this.applySeatedColor(widget);
+        this.applySeatColor(widget);
         batchEnd();
       };
     }
   }
 
-  // A seat's color is written when a player sits down, so changing seatedColor
-  // while somebody is already sitting there would otherwise only show up the
-  // next time the seat is taken.
-  applySeatedColor(widget) {
+  // A seat's color is only written when a player sits down or stands up, so
+  // editing seatedColor/emptyColor would otherwise only show up the next time
+  // the seat changes hands. Applies whichever of the two currently applies.
+  applySeatColor(widget) {
     const player = widget.get('player');
-    if(!player)
+    if(!player) {
+      const emptyColor = widget.get('emptyColor');
+      if(emptyColor)
+        this.inputValueUpdated(widget, 'color', emptyColor);
       return;
+    }
     const seatedColor = widget.get('seatedColor');
     const { activePlayers, activeColors } = getPlayerDetails();
     const color = !seatedColor || seatedColor == 'playerColor'
@@ -4590,18 +4616,18 @@ class PropertiesModule extends SidebarModule {
       batchStart();
       setDeltaCause(`${getPlayerDetails().playerName} changed the seated color of ${widget.id} in editor`);
       this.inputValueUpdated(widget, 'seatedColor', value === null ? 'playerColor' : value);
-      this.applySeatedColor(widget);
+      this.applySeatColor(widget);
       batchEnd();
     };
 
     new CheckboxInput(this, widget, 'Use player color', {
-      hint: 'On: the seat shows the seated player\'s color. Off: it always uses the fixed color below.',
+      hint: 'On: the seatedColor property stays at its special value "playerColor", so the seat takes the color of whoever sits down. Off: the fixed color below is used instead.',
       getValue: () => usesPlayerColor(),
       setValue: on => write(on ? null : (readColor() || widget.get('emptyColor') || '#999999')),
       listenTo: [ 'seatedColor' ]
     }).render(this.moduleDOM);
 
-    const colorInput = new ColorInput(this, widget, 'Seat color', {
+    const colorInput = new ColorInput(this, widget, 'Color', {
       hint: 'Fixed color used for this seat while a player is sitting in it.',
       getValue: () => readColor() || widget.get('emptyColor') || '#999999',
       setValue: value => write(value || '#999999'),
@@ -4628,6 +4654,9 @@ class PropertiesModule extends SidebarModule {
     wrap.appendChild(this.renderColorInput(widget, null, 'color', '#222222', 'css', cssClass));
     wrap.appendChild(this.renderNumberInput(widget, null, 'font-size', { step: 1, min: 0 }, '25px', 'css', cssClass));
 
+    // the chips go on their own line so the text/color/size columns line up
+    // with the rows that have no placeholders
+    const chipRow = (options.placeholders || []).length ? div(wrap, 'placeholderChipRow') : null;
     for(const placeholder of options.placeholders || []) {
       const chip = document.createElement('button');
       chip.className = 'placeholderChip';
@@ -4638,7 +4667,7 @@ class PropertiesModule extends SidebarModule {
         input.value = input.value.slice(0, at) + placeholder + input.value.slice(at);
         this.inputValueUpdated(widget, textProperty, input.value);
       };
-      wrap.appendChild(chip);
+      chipRow.appendChild(chip);
     }
 
     this.addPropertyListener(widget, textProperty, w => {
@@ -6489,7 +6518,7 @@ class PropertiesModule extends SidebarModule {
     return wrapper;
   }
 
-  renderCheckbox(widget, title, property, target = null) {
+  renderCheckbox(widget, title, property, target = null, hint = null) {
     const wrap = div(target || this.moduleDOM);
     const input = document.createElement('input');
     input.type = 'checkbox';
@@ -6500,6 +6529,8 @@ class PropertiesModule extends SidebarModule {
     label.textContent = title || property;
     wrap.appendChild(input);
     wrap.appendChild(label);
+    if(hint)
+      propertyInfoButton(label, html(hint));
 
     input.onchange = () => this.inputValueUpdated(widget, property, input.checked);
     this.addPropertyListener(widget, property, w => { input.checked = !!w.get(property); });

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -521,12 +521,13 @@ const editorTypeSections = {
 
 // Seat style presets (kept deliberately small). "Background color" shows the
 // seated player color via background:var(--color); "Fixed color" pins it to the
-// seat' colorEmpty through a .seated override. Used by seatStylePresets().
+// seat' seatedColor. Used by seatStylePresets().
 const SEAT_PRESET_BACKGROUND = {
   "width": 172,
   "height": 48,
   "borderRadius": 8,
-  "colorEmpty": "#ff0000",
+  "emptyColor": "#ff0000",
+  "seatedColor": "playerColor",
   "css": {
     "default": {
       "font-size": "21px",
@@ -548,7 +549,8 @@ const SEAT_PRESET_FIXED = {
   "width": 172,
   "height": 48,
   "borderRadius": 8,
-  "colorEmpty": "#ff0000",
+  "emptyColor": "#ff0000",
+  "seatedColor": "#ff0000",
   "css": {
     "default": {
       "font-size": "21px",
@@ -558,9 +560,6 @@ const SEAT_PRESET_FIXED = {
       "color": "white",
       "border": "2px solid #000000bb",
       "box-sizing": "border-box"
-    },
-    ".seated": {
-      "--color": "${PROPERTY colorEmpty} !important"
     },
     "> .basic": {
       "box-shadow": "initial",
@@ -4497,22 +4496,22 @@ class PropertiesModule extends SidebarModule {
     new CheckboxInput(this, widget, 'Hide turn marker', { property: 'hideTurn', hint: editorPropertyHints.hideTurn }).render(this.moduleDOM);
 
     this.addAppearanceSubTitle('When empty');
-    this.renderCompactStyledTextInput(widget, 'Text', 'displayEmpty', 'default');
-    new ColorInput(this, widget, 'Inactive color', { property: 'colorEmpty', hint: 'The border color while no player sits here.' }).render(this.moduleDOM);
+    this.renderCompactStyledTextInput(widget, 'Text', 'emptyText', 'default');
+    new ColorInput(this, widget, 'Inactive color', { property: 'emptyColor', hint: 'The border color while no player sits here.' }).render(this.moduleDOM);
     new CheckboxInput(this, widget, 'Hide when unused', { property: 'hideWhenUnused', hint: editorPropertyHints.hideWhenUnused }).render(this.moduleDOM);
 
     this.addAppearanceSubTitle('When seated');
-    this.renderCompactStyledTextInput(widget, 'Text', 'display', '.seated', {
+    this.renderCompactStyledTextInput(widget, 'Text', 'seatedText', '.seated', {
       placeholders: [ 'playerName', 'seatIndex' ]
     });
     this.renderSeatColorMode(widget);
 
-    this.renderOtherPropertiesSection(widget, [ 'player', 'hand', 'index', 'turn', 'skipTurn', 'hideTurn', 'hideWhenUnused', 'display', 'displayEmpty', 'color', 'colorEmpty' ]);
+    this.renderOtherPropertiesSection(widget, [ 'player', 'hand', 'index', 'turn', 'skipTurn', 'hideTurn', 'hideWhenUnused', 'seatedText', 'emptyText', 'color', 'seatedColor', 'emptyColor' ]);
   }
 
   // Style presets for seats: "Classic" is the plain default seat; "Background
   // color" shows the seated player's color as the seat background; "Fixed color"
-  // pins the seat to its colorEmpty regardless of who sits. Applying a preset
+  // pins the seat to its seatedColor regardless of who sits. Applying a preset
   // resets every style key the presets touch, so switching between them is clean.
   seatStylePresets() {
     return {
@@ -4536,12 +4535,18 @@ class PropertiesModule extends SidebarModule {
       // the state - renderReadonlyCopyRaw deletes state.id)
       const previewSeat = new Seat(`seatPreview_${widget.id}_${presetKey}`);
       // a sample color so "Background color" shows a colored seat; "Fixed color"
-      // ignores it (its .seated override pins --color to colorEmpty)
-      const button = this.renderWidgetButton(previewSeat, Object.assign({ type: 'seat', player: label, color: '#1e88e5', width: 150, height: 44 }, preset), row);
+      // overrides it with its own seatedColor
+      const previewColor = preset.seatedColor && preset.seatedColor != 'playerColor' ? preset.seatedColor : '#1e88e5';
+      const button = this.renderWidgetButton(previewSeat, Object.assign({ type: 'seat', player: label, color: previewColor, width: 150, height: 44 }, preset), row);
       button.title = label;
 
-      const presetCss = JSON.stringify(preset.css || null);
-      this.addPropertyListener(widget, 'css', w => button.classList.toggle('selected', JSON.stringify(w.get('css') || null) === presetCss));
+      // the presets differ in more than just css now, so compare every key they touch
+      const signature = state => JSON.stringify(Array.from(styleKeys).sort().map(k => state(k) ?? null));
+      // a key the preset does not set is reset to null, i.e. back to the widget default
+      const presetSignature = signature(k => k in preset ? preset[k] : widget.defaults[k]);
+      const update = () => button.classList.toggle('selected', signature(k => widget.get(k)) === presetSignature);
+      for(const key of styleKeys)
+        this.addPropertyListener(widget, key, update);
 
       button.onclick = async () => {
         batchStart();
@@ -4553,36 +4558,37 @@ class PropertiesModule extends SidebarModule {
     }
   }
 
-  // "Use player color" toggle: when on (default) the seat shows the seated
-  // player's color; when off, a fixed color is written as
-  // ".seated { --color: <color> !important }" so it overrides the per-player
-  // color the engine sets inline when someone sits down.
+  // "Use player color" toggle: it edits the seatedColor property, whose special
+  // value 'playerColor' (the default) means "use the color of whoever sits
+  // down"; any other value is the fixed color the seat gets while occupied.
   renderSeatColorMode(widget) {
-    const cssClass = '.seated';
-    const key = '--color';
-    const readOverride = () => {
-      const raw = parsePropertyFromCSS(widget.get('css'), key, null, cssClass);
-      return typeof raw === 'string' ? raw.replace(/\s*!important\s*$/i, '').trim() : null;
+    const readColor = () => {
+      const value = widget.get('seatedColor');
+      return !value || value == 'playerColor' ? null : value;
     };
-    const usesPlayerColor = () => readOverride() === null;
-    const writeOverride = value => this.inputValueUpdated(widget, 'css',
-      mergePropertyFromCSS(widget.get('css'), key, value === null ? null : `${value} !important`, cssClass));
+    const usesPlayerColor = () => readColor() === null;
+    const write = value => {
+      this.inputValueUpdated(widget, 'seatedColor', value === null ? 'playerColor' : value);
+      // a fixed color applies right away to a seat that is already occupied
+      if(value !== null && widget.get('player'))
+        this.inputValueUpdated(widget, 'color', value);
+    };
 
     new CheckboxInput(this, widget, 'Use player color', {
       hint: 'On: the seat shows the seated player\'s color. Off: it always uses the fixed color below.',
       getValue: () => usesPlayerColor(),
-      setValue: on => writeOverride(on ? null : (readOverride() || widget.get('colorEmpty') || '#999999')),
-      listenTo: [ 'css' ]
+      setValue: on => write(on ? null : (readColor() || widget.get('emptyColor') || '#999999')),
+      listenTo: [ 'seatedColor' ]
     }).render(this.moduleDOM);
 
     const colorInput = new ColorInput(this, widget, 'Seat color', {
       hint: 'Fixed color used for this seat while a player is sitting in it.',
-      getValue: () => readOverride() || widget.get('colorEmpty') || '#999999',
-      setValue: value => writeOverride(value || '#999999'),
-      listenTo: [ 'css' ]
+      getValue: () => readColor() || widget.get('emptyColor') || '#999999',
+      setValue: value => write(value || '#999999'),
+      listenTo: [ 'seatedColor' ]
     });
     colorInput.render(this.moduleDOM);
-    this.addPropertyListener(widget, 'css', () => colorInput.dom.style.display = usesPlayerColor() ? 'none' : '');
+    this.addPropertyListener(widget, 'seatedColor', () => colorInput.dom.style.display = usesPlayerColor() ? 'none' : '');
   }
 
   // compact one-line styled text input: text, color and font size side by
@@ -4654,7 +4660,7 @@ class PropertiesModule extends SidebarModule {
           batchStart();
           setDeltaCause(`${getPlayerDetails().playerName} removed player ${player} from seat ${widget.id} in editor`);
           await widget.set('player', null);
-          await widget.set('color', widget.get('colorEmpty'));
+          await widget.set('color', widget.get('emptyColor'));
           batchEnd();
         };
         row.appendChild(remove);
@@ -4666,7 +4672,7 @@ class PropertiesModule extends SidebarModule {
           batchStart();
           setDeltaCause(`${getPlayerDetails().playerName} took seat ${widget.id} in editor`);
           await widget.set('player', getPlayerDetails().playerName);
-          await widget.set('color', getPlayerDetails().playerColor);
+          await widget.set('color', widget.seatedColorFor(getPlayerDetails().playerColor));
           batchEnd();
         };
         container.appendChild(take);

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -6,6 +6,8 @@ let playerName = localStorage.getItem('playerName') || 'Guest' + Math.floor(rand
 let playerColor = 'red';
 let activePlayers = [];
 let activeColors = [];
+// every player the room knows, connected or not, mapped to their color
+let playerColors = {};
 let mouseCoords = [];
 localStorage.setItem('playerName', playerName);
 
@@ -14,6 +16,7 @@ export {
   playerColor,
   activePlayers,
   activeColors,
+  playerColors,
   mouseCoords
 }
 
@@ -23,6 +26,7 @@ function getPlayerDetails() {
     playerColor,
     activePlayers,
     activeColors,
+    playerColors,
     mouseCoords
   };
 }
@@ -38,6 +42,7 @@ function addPlayerCursor(playerName, playerColor) {
 }
 
 function fillPlayerList(players, active) {
+  playerColors = players;
   activePlayers = [...new Set(active)];
   activeColors = activePlayers.map(playerName=>players[playerName]);
   removeFromDOM('#playerList > div, #playerCursors > .cursor');

--- a/client/js/widgets/seat.js
+++ b/client/js/widgets/seat.js
@@ -12,14 +12,15 @@ class Seat extends Widget {
       turn: false,
       skipTurn: false,
       player: '',
-      display: 'playerName',
-      displayEmpty: 'click to sit',
+      seatedText: 'playerName',
+      emptyText: 'click to sit',
       hideTurn: false,
       hideWhenUnused: false,
       hand: 'hand',
 
       color: '#999999',
-      colorEmpty: '#999999',
+      seatedColor: 'playerColor',
+      emptyColor: '#999999',
       layer: -1,
       borderRadius: 5
     });
@@ -27,9 +28,9 @@ class Seat extends Widget {
 
   applyDeltaToDOM(delta) {
     super.applyDeltaToDOM(delta);
-    if(delta.index !== undefined || delta.player !== undefined || delta.display !== undefined || delta.displayEmpty !== undefined) {
-      const display = this.get('player') != '' ? this.get('display') : this.get('displayEmpty');
-      let displayedText = String(display || '')
+    if(delta.index !== undefined || delta.player !== undefined || delta.seatedText !== undefined || delta.emptyText !== undefined) {
+      const text = this.get('player') != '' ? this.get('seatedText') : this.get('emptyText');
+      let displayedText = String(text || '')
       displayedText = displayedText.replaceAll('seatIndex',this.get('index'))
       displayedText = displayedText.replaceAll('playerName',this.get('player'))
       setText(this.domElement, displayedText);
@@ -90,14 +91,22 @@ class Seat extends Widget {
     return p;
   }
 
+  // The color a seated player gives the seat: the special value 'playerColor'
+  // (the default) means "use the color of whoever sits down", anything else is
+  // used verbatim as the seat's color.
+  seatedColorFor(playerColor) {
+    const seatedColor = this.get('seatedColor');
+    return !seatedColor || seatedColor == 'playerColor' ? playerColor : seatedColor;
+  }
+
   //need to add a condition here to change the turn if the turn is in a seat that is empty
   async setPlayer() {
     if(this.get('player') == '') {
       await this.set('player', playerName);
-      await this.set('color', playerColor);
+      await this.set('color', this.seatedColorFor(playerColor));
     } else {
       await this.set('player', null);
-      await this.set('color', this.get('colorEmpty'));
+      await this.set('color', this.get('emptyColor'));
     }
   }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -491,7 +491,7 @@ export class Widget extends StateManaged {
     if(this.get('enlarge'))
       className += ' enlarge';
 
-    if(!this.get('display') && this.get('type') != 'seat') // seats already have a display property that does something else
+    if(!this.get('display'))
       className += ' hidden';
 
     if(this.isHighlighted)

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -114,7 +114,7 @@ function updateProperties(properties, v, globalProperties) {
   v<15 && v15SkipTurnProperty(properties);
   v<17 && v17MaterialSymbols(properties);
   v<20 && v20WhiteSpacePreWrap(properties, globalProperties);
-  v<22 && v22SeatProperties(properties);
+  v<22 && v22SeatProperties(properties, globalProperties);
 }
 
 function updateRoutine(routine, v, globalProperties) {
@@ -610,16 +610,65 @@ function v20WhiteSpacePreWrap(properties, globalProperties) {
 //   display      -> seatedText   (only on seats, "display" means something else everywhere else)
 //   displayEmpty -> emptyText
 //   colorEmpty   -> emptyColor
-// displayEmpty and colorEmpty are seat-only names, so they can be renamed
-// wherever they appear (properties, css, dynamic expressions, routines).
-function v22RenameSeatOnlyNames(json) {
-  return json.replace(/\bdisplayEmpty\b/g, 'emptyText').replace(/\bcolorEmpty\b/g, 'emptyColor');
+// displayEmpty and colorEmpty only ever meant something on a seat, so they are
+// renamed wherever a property NAME is expected: property keys, the property-name
+// fields of routine operations and "${PROPERTY ...}" references. Arbitrary
+// strings (labels, html, widget IDs, css class names, comments) are never
+// rewritten - they may legitimately contain those words.
+const v22SeatOnlyNames = { displayEmpty: 'emptyText', colorEmpty: 'emptyColor' };
+
+// routine operation fields that hold a widget property name
+const v22PropertyNameFields = { GET: 'property', SELECT: 'property', SET: 'property', RESET: 'property', SCORE: 'property', SORT: 'key' };
+
+// "${PROPERTY <name>}" / "${PROPERTY <name> OF <id>}" - the identifier syntax
+// matches what evaluateVariables() accepts. The "$variable" forms are left out
+// on purpose: what they point at cannot be known here.
+const v22PropertyExpression = /\$\{PROPERTY ([a-zA-Z0-9 _-]+?)(?: OF ([a-zA-Z0-9 _-]+))?\}/g;
+
+// The replacement for a property name, or null to keep it. "display" is a real
+// property on every widget, so it is only renamed where the widget it is read
+// from is known to be a seat.
+function v22SeatPropertyName(name, ofID, ownIsSeat, seatIDs) {
+  if(v22SeatOnlyNames[name])
+    return v22SeatOnlyNames[name];
+  if(name == 'display' && (ofID === undefined ? ownIsSeat : seatIDs.indexOf(ofID) != -1))
+    return 'seatedText';
+  return null;
 }
 
-// "${PROPERTY display}" without "OF" reads the widget the expression is written
-// on, so within a seat it can be renamed too.
-function v22RenameOwnPropertyDisplay(json) {
-  return json.replace(/(PROPERTY )display(\})/g, '$1seatedText$2');
+// A seat-only name where a property name is expected, keeping the '!' that
+// negates an entry in an inheritFrom list.
+function v22RenameSeatOnlyName(name) {
+  if(typeof name != 'string')
+    return name;
+  const negated = name.charAt(0) == '!';
+  const renamed = v22SeatOnlyNames[negated ? name.substr(1) : name];
+  return renamed ? (negated ? '!' + renamed : renamed) : name;
+}
+
+// Walks the whole value, renaming property references inside "${PROPERTY ...}"
+// expressions and inside the three structures that hold property names rather
+// than values: inheritFrom (widget ID -> '*' or a list of names), svgReplaces
+// (SVG color -> name) and a face object's dynamicProperties (face object
+// property -> name). Nothing else is touched.
+function v22RenameNames(value, ownIsSeat, seatIDs) {
+  if(typeof value == 'string')
+    return value.replace(v22PropertyExpression, (match, name, ofID) => {
+      const renamed = v22SeatPropertyName(name, ofID, ownIsSeat, seatIDs);
+      return renamed ? `\${PROPERTY ${renamed}${ofID === undefined ? '' : ` OF ${ofID}`}}` : match;
+    });
+
+  if(!value || typeof value != 'object')
+    return value;
+
+  for(const key in value) {
+    const nested = value[key];
+    if((key == 'inheritFrom' || key == 'svgReplaces' || key == 'dynamicProperties') && nested && typeof nested == 'object')
+      for(const name in nested)
+        nested[name] = Array.isArray(nested[name]) ? nested[name].map(v22RenameSeatOnlyName) : v22RenameSeatOnlyName(nested[name]);
+    value[key] = v22RenameNames(nested, ownIsSeat, seatIDs);
+  }
+  return value;
 }
 
 function v22RenameKey(object, from, to) {
@@ -629,31 +678,17 @@ function v22RenameKey(object, from, to) {
   }
 }
 
-function v22SeatProperties(properties) {
+function v22SeatProperties(properties, globalProperties) {
   const isSeat = properties.type == 'seat';
 
-  for(const key in properties) {
-    const value = properties[key];
-    if(typeof value != 'string' && (typeof value != 'object' || value === null))
-      continue;
-    const json = JSON.stringify(value);
-    if(json === undefined)
-      continue;
-    let updated = v22RenameSeatOnlyNames(json);
-    if(isSeat)
-      updated = v22RenameOwnPropertyDisplay(updated);
-    if(updated !== json)
-      properties[key] = JSON.parse(updated);
-  }
+  v22RenameNames(properties, isSeat, globalProperties.v22SeatIDs || []);
 
-  v22RenameKey(properties, 'displayEmpty', 'emptyText');
-  v22RenameKey(properties, 'colorEmpty', 'emptyColor');
+  for(const from in v22SeatOnlyNames)
+    v22RenameKey(properties, from, v22SeatOnlyNames[from]);
 
   // "display" is a boolean on every other widget, so it is only renamed on seats
   if(isSeat) {
     v22RenameKey(properties, 'display', 'seatedText');
-    if(properties.dynamicProperties && typeof properties.dynamicProperties == 'object')
-      v22RenameKey(properties.dynamicProperties, 'display', 'seatedText');
     v22SeatedColorFromCSS(properties);
   }
 }
@@ -691,58 +726,98 @@ function v22SeatedColorFromCSS(properties) {
     delete properties.css['.seated'];
 }
 
+// The property name an operation works on. GET also accepts a [ property, key ]
+// path and SORT a list of keys, so the name can sit inside an array.
+function v22OperationPropertyNames(operation, field) {
+  const value = operation[field];
+  if(typeof value == 'string')
+    return [ { get: () => value, set: name => operation[field] = name } ];
+  if(!Array.isArray(value) || !value.length)
+    return [];
+  // a GET property path names one property, the rest of the path are keys in it
+  const entries = operation.func == 'GET' ? [ value[0] ] : value;
+  return entries.map((entry, index) => typeof entry == 'string'
+    ? { get: () => value[index], set: name => value[index] = name }
+    : { get: () => entry && typeof entry == 'object' ? entry.key : undefined, set: name => entry.key = name });
+}
+
+// GET names its variable after the property unless one is given, so pin the old
+// name down before renaming - "${colorEmpty}" further down keeps working.
+function v22RenameOperationProperty(operation, field, entry, name) {
+  if(operation.func == 'GET' && operation.variable === undefined)
+    operation.variable = entry.get();
+  entry.set(name);
+}
+
 function v22SeatRoutine(routine, globalProperties) {
   const seatIDs = globalProperties.v22SeatIDs || [];
-  const seatIDPattern = seatIDs.map(id => id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
-  // ${PROPERTY display OF <seat>} can be renamed safely because the widget it
-  // reads from is known to be a seat (the ID in that syntax is a literal that
-  // runs up to the closing brace)
-  const propertyOfSeat = seatIDPattern
-    ? new RegExp(`(PROPERTY )display( OF (?:${seatIDPattern})\\})`, 'g') : null;
 
-  // A plain SET/GET of "display" cannot be resolved statically. It is only
-  // renamed when the collection it works on provably holds nothing but seats,
-  // or when the value uses a placeholder that only a seat text understands.
+  // What a collection provably holds: true = seats only, false = no seats at
+  // all, undefined = unknown. A plain SET/GET/SELECT of "display" cannot be
+  // resolved statically, so it is only renamed for a seats-only collection, or -
+  // when nothing is known about the collection - when the value uses a
+  // placeholder that only a seat text understands.
   const seatOnly = {};
 
-  for(const key in routine) {
-    const json = JSON.stringify(routine[key]);
-    if(json === undefined)
-      continue;
-    let updated = v22RenameSeatOnlyNames(json);
-    if(propertyOfSeat)
-      updated = updated.replace(propertyOfSeat, '$1seatedText$2');
-    if(updated !== json)
-      routine[key] = JSON.parse(updated);
-
-    const operation = routine[key];
+  for(const operation of routine) {
     if(!operation || typeof operation != 'object')
       continue;
     const collection = operation.collection || 'DEFAULT';
+    const field = v22PropertyNameFields[operation.func];
+    const propertyNames = field ? v22OperationPropertyNames(operation, field) : [];
+
+    for(const entry of propertyNames)
+      if(v22SeatOnlyNames[entry.get()])
+        v22RenameOperationProperty(operation, field, entry, v22SeatOnlyNames[entry.get()]);
 
     if(operation.func == 'SELECT') {
-      const selectsSeats = operation.type == 'seat';
+      const selectsSeats = v22SelectsSeats(operation);
       const mode = operation.mode || 'set';
       if(mode == 'set')
         seatOnly[collection] = selectsSeats;
       else if(mode == 'add')
-        seatOnly[collection] = seatOnly[collection] && selectsSeats;
+        seatOnly[collection] = v22Union(seatOnly[collection], selectsSeats);
       else if(mode == 'intersect')
-        seatOnly[collection] = seatOnly[collection] || selectsSeats;
+        seatOnly[collection] = v22Intersection(seatOnly[collection], selectsSeats);
       // 'remove' can never bring non-seats into the collection
-      if(selectsSeats && operation.property == 'display')
-        operation.property = 'seatedText';
     } else if(operation.func == 'CLONE') {
       delete seatOnly[collection];
     } else if(operation.func == 'CALL' || operation.func == 'FOREACH' || operation.func == 'IF') {
       // these run routines of their own which can refill any collection
       for(const name in seatOnly)
         delete seatOnly[name];
-    } else if((operation.func == 'SET' || operation.func == 'GET') && operation.property == 'display') {
-      if(seatOnly[collection] || (typeof operation.value == 'string' && /\b(playerName|seatIndex)\b/.test(operation.value)))
-        operation.property = 'seatedText';
     }
+
+    if([ 'SELECT', 'SET', 'GET' ].indexOf(operation.func) == -1)
+      continue;
+    // a SELECT filters on the type it selects, everything else on its collection
+    const targetsSeats = operation.func == 'SELECT' ? v22SelectsSeats(operation) : seatOnly[collection];
+    for(const entry of propertyNames)
+      if(entry.get() == 'display' && (targetsSeats === true || targetsSeats === undefined && v22SeatTextValue(operation)))
+        v22RenameOperationProperty(operation, field, entry, 'seatedText');
   }
+}
+
+// true if the SELECT provably picks only seats, false if it provably picks none,
+// undefined without a type filter
+function v22SelectsSeats(operation) {
+  if(operation.type === undefined || operation.type == 'all' || typeof operation.type != 'string')
+    return undefined;
+  return operation.type == 'seat';
+}
+
+function v22Union(a, b) {
+  return a === true && b === true ? true : (a === false || b === false ? false : undefined);
+}
+
+function v22Intersection(a, b) {
+  return a === true || b === true ? true : (a === false && b === false ? false : undefined);
+}
+
+// only a seat text understands these placeholders, so a value using one was
+// written for a seat even when the collection cannot be resolved
+function v22SeatTextValue(operation) {
+  return typeof operation.value == 'string' && /\b(playerName|seatIndex)\b/.test(operation.value);
 }
 
 function v21DisableHolderImageWidget(meta, state) {

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -823,11 +823,11 @@ function v22SelectsSeats(operation) {
 }
 
 function v22Union(a, b) {
-  return a === true && b === true ? true : (a === false || b === false ? false : undefined);
+  return a === true && b === true ? true : (a === false && b === false ? false : undefined);
 }
 
 function v22Intersection(a, b) {
-  return a === true || b === true ? true : (a === false && b === false ? false : undefined);
+  return a === false || b === false ? false : (a === true || b === true ? true : undefined);
 }
 
 // only a seat text understands these placeholders, so a value using one was

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -620,10 +620,25 @@ const v22SeatOnlyNames = { displayEmpty: 'emptyText', colorEmpty: 'emptyColor' }
 // routine operation fields that hold a widget property name
 const v22PropertyNameFields = { GET: 'property', SELECT: 'property', SET: 'property', RESET: 'property', SCORE: 'property', SORT: 'key' };
 
-// "${PROPERTY <name>}" / "${PROPERTY <name> OF <id>}" - the identifier syntax
-// matches what evaluateVariables() accepts. The "$variable" forms are left out
-// on purpose: what they point at cannot be known here.
-const v22PropertyExpression = /\$\{PROPERTY ([a-zA-Z0-9 _-]+?)(?: OF ([a-zA-Z0-9 _-]+))?\}/g;
+// "${PROPERTY <name>}" / "${PROPERTY <name> OF <id>}". The content is captured
+// in one piece and split afterwards: spelling the two identifiers out in the
+// pattern lets it backtrack quadratically on a crafted game file.
+const v22PropertyExpression = /\$\{PROPERTY ([^{}]*)\}/g;
+const v22PropertyIdentifier = /^[a-zA-Z0-9 _-]+$/;
+
+// name and target of a property expression, or null when it is not the plain
+// form evaluateVariables() resolves statically (a "$variable" indirection or an
+// identifier with characters it does not accept)
+function v22ParsePropertyExpression(content) {
+  // identifiers may contain spaces, so the first " OF " wins - the engine
+  // matches the name lazily and gets the same split
+  const of = content.indexOf(' OF ');
+  const name = of == -1 ? content : content.substr(0, of);
+  const ofID = of == -1 ? undefined : content.substr(of + 4);
+  if(!v22PropertyIdentifier.test(name) || ofID !== undefined && !v22PropertyIdentifier.test(ofID))
+    return null;
+  return { name, ofID };
+}
 
 // The replacement for a property name, or null to keep it. "display" is a real
 // property on every widget, so it is only renamed where the widget it is read
@@ -653,9 +668,10 @@ function v22RenameSeatOnlyName(name) {
 // property -> name). Nothing else is touched.
 function v22RenameNames(value, ownIsSeat, seatIDs) {
   if(typeof value == 'string')
-    return value.replace(v22PropertyExpression, (match, name, ofID) => {
-      const renamed = v22SeatPropertyName(name, ofID, ownIsSeat, seatIDs);
-      return renamed ? `\${PROPERTY ${renamed}${ofID === undefined ? '' : ` OF ${ofID}`}}` : match;
+    return value.replace(v22PropertyExpression, (match, content) => {
+      const expression = v22ParsePropertyExpression(content);
+      const renamed = expression && v22SeatPropertyName(expression.name, expression.ofID, ownIsSeat, seatIDs);
+      return renamed ? `\${PROPERTY ${renamed}${expression.ofID === undefined ? '' : ` OF ${expression.ofID}`}}` : match;
     });
 
   if(!value || typeof value != 'object')

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -616,40 +616,92 @@ function v22RenameSeatOnlyNames(json) {
   return json.replace(/\bdisplayEmpty\b/g, 'emptyText').replace(/\bcolorEmpty\b/g, 'emptyColor');
 }
 
+// "${PROPERTY display}" without "OF" reads the widget the expression is written
+// on, so within a seat it can be renamed too.
+function v22RenameOwnPropertyDisplay(json) {
+  return json.replace(/(PROPERTY )display(\})/g, '$1seatedText$2');
+}
+
+function v22RenameKey(object, from, to) {
+  if(object[from] !== undefined) {
+    object[to] = object[from];
+    delete object[from];
+  }
+}
+
 function v22SeatProperties(properties) {
+  const isSeat = properties.type == 'seat';
+
   for(const key in properties) {
     const value = properties[key];
-    if(typeof value == 'string' || (typeof value == 'object' && value !== null)) {
-      const json = JSON.stringify(value);
-      if(json !== undefined && /displayEmpty|colorEmpty/.test(json))
-        properties[key] = JSON.parse(v22RenameSeatOnlyNames(json));
-    }
+    if(typeof value != 'string' && (typeof value != 'object' || value === null))
+      continue;
+    const json = JSON.stringify(value);
+    if(json === undefined)
+      continue;
+    let updated = v22RenameSeatOnlyNames(json);
+    if(isSeat)
+      updated = v22RenameOwnPropertyDisplay(updated);
+    if(updated !== json)
+      properties[key] = JSON.parse(updated);
   }
 
-  if(properties.displayEmpty !== undefined) {
-    properties.emptyText = properties.displayEmpty;
-    delete properties.displayEmpty;
-  }
-  if(properties.colorEmpty !== undefined) {
-    properties.emptyColor = properties.colorEmpty;
-    delete properties.colorEmpty;
-  }
+  v22RenameKey(properties, 'displayEmpty', 'emptyText');
+  v22RenameKey(properties, 'colorEmpty', 'emptyColor');
 
   // "display" is a boolean on every other widget, so it is only renamed on seats
-  if(properties.type == 'seat' && properties.display !== undefined) {
-    properties.seatedText = properties.display;
-    delete properties.display;
+  if(isSeat) {
+    v22RenameKey(properties, 'display', 'seatedText');
+    if(properties.dynamicProperties && typeof properties.dynamicProperties == 'object')
+      v22RenameKey(properties.dynamicProperties, 'display', 'seatedText');
+    v22SeatedColorFromCSS(properties);
   }
+}
+
+// Before seatedColor existed, the editor's "Fixed color" preset pinned the color
+// of an occupied seat with a ".seated { --color: <color> !important }" rule that
+// beat the color the engine writes inline when someone sits down. seatedColor
+// does that job now, so the rule moves into the property.
+function v22SeatedColorFromCSS(properties) {
+  const seated = properties.css && typeof properties.css == 'object' ? properties.css['.seated'] : null;
+  if(!seated || typeof seated != 'object' || typeof seated['--color'] != 'string')
+    return;
+
+  // without !important the inline player color won anyway, so nothing to move
+  if(!/!important\s*$/i.test(seated['--color']))
+    return;
+  const value = seated['--color'].replace(/\s*!important\s*$/i, '').trim();
+
+  // the preset pointed at the seat's own empty color; anything else dynamic is
+  // left alone because seatedColor is used verbatim, not evaluated
+  const color = /^\$\{PROPERTY emptyColor\}$/.test(value) ? (properties.emptyColor || '#999999') : value;
+  if(!color || color.indexOf('${') != -1)
+    return;
+
+  properties.seatedColor = color;
+  // a seat that is occupied right now showed the fixed color through the
+  // override, so keep it there instead of falling back to the player color
+  if(properties.player)
+    properties.color = color;
+
+  delete seated['--color'];
+  if(!Object.keys(seated).length)
+    delete properties.css['.seated'];
 }
 
 function v22SeatRoutine(routine, globalProperties) {
   const seatIDs = globalProperties.v22SeatIDs || [];
   const seatIDPattern = seatIDs.map(id => id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
   // ${PROPERTY display OF <seat>} can be renamed safely because the widget it
-  // reads from is known to be a seat. A plain SET/GET of "display" cannot be
-  // resolved statically, so only the two seat placeholders give it away.
+  // reads from is known to be a seat (the ID in that syntax is a literal that
+  // runs up to the closing brace)
   const propertyOfSeat = seatIDPattern
-    ? new RegExp(`(PROPERTY\\s+)display(\\s+OF\\s+'?(?:${seatIDPattern})'?\\b)`, 'g') : null;
+    ? new RegExp(`(PROPERTY )display( OF (?:${seatIDPattern})\\})`, 'g') : null;
+
+  // A plain SET/GET of "display" cannot be resolved statically. It is only
+  // renamed when the collection it works on provably holds nothing but seats,
+  // or when the value uses a placeholder that only a seat text understands.
+  const seatOnly = {};
 
   for(const key in routine) {
     const json = JSON.stringify(routine[key]);
@@ -662,9 +714,31 @@ function v22SeatRoutine(routine, globalProperties) {
       routine[key] = JSON.parse(updated);
 
     const operation = routine[key];
-    if(operation && typeof operation == 'object' && operation.func == 'SET' && operation.property == 'display'
-       && typeof operation.value == 'string' && /\b(playerName|seatIndex)\b/.test(operation.value)) {
-      operation.property = 'seatedText';
+    if(!operation || typeof operation != 'object')
+      continue;
+    const collection = operation.collection || 'DEFAULT';
+
+    if(operation.func == 'SELECT') {
+      const selectsSeats = operation.type == 'seat';
+      const mode = operation.mode || 'set';
+      if(mode == 'set')
+        seatOnly[collection] = selectsSeats;
+      else if(mode == 'add')
+        seatOnly[collection] = seatOnly[collection] && selectsSeats;
+      else if(mode == 'intersect')
+        seatOnly[collection] = seatOnly[collection] || selectsSeats;
+      // 'remove' can never bring non-seats into the collection
+      if(selectsSeats && operation.property == 'display')
+        operation.property = 'seatedText';
+    } else if(operation.func == 'CLONE') {
+      delete seatOnly[collection];
+    } else if(operation.func == 'CALL' || operation.func == 'FOREACH' || operation.func == 'IF') {
+      // these run routines of their own which can refill any collection
+      for(const name in seatOnly)
+        delete seatOnly[name];
+    } else if((operation.func == 'SET' || operation.func == 'GET') && operation.property == 'display') {
+      if(seatOnly[collection] || (typeof operation.value == 'string' && /\b(playerName|seatIndex)\b/.test(operation.value)))
+        operation.property = 'seatedText';
     }
   }
 }

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -668,9 +668,11 @@ function v22SeatedColorFromCSS(properties) {
     return;
 
   // without !important the inline player color won anyway, so nothing to move
-  if(!/!important\s*$/i.test(seated['--color']))
+  const important = '!important';
+  const raw = seated['--color'].trimEnd();
+  if(!raw.toLowerCase().endsWith(important))
     return;
-  const value = seated['--color'].replace(/\s*!important\s*$/i, '').trim();
+  const value = raw.slice(0, -important.length).trim();
 
   // the preset pointed at the seat's own empty color; anything else dynamic is
   // left alone because seatedColor is used verbatim, not evaluated

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -1,4 +1,4 @@
-export const VERSION = 21;
+export const VERSION = 22;
 
 export default function FileUpdater(state) {
   const v = state._meta.version;
@@ -38,6 +38,9 @@ function computeGlobalProperties(state, v) {
   }
 
   v<20 && v20WhiteSpacePreWrapRoutineCheck(state, globalProperties);
+
+  if(v < 22)
+    globalProperties.v22SeatIDs = Object.keys(state).filter(id => state[id] && state[id].type == 'seat');
 
   return globalProperties;
 }
@@ -111,6 +114,7 @@ function updateProperties(properties, v, globalProperties) {
   v<15 && v15SkipTurnProperty(properties);
   v<17 && v17MaterialSymbols(properties);
   v<20 && v20WhiteSpacePreWrap(properties, globalProperties);
+  v<22 && v22SeatProperties(properties);
 }
 
 function updateRoutine(routine, v, globalProperties) {
@@ -136,6 +140,7 @@ function updateRoutine(routine, v, globalProperties) {
   v<11 && v11OwnerMOVEXY(routine);
   v<15 && v15SkipTurnRoutine(routine);
   v<16 && v16UpdateCountParameter(routine);
+  v<22 && v22SeatRoutine(routine, globalProperties);
 }
 
 function v2UpdateSelectDefault(routine) {
@@ -598,6 +603,70 @@ function v20WhiteSpacePreWrap(properties, globalProperties) {
 
   if(!properties.type && (hasMultipleWhitespaceOrNewline(String(properties.html)) || String(JSON.stringify(properties.inheritFrom)).match(/"html"/)) || (typeof properties.html == 'string' && globalProperties.v20WhiteSpacePreWrapForAllHtml) && !cssHasWhiteSpace(properties.css))
     properties.css = addWhiteSpacePreWrapToCss(properties.css);
+}
+
+// v22 renamed the seat's text/color properties so that "display" is free for the
+// generic show/hide boolean every other widget has:
+//   display      -> seatedText   (only on seats, "display" means something else everywhere else)
+//   displayEmpty -> emptyText
+//   colorEmpty   -> emptyColor
+// displayEmpty and colorEmpty are seat-only names, so they can be renamed
+// wherever they appear (properties, css, dynamic expressions, routines).
+function v22RenameSeatOnlyNames(json) {
+  return json.replace(/\bdisplayEmpty\b/g, 'emptyText').replace(/\bcolorEmpty\b/g, 'emptyColor');
+}
+
+function v22SeatProperties(properties) {
+  for(const key in properties) {
+    const value = properties[key];
+    if(typeof value == 'string' || (typeof value == 'object' && value !== null)) {
+      const json = JSON.stringify(value);
+      if(json !== undefined && /displayEmpty|colorEmpty/.test(json))
+        properties[key] = JSON.parse(v22RenameSeatOnlyNames(json));
+    }
+  }
+
+  if(properties.displayEmpty !== undefined) {
+    properties.emptyText = properties.displayEmpty;
+    delete properties.displayEmpty;
+  }
+  if(properties.colorEmpty !== undefined) {
+    properties.emptyColor = properties.colorEmpty;
+    delete properties.colorEmpty;
+  }
+
+  // "display" is a boolean on every other widget, so it is only renamed on seats
+  if(properties.type == 'seat' && properties.display !== undefined) {
+    properties.seatedText = properties.display;
+    delete properties.display;
+  }
+}
+
+function v22SeatRoutine(routine, globalProperties) {
+  const seatIDs = globalProperties.v22SeatIDs || [];
+  const seatIDPattern = seatIDs.map(id => id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+  // ${PROPERTY display OF <seat>} can be renamed safely because the widget it
+  // reads from is known to be a seat. A plain SET/GET of "display" cannot be
+  // resolved statically, so only the two seat placeholders give it away.
+  const propertyOfSeat = seatIDPattern
+    ? new RegExp(`(PROPERTY\\s+)display(\\s+OF\\s+'?(?:${seatIDPattern})'?\\b)`, 'g') : null;
+
+  for(const key in routine) {
+    const json = JSON.stringify(routine[key]);
+    if(json === undefined)
+      continue;
+    let updated = v22RenameSeatOnlyNames(json);
+    if(propertyOfSeat)
+      updated = updated.replace(propertyOfSeat, '$1seatedText$2');
+    if(updated !== json)
+      routine[key] = JSON.parse(updated);
+
+    const operation = routine[key];
+    if(operation && typeof operation == 'object' && operation.func == 'SET' && operation.property == 'display'
+       && typeof operation.value == 'string' && /\b(playerName|seatIndex)\b/.test(operation.value)) {
+      operation.property = 'seatedText';
+    }
+  }
 }
 
 function v21DisableHolderImageWidget(meta, state) {

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -595,7 +595,7 @@ export default async function convertPCIO(content) {
     } else if(widget.type == 'seat') {
       w.type = 'seat';
       w.display = 'seatIndex';
-      w.displayEmpty = 'seatIndex';
+      w.emptyText = 'seatIndex';
       w.hideWhenUnused = true;
       if(typeof widget.seatIndex == 'number')
         w.index = widget.seatIndex + 1;

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -594,7 +594,7 @@ export default async function convertPCIO(content) {
       }
     } else if(widget.type == 'seat') {
       w.type = 'seat';
-      w.display = 'seatIndex';
+      w.seatedText = 'seatIndex';
       w.emptyText = 'seatIndex';
       w.hideWhenUnused = true;
       if(typeof widget.seatIndex == 'number')

--- a/tests/client/property-inputs.test.js
+++ b/tests/client/property-inputs.test.js
@@ -95,10 +95,10 @@ describe('css helpers', () => {
       '#accent': 'accentColor1',
       '#outline': 'outlineColor2',
       '#border': 'borderColor',
-      '#empty': 'colorEmpty',
+      '#empty': 'emptyColor',
       '#secondary': 'secondaryColor',
       '#alsoIgnored': 'title'
-    })).toEqual([ 'color', 'accentColor1', 'outlineColor2', 'borderColor', 'colorEmpty', 'secondaryColor' ]);
+    })).toEqual([ 'color', 'accentColor1', 'outlineColor2', 'borderColor', 'emptyColor', 'secondaryColor' ]);
   });
 
   test('cssTextFromValue renders all value shapes', () => {

--- a/tests/client/property-inputs.test.js
+++ b/tests/client/property-inputs.test.js
@@ -37,8 +37,10 @@ const renderIconChip = new Function('div', 'html', 'mapAssetURLs', 'toNotoMonoch
 );
 
 const testWidgets = new Map();
-const cssHelpers = new Function('SidebarModule', 'widgets', propertiesSource + `;
+let playerDetails = { playerColors: {}, activePlayers: [], activeColors: [] };
+const cssHelpers = new Function('SidebarModule', 'widgets', 'getPlayerDetails', propertiesSource + `;
   return {
+    applySeatColor: PropertiesModule.prototype.applySeatColor,
     cssTextFromValue,
     cssStringRoundTrips,
     cssStringToObject,
@@ -59,7 +61,16 @@ const cssHelpers = new Function('SidebarModule', 'widgets', propertiesSource + `
     textSymbolClass,
     textValueFromSymbol
   };
-`)(class {}, testWidgets);
+`)(class {}, testWidgets, () => playerDetails);
+
+// the editor writes "color" through so seatedColor/emptyColor take effect right
+// away instead of only on the next sit/stand
+function seatColorUpdates(properties) {
+  const updates = [];
+  cssHelpers.applySeatColor.call({ inputValueUpdated: (widget, property, value) => updates.push([ property, value ]) },
+    { get: property => properties[property] });
+  return updates;
+}
 
 describe('css helpers', () => {
   test('basic properties exclude the generic inputs from other property sections', () => {
@@ -308,5 +319,31 @@ describe('property input helpers', () => {
 
     expect(inputHelpers.searchIconIndex('icon')).toHaveLength(100);
     expect(inputHelpers.searchImageIndex('icon')).toHaveLength(100);
+  });
+});
+
+describe('seat colors', () => {
+  beforeEach(() => {
+    playerDetails = { playerColors: { Alice: '#ff0000', Bob: '#00ff00' }, activePlayers: [ 'Alice' ], activeColors: [ '#ff0000' ] };
+  });
+
+  test('an empty seat takes its empty color', () => {
+    expect(seatColorUpdates({ player: '', emptyColor: '#999999', seatedColor: '#0000ff' })).toEqual([ [ 'color', '#999999' ] ]);
+  });
+
+  test('an occupied seat takes its fixed seated color', () => {
+    expect(seatColorUpdates({ player: 'Alice', emptyColor: '#999999', seatedColor: '#0000ff' })).toEqual([ [ 'color', '#0000ff' ] ]);
+  });
+
+  test('an occupied seat takes the player color back when the toggle goes on', () => {
+    expect(seatColorUpdates({ player: 'Alice', seatedColor: 'playerColor' })).toEqual([ [ 'color', '#ff0000' ] ]);
+  });
+
+  test('a seated player who disconnected still has a color', () => {
+    expect(seatColorUpdates({ player: 'Bob', seatedColor: 'playerColor' })).toEqual([ [ 'color', '#00ff00' ] ]);
+  });
+
+  test('nothing is written for a player the room does not know', () => {
+    expect(seatColorUpdates({ player: 'Carol', seatedColor: 'playerColor' })).toEqual([]);
   });
 });

--- a/tests/server/fileupdater.test.js
+++ b/tests/server/fileupdater.test.js
@@ -228,3 +228,29 @@ describe('v22 fixed seat color', () => {
     expect(updateWidgets({ seat: { type: 'seat', css } })).toEqual({ seat: { type: 'seat', css } });
   });
 });
+
+describe('v22 property expressions', () => {
+  test('leaves expressions it cannot resolve statically alone', () => {
+    const clickRoutine = [
+      { func: 'LABEL', value: '${PROPERTY $variable}' },
+      { func: 'LABEL', value: '${PROPERTY colorEmpty OF $variable}' },
+      { func: 'LABEL', value: '${PROPERTY colorEmpty!}' },
+      { func: 'LABEL', value: 'colorEmpty ${PROPERTY colorEmpty' }
+    ];
+    expect(updateWidgets({ button: { type: 'button', clickRoutine: JSON.parse(JSON.stringify(clickRoutine)) } }).button.clickRoutine).toEqual(clickRoutine);
+  });
+
+  test('splits the name from the target the way the engine does', () => {
+    expect(updateWidgets({
+      seat: { type: 'seat' },
+      button: { type: 'button', clickRoutine: [ { func: 'LABEL', value: '${PROPERTY colorEmpty OF a OF b}' } ] }
+    }).button.clickRoutine[0].value).toBe('${PROPERTY emptyColor OF a OF b}');
+  });
+
+  test('a long run of " OF " does not take forever', () => {
+    const value = '${PROPERTY ' + ' OF '.repeat(20000);
+    const started = Date.now();
+    updateWidgets({ button: { type: 'button', clickRoutine: [ { func: 'LABEL', value } ] } });
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+});

--- a/tests/server/fileupdater.test.js
+++ b/tests/server/fileupdater.test.js
@@ -163,6 +163,29 @@ describe('v22 seat property rename', () => {
     }).button.clickRoutine[1]).toEqual({ func: 'SET', property: 'display', value: '${playerName}' });
   });
 
+  test('tracks whether add and intersect collections can contain seats', () => {
+    expect(updateWidgets({
+      button: {
+        type: 'button',
+        clickRoutine: [
+          { func: 'SELECT', type: 'label', collection: 'added' },
+          { func: 'SELECT', type: 'all', collection: 'added', mode: 'add' },
+          { func: 'SET', property: 'display', value: '${playerName}', collection: 'added' },
+          { func: 'SELECT', type: 'all', collection: 'intersected' },
+          { func: 'SELECT', type: 'label', collection: 'intersected', mode: 'intersect' },
+          { func: 'SET', property: 'display', value: '${playerName}', collection: 'intersected' }
+        ]
+      }
+    }).button.clickRoutine).toEqual([
+      { func: 'SELECT', type: 'label', collection: 'added' },
+      { func: 'SELECT', type: 'all', collection: 'added', mode: 'add' },
+      { func: 'SET', property: 'seatedText', value: '${playerName}', collection: 'added' },
+      { func: 'SELECT', type: 'all', collection: 'intersected' },
+      { func: 'SELECT', type: 'label', collection: 'intersected', mode: 'intersect' },
+      { func: 'SET', property: 'display', value: '${playerName}', collection: 'intersected' }
+    ]);
+  });
+
   test('still renames display after a SELECT that could have picked seats', () => {
     expect(updateWidgets({
       button: {

--- a/tests/server/fileupdater.test.js
+++ b/tests/server/fileupdater.test.js
@@ -1,0 +1,172 @@
+import FileUpdater, { VERSION } from '../../server/fileupdater.mjs';
+
+// The v22 migration renames the seat text/color properties and hands "display"
+// over to the generic show/hide boolean. Getting that wrong is not recoverable
+// once a room has been saved, so every rule it applies is pinned down here.
+function updateFromV21(state) {
+  return FileUpdater(Object.assign({ _meta: { version: 21 } }, state));
+}
+
+function updateWidgets(widgets) {
+  const state = updateFromV21(widgets);
+  delete state._meta;
+  return state;
+}
+
+describe('v22 seat property rename', () => {
+  test('renames the seat properties and leaves other widgets alone', () => {
+    expect(updateWidgets({
+      seat: { type: 'seat', display: 'playerName', displayEmpty: 'sit down', colorEmpty: '#ff0000' },
+      card: { type: 'card', display: false }
+    })).toEqual({
+      seat: { type: 'seat', seatedText: 'playerName', emptyText: 'sit down', emptyColor: '#ff0000' },
+      card: { type: 'card', display: false }
+    });
+  });
+
+  test('bumps the version', () => {
+    expect(updateFromV21({})._meta.version).toBe(VERSION);
+  });
+
+  test('renames the seat-only names wherever they appear', () => {
+    expect(updateWidgets({
+      label: {
+        type: 'label',
+        css: { color: '${PROPERTY colorEmpty OF seat}' },
+        dynamicProperties: { text: [ { func: 'GET', property: 'displayEmpty' } ] }
+      }
+    })).toEqual({
+      label: {
+        type: 'label',
+        css: { color: '${PROPERTY emptyColor OF seat}' },
+        dynamicProperties: { text: [ { func: 'GET', property: 'emptyText' } ] }
+      }
+    });
+  });
+
+  test('renames a dynamicProperties key on a seat but not on other widgets', () => {
+    expect(updateWidgets({
+      seat: { type: 'seat', dynamicProperties: { display: [ { func: 'VAR' } ] } },
+      card: { type: 'card', dynamicProperties: { display: [ { func: 'VAR' } ] } }
+    })).toEqual({
+      seat: { type: 'seat', dynamicProperties: { seatedText: [ { func: 'VAR' } ] } },
+      card: { type: 'card', dynamicProperties: { display: [ { func: 'VAR' } ] } }
+    });
+  });
+
+  test('renames ${PROPERTY display OF <seat>} but not the same for other widgets', () => {
+    expect(updateWidgets({
+      seat: { type: 'seat' },
+      card: { type: 'card' },
+      button: {
+        type: 'button',
+        clickRoutine: [
+          { func: 'LABEL', value: '${PROPERTY display OF seat}' },
+          { func: 'LABEL', value: '${PROPERTY display OF card}' }
+        ]
+      }
+    }).button.clickRoutine).toEqual([
+      { func: 'LABEL', value: '${PROPERTY seatedText OF seat}' },
+      { func: 'LABEL', value: '${PROPERTY display OF card}' }
+    ]);
+  });
+
+  test('renames ${PROPERTY display} inside a seat only', () => {
+    expect(updateWidgets({
+      seat: { type: 'seat', css: { color: '${PROPERTY display}' } },
+      card: { type: 'card', css: { color: '${PROPERTY display}' } }
+    })).toEqual({
+      seat: { type: 'seat', css: { color: '${PROPERTY seatedText}' } },
+      card: { type: 'card', css: { color: '${PROPERTY display}' } }
+    });
+  });
+
+  test('renames SET display when the value uses a seat text placeholder', () => {
+    expect(updateWidgets({
+      button: {
+        type: 'button',
+        clickRoutine: [
+          { func: 'SET', property: 'display', value: 'seat playerName' },
+          { func: 'SET', property: 'display', value: false }
+        ]
+      }
+    }).button.clickRoutine).toEqual([
+      { func: 'SET', property: 'seatedText', value: 'seat playerName' },
+      { func: 'SET', property: 'display', value: false }
+    ]);
+  });
+
+  test('renames display on a collection that provably holds only seats', () => {
+    expect(updateWidgets({
+      button: {
+        type: 'button',
+        clickRoutine: [
+          { func: 'SELECT', type: 'seat' },
+          { func: 'SET', property: 'display', value: '' },
+          { func: 'GET', property: 'display', variable: 'text' },
+          { func: 'SELECT', type: 'card', collection: 'cards' },
+          { func: 'SET', property: 'display', value: '', collection: 'cards' }
+        ]
+      }
+    }).button.clickRoutine).toEqual([
+      { func: 'SELECT', type: 'seat' },
+      { func: 'SET', property: 'seatedText', value: '' },
+      { func: 'GET', property: 'seatedText', variable: 'text' },
+      { func: 'SELECT', type: 'card', collection: 'cards' },
+      { func: 'SET', property: 'display', value: '', collection: 'cards' }
+    ]);
+  });
+
+  test('forgets what a collection holds once a nested routine could have refilled it', () => {
+    expect(updateWidgets({
+      button: {
+        type: 'button',
+        clickRoutine: [
+          { func: 'SELECT', type: 'seat' },
+          { func: 'IF', condition: true, thenRoutine: [] },
+          { func: 'SET', property: 'display', value: '' }
+        ]
+      }
+    }).button.clickRoutine[2]).toEqual({ func: 'SET', property: 'display', value: '' });
+  });
+
+  test('renames a SELECT that filters seats by display', () => {
+    expect(updateWidgets({
+      button: { type: 'button', clickRoutine: [ { func: 'SELECT', type: 'seat', property: 'display', value: 'x' } ] }
+    }).button.clickRoutine).toEqual([ { func: 'SELECT', type: 'seat', property: 'seatedText', value: 'x' } ]);
+  });
+});
+
+describe('v22 fixed seat color', () => {
+  test('moves the old .seated override into seatedColor', () => {
+    expect(updateWidgets({
+      seat: { type: 'seat', css: { default: { border: 'none' }, '.seated': { '--color': '#ff0000 !important' } } }
+    })).toEqual({
+      seat: { type: 'seat', seatedColor: '#ff0000', css: { default: { border: 'none' } } }
+    });
+  });
+
+  test('resolves the preset that pointed at the empty color', () => {
+    expect(updateWidgets({
+      seat: { type: 'seat', colorEmpty: '#00ff00', css: { '.seated': { '--color': '${PROPERTY colorEmpty} !important' } } }
+    })).toEqual({
+      seat: { type: 'seat', emptyColor: '#00ff00', seatedColor: '#00ff00', css: {} }
+    });
+  });
+
+  test('keeps an occupied seat on its fixed color', () => {
+    expect(updateWidgets({
+      seat: { type: 'seat', player: 'Alice', color: '#123456', css: { '.seated': { '--color': '#ff0000 !important' } } }
+    }).seat).toMatchObject({ seatedColor: '#ff0000', color: '#ff0000' });
+  });
+
+  test('leaves an override without !important alone, it never won anyway', () => {
+    const css = { '.seated': { '--color': '#ff0000' } };
+    expect(updateWidgets({ seat: { type: 'seat', css } })).toEqual({ seat: { type: 'seat', css } });
+  });
+
+  test('leaves an override it cannot resolve alone', () => {
+    const css = { '.seated': { '--color': '${PROPERTY color OF other} !important' } };
+    expect(updateWidgets({ seat: { type: 'seat', css } })).toEqual({ seat: { type: 'seat', css } });
+  });
+});

--- a/tests/server/fileupdater.test.js
+++ b/tests/server/fileupdater.test.js
@@ -28,30 +28,64 @@ describe('v22 seat property rename', () => {
     expect(updateFromV21({})._meta.version).toBe(VERSION);
   });
 
-  test('renames the seat-only names wherever they appear', () => {
+  test('renames the seat-only names wherever a property name is expected', () => {
     expect(updateWidgets({
       label: {
         type: 'label',
         css: { color: '${PROPERTY colorEmpty OF seat}' },
-        dynamicProperties: { text: [ { func: 'GET', property: 'displayEmpty' } ] }
+        inheritFrom: { seat: [ 'colorEmpty', '!displayEmpty' ], other: '*' },
+        svgReplaces: { '#fill': 'colorEmpty' },
+        clickRoutine: [ { func: 'SET', property: 'displayEmpty', value: 'x' } ]
       }
     })).toEqual({
       label: {
         type: 'label',
         css: { color: '${PROPERTY emptyColor OF seat}' },
-        dynamicProperties: { text: [ { func: 'GET', property: 'emptyText' } ] }
+        inheritFrom: { seat: [ 'emptyColor', '!emptyText' ], other: '*' },
+        svgReplaces: { '#fill': 'emptyColor' },
+        clickRoutine: [ { func: 'SET', property: 'emptyText', value: 'x' } ]
       }
     });
   });
 
-  test('renames a dynamicProperties key on a seat but not on other widgets', () => {
+  test('leaves the seat-only names alone where they are not property names', () => {
+    const state = {
+      label: {
+        type: 'label',
+        parent: 'colorEmpty',
+        text: 'show displayEmpty here',
+        classes: 'colorEmpty',
+        html: '<div class="displayEmpty">colorEmpty</div>',
+        clickRoutine: [ { func: 'LABEL', label: 'colorEmpty', value: 'displayEmpty' } ]
+      },
+      colorEmpty: { type: 'holder', displayEmpty: 'kept as a property' }
+    };
+    const updated = updateWidgets(JSON.parse(JSON.stringify(state)));
+    expect(updated.label).toEqual(state.label);
+    expect(updated.colorEmpty).toEqual({ type: 'holder', emptyText: 'kept as a property' });
+  });
+
+  test('renames a face object dynamicProperties value but not its key', () => {
     expect(updateWidgets({
-      seat: { type: 'seat', dynamicProperties: { display: [ { func: 'VAR' } ] } },
-      card: { type: 'card', dynamicProperties: { display: [ { func: 'VAR' } ] } }
+      deck: { type: 'deck', faceTemplates: [ { objects: [ { type: 'text', display: true, dynamicProperties: { display: 'colorEmpty' } } ] } ] }
     })).toEqual({
-      seat: { type: 'seat', dynamicProperties: { seatedText: [ { func: 'VAR' } ] } },
-      card: { type: 'card', dynamicProperties: { display: [ { func: 'VAR' } ] } }
+      deck: { type: 'deck', faceTemplates: [ { objects: [ { type: 'text', display: true, dynamicProperties: { display: 'emptyColor' } } ] } ] }
     });
+  });
+
+  test('keeps the variable name a GET derived from the property it read', () => {
+    expect(updateWidgets({
+      button: {
+        type: 'button',
+        clickRoutine: [
+          { func: 'GET', property: 'colorEmpty' },
+          { func: 'SET', property: 'color', value: '${colorEmpty}' }
+        ]
+      }
+    }).button.clickRoutine).toEqual([
+      { func: 'GET', property: 'emptyColor', variable: 'colorEmpty' },
+      { func: 'SET', property: 'color', value: '${colorEmpty}' }
+    ]);
   });
 
   test('renames ${PROPERTY display OF <seat>} but not the same for other widgets', () => {
@@ -115,6 +149,30 @@ describe('v22 seat property rename', () => {
       { func: 'SELECT', type: 'card', collection: 'cards' },
       { func: 'SET', property: 'display', value: '', collection: 'cards' }
     ]);
+  });
+
+  test('leaves display alone on a collection that provably holds no seats', () => {
+    expect(updateWidgets({
+      button: {
+        type: 'button',
+        clickRoutine: [
+          { func: 'SELECT', type: 'label' },
+          { func: 'SET', property: 'display', value: '${playerName}' }
+        ]
+      }
+    }).button.clickRoutine[1]).toEqual({ func: 'SET', property: 'display', value: '${playerName}' });
+  });
+
+  test('still renames display after a SELECT that could have picked seats', () => {
+    expect(updateWidgets({
+      button: {
+        type: 'button',
+        clickRoutine: [
+          { func: 'SELECT', property: 'player', value: '${playerName}' },
+          { func: 'SET', property: 'display', value: '${playerName}' }
+        ]
+      }
+    }).button.clickRoutine[1]).toEqual({ func: 'SET', property: 'seatedText', value: '${playerName}' });
   });
 
   test('forgets what a collection holds once a nested routine could have refilled it', () => {

--- a/validator/validate_gamefile.js
+++ b/validator/validate_gamefile.js
@@ -150,7 +150,7 @@ const WIDGET_PROPERTIES = {
     },
     Seat: {
         ...COMMON_PROPERTIES,
-        typeClasses: 'any', movable: 'boolean', index: 'any', turn: 'any', skipTurn: 'any', player: 'any', display: 'any', displayEmpty: 'any', hideTurn: 'any', hideWhenUnused: 'any', hand: 'id', color: 'any', colorEmpty: 'any', layer: 'any', borderRadius: 'any'
+        typeClasses: 'any', movable: 'boolean', index: 'any', turn: 'any', skipTurn: 'any', player: 'any', seatedText: 'any', emptyText: 'any', hideTurn: 'any', hideWhenUnused: 'any', hand: 'id', color: 'any', seatedColor: 'any', emptyColor: 'any', layer: 'any', borderRadius: 'any'
     },
     Spinner: {
         ...COMMON_PROPERTIES,


### PR DESCRIPTION
Seats used `display` for the text shown while occupied, which blocked the generic widget `display` show/hide boolean from working on them. This renames the seat properties and frees `display` up.

### Property changes (widget type `seat`)
| old | new |
| --- | --- |
| `display` | `seatedText` |
| `displayEmpty` | `emptyText` |
| `colorEmpty` | `emptyColor` |
| — | `seatedColor` (new, default `playerColor`) |

- `display` now behaves on seats exactly like on every other widget (the `type != 'seat'` exception in `Widget.classes()` is gone).
- `seatedColor` decides the seat's color while a player sits in it: the special default value `playerColor` keeps the previous behavior (use the color of whoever sits down); any other value is passed through to `color` verbatim.

### Editor
- The "Use player color" toggle and the "Fixed color" style preset now write `seatedColor` instead of the `.seated { --color: <color> !important }` css override hack.
- Changing `seatedColor`/`emptyColor` applies right away to a seat that is currently in that state, instead of only on the next sit-down/stand-up; the two property writes go out as one delta/undo step.
- Preset selection highlighting compares the structural keys (`width`/`height`/`borderRadius`/`css`) plus whether `seatedColor` is `playerColor` or a fixed color - tweaking a color no longer de-selects the preset.
- "When empty" and "When seated" are symmetric: both have a "Text" and a "Color" row, the placeholder chips sit on their own line so the two rows line up, and the preset thumbnails show a short sample name with the preset label below the preview.
- The "Fixed color" preset leaves the empty seat neutral grey instead of pinning both states to the same red, so a free seat stays recognizable as free.
- `display` gets a curated "Visible" checkbox in the generic section of every widget type - that is the capability this PR unlocks for seats, and it had no control at all before.

### File updater (v22)
`server/fileupdater.mjs` migrates existing games. The rename is structural: it only rewrites places where a property *name* is expected — property keys, the property-name fields of routine operations (`SET`/`GET`/`SELECT`/`SORT`/`SCORE`/`RESET`), the name maps `inheritFrom`/`svgReplaces`/`dynamicProperties` and `${PROPERTY …}` references. Ordinary strings — label text, html, css class names, widget IDs and references to them — are never touched, even when they contain one of the old names.
- renames the properties on seat widgets;
- `displayEmpty`/`colorEmpty` only ever meant something on a seat, so they are renamed in all of those places regardless of widget type. A `GET` that took its variable name from the property it read keeps that variable name (it just becomes explicit), so a `${colorEmpty}` further down the routine still resolves;
- the old "Fixed color" preset's `.seated { --color: <color> !important }` rule is converted into `seatedColor`, and a seat that is occupied at migration time keeps that color;
- `display` is ambiguous (a boolean on every other widget), so it is only renamed where it is provably a seat's:
  - on `type: 'seat'` widgets,
  - in `${PROPERTY display OF <known seat id>}` expressions and in `${PROPERTY display}` inside a seat,
  - in `SET`/`GET`/`SELECT` operations working on a collection that provably holds nothing but seats,
  - in `SET property: 'display'` operations whose value contains the `playerName`/`seatIndex` placeholders, unless the collection provably holds no seat at all.

Known limits of that last point: a `SET display` on a collection whose contents cannot be determined statically (e.g. filled inside a nested `IF`/`FOREACH`, or a `CLONE` that overrides `display` on a seat) is left alone. Such a seat keeps working but loses its label — and `SET display ''`/`false` now hides it instead of blanking the text.

**Behavior change worth a changelog line:** a routine that hides a broad selection (`SELECT` → `SET display false`) used to skip seats because of the `Widget.classes()` exception. It now hides them like any other widget. That is the point of the PR, and the migration rewrites the cases it can prove, but games doing this dynamically will notice.

The wiki's Widgets page still documents `display`/`displayEmpty`/`colorEmpty` for seats and needs updating alongside this. Worth covering there: `seatedColor`'s magic `playerColor` value, and that `seatedColor`/`emptyColor` only take effect the next time the seat changes hands when they are set from a routine or the JSON editor (the properties panel writes `color` through for you).

### Verification
- `npm test` — including a new `tests/server/fileupdater.test.js` pinning down every rule of the v22 step (seat vs non-seat `display`, `PROPERTY … OF`, the collection tracking, the css conversion).
- Ran the v22 step over all 571 library/tutorial state files: only seat text/color properties change, no `display` on a non-seat is touched, and no seat ends up hidden.
- Two clients in a browser: a player sits down and disconnects, then the editor switches that seat to a fixed color and back to "Use player color" — the disconnected player's color comes back.
- Booted the server with `minifyJavascript: true` (the failing "Production Environment" check) and drove a browser through: a v21 state with the old property names and the old fixed-color css hack, sitting down in the seats, and a `SELECT type: seat` → `SET display false` routine — text and colors come out exactly as before the rename.
- TestCafe `editor.js`, `routines.js` and `publiclibrary-1.js` pass locally.

`validator/validate_gamefile.js` and `server/pcioimport.mjs` updated too.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3080/pr-test (or any other room on that server)


