### PR TITLE
Build routines in plain language in the Automations section

### DIFF
--- a/client/css/editor/routineBuilder.css
+++ b/client/css/editor/routineBuilder.css
@@ -1,0 +1,218 @@
+/* Plain language routine builder in the Automations section of Edit Widgets. */
+
+.tune.editorModule .routineBuilderHeader {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.tune.editorModule .routineBuilderProperty {
+  flex: 1;
+  font-family: monospace;
+  font-size: 11px;
+  color: #888;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tune.editorModule .routineBuilderHeader button {
+  padding: 0;
+  min-width: 22px;
+  border: 0;
+  background: transparent;
+  color: #7c7c7c;
+  cursor: pointer;
+}
+
+.tune.editorModule .routineBuilderHeader button:hover {
+  color: #333;
+}
+
+.tune.editorModule .routineStepList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.tune.editorModule .routineEmpty {
+  font-size: 12px;
+  color: #888;
+  padding: 4px 0;
+}
+
+.tune.editorModule .routineStep {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background-color: #f9f9f9;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tune.editorModule .routineStepHeader {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.tune.editorModule .routineStepIndex {
+  min-width: 18px;
+  height: 18px;
+  border-radius: 9px;
+  background: #ddd;
+  color: #555;
+  font-size: 11px;
+  line-height: 18px;
+  text-align: center;
+}
+
+.tune.editorModule .routineStepTitle {
+  flex: 1;
+  font-size: 12px;
+  font-weight: bold;
+  color: #444;
+}
+
+.tune.editorModule .routineStepControls {
+  display: flex;
+  gap: 2px;
+}
+
+.tune.editorModule .routineStepControls button,
+.tune.editorModule .routineClauseControls button {
+  padding: 0;
+  min-width: 20px;
+  border: 0;
+  background: transparent;
+  color: #7c7c7c;
+  cursor: pointer;
+}
+
+.tune.editorModule .routineStepControls button:hover,
+.tune.editorModule .routineClauseControls button:hover {
+  color: #333;
+}
+
+.tune.editorModule .routineStepControls button:disabled {
+  color: #ccc;
+  cursor: default;
+}
+
+/* The sentence itself wraps over as many lines as the narrow sidebar needs. */
+.tune.editorModule .routineSentence {
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 3px;
+  font-size: 13px;
+  color: #333;
+  line-height: 1.6;
+}
+
+.tune.editorModule .routineChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.tune.editorModule .routineTextInput {
+  font-size: 12px;
+  padding: 1px 4px;
+  min-width: 0;
+  width: 90px;
+  border: 1px solid #bbb;
+  border-radius: 3px;
+  background: #fff;
+}
+
+.tune.editorModule .routineCountInput {
+  width: 50px;
+}
+
+.tune.editorModule .routineSelect,
+.tune.editorModule .routineVerb,
+.tune.editorModule .routineAddClause,
+.tune.editorModule .routineAddStep,
+.tune.editorModule .routineAddAutomation {
+  font-size: 12px;
+  padding: 1px 2px;
+  max-width: 100%;
+  border: 1px solid #bbb;
+  border-radius: 3px;
+  background: #fff;
+}
+
+.tune.editorModule .routineVerb {
+  align-self: flex-start;
+}
+
+.tune.editorModule .routineClause {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+  padding-left: 12px;
+  border-left: 2px solid #ddd;
+}
+
+.tune.editorModule .routineNoteInput {
+  flex: 1;
+  font-size: 12px;
+  font-style: italic;
+  padding: 1px 4px;
+  min-width: 0;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  background: #fff;
+}
+
+.tune.editorModule .routineAddClause,
+.tune.editorModule .routineAddStep,
+.tune.editorModule .routineAddAutomation {
+  align-self: flex-start;
+  max-width: 240px;
+  color: #666;
+}
+
+.tune.editorModule .routineAdvanced button {
+  align-self: flex-start;
+}
+
+.tune.editorModule .routineBuilderFooter {
+  margin-top: 6px;
+}
+
+.tune.editorModule .routineAddAutomation {
+  margin: 4px 0 10px 0;
+}
+
+.tune.editorModule .routineAdvanced {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tune.editorModule .routineAdvancedHint {
+  font-size: 11px;
+  color: #888;
+}
+
+.tune.editorModule .routineAdvancedJSON {
+  margin: 0;
+  padding: 4px;
+  font-family: monospace;
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  max-height: 160px;
+  overflow: auto;
+}
+
+.tune.editorModule .routineStepPopouts:empty {
+  display: none;
+}

--- a/client/js/editor/routineBuilder.js
+++ b/client/js/editor/routineBuilder.js
@@ -1,0 +1,481 @@
+// Renders one routine of one widget as a list of plain language step cards.
+// The sentences, verbs and clauses come from routineTemplates.js; this file only
+// turns them into DOM and writes the edited routine array back through the same
+// path the rest of the Edit Widgets module uses.
+//
+// Everything is live-write: each change replaces the whole routine array with a
+// single delta, so the Undo module handles undo for free and an open JSON editor
+// stays in sync.
+
+class RoutineBuilder {
+  constructor(module, widget, property, target) {
+    this.module = module;
+    this.widget = widget;
+    this.property = property;
+    this.list = div(target, 'routineStepList');
+    this.footer = div(target, 'routineBuilderFooter');
+    this.renderAddStep();
+    this.renderSteps();
+
+    this.module.addPropertyListener(widget, property, _=>{
+      if(!this.list.contains(document.activeElement))
+        this.renderSteps();
+    });
+  }
+
+  routine() {
+    const value = this.widget.get(this.property);
+    return Array.isArray(value) ? value : [];
+  }
+
+  // A deep copy so untouched steps are written back exactly as they were read.
+  editableRoutine() {
+    return JSON.parse(JSON.stringify(this.routine()));
+  }
+
+  save(routine) {
+    this.module.inputValueUpdated(this.widget, this.property, routine);
+  }
+
+  // mutate gets the copy of the step at index; the routine is saved afterwards.
+  updateStep(index, mutate, rerender=false) {
+    const routine = this.editableRoutine();
+    mutate(routine[index], routine);
+    this.save(routine);
+    if(rerender)
+      this.renderSteps();
+  }
+
+  moveStep(index, offset) {
+    const routine = this.editableRoutine();
+    routine.splice(index + offset, 0, routine.splice(index, 1)[0]);
+    this.save(routine);
+    this.renderSteps();
+  }
+
+  removeStep(index) {
+    const routine = this.editableRoutine();
+    routine.splice(index, 1);
+    this.save(routine);
+    this.renderSteps();
+  }
+
+  addStep(func) {
+    const routine = this.editableRoutine();
+    routine.push(routineBuilderNewOperation(func));
+    this.save(routine);
+    this.renderSteps();
+  }
+
+  renderSteps() {
+    this.list.innerHTML = '';
+    const routine = this.routine();
+    if(!routine.length)
+      div(this.list, 'routineEmpty', html(routineBuilderText('ui.emptyRoutine')));
+    routine.forEach((operation, index)=>this.renderStep(operation, index, routine));
+  }
+
+  renderStep(operation, index, routine) {
+    const card = div(this.list, 'routineStep');
+    const header = div(card, 'routineStepHeader');
+    div(header, 'routineStepIndex', html(index + 1));
+
+    const match = routineBuilderMatch(operation);
+    const title = div(header, 'routineStepTitle');
+    if(match)
+      title.textContent = routineBuilderText(`op.${operation.func}`);
+    else if(typeof operation === 'string')
+      title.textContent = operation.trim().startsWith('//') ? 'Note' : 'Expression';
+    else
+      title.textContent = (operation && operation.func) || 'Step';
+
+    const controls = div(header, 'routineStepControls');
+    this.addIconButton(controls, 'arrow_upward', routineBuilderText('ui.moveUp'), _=>this.moveStep(index, -1), index == 0);
+    this.addIconButton(controls, 'arrow_downward', routineBuilderText('ui.moveDown'), _=>this.moveStep(index, 1), index == routine.length - 1);
+    this.addIconButton(controls, 'delete', routineBuilderText('ui.removeStep'), _=>this.removeStep(index));
+
+    if(match)
+      this.renderSupportedStep(card, operation, index, match);
+    else
+      this.renderAdvancedStep(card, operation, index);
+  }
+
+  renderSupportedStep(card, operation, index, match) {
+    const { template, variant } = match;
+    const popouts = document.createElement('div');
+    popouts.className = 'routineStepPopouts';
+
+    if(template.variants.length > 1) {
+      const verb = document.createElement('select');
+      verb.className = 'routineVerb';
+      for(const candidate of template.variants) {
+        const option = document.createElement('option');
+        option.value = candidate.id;
+        option.textContent = routineBuilderText(`verb.${operation.func}.${candidate.id}`);
+        verb.appendChild(option);
+      }
+      verb.value = variant.id;
+      verb.onchange = _=>this.updateStep(index, step=>{
+        template.variants.find(candidate=>candidate.id == verb.value).apply(step);
+      }, true);
+      card.appendChild(verb);
+    }
+
+    const sentence = div(card, 'routineSentence');
+    this.renderSentence(sentence, popouts, routineBuilderText(`variant.${operation.func}.${variant.id}`), variant.fields, operation, index);
+
+    const clauses = routineBuilderVariantClauses(template, variant);
+    for(const clause of clauses) {
+      if(!routineBuilderClauseIsSet(clause, operation))
+        continue;
+      const row = div(card, 'routineClause');
+      const text = div(row, 'routineSentence');
+      this.renderSentence(text, popouts, routineBuilderText(`clause.${operation.func}.${clause.id}`), routineBuilderClauseFields(clause), operation, index);
+      this.addIconButton(div(row, 'routineClauseControls'), 'close', routineBuilderText('ui.optionRemove'), _=>this.updateStep(index, step=>{
+        if(clause.remove)
+          clause.remove(step);
+        else
+          for(const key of routineBuilderClauseKeys(clause))
+            delete step[key];
+      }, true));
+    }
+
+    this.renderNote(card, operation, index);
+
+    const unset = clauses.filter(clause=>!routineBuilderClauseIsSet(clause, operation));
+    const options = unset.map(clause=>({
+      value: clause.id,
+      label: routineBuilderText(`clause.${operation.func}.${clause.id}`).replace(/\{[^}]+\}/g, '...')
+    }));
+    if(operation.comment === undefined && operation.note === undefined)
+      options.push({ value: '__note', label: routineBuilderText('ui.noteAdd') });
+    if(!options.length)
+      return card.appendChild(popouts);
+
+    const add = document.createElement('select');
+    add.className = 'routineAddClause';
+    add.innerHTML = `<option value="">+ ${html(routineBuilderText('ui.optionAdd'))}</option>` + options.map(option=>`<option value="${html(option.value)}">${html(option.label)}</option>`).join('');
+    add.onchange = _=>{
+      const chosen = add.value;
+      add.value = '';
+      if(!chosen)
+        return;
+      this.updateStep(index, step=>{
+        if(chosen == '__note') {
+          step.comment = '';
+          return;
+        }
+        const clause = unset.find(candidate=>candidate.id == chosen);
+        if(clause.add)
+          clause.add(step);
+        else
+          for(const field of routineBuilderClauseFields(clause))
+            step[field.key] = routineBuilderFieldValue(field, step);
+      }, true);
+    };
+    card.appendChild(add);
+    card.appendChild(popouts);
+  }
+
+  renderNote(card, operation, index) {
+    const key = operation.note !== undefined ? 'note' : 'comment';
+    if(operation[key] === undefined)
+      return;
+    const row = div(card, 'routineClause routineNote');
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'routineNoteInput';
+    input.placeholder = routineBuilderText('ui.notePlaceholder');
+    input.value = operation[key];
+    input.oninput = _=>this.updateStep(index, step=>{ step[key] = input.value; });
+    row.appendChild(input);
+    this.addIconButton(div(row, 'routineClauseControls'), 'close', routineBuilderText('ui.optionRemove'), _=>this.updateStep(index, step=>{ delete step[key]; }, true));
+  }
+
+  renderAdvancedStep(card, operation, index) {
+    if(typeof operation === 'string' && operation.trim().startsWith('//')) {
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.className = 'routineNoteInput';
+      input.value = operation.replace(/^\s*\/\/\s?/, '');
+      input.oninput = _=>this.updateStep(index, (_step, routine)=>{ routine[index] = `// ${input.value}`; });
+      card.appendChild(input);
+      return;
+    }
+
+    const body = div(card, 'routineAdvanced');
+    div(body, 'routineAdvancedHint', html(routineBuilderText('ui.unsupported')));
+    const code = document.createElement('pre');
+    code.className = 'routineAdvancedJSON';
+    code.textContent = JSON.stringify(operation, null, 2);
+    body.appendChild(code);
+    const jump = document.createElement('button');
+    jump.setAttribute('icon', 'data_object');
+    jump.textContent = routineBuilderText('ui.editInJSON');
+    jump.onclick = _=>routineBuilderOpenJSONEditor();
+    body.appendChild(jump);
+  }
+
+  // Splits "Move {count} from {from} to {to}" into text and chips.
+  renderSentence(target, popouts, sentence, fields, operation, index) {
+    for(const part of sentence.split(/(\{[a-zA-Z]+\})/)) {
+      if(!part)
+        continue;
+      const placeholder = part.match(/^\{([a-zA-Z]+)\}$/);
+      if(!placeholder) {
+        const text = document.createElement('span');
+        text.textContent = part;
+        target.appendChild(text);
+        continue;
+      }
+      const field = fields.find(candidate=>candidate.name == placeholder[1]);
+      if(field)
+        this.renderField(target, popouts, field, operation, index);
+    }
+  }
+
+  renderField(target, popouts, field, operation, index) {
+    const chip = div(target, 'routineChip');
+    const write = (key, value)=>this.updateStep(index, step=>{
+      if(value === undefined)
+        delete step[key];
+      else
+        step[key] = value;
+    });
+
+    if(field.kind == 'holderOrPick' || field.kind == 'labelOrPick')
+      return this.renderDualField(chip, popouts, field, operation, index);
+    if(field.kind == 'widget')
+      return this.renderWidgetField(chip, popouts, field, operation, index);
+    if(field.kind == 'pick')
+      return this.renderPickField(chip, routineBuilderFieldValue(field, operation), index, value=>write(field.key, value));
+    if(field.kind == 'value')
+      return this.renderValueField(chip, field, operation, index);
+    if(field.kind == 'enum')
+      return this.renderEnumField(chip, field, operation, index);
+    if(field.kind == 'widgetType')
+      return this.renderWidgetTypeField(chip, field, operation, index);
+    if(field.kind == 'countOrAll')
+      return this.renderCountField(chip, field, operation, index);
+
+    const input = document.createElement('input');
+    input.type = field.kind == 'number' ? 'number' : 'text';
+    input.className = 'routineTextInput';
+    if(field.kind == 'property')
+      input.setAttribute('list', routineBuilderPropertyDatalist());
+    const value = routineBuilderFieldValue(field, operation);
+    input.value = value === undefined || value === null ? '' : value;
+    input.oninput = _=>write(field.key, field.kind == 'number' ? +input.value || 0 : input.value);
+    chip.appendChild(input);
+  }
+
+  renderWidgetField(chip, popouts, field, operation, index) {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'routineTextInput';
+    const current = _=>{
+      const value = routineBuilderFieldValue(field, operation);
+      return typeof value === 'string' ? value : '';
+    };
+    input.value = current();
+    input.oninput = _=>this.updateStep(index, step=>{ step[field.key] = input.value; });
+    chip.appendChild(input);
+
+    const popoutControls = this.module.renderWidgetSelectPopout(chip, this.widget, {
+      title: routineBuilderText('ui.pickWidget'),
+      pickerKey: `routine:${this.property}:${index}:${field.key}`,
+      typeFilter: field.typeFilter || '',
+      getSelectedIDs: _=>current() ? [ current() ] : [],
+      apply: widgetID=>this.updateStep(index, step=>{ step[field.key] = widgetID; }, true)
+    });
+    popouts.appendChild(popoutControls.popout);
+  }
+
+  // widgetOptionLabel adds an entry that switches the chip over to a single
+  // widget instead of a group (see renderDualField).
+  renderPickField(chip, value, index, apply, widgetOptionLabel) {
+    const select = document.createElement('select');
+    select.className = 'routineSelect';
+    const names = routineBuilderCollections(this.routine(), index);
+    if(value != ROUTINE_SINGLE_WIDGET && names.indexOf(value) == -1)
+      names.push(value);
+    for(const name of names) {
+      const option = document.createElement('option');
+      option.value = name;
+      option.textContent = name == 'DEFAULT' ? routineBuilderText('pick.default') : routineBuilderText('pick.named', { name });
+      select.appendChild(option);
+    }
+    const custom = document.createElement('option');
+    custom.value = '__custom';
+    custom.textContent = routineBuilderText('pick.custom');
+    select.appendChild(custom);
+    if(widgetOptionLabel) {
+      const single = document.createElement('option');
+      single.value = ROUTINE_SINGLE_WIDGET;
+      single.textContent = widgetOptionLabel;
+      select.appendChild(single);
+    }
+    select.value = value;
+    select.onchange = _=>{
+      if(select.value != '__custom')
+        return apply(select.value);
+      const name = prompt(routineBuilderText('pick.customPrompt'), value);
+      select.value = value;
+      if(name)
+        apply(name);
+    };
+    chip.appendChild(select);
+  }
+
+  // LABEL / FLIP / SHUFFLE take either a widget ID or a collection name, so one
+  // chip offers both and the sentence stays the same.
+  renderDualField(chip, popouts, field, operation, index) {
+    const keys = routineBuilderDualKeys[field.kind];
+    const usesWidget = operation[keys.id] !== undefined;
+
+    this.renderPickField(chip, usesWidget ? ROUTINE_SINGLE_WIDGET : (operation[keys.collection] || 'DEFAULT'), index, value=>this.updateStep(index, step=>{
+      if(value == ROUTINE_SINGLE_WIDGET) {
+        delete step[keys.collection];
+        step[keys.id] = '';
+      } else {
+        delete step[keys.id];
+        step[keys.collection] = value;
+      }
+    }, true), routineBuilderText(keys.idLabel));
+
+    if(usesWidget)
+      this.renderWidgetField(chip, popouts, { key: keys.id, kind: 'widget', typeFilter: keys.typeFilter }, operation, index);
+  }
+
+  // Literal value or one of the values an earlier step remembered. Anything
+  // else (a full ${...} expression) keeps working as typed text.
+  renderValueField(chip, field, operation, index) {
+    const value = routineBuilderFieldValue(field, operation);
+    const variables = routineBuilderVariables(this.routine(), index);
+    const asVariable = typeof value === 'string' && value.match(/^\$\{([^}]+)\}$/);
+    const currentVariable = asVariable && variables.indexOf(asVariable[1]) != -1 ? asVariable[1] : '';
+
+    const select = document.createElement('select');
+    select.className = 'routineSelect';
+    select.innerHTML = `<option value="">${html(routineBuilderText('ui.useValue'))}</option>` +
+      variables.map(name=>`<option value="${html(name)}">${html(routineBuilderText('ui.valueOfVariable', { name }))}</option>`).join('');
+    select.value = currentVariable;
+    select.onchange = _=>this.updateStep(index, step=>{
+      step[field.key] = select.value ? `\${${select.value}}` : '';
+    }, true);
+    if(variables.length)
+      chip.appendChild(select);
+
+    if(currentVariable)
+      return;
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'routineTextInput';
+    input.value = value === undefined || value === null ? '' : value;
+    input.oninput = _=>this.updateStep(index, step=>{ step[field.key] = propertyInputNumberOrText(input.value); });
+    chip.appendChild(input);
+  }
+
+  renderEnumField(chip, field, operation, index) {
+    const select = document.createElement('select');
+    select.className = 'routineSelect';
+    for(const value of field.values) {
+      const option = document.createElement('option');
+      option.value = value;
+      option.textContent = routineBuilderText(`enum.${operation.func}.${field.key}.${value}`);
+      select.appendChild(option);
+    }
+    select.value = routineBuilderFieldValue(field, operation);
+    select.onchange = _=>this.updateStep(index, step=>{ step[field.key] = select.value; });
+    chip.appendChild(select);
+  }
+
+  renderWidgetTypeField(chip, field, operation, index) {
+    const select = document.createElement('select');
+    select.className = 'routineSelect';
+    for(const type of routineBuilderWidgetTypes) {
+      const option = document.createElement('option');
+      option.value = type;
+      option.textContent = type == 'all' ? 'all' : (editorTypeNames[type] || type).toLowerCase();
+      select.appendChild(option);
+    }
+    const value = routineBuilderFieldValue(field, operation);
+    if(routineBuilderWidgetTypes.indexOf(value) == -1) {
+      const option = document.createElement('option');
+      option.value = value;
+      option.textContent = value;
+      select.appendChild(option);
+    }
+    select.value = value;
+    select.onchange = _=>this.updateStep(index, step=>{ step[field.key] = select.value; });
+    chip.appendChild(select);
+  }
+
+  // Accepts a number or the word "all". Legacy routines store 0 for "all".
+  renderCountField(chip, field, operation, index) {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'routineTextInput routineCountInput';
+    const value = routineBuilderFieldValue(field, operation);
+    input.value = value === 0 || value === 'all' ? 'all' : value;
+    input.oninput = _=>this.updateStep(index, step=>{
+      step[field.key] = /^\s*all\s*$/i.test(input.value) ? 'all' : (+input.value || 0);
+    });
+    chip.appendChild(input);
+  }
+
+  renderAddStep() {
+    const select = document.createElement('select');
+    select.className = 'routineAddStep';
+    let options = `<option value="">+ ${html(routineBuilderText('ui.addStep'))}</option>`;
+    for(const category of routineBuilderCategories)
+      options += `<optgroup label="${html(routineBuilderText(`category.${category.id}`))}">` +
+        category.funcs.map(func=>`<option value="${func}">${html(routineBuilderText(`op.${func}`))}</option>`).join('') + '</optgroup>';
+    select.innerHTML = options;
+    select.onchange = _=>{
+      const func = select.value;
+      select.value = '';
+      if(func)
+        this.addStep(func);
+    };
+    this.footer.appendChild(select);
+  }
+
+  addIconButton(target, icon, title, onclick, disabled=false) {
+    const button = document.createElement('button');
+    button.setAttribute('icon', icon);
+    button.title = title;
+    button.disabled = disabled;
+    button.onclick = onclick;
+    target.appendChild(button);
+    return button;
+  }
+}
+
+function routineBuilderOpenJSONEditor() {
+  const jsonModuleButton = $('#editorSidebar button[icon=data_object]');
+  if(jsonModuleButton)
+    jsonModuleButton.click();
+}
+
+const ROUTINE_SINGLE_WIDGET = '__widget';
+
+// One shared datalist with the property names actually used in this room, so
+// the property chips suggest instead of demanding spelling knowledge.
+function routineBuilderPropertyDatalist() {
+  const id = 'routineBuilderProperties';
+  let datalist = $(`#${id}`);
+  if(!datalist) {
+    datalist = document.createElement('datalist');
+    datalist.id = id;
+    document.body.appendChild(datalist);
+  }
+  const names = new Set();
+  for(const widget of widgets.values())
+    for(const property in widget.state)
+      if(!property.match(/^_/))
+        names.add(property);
+  datalist.innerHTML = [...names].sort().map(name=>`<option value="${html(name)}">`).join('');
+  return id;
+}

