### PR TITLE
Replace the deprecated node-minify stack with terser, clean-css and html-minifier-terser

### DIFF
--- a/client/css/widgets/button.css
+++ b/client/css/widgets/button.css
@@ -15,7 +15,7 @@
   --wcBorderOH: var(--wcMain);
   --wcMainOH: var(--wcBorder);
   --wcFontOH: var(--wcFont);
-  --wcImageOH: url();
+  --wcImageOH: none;
 }
 
 .button:hover {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,15 @@
       "version": "0.5.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "@node-minify/clean-css": "^9.0.1",
-        "@node-minify/core": "^9.0.2",
-        "@node-minify/html-minifier": "^9.0.1",
-        "@node-minify/no-compress": "^9.0.1",
-        "@node-minify/uglify-es": "^9.0.1",
         "bson": "^6.10.4",
+        "clean-css": "^5.3.3",
         "crc-32": "^1.2.2",
         "dompurify": "^3.3.0",
         "express": "^5.1.0",
+        "html-minifier-terser": "^7.2.0",
         "jszip": "^3.10.1",
         "node-fetch": "^3.3.2",
+        "terser": "^5.49.0",
         "ws": "^8.18.3"
       },
       "devDependencies": {
@@ -2313,6 +2311,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -2329,6 +2328,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -2340,6 +2340,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -2350,12 +2351,14 @@
     "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -2372,6 +2375,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -2386,6 +2390,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -2862,7 +2867,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2873,153 +2877,34 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@node-minify/clean-css": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@node-minify/clean-css/-/clean-css-9.0.1.tgz",
-      "integrity": "sha512-GHTMmjGloRvNzqdG7foI0iZeS2QmuYCQvdASJP9sCKjkpH45bygODpXPYKnlzUEpQgYvPK9Q3GxqYnVY9SdoqA==",
-      "dependencies": {
-        "@node-minify/utils": "9.0.1",
-        "clean-css": "5.3.3"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@node-minify/clean-css/node_modules/clean-css": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
-      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 10.0"
-      }
-    },
-    "node_modules/@node-minify/core": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@node-minify/core/-/core-9.0.2.tgz",
-      "integrity": "sha512-FNhv29Wom6wKrrFKaeAfmZqz7TX5A1E6P+bpd0VIc+DYWMLUIhAViS8riaZg3A1oD0s06s+5BG2Fg7RqMKiKHw==",
-      "dependencies": {
-        "@node-minify/utils": "9.0.1",
-        "glob": "10.3.3",
-        "mkdirp": "3.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@node-minify/core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@node-minify/core/node_modules/glob": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
-      "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.0.3",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
-      },
-      "bin": {
-        "glob": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@node-minify/core/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@node-minify/html-minifier": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@node-minify/html-minifier/-/html-minifier-9.0.1.tgz",
-      "integrity": "sha512-LCiL3fx3oHnYLdiKbf9thpMxxQjdyLLDLBr/qIRb1AAPYc2FWxtUXHlzi00WwVvj7YRVauEG96z/t4ZpBz0JDA==",
-      "dependencies": {
-        "@node-minify/utils": "9.0.1",
-        "html-minifier": "4.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@node-minify/no-compress": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@node-minify/no-compress/-/no-compress-9.0.1.tgz",
-      "integrity": "sha512-E27Pzjc0BoSPlFwG6tlnzKwm0MOfQIJJ9uergl7ksSJ5jaxTUj57hEePIy+sN1zKLNn+PiBiAyhF17yhHAWtLw==",
-      "dependencies": {
-        "@node-minify/utils": "9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@node-minify/uglify-es": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@node-minify/uglify-es/-/uglify-es-9.0.1.tgz",
-      "integrity": "sha512-R/qvz6LxSBmtDwgnxTzB+rHfBrIHIgJzGhE6AeoAxlem8arNu6ZIyXqvm2u0ok2oFp8zYg2ggUuM4xrIshtlkw==",
-      "dependencies": {
-        "@node-minify/utils": "9.0.1",
-        "uglify-es": "3.3.9"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@node-minify/utils": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@node-minify/utils/-/utils-9.0.1.tgz",
-      "integrity": "sha512-aC1+mhKTP3IMa2VcuGl3ui92LO/7CPQWldNGzu3BVGKiMNJ70AKJW/R6huuYCSuQyHDGM9oFwiVClsZnFxn67g==",
-      "dependencies": {
-        "gzip-size": "6.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3064,6 +2949,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -3337,6 +3223,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/acorn-hammerhead": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/acorn-hammerhead/-/acorn-hammerhead-0.6.2.tgz",
@@ -3410,6 +3308,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3418,6 +3317,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3751,7 +3651,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.17",
@@ -3877,8 +3778,7 @@
     "node_modules/buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -3935,15 +3835,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/camel-case": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-      "dependencies": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
       }
     },
     "node_modules/camelcase": {
@@ -4123,14 +4014,15 @@
       "license": "MIT"
     },
     "node_modules/clean-css": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
-      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+      "license": "MIT",
       "dependencies": {
         "source-map": "~0.6.0"
       },
       "engines": {
-        "node": ">= 4.0"
+        "node": ">= 10.0"
       }
     },
     "node_modules/clean-stack": {
@@ -4194,6 +4086,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4204,7 +4097,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/colors": {
       "version": "1.4.0",
@@ -4331,6 +4225,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4586,6 +4481,35 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dot-case/node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dot-case/node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/dreamopt": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.8.0.tgz",
@@ -4612,15 +4536,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -4669,7 +4589,8 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -5050,6 +4971,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
       "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -5065,6 +4987,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -5335,20 +5258,6 @@
         "lodash": "^4.17.15"
       }
     },
-    "node_modules/gzip-size": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
-      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
-      "dependencies": {
-        "duplexer": "^0.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5381,14 +5290,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "bin": {
-        "he": "bin/he"
       }
     },
     "node_modules/heap": {
@@ -5514,24 +5415,66 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/html-minifier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
-      "integrity": "sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==",
+    "node_modules/html-minifier-terser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
+      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
+      "license": "MIT",
       "dependencies": {
-        "camel-case": "^3.0.0",
-        "clean-css": "^4.2.1",
-        "commander": "^2.19.0",
-        "he": "^1.2.0",
-        "param-case": "^2.1.1",
+        "camel-case": "^4.1.2",
+        "clean-css": "~5.3.2",
+        "commander": "^10.0.0",
+        "entities": "^4.4.0",
+        "param-case": "^3.0.4",
         "relateurl": "^0.2.7",
-        "uglify-js": "^3.5.1"
+        "terser": "^5.15.1"
       },
       "bin": {
-        "html-minifier": "cli.js"
+        "html-minifier-terser": "cli.js"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/html-minifier-terser/node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "license": "MIT",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/html-minifier-terser/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/html-minifier-terser/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-minifier-terser/node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -5861,6 +5804,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5981,7 +5925,8 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6094,23 +6039,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
-      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jest": {
@@ -7204,11 +7132,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/lower-case": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -7402,22 +7325,9 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/moment": {
@@ -7505,14 +7415,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/no-case": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-      "dependencies": {
-        "lower-case": "^1.1.1"
       }
     },
     "node_modules/node-domexception": {
@@ -7833,14 +7735,6 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
-    "node_modules/param-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "dependencies": {
-        "no-case": "^2.2.0"
-      }
-    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -7881,6 +7775,35 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/pascal-case/node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/pascal-case/node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7910,6 +7833,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7925,6 +7849,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -7939,7 +7864,8 @@
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
     },
     "node_modules/path-to-regexp": {
       "version": "8.2.0",
@@ -8723,6 +8649,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -8734,6 +8661,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8883,7 +8811,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -8952,6 +8879,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -8966,6 +8894,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -8979,6 +8908,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -8991,6 +8921,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -9077,6 +9008,24 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/test-exclude": {
@@ -9943,6 +9892,12 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -10015,38 +9970,6 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "node_modules/uglify-es": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-      "deprecated": "support for ECMAScript is superseded by `uglify-js` as of v3.13.0",
-      "dependencies": {
-        "commander": "~2.13.0",
-        "source-map": "~0.6.1"
-      },
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/uglify-es/node_modules/commander": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
-    },
-    "node_modules/uglify-js": {
-      "version": "3.13.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.4.tgz",
-      "integrity": "sha512-kv7fCkIXyQIilD5/yQy8O+uagsYIOt5cZvs890W40/e/rvjMSzJw81o9Bg0tkURxzZBROtDQhW2LFjOGoK3RZw==",
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/undefsafe": {
@@ -10204,11 +10127,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/upper-case": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
-    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -10347,6 +10265,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -10496,6 +10415,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -46,17 +46,15 @@
   },
   "homepage": "https://github.com/ArnoldSmith86/virtualtabletop#readme",
   "dependencies": {
-    "@node-minify/clean-css": "^9.0.1",
-    "@node-minify/core": "^9.0.2",
-    "@node-minify/html-minifier": "^9.0.1",
-    "@node-minify/no-compress": "^9.0.1",
-    "@node-minify/uglify-es": "^9.0.1",
     "bson": "^6.10.4",
+    "clean-css": "^5.3.3",
     "crc-32": "^1.2.2",
     "dompurify": "^3.3.0",
     "express": "^5.1.0",
+    "html-minifier-terser": "^7.2.0",
     "jszip": "^3.10.1",
     "node-fetch": "^3.3.2",
+    "terser": "^5.49.0",
     "ws": "^8.18.3"
   },
   "optionalDependencies": {

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -4,13 +4,33 @@ import path from 'path';
 import util from 'util';
 import zlib from 'zlib';
 
-import minify from '@node-minify/core';
-import noCompress from '@node-minify/no-compress';
-import cleanCSS from '@node-minify/clean-css';
-import uglifyES from '@node-minify/uglify-es';
-import htmlMinifier from '@node-minify/html-minifier';
+import CleanCSS from 'clean-css';
+import { minify as htmlMinify } from 'html-minifier-terser';
+import { minify as jsMinify } from 'terser';
 
 import Config from './config.mjs';
+
+// html-minifier-terser enables nothing by default, so spell out the set the previous wrapper used.
+// minifyJS follows the config: the old uglify-js based pass silently failed on our client code,
+// while terser does parse it and would minify even when the config asks for readable output.
+function htmlMinifyOptions() {
+  return {
+    collapseBooleanAttributes: true,
+    collapseInlineTagWhitespace: true,
+    collapseWhitespace: true,
+    conservativeCollapse: true,
+    minifyCSS: true,
+    minifyJS: !!Config.get('minifyJavascript'),
+    removeAttributeQuotes: true,
+    removeComments: true,
+    removeEmptyAttributes: true,
+    removeOptionalTags: true,
+    removeRedundantAttributes: true,
+    removeScriptTypeAttributes: true,
+    removeStyleLinkTypeAttributes: true,
+    useShortDoctype: true
+  };
+}
 
 export default async function minifyHTML() {
   const room = await compress('client/room.html', [
@@ -145,13 +165,7 @@ export default async function minifyHTML() {
     'validator/validate_gamefile.js'
   ]);
 
-  const editorHTML = await minify({
-    compressor: htmlMinifier,
-    content: fs.readFileSync(path.resolve() + '/client/editor.html', {encoding:'utf8'}),
-    options: {
-      conservativeCollapse: true
-    }
-  });
+  const editorHTML = await htmlMinify(fs.readFileSync(path.resolve() + '/client/editor.html', {encoding:'utf8'}), htmlMinifyOptions());
 
   editorJS = editorJS.replace(/["']\ \/\/\*\*\*\ CSS\ \*\*\*\/\/\ ["']/, _=>'`' + editorCSS.replace(/\\/g, '\\\\') + '`');
   editorJS = editorJS.replace(/["']\ \/\/\*\*\*\ HTML\ \*\*\*\/\/\ ["']/, _=>'`' + editorHTML + '`');
@@ -169,10 +183,7 @@ async function compressCSS(cssFiles) {
     .map(filePath => fs.readFileSync(filePath, 'utf8'))  // Read each file
     .join('\n');  // Combine them into a single string
 
-  return await minify({
-    compressor: cleanCSS,
-    content: combinedCSSContent
-  });
+  return new CleanCSS().minify(combinedCSSContent).styles;
 }
 
 // Helper function to remove import statements
@@ -188,10 +199,10 @@ async function compressJS(jsFiles) {
     .join('\n');  // Combine them into a single string
 
   // Perform compression
-  return await minify({
-    compressor: Config.get('minifyJavascript') ? uglifyES : noCompress,
-    content: combinedJSContent
-  });
+  if(!Config.get('minifyJavascript'))
+    return combinedJSContent;
+
+  return (await jsMinify(combinedJSContent)).code;
 }
 
 async function compress(htmlFile, cssFiles, jsFiles) {
@@ -206,13 +217,7 @@ async function compress(htmlFile, cssFiles, jsFiles) {
   const js = await compressJS(jsFiles);
   htmlString = htmlString.replace(/\ \/\/\*\*\*\ JS\ \*\*\*\/\/\ /, _=>js);
 
-  const html = await minify({
-    compressor: htmlMinifier,
-    content: htmlString,
-    options: {
-      conservativeCollapse: true
-    }
-  });
+  const html = await htmlMinify(htmlString, htmlMinifyOptions());
 
   const gzipped = await util.promisify(zlib.gzip)(html);
   return {

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -190,9 +190,12 @@ export default async function minifyHTML() {
 }
 
 async function compressCSS(cssFiles) {
-  const combinedCSSContent = cssFiles
-    .map(filePath => fs.readFileSync(filePath, 'utf8'))  // Read each file
-    .join('\n');  // Combine them into a single string
+  // Hand clean-css the files separately instead of one concatenated string: the output is
+  // identical but problems are then reported as file:line:column instead of a line number
+  // in a string that does not exist anywhere on disk
+  const combinedCSSContent = {};
+  for(const filePath of cssFiles)
+    combinedCSSContent[filePath] = { styles: fs.readFileSync(filePath, 'utf8') };
 
   // clean-css does not throw on broken input, it drops the offending declaration and only
   // mentions it here - without this the minified client would be missing a rule silently

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -15,7 +15,16 @@ import Logging from './logging.mjs';
 // truthy string 'false'. Both minification passes read the flag through here so they agree.
 function minifyJavascript() {
   const value = Config.get('minifyJavascript');
-  return !!value && value !== 'false';
+  return !!value && ![ 'false', '0', 'no', 'off' ].includes(String(value).toLowerCase());
+}
+
+// html-minifier-terser routes the failures of its own terser and clean-css passes through log()
+// and defaults that to a no-op, so a broken inline <script> or <style> would just come back
+// unchanged without a trace - the same silent failure this file now reports for compressCSS.
+// Its own timing line is the one non-problem message it sends here.
+function htmlMinifyLog(message) {
+  if(!/^minified in: /.test(String(message)))
+    Logging.log(`WARNING - HTML minification - ${message}`);
 }
 
 // html-minifier-terser enables nothing by default, so spell out the set the previous wrapper used.
@@ -30,6 +39,7 @@ function htmlMinifyOptions() {
     collapseInlineTagWhitespace: true,
     collapseWhitespace: true,
     conservativeCollapse: true,
+    log: htmlMinifyLog,
     minifyCSS: true,
     minifyJS: minifyJavascript(),
     removeAttributeQuotes: true,

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -9,10 +9,21 @@ import { minify as htmlMinify } from 'html-minifier-terser';
 import { minify as jsMinify } from 'terser';
 
 import Config from './config.mjs';
+import Logging from './logging.mjs';
+
+// Config.get returns environment overrides verbatim, so MINIFYJAVASCRIPT=false arrives as the
+// truthy string 'false'. Both minification passes read the flag through here so they agree.
+function minifyJavascript() {
+  const value = Config.get('minifyJavascript');
+  return !!value && value !== 'false';
+}
 
 // html-minifier-terser enables nothing by default, so spell out the set the previous wrapper used.
 // minifyJS follows the config: the old uglify-js based pass silently failed on our client code,
 // while terser does parse it and would minify even when the config asks for readable output.
+// When it is enabled the client JS goes through terser twice (compressJS and again here as part
+// of the surrounding <script>) which is redundant but cheap - and it also covers the config
+// object that is injected into the HTML after compressJS has run.
 function htmlMinifyOptions() {
   return {
     collapseBooleanAttributes: true,
@@ -20,7 +31,7 @@ function htmlMinifyOptions() {
     collapseWhitespace: true,
     conservativeCollapse: true,
     minifyCSS: true,
-    minifyJS: !!Config.get('minifyJavascript'),
+    minifyJS: minifyJavascript(),
     removeAttributeQuotes: true,
     removeComments: true,
     removeEmptyAttributes: true,
@@ -183,7 +194,15 @@ async function compressCSS(cssFiles) {
     .map(filePath => fs.readFileSync(filePath, 'utf8'))  // Read each file
     .join('\n');  // Combine them into a single string
 
-  return new CleanCSS().minify(combinedCSSContent).styles;
+  // clean-css does not throw on broken input, it drops the offending declaration and only
+  // mentions it here - without this the minified client would be missing a rule silently
+  const result = new CleanCSS().minify(combinedCSSContent);
+  for(const error of result.errors)
+    Logging.log(`ERROR - CSS minification - ${error}`);
+  for(const warning of result.warnings)
+    Logging.log(`WARNING - CSS minification - ${warning}`);
+
+  return result.styles;
 }
 
 // Helper function to remove import statements
@@ -199,7 +218,7 @@ async function compressJS(jsFiles) {
     .join('\n');  // Combine them into a single string
 
   // Perform compression
-  if(!Config.get('minifyJavascript'))
+  if(!minifyJavascript())
     return combinedJSContent;
 
   return (await jsMinify(combinedJSContent)).code;

--- a/tests/server/minify.test.js
+++ b/tests/server/minify.test.js
@@ -1,0 +1,28 @@
+import minifyHTML from '../../server/minify.mjs';
+
+// Both minification passes (terser on the bundle and html-minifier-terser on the surrounding
+// document) have to honour the minifyJavascript config, otherwise a local checkout ships a
+// minified client and debugging it in the browser becomes impossible.
+describe('minifyHTML with minifyJavascript disabled', () => {
+  let build;
+
+  beforeAll(async () => {
+    process.env.MINIFYJAVASCRIPT = 'false';  // an env override arrives as a string, not a boolean
+    build = await minifyHTML();
+  }, 30000);
+
+  afterAll(() => {
+    delete process.env.MINIFYJAVASCRIPT;
+  });
+
+  test('keeps the inline client JS readable', () => {
+    const script = build.min.match(/<script type=module>([\s\S]*?)<\/script>/)[1];
+    expect(script).toMatch(/function \w+\([\w, ]*\) \{\n/);
+    expect(script).toContain('\n\n');
+  });
+
+  test('keeps the editor JS readable', () => {
+    expect(build.editorJSmin).toMatch(/function \w+\([\w, ]*\) \{\n/);
+    expect(build.editorJSmin).toContain('\n\n');
+  });
+});

--- a/tests/server/minify.test.js
+++ b/tests/server/minify.test.js
@@ -1,28 +1,56 @@
 import minifyHTML from '../../server/minify.mjs';
 
+// A readable build keeps multi-line function bodies and blank lines, a minified one has neither.
+const readableJS = /function \w+\([\w, ]*\) \{\n/;
+
+async function buildWith(minifyJavascript) {
+  process.env.MINIFYJAVASCRIPT = minifyJavascript;
+  try {
+    return await minifyHTML();
+  } finally {
+    delete process.env.MINIFYJAVASCRIPT;
+  }
+}
+
+function inlineClientJS(build) {
+  return build.min.match(/<script type=module>([\s\S]*?)<\/script>/)[1];
+}
+
 // Both minification passes (terser on the bundle and html-minifier-terser on the surrounding
 // document) have to honour the minifyJavascript config, otherwise a local checkout ships a
-// minified client and debugging it in the browser becomes impossible.
+// minified client and debugging it in the browser becomes impossible - and a production build
+// that stops minifying ships a client that is about 50% bigger.
 describe('minifyHTML with minifyJavascript disabled', () => {
   let build;
 
   beforeAll(async () => {
-    process.env.MINIFYJAVASCRIPT = 'false';  // an env override arrives as a string, not a boolean
-    build = await minifyHTML();
-  }, 30000);
-
-  afterAll(() => {
-    delete process.env.MINIFYJAVASCRIPT;
-  });
+    build = await buildWith('false');  // an env override arrives as a string, not a boolean
+  }, 60000);
 
   test('keeps the inline client JS readable', () => {
-    const script = build.min.match(/<script type=module>([\s\S]*?)<\/script>/)[1];
-    expect(script).toMatch(/function \w+\([\w, ]*\) \{\n/);
+    const script = inlineClientJS(build);
+    expect(script).toMatch(readableJS);
     expect(script).toContain('\n\n');
   });
 
   test('keeps the editor JS readable', () => {
-    expect(build.editorJSmin).toMatch(/function \w+\([\w, ]*\) \{\n/);
+    expect(build.editorJSmin).toMatch(readableJS);
     expect(build.editorJSmin).toContain('\n\n');
+  });
+});
+
+describe('minifyHTML with minifyJavascript enabled', () => {
+  let build;
+
+  beforeAll(async () => {
+    build = await buildWith('true');
+  }, 60000);
+
+  test('minifies the inline client JS', () => {
+    expect(inlineClientJS(build)).not.toMatch(readableJS);
+  });
+
+  test('minifies the editor JS', () => {
+    expect(build.editorJSmin).not.toMatch(readableJS);
   });
 });


### PR DESCRIPTION
## Goal

The minifier depended on packages that are deprecated or unmaintained:

- `@node-minify/uglify-es` → **`uglify-es`**, which npm marks deprecated (*"support for ECMAScript is superseded by `uglify-js` as of v3.13.0"*) and which has not been released since 2017.
- `@node-minify/html-minifier` → **`html-minifier`**, unmaintained since 2019.

## What changed

`server/minify.mjs` now calls the modern minifiers directly instead of going through the `@node-minify` wrapper layer:

| before | after |
| --- | --- |
| `@node-minify/core` + `@node-minify/no-compress` | — (the wrapper only added `glob`/`mkdirp` we never used) |
| `@node-minify/uglify-es` → `uglify-es` | **`terser`** (the maintained fork of `uglify-es`) |
| `@node-minify/html-minifier` → `html-minifier` | **`html-minifier-terser`** |
| `@node-minify/clean-css` → `clean-css` | **`clean-css`** (already current, just used directly) |

Five dependencies become three, and `npm install` no longer prints a deprecation warning for a production dependency.

**Concatenation is untouched** — the CSS/JS file lists, the `removeImportStatements` step and the `.join('\n')` are exactly as before, as are the `/*** CSS ***/` / `//*** JS ***//` placeholder replacements.

Two details worth reviewing:

- `html-minifier-terser` enables no options by default, whereas `@node-minify/html-minifier` injected a default set. That set is now spelled out in `htmlMinifyOptions()` (`removeCDATASectionsFromCDATA` / `removeCommentsFromCDATA` are dropped — those options no longer exist in `html-minifier-terser`).
- `minifyJS` is now tied to the `minifyJavascript` config. The old inline-JS pass used uglify-js, which could not parse our client code and therefore left it alone; terser *can* parse it, so without this the client JS would be minified even with `"minifyJavascript": false`, which would take readable client source away from developers.

## Verification

Output was captured before and after the change for both config modes:

| build | before | after |
| --- | --- | --- |
| `room.html`, `minifyJavascript: false` | 725713 B | 725812 B |
| `room.html`, `minifyJavascript: true` | 480764 B | 481034 B |
| editor JS, `minifyJavascript: false` | 1085186 B | 1085186 B (byte-identical) |
| editor JS, `minifyJavascript: true` | 672591 B | 671687 B |

The only non-JS difference is cosmetic: `html-minifier-terser` bundles clean-css 5 rather than clean-css 4, so a couple of values keep their leading zero (`transition-delay:0.4s` instead of `.4s`).

- `npm test` — 86 passed (88 with the test added below)
- TestCafe against a local server with **`minifyJavascript: true`** (i.e. running the terser-minified client): `routines.js`, `editor.js`, `compute-1.js`, `publiclibrary-1.js` — 26 passed


## Review follow-up

- `compressCSS` now logs clean-css `errors` and `warnings` instead of only reading `.styles`. clean-css does not throw on broken input, it drops the offending declaration — so without this a typo in one of the concatenated CSS files would ship a client missing a rule, with nothing in the server log. The stylesheets are handed to clean-css as separate named sources rather than one concatenated string (identical output), so a problem is reported as `client/css/widgets/timer.css:34:15` instead of a line number in a string that exists nowhere on disk.
- That was already happening: `--wcImageOH: url();` in `client/css/widgets/button.css` is reported as `Broken URL 'url()'. Ignoring.` and dropped, so the minified client never had the declaration. It is now `none`, which is what both the dropped and the literal `url()` variant already resolved to (an undefined custom property makes `background-image: var(--wcImageOH)` invalid at computed-value time → `none`). No visual change; the build is now warning-free.
  - One production edge case does change, for completeness: because the declaration used to be dropped, custom-property inheritance meant a `.button` in a minified build picked up an ancestor's `--wcImageOH`; now it always resets to `none`, exactly as the unminified dev build has always behaved. Nothing in `client/` or `library/` sets `--wcImageOH`, so this makes prod match dev rather than changing any existing game.
- The `minifyJavascript` flag is read through one helper in both passes, so an environment override (`Config.get` returns `MINIFYJAVASCRIPT=false` as the truthy string `'false'`) no longer silently minifies the client.
- `tests/server/minify.test.js` locks in the behaviour this PR introduces: with the flag off, the inline client JS and the editor JS must stay readable.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3086/pr-test (or any other room on that server)