--- a/client/js/editor/routineTemplates.js
+++ b/client/js/editor/routineTemplates.js
@@ -1,0 +1,589 @@
+// Data model behind the beginner friendly routine builder that the Automations
+// section of the Edit Widgets module renders (see issue #3078).
+//
+// A step card's sentence is composed, not looked up. Every operation gets:
+//   * a small table of VARIANTS - the leading verb of the sentence. Picking a
+//     different verb rewrites the parameters and the sentence together, so the
+//     user never picks "the relation parameter", they pick another sentence.
+//   * a list of optional CLAUSES - one phrase each, which only appears while
+//     its parameter is set and vanishes together with it.
+// Rendering picks the first matching variant. An operation that no variant
+// matches, or that carries a parameter this table does not know, renders as a
+// read only advanced card so nothing is ever lost or misrepresented.
+//
+// Every user facing string lives in routineBuilderStrings so the whole builder
+// can be translated from a single table.
+
+const routineBuilderStrings = {
+  'ui.addAutomation': 'Add automation',
+  'ui.addStep': 'Add step',
+  'ui.customRoutine': 'Custom name...',
+  'ui.customRoutinePrompt': 'Name of the new automation (without the "Routine" ending):',
+  'ui.deleteRoutine': 'Remove this automation',
+  'ui.editInJSON': 'Edit in JSON editor',
+  'ui.emptyRoutine': 'No steps yet.',
+  'ui.moveDown': 'Move down',
+  'ui.moveUp': 'Move up',
+  'ui.noteAdd': 'Add a note',
+  'ui.notePlaceholder': 'Note for yourself',
+  'ui.optionAdd': 'Add option',
+  'ui.optionRemove': 'Remove this option',
+  'ui.pickWidget': 'Select a widget',
+  'ui.removeStep': 'Remove this step',
+  'ui.stepCount': '{count} steps',
+  'ui.stepCountOne': '1 step',
+  'ui.unsupported': 'This step uses options the builder does not know yet. It runs unchanged - open the JSON editor to edit it.',
+  'ui.useValue': 'a value',
+  'ui.valueOfVariable': 'the saved value {name}',
+
+  'pick.default': 'the picked widgets',
+  'pick.named': 'the widgets called {name}',
+  'pick.custom': 'another name...',
+  'pick.holder': 'the holder',
+  'pick.widget': 'the widget',
+  'pick.customPrompt': 'Name of the group of widgets:',
+
+  'category.cards': 'Cards and pieces',
+  'category.pick': 'Picking and counting',
+  'category.change': 'Changing things',
+  'category.flow': 'Reusing routines',
+
+  'routine.clickRoutine': 'When this is clicked',
+  'routine.doubleClickRoutine': 'When this is double clicked',
+  'routine.changeRoutine': 'When this changes',
+  'routine.enterRoutine': 'When a widget is dropped into this',
+  'routine.leaveRoutine': 'When a widget is taken out of this',
+  'routine.globalUpdateRoutine': 'When anything in the game changes',
+  'routine.custom': 'Reusable action: {name}',
+  'routine.propertyChange': 'When {name} changes',
+
+  'op.MOVE': 'Move cards',
+  'op.FLIP': 'Flip cards',
+  'op.SHUFFLE': 'Shuffle',
+  'op.RECALL': 'Gather cards back',
+  'op.SELECT': 'Pick widgets',
+  'op.COUNT': 'Count widgets',
+  'op.GET': 'Read a property',
+  'op.SET': 'Change a property',
+  'op.LABEL': 'Change a text',
+  'op.CLICK': 'Click widgets',
+  'op.CALL': 'Run another automation',
+
+  'verb.MOVE.fromHolder': 'Move cards from a holder',
+  'verb.MOVE.fromPick': 'Move the picked widgets',
+  'variant.MOVE.fromHolder': 'Move {count} from {from} to {to}',
+  'variant.MOVE.fromPick': 'Move {which} to {to}',
+  'clause.MOVE.count': 'at most {count} of them',
+  'clause.MOVE.face': 'and turn them to face {face}',
+  'clause.MOVE.fillTo': 'but only until the target holds {fillTo}',
+
+  'verb.FLIP.over': 'Flip over',
+  'verb.FLIP.up': 'Turn face up',
+  'verb.FLIP.down': 'Turn face down',
+  'verb.FLIP.toFace': 'Turn to a specific face',
+  'verb.FLIP.cycle': 'Cycle through the faces',
+  'variant.FLIP.over': 'Flip {which} over',
+  'variant.FLIP.up': 'Turn {which} face up',
+  'variant.FLIP.down': 'Turn {which} face down',
+  'variant.FLIP.toFace': 'Turn {which} to face {face}',
+  'variant.FLIP.cycle': 'Cycle the face of {which} {faceCycle}',
+  'clause.FLIP.count': 'but only the first {count}',
+  'enum.FLIP.faceCycle.forward': 'forwards',
+  'enum.FLIP.faceCycle.backward': 'backwards',
+  'enum.FLIP.faceCycle.random': 'randomly',
+
+  'variant.SHUFFLE.shuffle': 'Shuffle {which}',
+  'clause.SHUFFLE.mode': 'the {mode} way',
+  'clause.SHUFFLE.modeValue': 'repeated {modeValue} times',
+  'enum.SHUFFLE.mode.overhand': 'overhand',
+  'enum.SHUFFLE.mode.reverse': 'reversing',
+  'enum.SHUFFLE.mode.riffle': 'riffle',
+  'enum.SHUFFLE.mode.seeded': 'seeded random',
+  'enum.SHUFFLE.mode.true random': 'truly random',
+
+  'variant.RECALL.recall': 'Gather all cards back into {holder}',
+  'clause.RECALL.owned': 'but leave the cards players own where they are',
+  'clause.RECALL.inHolder': 'but only pick up cards lying loose on the table',
+  'clause.RECALL.byDistance': 'taking the nearest cards first',
+  'clause.RECALL.excludeCollection': 'except {excludeCollection}',
+
+  'verb.SELECT.set': 'Pick widgets',
+  'verb.SELECT.add': 'Add widgets to the pick',
+  'verb.SELECT.remove': 'Remove widgets from the pick',
+  'verb.SELECT.intersect': 'Narrow the pick down',
+  'variant.SELECT.set': 'Pick {type} widgets',
+  'variant.SELECT.add': 'Add {type} widgets to the pick',
+  'variant.SELECT.remove': 'Remove {type} widgets from the pick',
+  'variant.SELECT.intersect': 'Narrow the pick down to {type} widgets',
+  'clause.SELECT.where': 'where {property} {relation} {value}',
+  'clause.SELECT.source': 'out of {source}',
+  'clause.SELECT.max': 'at most {max} of them',
+  'clause.SELECT.random': 'chosen at random',
+  'clause.SELECT.sortBy': 'sorted by {sortBy}',
+  'clause.SELECT.collection': 'and call them {collection}',
+  'enum.SELECT.relation.<': 'is less than',
+  'enum.SELECT.relation.<=': 'is at most',
+  'enum.SELECT.relation.==': 'is',
+  'enum.SELECT.relation.===': 'is exactly',
+  'enum.SELECT.relation.!=': 'is not',
+  'enum.SELECT.relation.>=': 'is at least',
+  'enum.SELECT.relation.>': 'is more than',
+  'enum.SELECT.relation.in': 'is one of',
+
+  'verb.COUNT.pick': 'Count the picked widgets',
+  'verb.COUNT.holder': 'Count what is in a holder',
+  'verb.COUNT.owner': 'Count what a player owns',
+  'variant.COUNT.pick': 'Count {which} and remember it as {variable}',
+  'variant.COUNT.holder': 'Count what is in {holder} and remember it as {variable}',
+  'variant.COUNT.owner': 'Count the widgets owned by {owner} and remember it as {variable}',
+
+  'verb.GET.first': 'Read the first one',
+  'verb.GET.last': 'Read the last one',
+  'verb.GET.sum': 'Add them up',
+  'verb.GET.average': 'Average them',
+  'verb.GET.median': 'Take the median',
+  'verb.GET.min': 'Take the smallest',
+  'verb.GET.max': 'Take the biggest',
+  'verb.GET.array': 'Collect them all',
+  'variant.GET.first': 'Read {property} of {which} and remember it as {variable}',
+  'variant.GET.last': 'Read {property} of the last of {which} and remember it as {variable}',
+  'variant.GET.sum': 'Add up {property} of {which} and remember it as {variable}',
+  'variant.GET.average': 'Average {property} of {which} and remember it as {variable}',
+  'variant.GET.median': 'Take the median {property} of {which} and remember it as {variable}',
+  'variant.GET.min': 'Take the smallest {property} of {which} and remember it as {variable}',
+  'variant.GET.max': 'Take the biggest {property} of {which} and remember it as {variable}',
+  'variant.GET.array': 'Collect {property} of all of {which} and remember it as {variable}',
+  'clause.GET.skipMissing': 'ignoring widgets that do not have it',
+
+  'verb.SET.set': 'Set it',
+  'verb.SET.inc': 'Increase it',
+  'verb.SET.dec': 'Decrease it',
+  'verb.SET.mul': 'Multiply it',
+  'verb.SET.div': 'Divide it',
+  'verb.SET.toggle': 'Switch it on or off',
+  'verb.SET.append': 'Add text to it',
+  'variant.SET.set': 'Set {property} of {which} to {value}',
+  'variant.SET.inc': 'Increase {property} of {which} by {value}',
+  'variant.SET.dec': 'Decrease {property} of {which} by {value}',
+  'variant.SET.mul': 'Multiply {property} of {which} by {value}',
+  'variant.SET.div': 'Divide {property} of {which} by {value}',
+  'variant.SET.toggle': 'Switch {property} of {which} on or off',
+  'variant.SET.append': 'Append {value} to {property} of {which}',
+
+  'verb.LABEL.set': 'Set the text',
+  'verb.LABEL.inc': 'Increase the number',
+  'verb.LABEL.dec': 'Decrease the number',
+  'verb.LABEL.append': 'Append text',
+  'variant.LABEL.set': 'Set the text of {which} to {value}',
+  'variant.LABEL.inc': 'Increase {which} by {value}',
+  'variant.LABEL.dec': 'Decrease {which} by {value}',
+  'variant.LABEL.append': 'Append {value} to the text of {which}',
+
+  'variant.CLICK.click': 'Click {count} of {which}',
+  'clause.CLICK.mode': 'and {mode}',
+  'enum.CLICK.mode.respect': 'respect their settings',
+  'enum.CLICK.mode.ignoreClickable': 'click them even if they are not clickable',
+  'enum.CLICK.mode.ignoreClickRoutine': 'do not run their own click automation',
+  'enum.CLICK.mode.ignoreAll': 'ignore both clickable and their own click automation',
+
+  'variant.CALL.call': 'Run the automation {routine}',
+  'clause.CALL.widget': 'of the widget {widget}',
+  'clause.CALL.variable': 'and remember its result as {variable}',
+  'clause.CALL.return': 'without waiting for a result'
+};
+
+function routineBuilderText(key, replacements) {
+  let text = routineBuilderStrings[key];
+  if(text === undefined)
+    return key;
+  for(const name in replacements || {})
+    text = text.split(`{${name}}`).join(replacements[name]);
+  return text;
+}
+
+// widget types offered by the "which kind of widget" chips
+const routineBuilderWidgetTypes = [ 'all', 'basic', 'button', 'canvas', 'card', 'deck', 'dice', 'holder', 'label', 'line', 'pile', 'scoreboard', 'seat', 'spinner', 'timer' ];
+
+// The eleven operations agreed for the first version. They cover 77% of all
+// operations used by the games in library/.
+const routineBuilderOperations = {
+  MOVE: {
+    template: { func: 'MOVE', from: '', to: '', count: 1 },
+    variants: [
+      {
+        id: 'fromHolder',
+        match: op=>op.from !== undefined,
+        apply: op=>{ delete op.collection; if(op.from === undefined) op.from = ''; if(op.to === undefined) op.to = ''; },
+        fields: [
+          { name: 'count', key: 'count', kind: 'countOrAll', fallback: 1 },
+          { name: 'from', key: 'from', kind: 'widget', typeFilter: 'holder' },
+          { name: 'to', key: 'to', kind: 'widget', typeFilter: 'holder' }
+        ]
+      },
+      {
+        id: 'fromPick',
+        match: op=>op.from === undefined,
+        apply: op=>{ delete op.from; delete op.count; if(op.to === undefined) op.to = ''; },
+        fields: [
+          { name: 'which', key: 'collection', kind: 'pick' },
+          { name: 'to', key: 'to', kind: 'widget', typeFilter: 'holder' }
+        ]
+      }
+    ],
+    clauses: [
+      { id: 'count', variants: [ 'fromPick' ], fields: [ { name: 'count', key: 'count', kind: 'countOrAll', fallback: 1 } ] },
+      { id: 'face', fields: [ { name: 'face', key: 'face', kind: 'number', fallback: 0 } ] },
+      { id: 'fillTo', fields: [ { name: 'fillTo', key: 'fillTo', kind: 'number', fallback: 1 } ] }
+    ]
+  },
+
+  FLIP: {
+    template: { func: 'FLIP', face: 0 },
+    keys: [ 'face', 'faceCycle' ],
+    variants: [
+      { id: 'cycle', match: op=>op.faceCycle !== undefined && op.faceCycle !== null,
+        apply: op=>{ delete op.face; op.faceCycle = op.faceCycle || 'forward'; },
+        fields: [ { name: 'which', key: '', kind: 'holderOrPick' }, { name: 'faceCycle', key: 'faceCycle', kind: 'enum', values: [ 'forward', 'backward', 'random' ], fallback: 'forward' } ] },
+      { id: 'up', match: op=>op.face === 0, apply: op=>{ delete op.faceCycle; op.face = 0; },
+        fields: [ { name: 'which', key: '', kind: 'holderOrPick' } ] },
+      { id: 'down', match: op=>op.face === 1, apply: op=>{ delete op.faceCycle; op.face = 1; },
+        fields: [ { name: 'which', key: '', kind: 'holderOrPick' } ] },
+      { id: 'toFace', match: op=>typeof op.face === 'number', apply: op=>{ delete op.faceCycle; op.face = 2; },
+        fields: [ { name: 'which', key: '', kind: 'holderOrPick' }, { name: 'face', key: 'face', kind: 'number', fallback: 0 } ] },
+      { id: 'over', match: op=>op.face === undefined || op.face === null, apply: op=>{ delete op.faceCycle; delete op.face; },
+        fields: [ { name: 'which', key: '', kind: 'holderOrPick' } ] }
+    ],
+    clauses: [
+      { id: 'count', fields: [ { name: 'count', key: 'count', kind: 'countOrAll', fallback: 1 } ] }
+    ]
+  },
+
+  SHUFFLE: {
+    template: { func: 'SHUFFLE' },
+    variants: [
+      { id: 'shuffle', match: _=>true, apply: _=>{},
+        fields: [ { name: 'which', key: '', kind: 'holderOrPick' } ] }
+    ],
+    clauses: [
+      { id: 'mode', fields: [ { name: 'mode', key: 'mode', kind: 'enum', values: [ 'overhand', 'reverse', 'riffle', 'seeded', 'true random' ], fallback: 'overhand' } ] },
+      { id: 'modeValue', fields: [ { name: 'modeValue', key: 'modeValue', kind: 'number', fallback: 1 } ] }
+    ]
+  },
+
+  RECALL: {
+    template: { func: 'RECALL', holder: '' },
+    variants: [
+      { id: 'recall', match: _=>true, apply: op=>{ if(op.holder === undefined) op.holder = ''; },
+        fields: [ { name: 'holder', key: 'holder', kind: 'widget', typeFilter: 'holder' } ] }
+    ],
+    clauses: [
+      { id: 'owned', key: 'owned', isSet: op=>op.owned === false, add: op=>{ op.owned = false; }, fields: [] },
+      { id: 'inHolder', key: 'inHolder', isSet: op=>op.inHolder === false, add: op=>{ op.inHolder = false; }, fields: [] },
+      { id: 'byDistance', key: 'byDistance', isSet: op=>op.byDistance === true, add: op=>{ op.byDistance = true; }, fields: [] },
+      { id: 'excludeCollection', fields: [ { name: 'excludeCollection', key: 'excludeCollection', kind: 'pick' } ] }
+    ]
+  },
+
+  SELECT: {
+    template: { func: 'SELECT', type: 'all', property: 'id', value: '' },
+    keys: [ 'mode' ],
+    variants: [
+      { id: 'set', match: op=>op.mode === undefined || op.mode === 'set', apply: op=>{ delete op.mode; }, fields: [ { name: 'type', key: 'type', kind: 'widgetType', fallback: 'all' } ] },
+      { id: 'add', match: op=>op.mode === 'add', apply: op=>{ op.mode = 'add'; }, fields: [ { name: 'type', key: 'type', kind: 'widgetType', fallback: 'all' } ] },
+      { id: 'remove', match: op=>op.mode === 'remove', apply: op=>{ op.mode = 'remove'; }, fields: [ { name: 'type', key: 'type', kind: 'widgetType', fallback: 'all' } ] },
+      { id: 'intersect', match: op=>op.mode === 'intersect', apply: op=>{ op.mode = 'intersect'; }, fields: [ { name: 'type', key: 'type', kind: 'widgetType', fallback: 'all' } ] }
+    ],
+    clauses: [
+      { id: 'where', key: 'property',
+        isSet: op=>op.property !== undefined,
+        add: op=>{ op.property = 'id'; if(op.value === undefined) op.value = ''; },
+        remove: op=>{ delete op.property; delete op.relation; delete op.value; },
+        fields: [
+          { name: 'property', key: 'property', kind: 'property', fallback: 'id' },
+          { name: 'relation', key: 'relation', kind: 'enum', values: [ '<', '<=', '==', '===', '!=', '>=', '>', 'in' ], fallback: '==' },
+          { name: 'value', key: 'value', kind: 'value', fallback: '' }
+        ] },
+      { id: 'source', fields: [ { name: 'source', key: 'source', kind: 'pick', fallback: 'DEFAULT' } ] },
+      { id: 'max', fields: [ { name: 'max', key: 'max', kind: 'number', fallback: 1 } ] },
+      { id: 'random', key: 'random', isSet: op=>op.random === true, add: op=>{ op.random = true; }, fields: [] },
+      { id: 'sortBy', fields: [ { name: 'sortBy', key: 'sortBy', kind: 'property', fallback: 'value' } ] },
+      { id: 'collection', fields: [ { name: 'collection', key: 'collection', kind: 'text', fallback: 'myPick' } ] }
+    ]
+  },
+
+  COUNT: {
+    template: { func: 'COUNT' },
+    variants: [
+      { id: 'holder', match: op=>op.holder !== undefined, apply: op=>{ delete op.owner; delete op.collection; if(op.holder === undefined) op.holder = ''; },
+        fields: [ { name: 'holder', key: 'holder', kind: 'widget', typeFilter: 'holder' }, { name: 'variable', key: 'variable', kind: 'variable', fallback: 'COUNT' } ] },
+      { id: 'owner', match: op=>op.owner !== undefined && op.owner !== null, apply: op=>{ delete op.holder; delete op.collection; op.owner = ''; },
+        fields: [ { name: 'owner', key: 'owner', kind: 'text', fallback: '' }, { name: 'variable', key: 'variable', kind: 'variable', fallback: 'COUNT' } ] },
+      { id: 'pick', match: _=>true, apply: op=>{ delete op.holder; delete op.owner; },
+        fields: [ { name: 'which', key: 'collection', kind: 'pick' }, { name: 'variable', key: 'variable', kind: 'variable', fallback: 'COUNT' } ] }
+    ],
+    clauses: []
+  },
+
+  GET: {
+    template: { func: 'GET', property: 'id', variable: 'value' },
+    keys: [ 'aggregation' ],
+    variants: [ 'first', 'last', 'sum', 'average', 'median', 'min', 'max', 'array' ].map(aggregation=>({
+      id: aggregation,
+      match: op=>(op.aggregation || 'first') === aggregation,
+      apply: op=>{ if(aggregation === 'first') delete op.aggregation; else op.aggregation = aggregation; },
+      fields: [
+        { name: 'property', key: 'property', kind: 'property', fallback: 'id' },
+        { name: 'which', key: 'collection', kind: 'pick' },
+        { name: 'variable', key: 'variable', kind: 'variable', fallback: op=>op.property || 'id' }
+      ]
+    })),
+    clauses: [
+      { id: 'skipMissing', key: 'skipMissing', isSet: op=>op.skipMissing === true, add: op=>{ op.skipMissing = true; }, fields: [] }
+    ]
+  },
+
+  SET: {
+    template: { func: 'SET', property: 'value', value: 1 },
+    keys: [ 'relation' ],
+    variants: [
+      { id: 'toggle', match: op=>op.relation === '!', apply: op=>{ op.relation = '!'; delete op.value; },
+        fields: [ { name: 'property', key: 'property', kind: 'property', fallback: 'value' }, { name: 'which', key: 'collection', kind: 'pick' } ] },
+      { id: 'inc', match: op=>op.relation === '+' && typeof op.value !== 'string', apply: op=>{ op.relation = '+'; op.value = 1; },
+        fields: routineBuilderSetFields() },
+      { id: 'append', match: op=>op.relation === '+', apply: op=>{ op.relation = '+'; op.value = ''; },
+        fields: routineBuilderSetFields() },
+      { id: 'dec', match: op=>op.relation === '-', apply: op=>{ op.relation = '-'; if(typeof op.value !== 'number') op.value = 1; },
+        fields: routineBuilderSetFields() },
+      { id: 'mul', match: op=>op.relation === '*', apply: op=>{ op.relation = '*'; if(typeof op.value !== 'number') op.value = 2; },
+        fields: routineBuilderSetFields() },
+      { id: 'div', match: op=>op.relation === '/', apply: op=>{ op.relation = '/'; if(typeof op.value !== 'number') op.value = 2; },
+        fields: routineBuilderSetFields() },
+      // "==" is accepted by the engine and treated like "=", so it renders as Set
+      { id: 'set', match: op=>op.relation === undefined || op.relation === '=' || op.relation === '==', apply: op=>{ delete op.relation; if(op.value === undefined) op.value = ''; },
+        fields: routineBuilderSetFields() }
+    ],
+    clauses: []
+  },
+
+  LABEL: {
+    template: { func: 'LABEL', value: '' },
+    keys: [ 'mode' ],
+    variants: [
+      { id: 'inc', match: op=>op.mode === 'inc', apply: op=>{ op.mode = 'inc'; if(typeof op.value !== 'number') op.value = 1; }, fields: routineBuilderLabelFields() },
+      { id: 'dec', match: op=>op.mode === 'dec', apply: op=>{ op.mode = 'dec'; if(typeof op.value !== 'number') op.value = 1; }, fields: routineBuilderLabelFields() },
+      { id: 'append', match: op=>op.mode === 'append', apply: op=>{ op.mode = 'append'; if(typeof op.value !== 'string') op.value = ''; }, fields: routineBuilderLabelFields() },
+      { id: 'set', match: op=>op.mode === undefined || op.mode === 'set', apply: op=>{ delete op.mode; if(op.value === undefined) op.value = ''; }, fields: routineBuilderLabelFields() }
+    ],
+    clauses: []
+  },
+
+  CLICK: {
+    template: { func: 'CLICK' },
+    variants: [
+      { id: 'click', match: _=>true, apply: _=>{},
+        fields: [ { name: 'count', key: 'count', kind: 'number', fallback: 1 }, { name: 'which', key: 'collection', kind: 'pick' } ] }
+    ],
+    clauses: [
+      { id: 'mode', fields: [ { name: 'mode', key: 'mode', kind: 'enum', values: [ 'respect', 'ignoreClickable', 'ignoreClickRoutine', 'ignoreAll' ], fallback: 'ignoreClickRoutine' } ] }
+    ]
+  },
+
+  CALL: {
+    template: { func: 'CALL', routine: '' },
+    variants: [
+      { id: 'call', match: _=>true, apply: op=>{ if(op.routine === undefined) op.routine = ''; },
+        fields: [ { name: 'routine', key: 'routine', kind: 'text', fallback: 'clickRoutine' } ] }
+    ],
+    clauses: [
+      { id: 'widget', fields: [ { name: 'widget', key: 'widget', kind: 'widget' } ] },
+      { id: 'variable', fields: [ { name: 'variable', key: 'variable', kind: 'variable', fallback: 'result' } ] },
+      { id: 'return', key: 'return', isSet: op=>op.return === false, add: op=>{ op.return = false; }, fields: [] }
+    ]
+  }
+};
+
+function routineBuilderSetFields() {
+  return [
+    { name: 'property', key: 'property', kind: 'property', fallback: 'value' },
+    { name: 'which', key: 'collection', kind: 'pick' },
+    { name: 'value', key: 'value', kind: 'value', fallback: '' }
+  ];
+}
+
+function routineBuilderLabelFields() {
+  return [
+    { name: 'which', key: '', kind: 'labelOrPick' },
+    { name: 'value', key: 'value', kind: 'value', fallback: '' }
+  ];
+}
+
+// Operations offered by the "Add step" menu, grouped by what the user wants to
+// do rather than alphabetically.
+const routineBuilderCategories = [
+  { id: 'cards', funcs: [ 'MOVE', 'FLIP', 'SHUFFLE', 'RECALL' ] },
+  { id: 'pick', funcs: [ 'SELECT', 'COUNT', 'GET' ] },
+  { id: 'change', funcs: [ 'SET', 'LABEL', 'CLICK' ] },
+  { id: 'flow', funcs: [ 'CALL' ] }
+];
+
+// Chips of these kinds swap between a widget ID parameter and a collection
+// name, so they own two keys instead of one.
+const routineBuilderDualKeys = {
+  holderOrPick: { id: 'holder', collection: 'collection', idLabel: 'pick.holder', typeFilter: 'holder' },
+  labelOrPick: { id: 'label', collection: 'collection', idLabel: 'pick.widget', typeFilter: '' }
+};
+
+// Value a chip shows: the parameter when it is set, otherwise the default the
+// engine would apply, so a sentence never reads "undefined".
+const routineBuilderKindFallbacks = { pick: 'DEFAULT', widget: '', text: '', property: '', variable: '', value: '', number: 0, countOrAll: 'all' };
+
+function routineBuilderFieldValue(field, operation) {
+  const value = field.key ? operation[field.key] : undefined;
+  if(value !== undefined)
+    return value;
+  if(field.fallback !== undefined)
+    return typeof field.fallback === 'function' ? field.fallback(operation) : field.fallback;
+  return routineBuilderKindFallbacks[field.kind];
+}
+
+function routineBuilderClauseFields(clause) {
+  return clause.fields || [];
+}
+
+function routineBuilderClauseKeys(clause) {
+  const keys = clause.key ? [ clause.key ] : [];
+  for(const field of routineBuilderClauseFields(clause))
+    if(keys.indexOf(field.key) == -1)
+      keys.push(field.key);
+  return keys;
+}
+
+function routineBuilderClauseIsSet(clause, operation) {
+  if(clause.isSet)
+    return clause.isSet(operation);
+  return routineBuilderClauseKeys(clause).some(key=>operation[key] !== undefined);
+}
+
+function routineBuilderVariantClauses(template, variant) {
+  return template.clauses.filter(clause=>!clause.variants || clause.variants.indexOf(variant.id) != -1);
+}
+
+function routineBuilderFieldKeys(field) {
+  return routineBuilderDualKeys[field.kind] ? Object.values(routineBuilderDualKeys[field.kind]) : [ field.key ];
+}
+
+// Returns { template, variant } when the operation can be rendered as a
+// sentence, null when it has to fall back to the read only advanced card. An
+// operation carrying a parameter this table does not know is deliberately not
+// supported: the card would otherwise show a sentence that leaves out part of
+// what the step actually does.
+function routineBuilderMatch(operation) {
+  if(typeof operation != 'object' || operation === null || Array.isArray(operation))
+    return null;
+  const template = routineBuilderOperations[operation.func];
+  if(!template)
+    return null;
+  const variant = template.variants.find(candidate=>candidate.match(operation));
+  if(!variant)
+    return null;
+
+  const known = { func: 1, comment: 1, note: 1 };
+  for(const key of template.keys || [])
+    known[key] = 1;
+  for(const field of variant.fields)
+    for(const key of routineBuilderFieldKeys(field))
+      known[key] = 1;
+  for(const clause of routineBuilderVariantClauses(template, variant))
+    for(const key of routineBuilderClauseKeys(clause))
+      known[key] = 1;
+
+  for(const key in operation)
+    if(!known[key])
+      return null;
+
+  return { template, variant };
+}
+
+function routineBuilderSupports(operation) {
+  return routineBuilderMatch(operation) !== null;
+}
+
+// Builds a new operation object for the "Add step" menu.
+function routineBuilderNewOperation(func) {
+  const template = routineBuilderOperations[func];
+  return template ? JSON.parse(JSON.stringify(template.template)) : { func };
+}
+
+// The names of the values that earlier steps of the same routine remember, so a
+// value chip can offer them instead of making the user type ${...} by hand.
+// Names arriving from outside (arguments of a CALL into this routine) cannot be
+// known statically, which is why typing a name stays a first class path.
+function routineBuilderVariables(routine, index) {
+  const names = [];
+  const add = name=>{
+    if(typeof name === 'string' && name && names.indexOf(name) == -1)
+      names.push(name);
+  };
+
+  for(const operation of (Array.isArray(routine) ? routine : []).slice(0, index)) {
+    if(typeof operation === 'string') {
+      const match = operation.match(/^\s*var\s+([a-zA-Z_$][\w$]*)\s+=/);
+      if(match)
+        add(match[1]);
+      continue;
+    }
+    if(typeof operation != 'object' || operation === null)
+      continue;
+
+    if(operation.func == 'COUNT')
+      add(operation.variable || 'COUNT');
+    if(operation.func == 'GET')
+      add(operation.variable || operation.property || 'id');
+    if(operation.func == 'CALL' && operation.return !== false)
+      add(operation.variable || 'result');
+    if(operation.func == 'UPLOAD')
+      add(operation.variable || 'uploadedFileName');
+    if(operation.func == 'VAR')
+      for(const name in operation.variables || {})
+        add(name);
+    if(operation.func == 'INPUT')
+      for(const field of operation.fields || [])
+        if(field && typeof field === 'object')
+          add(field.variable || field.label);
+  }
+
+  return names;
+}
+
+// The collection names an earlier step filled, offered by the "which widgets"
+// chips.
+function routineBuilderCollections(routine, index) {
+  const names = [ 'DEFAULT' ];
+  for(const operation of (Array.isArray(routine) ? routine : []).slice(0, index)) {
+    if(typeof operation != 'object' || operation === null)
+      continue;
+    const name = operation.collection;
+    if(typeof name === 'string' && name && names.indexOf(name) == -1)
+      names.push(name);
+  }
+  return names;
+}
+
+// Routine properties every widget understands, offered by the "Add automation"
+// menu and listed in this order.
+const routineBuilderStandardRoutines = [ 'clickRoutine', 'doubleClickRoutine', 'changeRoutine', 'enterRoutine', 'leaveRoutine', 'globalUpdateRoutine' ];
+
+function routineBuilderRoutineOrder(property) {
+  const index = routineBuilderStandardRoutines.indexOf(property);
+  return index == -1 ? routineBuilderStandardRoutines.length : index;
+}
+
+// Human readable heading for a routine property of a widget.
+function routineBuilderRoutineLabel(property) {
+  if(routineBuilderStrings[`routine.${property}`])
+    return routineBuilderText(`routine.${property}`);
+  const propertyChange = property.match(/^(.+)ChangeRoutine$/);
+  if(propertyChange)
+    return routineBuilderText('routine.propertyChange', { name: propertyChange[1] });
+  return routineBuilderText('routine.custom', { name: property.replace(/Routine$/, '') });
+}

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -4004,29 +4004,68 @@ class PropertiesModule extends SidebarModule {
     this.renderGenericProperties(widget, exclude);
   }
 
+  // Every routine the widget has, each one built from plain language step cards
+  // (see routineTemplates.js / routineBuilder.js). The JSON editor stays the
+  // power tool - both views edit the very same array.
   renderAutomationsSection(widget) {
-    const playerRoutines = [ 'clickRoutine', 'doubleClickRoutine', 'changeRoutine', 'enterRoutine', 'leaveRoutine' ]
-      .filter(property => property == 'clickRoutine' || widget.state[property] !== undefined);
-    if(!playerRoutines.length)
-      return [];
+    const routineProperties = Object.keys(widget.state)
+      .filter(property => /Routine$/.test(property) && Array.isArray(widget.state[property]))
+      .sort((a, b) => routineBuilderRoutineOrder(a) - routineBuilderRoutineOrder(b) || a.localeCompare(b));
 
     this.addSubHeader('Automations');
-    for(const property of playerRoutines) {
-      const row = div(this.moduleDOM, 'propertyInput automationInput');
-      const label = document.createElement('label');
-      label.textContent = property.replace(/Routine$/, '').replace(/([A-Z])/g, ' $1').replace(/^./, char=>char.toUpperCase());
-      row.appendChild(label);
-      const button = document.createElement('button');
-      button.setAttribute('icon', 'data_object');
-      button.textContent = `Edit ${property} in JSON editor`;
-      button.onclick = () => {
-        const jsonModuleButton = $('#editorSidebar button[icon=data_object]');
-        if(jsonModuleButton)
-          jsonModuleButton.click();
-      };
-      row.appendChild(button);
+    for(const property of routineProperties) {
+      this.renderCollapsibleSection(routineBuilderRoutineLabel(property), routineProperties.length > 1, body => {
+        const header = div(body, 'routineBuilderHeader');
+        div(header, 'routineBuilderProperty', html(property));
+        const jsonButton = document.createElement('button');
+        jsonButton.setAttribute('icon', 'data_object');
+        jsonButton.title = routineBuilderText('ui.editInJSON');
+        jsonButton.onclick = () => routineBuilderOpenJSONEditor();
+        header.appendChild(jsonButton);
+        const removeButton = document.createElement('button');
+        removeButton.setAttribute('icon', 'delete');
+        removeButton.title = routineBuilderText('ui.deleteRoutine');
+        removeButton.onclick = () => {
+          this.inputValueUpdated(widget, property, null);
+          this.onSelectionChangedWhileActive(selectedWidgets);
+        };
+        header.appendChild(removeButton);
+
+        new RoutineBuilder(this, widget, property, body);
+      }, null, `${widget.id}:${property}`, {
+        renderSummary: summary => this.addPropertyListener(widget, property, w => {
+          const steps = Array.isArray(w.get(property)) ? w.get(property).length : 0;
+          summary.textContent = steps == 1
+            ? routineBuilderText('ui.stepCountOne')
+            : routineBuilderText('ui.stepCount', { count: steps });
+        })
+      });
     }
-    return playerRoutines;
+
+    const missing = routineBuilderStandardRoutines.filter(property => routineProperties.indexOf(property) == -1);
+    const addSelect = document.createElement('select');
+    addSelect.className = 'routineAddAutomation';
+    addSelect.innerHTML = `<option value="">+ ${html(routineBuilderText('ui.addAutomation'))}</option>` +
+      missing.map(property => `<option value="${html(property)}">${html(routineBuilderRoutineLabel(property))}</option>`).join('') +
+      `<option value="__custom">${html(routineBuilderText('ui.customRoutine'))}</option>`;
+    addSelect.onchange = () => {
+      let property = addSelect.value;
+      addSelect.value = '';
+      if(!property)
+        return;
+      if(property == '__custom') {
+        const name = prompt(routineBuilderText('ui.customRoutinePrompt'), 'myAction');
+        if(!name)
+          return;
+        property = name.replace(/Routine$/, '') + 'Routine';
+      }
+      if(!Array.isArray(widget.state[property]))
+        this.inputValueUpdated(widget, property, []);
+      this.onSelectionChangedWhileActive(selectedWidgets);
+    };
+    this.moduleDOM.appendChild(addSelect);
+
+    return routineProperties;
   }
 
   // --- shared curated inputs ---

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -90,6 +90,7 @@ export default async function minifyHTML() {
     'client/css/editor/sidebar.css',
     'client/css/editor/sidebarModules.css',
     'client/css/editor/sidebarProperties.css',
+    'client/css/editor/routineBuilder.css',
     'client/css/editor/propertyInputs.css',
     'client/css/editor/deckeditor.css',
 
@@ -129,6 +130,8 @@ export default async function minifyHTML() {
     'client/js/editor/dragbuttons/resize.js',
     'client/js/editor/sidebarModule.js',
     'client/js/editor/propertyInputs.js',
+    'client/js/editor/routineTemplates.js',
+    'client/js/editor/routineBuilder.js',
     'client/js/editor/sidebar/properties.js',
     'client/js/editor/sidebar/undo.js',
     'client/js/editor/sidebar/json.js',

--- a/tests/client/routine-templates.test.js
+++ b/tests/client/routine-templates.test.js
@@ -1,0 +1,213 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// routineTemplates.js is a plain script that gets concatenated by
+// server/minify.mjs, so evaluate the source and grab the pure helpers.
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const source = fs.readFileSync(path.join(dir, '../../client/js/editor/routineTemplates.js'), 'utf8');
+
+const {
+  routineBuilderStrings,
+  routineBuilderText,
+  routineBuilderOperations,
+  routineBuilderCategories,
+  routineBuilderClauseFields,
+  routineBuilderClauseKeys,
+  routineBuilderFieldValue,
+  routineBuilderVariantClauses,
+  routineBuilderMatch,
+  routineBuilderSupports,
+  routineBuilderNewOperation,
+  routineBuilderVariables,
+  routineBuilderCollections,
+  routineBuilderRoutineLabel
+} = new Function(source + `;
+  return {
+    routineBuilderStrings,
+    routineBuilderText,
+    routineBuilderOperations,
+    routineBuilderCategories,
+    routineBuilderClauseFields,
+    routineBuilderClauseKeys,
+    routineBuilderFieldValue,
+    routineBuilderVariantClauses,
+    routineBuilderMatch,
+    routineBuilderSupports,
+    routineBuilderNewOperation,
+    routineBuilderVariables,
+    routineBuilderCollections,
+    routineBuilderRoutineLabel
+  };
+`)();
+
+const placeholders = sentence => [ ...sentence.matchAll(/\{([a-zA-Z]+)\}/g) ].map(match => match[1]);
+
+describe('routine builder string table', () => {
+  test('every operation, verb, clause and enum value has a translatable string', () => {
+    for(const func in routineBuilderOperations) {
+      const template = routineBuilderOperations[func];
+      expect(routineBuilderStrings[`op.${func}`]).toBeDefined();
+      for(const variant of template.variants) {
+        expect(routineBuilderStrings[`variant.${func}.${variant.id}`]).toBeDefined();
+        if(template.variants.length > 1)
+          expect(routineBuilderStrings[`verb.${func}.${variant.id}`]).toBeDefined();
+      }
+      for(const clause of template.clauses) {
+        expect(routineBuilderStrings[`clause.${func}.${clause.id}`]).toBeDefined();
+        for(const field of routineBuilderClauseFields(clause))
+          for(const value of field.values || [])
+            expect(routineBuilderStrings[`enum.${func}.${field.key}.${value}`]).toBeDefined();
+      }
+      for(const variant of template.variants)
+        for(const field of variant.fields)
+          for(const value of field.values || [])
+            expect(routineBuilderStrings[`enum.${func}.${field.key}.${value}`]).toBeDefined();
+    }
+  });
+
+  test('every placeholder of a sentence has a matching field', () => {
+    for(const func in routineBuilderOperations) {
+      const template = routineBuilderOperations[func];
+      for(const variant of template.variants)
+        for(const name of placeholders(routineBuilderText(`variant.${func}.${variant.id}`)))
+          expect(variant.fields.map(field => field.name)).toContain(name);
+      for(const clause of template.clauses)
+        for(const name of placeholders(routineBuilderText(`clause.${func}.${clause.id}`)))
+          expect(routineBuilderClauseFields(clause).map(field => field.name)).toContain(name);
+    }
+  });
+
+  test('the add step menu offers every supported operation exactly once', () => {
+    const offered = routineBuilderCategories.flatMap(category => category.funcs);
+    expect([ ...offered ].sort()).toEqual(Object.keys(routineBuilderOperations).sort());
+  });
+
+  test('a new step of every offered operation renders as a sentence', () => {
+    for(const func of routineBuilderCategories.flatMap(category => category.funcs))
+      expect(routineBuilderSupports(routineBuilderNewOperation(func))).toBe(true);
+  });
+});
+
+// Shapes taken from the frequency analysis of library/games in issue #3078.
+const realWorldOperations = [
+  [ { func: 'SET', property: 'rotation', value: 90 }, 'SET', 'set' ],
+  [ { func: 'SET', collection: 'hand', property: 'value', relation: '+', value: 1 }, 'SET', 'inc' ],
+  [ { func: 'SET', property: 'score', relation: '-', value: 1 }, 'SET', 'dec' ],
+  [ { func: 'SET', property: 'clickable', relation: '!' }, 'SET', 'toggle' ],
+  [ { func: 'SET', property: 'text', relation: '+', value: ' (used)' }, 'SET', 'append' ],
+  [ { func: 'SET', property: 'x', relation: '*', value: 2 }, 'SET', 'mul' ],
+  // the engine rewrites "==" to "=" with a warning, so it is still a plain Set
+  [ { func: 'SET', property: 'value', relation: '==', value: 3 }, 'SET', 'set' ],
+  [ { func: 'SELECT', property: 'cardType', value: 'ace' }, 'SELECT', 'set' ],
+  [ { func: 'SELECT', type: 'card', property: 'deck', value: 'main', max: 5, random: true, collection: 'draw' }, 'SELECT', 'set' ],
+  [ { func: 'SELECT', mode: 'add', property: 'owner', relation: 'in', value: [ 'red' ] }, 'SELECT', 'add' ],
+  [ { func: 'SELECT', mode: 'remove', property: 'id', value: 'x1' }, 'SELECT', 'remove' ],
+  [ { func: 'SELECT' }, 'SELECT', 'set' ],
+  [ { func: 'GET', property: 'value', variable: 'v' }, 'GET', 'first' ],
+  [ { func: 'GET', property: 'score', aggregation: 'sum', variable: 'total', skipMissing: true }, 'GET', 'sum' ],
+  [ { func: 'CALL', routine: 'dealRoutine' }, 'CALL', 'call' ],
+  [ { func: 'CALL', routine: 'dealRoutine', widget: 'deck1', variable: 'r' }, 'CALL', 'call' ],
+  [ { func: 'MOVE', from: 'deck1', to: 'hand1', count: 5 }, 'MOVE', 'fromHolder' ],
+  [ { func: 'MOVE', to: 'discard' }, 'MOVE', 'fromPick' ],
+  [ { func: 'MOVE', collection: 'draw', to: 'hand1', count: 2 }, 'MOVE', 'fromPick' ],
+  // legacy saves store count 0 for "all"
+  [ { func: 'MOVE', from: 'deck1', to: 'hand1', count: 0 }, 'MOVE', 'fromHolder' ],
+  [ { func: 'LABEL', label: 'scoreLabel', value: 'Ready' }, 'LABEL', 'set' ],
+  [ { func: 'LABEL', label: 'scoreLabel', mode: 'inc', value: 1 }, 'LABEL', 'inc' ],
+  [ { func: 'LABEL', collection: 'labels', mode: 'append', value: ' done' }, 'LABEL', 'append' ],
+  [ { func: 'COUNT' }, 'COUNT', 'pick' ],
+  [ { func: 'COUNT', holder: 'deck1', variable: 'left' }, 'COUNT', 'holder' ],
+  [ { func: 'COUNT', owner: 'red' }, 'COUNT', 'owner' ],
+  [ { func: 'FLIP', holder: 'deck1', face: 0 }, 'FLIP', 'up' ],
+  [ { func: 'FLIP', face: 1, count: 3 }, 'FLIP', 'down' ],
+  [ { func: 'FLIP', collection: 'hand', faceCycle: 'forward' }, 'FLIP', 'cycle' ],
+  [ { func: 'FLIP' }, 'FLIP', 'over' ],
+  [ { func: 'CLICK', collection: 'buttons', count: 2, mode: 'ignoreClickRoutine' }, 'CLICK', 'click' ],
+  [ { func: 'RECALL', holder: 'deck1' }, 'RECALL', 'recall' ],
+  [ { func: 'RECALL', holder: 'deck1', owned: false, byDistance: true }, 'RECALL', 'recall' ],
+  [ { func: 'SHUFFLE', holder: 'deck1' }, 'SHUFFLE', 'shuffle' ],
+  [ { func: 'SHUFFLE', collection: 'draw', mode: 'riffle' }, 'SHUFFLE', 'shuffle' ]
+];
+
+describe('routine builder operation matching', () => {
+  test.each(realWorldOperations)('%j renders as the %s/%s sentence', (operation, func, variantID) => {
+    const match = routineBuilderMatch(operation);
+    expect(match).not.toBeNull();
+    expect(match.variant.id).toBe(variantID);
+  });
+
+  test('rendering never touches the operation', () => {
+    for(const [ operation ] of realWorldOperations) {
+      const before = JSON.stringify(operation);
+      routineBuilderMatch(operation);
+      expect(JSON.stringify(operation)).toBe(before);
+    }
+  });
+
+  test('every placeholder of the chosen sentence resolves to a value or a fallback', () => {
+    for(const [ operation, func ] of realWorldOperations) {
+      const { variant } = routineBuilderMatch(operation);
+      for(const name of placeholders(routineBuilderText(`variant.${func}.${variant.id}`))) {
+        const field = variant.fields.find(candidate => candidate.name == name);
+        // dual chips carry their own two keys and always render something
+        expect(field.key === '' || routineBuilderFieldValue(field, operation) !== undefined).toBe(true);
+      }
+    }
+  });
+
+  test('switching the verb rewrites the parameters together with the sentence', () => {
+    const operation = { func: 'SET', property: 'value', value: 5 };
+    const template = routineBuilderOperations.SET;
+    template.variants.find(variant => variant.id == 'toggle').apply(operation);
+    expect(operation).toEqual({ func: 'SET', property: 'value', relation: '!' });
+    expect(routineBuilderMatch(operation).variant.id).toBe('toggle');
+
+    template.variants.find(variant => variant.id == 'inc').apply(operation);
+    expect(operation).toEqual({ func: 'SET', property: 'value', relation: '+', value: 1 });
+    expect(routineBuilderMatch(operation).variant.id).toBe('inc');
+  });
+
+  test('anything the table cannot fully represent stays an advanced card', () => {
+    // applyVariables is a real SET parameter the builder does not know yet
+    expect(routineBuilderSupports({ func: 'SET', property: 'x', value: 1, applyVariables: [ 'x' ] })).toBe(false);
+    expect(routineBuilderSupports({ func: 'IF', condition: '${x}' })).toBe(false);
+    expect(routineBuilderSupports({ func: 'INPUT', header: 'hi', fields: [] })).toBe(false);
+    expect(routineBuilderSupports({ func: 'SET', property: 'x', relation: '${op}', value: 1 })).toBe(false);
+    expect(routineBuilderSupports('var a = 1')).toBe(false);
+    expect(routineBuilderSupports(null)).toBe(false);
+  });
+});
+
+describe('routine builder value and collection scanning', () => {
+  const routine = [
+    { func: 'COUNT', holder: 'deck1' },
+    { func: 'GET', property: 'value', collection: 'hand' },
+    { func: 'CALL', routine: 'sub' },
+    { func: 'CALL', routine: 'sub2', return: false },
+    'var doubled = ${COUNT} * 2',
+    { func: 'SELECT', property: 'deck', value: 'main', collection: 'draw' },
+    { func: 'SET', property: 'value', value: 1 }
+  ];
+
+  test('offers the values remembered by earlier steps only', () => {
+    expect(routineBuilderVariables(routine, routine.length)).toEqual([ 'COUNT', 'value', 'result', 'doubled' ]);
+    expect(routineBuilderVariables(routine, 1)).toEqual([ 'COUNT' ]);
+    expect(routineBuilderVariables(routine, 0)).toEqual([]);
+  });
+
+  test('offers the groups of widgets earlier steps filled', () => {
+    expect(routineBuilderCollections(routine, routine.length)).toEqual([ 'DEFAULT', 'hand', 'draw' ]);
+  });
+});
+
+describe('routine builder headings', () => {
+  test.each([
+    [ 'clickRoutine', 'When this is clicked' ],
+    [ 'enterRoutine', 'When a widget is dropped into this' ],
+    [ 'millisecondsChangeRoutine', 'When milliseconds changes' ],
+    [ 'dealRoutine', 'Reusable action: deal' ]
+  ])('%s reads as "%s"', (property, expected) => {
+    expect(routineBuilderRoutineLabel(property)).toBe(expected);
+  });
+});


### PR DESCRIPTION
Implements the version 1 scope agreed in #3078: a beginner-friendly UI for creating and editing routines, living inside the existing **Automations** section of the Edit Widgets module — alongside, not instead of, the JSON editor.

## The problem

`renderAutomationsSection()` listed five hardcoded routine properties and gave each one a button whose entire behaviour was "open the JSON module" — it didn't even navigate to the routine you clicked. A game builder who can drag widgets and set a colour had no way to author automation without learning JSON.

## What this does

Every routine of the selected widget is now a collapsible section of **step cards written as sentences**, with the editable parts as inline chips:

> **Pick** `card` widgets
> &nbsp;&nbsp;where `cardType` `is` `ace`
> &nbsp;&nbsp;at most `3` of them
> &nbsp;&nbsp;chosen at random
> &nbsp;&nbsp;and call them `aces`

![the builder on an existing routine](https://agent.virtualtabletop.io/reports/pr/1532557671599968467/routine-builder-existing-routine.png)

### The model (`client/js/editor/routineTemplates.js`)

A card's sentence is **composed, not looked up**. Each operation gets:

* a small table of **variants** — the leading verb. Picking a different verb rewrites the parameters *and* the sentence together, so the user never picks "the `relation` parameter", they pick another sentence (`SET` → Set / Increase / Decrease / Multiply / Divide / Switch on or off / Append).
* a list of optional **clauses** — one phrase each, appearing only while its parameter is set and vanishing with it (`SELECT`'s `max` / `random` / `sortBy` / `source` / `collection`).

Version 1 covers the eleven operations agreed in the issue — **SET, SELECT, GET, CALL, MOVE, LABEL, COUNT, FLIP, CLICK, RECALL, SHUFFLE** — which are 77% of all operations in `library/games`.

### Nothing is lost, nothing is misrepresented

An operation no variant matches, **or that carries a parameter the table doesn't know**, renders as a read-only advanced card showing its JSON, still reorderable and deletable, with a jump to the JSON editor. So `IF`, `FOREACH`, `INPUT`, `SET` with `applyVariables`, and free-form expressions all open fine — the module works on real games, not just trivial ones. `// …` string steps render as an editable note.

![an unsupported step falls back to an advanced card](https://agent.virtualtabletop.io/reports/pr/1532557671599968467/routine-builder-advanced-card.png)

### Editing

* **Add / delete / move up / down** per step; add-step menu grouped by intent (Cards and pieces, Picking and counting, Changing things, Reusing routines) rather than alphabetically. No drag-to-reorder in v1, as agreed.
* **Widget chips reuse the existing room picker** (`renderWidgetSelectPopout` / `startWidgetPicker`) — "Pick in the room", type filter, ID search — no new picking code.
* **Value chips** accept a literal or one of the values earlier steps of the *same* routine remember (`COUNT.variable`, `GET.variable`, `CALL.return`, `VAR`, `INPUT` fields, `var x = …` lines), so `${…}` never has to be typed. Unknown names stay silent, as agreed.
* **Live-write**: each change replaces the whole routine array as one delta through `inputValueUpdated()` → `widget.set()`. Undo works for free and an open JSON editor stays in sync. Untouched steps are written back exactly as they were read (deep copy, only the edited step mutated).
* The section now lists **all** `*Routine` properties actually present — including custom ones that `CALL` targets, which were previously invisible — plus an "Add automation" menu with the standard routines and a custom name.

![adding an automation from scratch](https://agent.virtualtabletop.io/reports/pr/1532557671599968467/routine-builder-new-routine.png)

### Translation

Per the flagged comment on the issue, every user-facing string — operation names, verbs, sentences, clauses, enum values in words ("is more than", "do not run their own click automation") — lives in a single `routineBuilderStrings` table in `routineTemplates.js`, so the whole builder can be translated from one place.

## Not in this version

Deliberately, per the scoping discussion: `IF`/`FOREACH`/`INPUT` editing, `CALL` arguments, drag-to-reorder, per-card validity badges, and a ▶ Test run. Those stay advanced-card / JSON territory for now.

## Files

| | |
|---|---|
| `client/js/editor/routineTemplates.js` | new — the variant/clause tables and the string table (pure data + pure functions) |
| `client/js/editor/routineBuilder.js` | new — turns them into DOM and writes the routine back |
| `client/css/editor/routineBuilder.css` | new — step card styling; sentences wrap in the narrow sidebar |
| `client/js/editor/sidebar/properties.js` | `renderAutomationsSection()` rewritten |
| `server/minify.mjs` | the three new files added to the editor bundle |
| `tests/client/routine-templates.test.js` | new — 49 jest tests |

No widget property, routine operation or parameter was added, renamed or removed, so `validator/` and the `jeCommands` table in `jsonedit.js` need no changes.

## Testing

* `npm test` — 135 jest tests pass, including the new suite: every verb/clause/enum has a translatable string, every sentence placeholder resolves to a field, rendering never mutates the operation, verb switching rewrites parameters coherently, and 36 real-world operation shapes taken from the frequency analysis in #3078 (including legacy `MOVE count: 0` and `SET relation: "=="`) each render as the expected sentence.
* TestCafe `editor.js` (16 tests) and `routines.js` (4 tests) pass locally.
* Driven end-to-end in a real browser: a 12-step `clickRoutine` covering all eleven operations plus an `IF` and a `//` note renders correctly with no console errors; switching a verb, adding a step, adding an automation and opening the room widget picker all write the expected JSON and leave the untouched steps byte-identical.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3081/pr-test (or any other room on that server)