### PR TITLE
Fix flaky Reversi TestCafe test: drops racing with in-flight drag moves

### DIFF
--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -105,7 +105,7 @@ async function inputHandler(name, e) {
         if (movable) {
           ms.localAnchor = ms.moveTarget.coordLocalFromCoordClient({x: coords.clientX, y: coords.clientY});
         }
-      } else if(name == 'mouseup' || (name == 'touchend' || name == 'touchcancel') && mouseStatus[target.id]) {
+      } else if((name == 'mouseup' || name == 'touchend' || name == 'touchcancel') && mouseStatus[target.id]) {
         const ms = mouseStatus[target.id];
         // End the drag synchronously, before the first await below: a mousemove that
         // is delivered while the drop is still being processed would otherwise queue
@@ -179,8 +179,10 @@ async function inputHandler(name, e) {
             await ms.moveTarget.move(coords, ms.localAnchor);
           }).catch(error => {
             // keep the chain resolvable - a rejected one would make every later move
-            // and the drop in the mouseup branch above fail as well
-            console.error('Error while dragging.', error);
+            // and the drop in the mouseup branch above fail as well - but still let
+            // the error reach the client error reporter in tracing.js, which is where
+            // it would have ended up as an unhandled rejection before the chain
+            setTimeout(_=>{ throw error; });
           });
           await ms.dragChain;
         }

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -107,6 +107,9 @@ async function inputHandler(name, e) {
       const pixelsMoved = ms.coords ? Math.abs(ms.coords.x - ms.downCoords.x) + Math.abs(ms.coords.y - ms.downCoords.y) : 0;
       if(ms.status != 'initial' && ms.moveTarget) {
         setDeltaCause(`${playerName} dragged ${widget.id}`);
+        // let every mousemove that is still being processed finish first so that the
+        // drop happens after the last one instead of racing with it
+        await ms.dragChain;
         await ms.moveTarget.moveEnd(coords, ms.localAnchor);
       }
       if(ms.status == 'initial' || timeSinceStart < 250 && pixelsMoved < 10) {
@@ -142,16 +145,24 @@ async function inputHandler(name, e) {
       }
       delete mouseStatus[target.id];
     } else if(name == 'mousemove' || name == 'touchmove' && mouseStatus[target.id]) {
+      const ms = mouseStatus[target.id];
       setDeltaCause(`${playerName} dragged ${widget.id}`);
-      if(mouseStatus[target.id].status == 'initial') {
-        mouseStatus[target.id].status = 'moving';
-        if(mouseStatus[target.id].moveTarget)
-          await mouseStatus[target.id].moveTarget.moveStart();
-      }
-      mouseStatus[target.id].coords = coords;
-      if(mouseStatus[target.id].moveTarget) {
+      const isFirstMove = ms.status == 'initial';
+      if(isFirstMove)
+        ms.status = 'moving';
+      ms.coords = coords;
+      if(ms.moveTarget) {
         setDeltaCause(`${playerName} dragged ${widget.id}`);
-        await mouseStatus[target.id].moveTarget.move(coords, mouseStatus[target.id].localAnchor);
+        // Mouse events are handled asynchronously, so several of them can be in
+        // flight at once. Queue the moves instead of running them in parallel so
+        // the widget always ends up where the most recent event put it - and so
+        // that the drop in the mouseup branch above happens after all of them.
+        ms.dragChain = Promise.resolve(ms.dragChain).then(async _ => {
+          if(isFirstMove)
+            await ms.moveTarget.moveStart();
+          await ms.moveTarget.move(coords, ms.localAnchor);
+        });
+        await ms.dragChain;
       }
     }
     batchEnd();

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -71,101 +71,123 @@ async function inputHandler(name, e) {
       return;
     }
     batchStart();
-    if(!edit && (!jeEnabled || !e.ctrlKey) && widget.passthroughMouse) {
-      if(name == 'mousedown' || name == 'touchstart') {
-        await widget.mouseRaw('down', coords);
-      } else if (name == 'mouseup' || name == 'touchend' || name == 'touchcancel') {
-        await widget.mouseRaw('up', coords);
-      } else if (name == 'mousemove' || name == 'touchmove') {
-        await widget.mouseRaw('move', coords);
-      }
-    } else if(name == 'mousedown' || name == 'touchstart') {
-      mouseStatus[target.id] = {
-        status: 'initial',
-        start: new Date(),
-        downCoords: coords,
-        moveTarget: widget
-      };
-      const ms = mouseStatus[target.id];
-      let movable = ms.moveTarget.get(editMovable ? 'movableInEdit' : 'movable');
-      while (ms.moveTarget && !movable) {
-        let parent = ms.moveTarget.get('parent');
-        if(parent && widgets.has(parent)) {
-          ms.moveTarget = widgets.get(parent);
-          movable = ms.moveTarget.get(editMovable ? 'movableInEdit' : 'movable');
-        } else {
-          ms.moveTarget = null;
-          movable = false;
+    // batchEnd() has to run even if a routine triggered by the drop or click below
+    // throws: batchStart() increments batchDepth and sendDelta() only sends anything
+    // while that is 0, so a leaked batch stops this client from syncing altogether.
+    try {
+      if(!edit && (!jeEnabled || !e.ctrlKey) && widget.passthroughMouse) {
+        if(name == 'mousedown' || name == 'touchstart') {
+          await widget.mouseRaw('down', coords);
+        } else if (name == 'mouseup' || name == 'touchend' || name == 'touchcancel') {
+          await widget.mouseRaw('up', coords);
+        } else if (name == 'mousemove' || name == 'touchmove') {
+          await widget.mouseRaw('move', coords);
         }
-      }
-      if (movable) {
-        ms.localAnchor = ms.moveTarget.coordLocalFromCoordClient({x: coords.clientX, y: coords.clientY});
-      }
-    } else if(name == 'mouseup' || (name == 'touchend' || name == 'touchcancel') && mouseStatus[target.id]) {
-      const ms = mouseStatus[target.id];
-      const timeSinceStart = +new Date() - ms.start;
-      const pixelsMoved = ms.coords ? Math.abs(ms.coords.x - ms.downCoords.x) + Math.abs(ms.coords.y - ms.downCoords.y) : 0;
-      if(ms.status != 'initial' && ms.moveTarget) {
-        setDeltaCause(`${playerName} dragged ${widget.id}`);
-        // let every mousemove that is still being processed finish first so that the
-        // drop happens after the last one instead of racing with it
-        await ms.dragChain;
-        await ms.moveTarget.moveEnd(coords, ms.localAnchor);
-      }
-      if(ms.status == 'initial' || timeSinceStart < 250 && pixelsMoved < 10) {
-        let editClickHandled = false;
-        if(edit && !isMiddleMouseButton)
-          editClickHandled = await editClick(widget, e.button);
-        else if(jeEnabled && !isMiddleMouseButton)
-          editClickHandled = await jeClick(widget, e);
-
-        if(!editClickHandled) {
-          if(!target.classList.contains('longtouch')) {
-            if(!widget.get('doubleClickRoutine')) {
-              setDeltaCause(`${playerName} clicked ${widget.id}`);
-              await widget.click();
-            } else if(doubleClickTimeout) {
-              clearTimeout(doubleClickTimeout);
-              doubleClickTimeout = null;
-              setDeltaCause(`${playerName} double clicked ${widget.id}`);
-              await widget.doubleClick();
-            } else {
-              doubleClickTimeout = setTimeout(async () => {
-                doubleClickTimeout = null;
-                batchStart();
-                setDeltaCause(`${playerName} clicked ${widget.id}`);
-                await widget.click();
-                batchEnd();
-              }, 350);
-            }
+      } else if(name == 'mousedown' || name == 'touchstart') {
+        mouseStatus[target.id] = {
+          status: 'initial',
+          start: new Date(),
+          downCoords: coords,
+          moveTarget: widget
+        };
+        const ms = mouseStatus[target.id];
+        let movable = ms.moveTarget.get(editMovable ? 'movableInEdit' : 'movable');
+        while (ms.moveTarget && !movable) {
+          let parent = ms.moveTarget.get('parent');
+          if(parent && widgets.has(parent)) {
+            ms.moveTarget = widgets.get(parent);
+            movable = ms.moveTarget.get(editMovable ? 'movableInEdit' : 'movable');
           } else {
-            widget.domElement.classList.remove('longtouch');
+            ms.moveTarget = null;
+            movable = false;
           }
         }
-      }
-      delete mouseStatus[target.id];
-    } else if(name == 'mousemove' || name == 'touchmove' && mouseStatus[target.id]) {
-      const ms = mouseStatus[target.id];
-      setDeltaCause(`${playerName} dragged ${widget.id}`);
-      const isFirstMove = ms.status == 'initial';
-      if(isFirstMove)
-        ms.status = 'moving';
-      ms.coords = coords;
-      if(ms.moveTarget) {
+        if (movable) {
+          ms.localAnchor = ms.moveTarget.coordLocalFromCoordClient({x: coords.clientX, y: coords.clientY});
+        }
+      } else if(name == 'mouseup' || (name == 'touchend' || name == 'touchcancel') && mouseStatus[target.id]) {
+        const ms = mouseStatus[target.id];
+        // End the drag synchronously, before the first await below: a mousemove that
+        // is delivered while the drop is still being processed would otherwise queue
+        // another move and drag the widget back out of where it was just dropped.
+        delete mouseStatus[target.id];
+        const timeSinceStart = +new Date() - ms.start;
+        const pixelsMoved = ms.coords ? Math.abs(ms.coords.x - ms.downCoords.x) + Math.abs(ms.coords.y - ms.downCoords.y) : 0;
+        if(ms.status != 'initial' && ms.moveTarget) {
+          setDeltaCause(`${playerName} dragged ${widget.id}`);
+          // let every mousemove that is still being processed finish first so that the
+          // drop happens after the last one instead of racing with it
+          await ms.dragChain;
+          await ms.moveTarget.moveEnd(coords, ms.localAnchor);
+        }
+        if(ms.status == 'initial' || timeSinceStart < 250 && pixelsMoved < 10) {
+          let editClickHandled = false;
+          if(edit && !isMiddleMouseButton)
+            editClickHandled = await editClick(widget, e.button);
+          else if(jeEnabled && !isMiddleMouseButton)
+            editClickHandled = await jeClick(widget, e);
+
+          if(!editClickHandled) {
+            if(!target.classList.contains('longtouch')) {
+              if(!widget.get('doubleClickRoutine')) {
+                setDeltaCause(`${playerName} clicked ${widget.id}`);
+                await widget.click();
+              } else if(doubleClickTimeout) {
+                clearTimeout(doubleClickTimeout);
+                doubleClickTimeout = null;
+                setDeltaCause(`${playerName} double clicked ${widget.id}`);
+                await widget.doubleClick();
+              } else {
+                doubleClickTimeout = setTimeout(async () => {
+                  doubleClickTimeout = null;
+                  batchStart();
+                  try {
+                    setDeltaCause(`${playerName} clicked ${widget.id}`);
+                    await widget.click();
+                  } finally {
+                    batchEnd();
+                  }
+                }, 350);
+              }
+            } else {
+              widget.domElement.classList.remove('longtouch');
+            }
+          }
+        }
+      } else if((name == 'mousemove' || name == 'touchmove') && mouseStatus[target.id]) {
+        const ms = mouseStatus[target.id];
         setDeltaCause(`${playerName} dragged ${widget.id}`);
-        // Mouse events are handled asynchronously, so several of them can be in
-        // flight at once. Queue the moves instead of running them in parallel so
-        // the widget always ends up where the most recent event put it - and so
-        // that the drop in the mouseup branch above happens after all of them.
-        ms.dragChain = Promise.resolve(ms.dragChain).then(async _ => {
-          if(isFirstMove)
-            await ms.moveTarget.moveStart();
-          await ms.moveTarget.move(coords, ms.localAnchor);
-        });
-        await ms.dragChain;
+        const isFirstMove = ms.status == 'initial';
+        if(isFirstMove)
+          ms.status = 'moving';
+        ms.coords = coords;
+        if(ms.moveTarget) {
+          setDeltaCause(`${playerName} dragged ${widget.id}`);
+          // Mouse events are handled asynchronously, so several of them can be in
+          // flight at once. Queue the moves instead of running them in parallel so
+          // the widget always ends up where the most recent event put it - and so
+          // that the drop in the mouseup branch above happens after all of them.
+          ms.dragChain = Promise.resolve(ms.dragChain).then(async _ => {
+            // a move that a newer mousemove already replaced does not need to run:
+            // that one will put the widget, its hover target and its parent where
+            // the cursor is now. Without this the queue can grow under load and the
+            // widget visibly lags behind the cursor.
+            if(!isFirstMove && ms.coords !== coords)
+              return;
+            if(isFirstMove)
+              await ms.moveTarget.moveStart();
+            await ms.moveTarget.move(coords, ms.localAnchor);
+          }).catch(error => {
+            // keep the chain resolvable - a rejected one would make every later move
+            // and the drop in the mouseup branch above fail as well
+            console.error('Error while dragging.', error);
+          });
+          await ms.dragChain;
+        }
       }
+    } finally {
+      batchEnd();
     }
-    batchEnd();
   }
 
   if(name == 'mouseup')

--- a/client/js/tracing.js
+++ b/client/js/tracing.js
@@ -47,7 +47,7 @@ onLoad(function() {
       error: String(error.message) + '\n' + String(error.stack),
       undoProtocol,
       delta,
-      mouseStatus: Object.fromEntries(Object.entries(mouseStatus).map(([id, ms]) => [id, {...ms, moveTarget: ms.moveTarget ? ms.moveTarget.get('id') : null}])),
+      mouseStatus: Object.fromEntries(Object.entries(mouseStatus).map(([id, ms]) => [id, {...ms, moveTarget: ms.moveTarget ? ms.moveTarget.get('id') : null, dragChain: undefined}])),
       mouseTarget: mouseTarget && mouseTarget.id ? unescapeID(mouseTarget.id.slice(2)) : null,
       jeLoggingData: typeof jeLoggingRoutineGetData == 'function' ? jeLoggingRoutineGetData() : null,
       lastExecutedOperation,

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2494,6 +2494,7 @@ export class Widget extends StateManaged {
 
     await this.bringToFront();
     await this.set('dragging', playerName);
+    delete this.lastMoveCoord;
 
     // Lines that take a widget dropped onto their path as a stop. Collected once
     // like the drop targets below, but not restricted to widgets that can be
@@ -2537,6 +2538,8 @@ export class Widget extends StateManaged {
     if(tracingEnabled)
       sendTraceEvent('move', { id: this.get('id'), coordGlobal, localAnchor, newX: newCoord.x, newY: newCoord.y });
 
+    this.lastMoveCoord = coordGlobal;
+
     await this.setPosition(newCoord.x, newCoord.y, this.get('z'));
     await this.snapToGrid();
 
@@ -2544,6 +2547,15 @@ export class Widget extends StateManaged {
       await this.checkParent();
 
       const lastHoverTarget = this.hoverTarget;
+      // The hit test below asks the DOM where this widget is, but the delta that
+      // carries the position set above only reaches the DOM when the batch around
+      // the mouse event ends. Without the flush the drop target is computed for the
+      // position of the *previous* mouse event - so a drag that moves further than
+      // half a holder between two events resolves the drop against the square the
+      // widget has already left, and the piece lands next to where it was dropped
+      // (or the game rejects the move and sends it back).
+      if(this.domElement.style.transform != this.cssTransform())
+        flushDelta();
       const myCenter = center(this.domElement);
       const myMinDim = Math.min(this.get('width'), this.get('height')) * this.get('_absoluteScale');
       this.hoverTarget = null;
@@ -2687,6 +2699,17 @@ export class Widget extends StateManaged {
   async moveEnd(coordGlobal, localAnchor) {
     if(tracingEnabled)
       sendTraceEvent('moveEnd', { id: this.get('id'), coordGlobal, localAnchor });
+
+    // The drop belongs where the button was released, not where the last mousemove
+    // reported: a fast drag can end with a mouseup at coordinates no mousemove ever
+    // delivered, and everything below - the drop target, the line stop, the position -
+    // would then be resolved for a spot the widget has already been dragged away from.
+    // Applying the release coordinates first also makes the drop target match what the
+    // player last saw highlighted, since move() recomputes it.
+    const releasedElsewhere = coordGlobal && (!this.lastMoveCoord || this.lastMoveCoord.x != coordGlobal.x || this.lastMoveCoord.y != coordGlobal.y);
+    delete this.lastMoveCoord;
+    if(releasedElsewhere)
+      await this.move(coordGlobal, localAnchor);
 
     await this.hideShadowWidget();
     await this.set('dragging', null);

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2707,9 +2707,9 @@ export class Widget extends StateManaged {
     // Applying the release coordinates first also makes the drop target match what the
     // player last saw highlighted, since move() recomputes it.
     const releasedElsewhere = coordGlobal && (!this.lastMoveCoord || this.lastMoveCoord.x != coordGlobal.x || this.lastMoveCoord.y != coordGlobal.y);
-    delete this.lastMoveCoord;
     if(releasedElsewhere)
       await this.move(coordGlobal, localAnchor);
+    delete this.lastMoveCoord;
 
     await this.hideShadowWidget();
     await this.set('dragging', null);

--- a/tests/testcafe/publiclibrary-2.js
+++ b/tests/testcafe/publiclibrary-2.js
@@ -1,5 +1,3 @@
-import { Selector } from 'testcafe';
-
 import { publicLibraryButtons } from './publiclibrary-util.js';
 import { setupTestEnvironment } from './test-util.js';
 
@@ -7,13 +5,13 @@ setupTestEnvironment();
 
 publicLibraryButtons('Reversi',            0, '35e0017570f9ecd206a2317c1528be36',
        [
-         [ ()=>Selector("#w_zpiece15"), ()=>Selector("#w_sq23") ],
-         [ ()=>Selector("#w_zpiece78"), ()=>Selector("#w_sq22") ],
-         [ ()=>Selector("#w_zpiece40"), ()=>Selector("#w_sq32") ],
-         [ ()=>Selector("#w_zpiece72"), ()=>Selector("#w_sq12") ],
-         [ ()=>Selector("#w_zpiece72"), ()=>Selector("#w_sq24") ],
-         [ ()=>Selector("#w_zpiece19"), ()=>Selector("#w_sq35") ],
-         [ ()=>Selector("#w_zpiece08"), ()=>Selector("#w_sq53") ]
+         [ 'zpiece15', 'sq23', true ],
+         [ 'zpiece78', 'sq22', true ],
+         [ 'zpiece40', 'sq32', true ],
+         [ 'zpiece72', 'sq12', false ], // not a legal move: the piece bounces back into the holder
+         [ 'zpiece72', 'sq24', true ],
+         [ 'zpiece19', 'sq35', true ],
+         [ 'zpiece08', 'sq53', true ]
        ]);
 publicLibraryButtons('Reward',             0, '5290d9113f42a3c0e458a788b5a1ea99', [
   'gmex', 'kprc', 'oksq', 'j1wz', 'vfhn', 'seat1', 'next'

--- a/tests/testcafe/publiclibrary-2.js
+++ b/tests/testcafe/publiclibrary-2.js
@@ -5,13 +5,13 @@ setupTestEnvironment();
 
 publicLibraryButtons('Reversi',            0, '35e0017570f9ecd206a2317c1528be36',
        [
-         [ 'zpiece15', 'sq23', true ],
-         [ 'zpiece78', 'sq22', true ],
-         [ 'zpiece40', 'sq32', true ],
-         [ 'zpiece72', 'sq12', false ], // not a legal move: the piece bounces back into the holder
-         [ 'zpiece72', 'sq24', true ],
-         [ 'zpiece19', 'sq35', true ],
-         [ 'zpiece08', 'sq53', true ]
+         { from: 'zpiece15', to: 'sq23', sticks: true  },
+         { from: 'zpiece78', to: 'sq22', sticks: true  },
+         { from: 'zpiece40', to: 'sq32', sticks: true  },
+         { from: 'zpiece72', to: 'sq12', sticks: false }, // not a legal move: the piece bounces back into the holder
+         { from: 'zpiece72', to: 'sq24', sticks: true  },
+         { from: 'zpiece19', to: 'sq35', sticks: true  },
+         { from: 'zpiece08', to: 'sq53', sticks: true  }
        ]);
 publicLibraryButtons('Reward',             0, '5290d9113f42a3c0e458a788b5a1ea99', [
   'gmex', 'kprc', 'oksq', 'j1wz', 'vfhn', 'seat1', 'next'

--- a/tests/testcafe/publiclibrary-util.js
+++ b/tests/testcafe/publiclibrary-util.js
@@ -40,7 +40,7 @@ export function publicLibraryButtons(game, variant, md5, tests) {
           // (whose turn it is, which squares are legal targets, ...), so let the game
           // finish evaluating that one before dropping the next piece - otherwise the
           // drop can be rejected and the test fails with an unrelated-looking hash.
-          await waitForStableState();
+          const stateBeforeDrag = await waitForStableState();
 
           const { from, to, sticks } = b;
           // dragged at full speed on purpose: that is the coarse pointer sampling
@@ -53,10 +53,12 @@ export function publicLibraryButtons(game, variant, md5, tests) {
           // wrong result is reported at the drag that caused it instead of surfacing
           // as an unrelated-looking state hash mismatch at the end of the test.
           if(sticks !== undefined) {
-            // wait for the game to finish reacting to the drop first - a rejected
-            // drop is only sent back once the game has evaluated it, so asserting
-            // right away would pass even if the piece was wrongly accepted
-            await waitForStableState();
+            // wait for the drag to reach the server and for the game to finish
+            // reacting to it - a rejected drop is only sent back once the game has
+            // evaluated it, so asserting right away would pass even if the piece was
+            // wrongly accepted (and 'stable' before the drop has even arrived says
+            // nothing at all)
+            await waitForStableState({ differentFrom: stateBeforeDrag });
             await t
               .expect(Selector(`#w_${escapeID(to)}`).find(`#w_${escapeID(from)}`).exists)
               .eql(sticks, `dragging ${from} onto ${to} should ${sticks ? '' : 'not '}have been accepted`);

--- a/tests/testcafe/publiclibrary-util.js
+++ b/tests/testcafe/publiclibrary-util.js
@@ -42,21 +42,24 @@ export function publicLibraryButtons(game, variant, md5, tests) {
           // drop can be rejected and the test fails with an unrelated-looking hash.
           await waitForStableState();
 
-          const [ from, to, expectDrop ] = b;
-          await t.dragToElement(`#w_${escapeID(from)}`, `#w_${escapeID(to)}`, { speed:0.5 });
+          const { from, to, sticks } = b;
+          // dragged at full speed on purpose: that is the coarse pointer sampling
+          // under which a drop used to be resolved against the square the piece had
+          // already been dragged away from
+          await t.dragToElement(`#w_${escapeID(from)}`, `#w_${escapeID(to)}`, { speed:1 });
 
           // Some games reject a drop and send the piece back. Where the test knows
           // whether the drop is supposed to be accepted, check it right here so a
           // wrong result is reported at the drag that caused it instead of surfacing
           // as an unrelated-looking state hash mismatch at the end of the test.
-          if(expectDrop !== undefined) {
+          if(sticks !== undefined) {
             // wait for the game to finish reacting to the drop first - a rejected
             // drop is only sent back once the game has evaluated it, so asserting
             // right away would pass even if the piece was wrongly accepted
             await waitForStableState();
             await t
               .expect(Selector(`#w_${escapeID(to)}`).find(`#w_${escapeID(from)}`).exists)
-              .eql(expectDrop, `dragging ${from} onto ${to} should ${expectDrop ? '' : 'not '}have been accepted`);
+              .eql(sticks, `dragging ${from} onto ${to} should ${sticks ? '' : 'not '}have been accepted`);
           }
         }
   });

--- a/tests/testcafe/publiclibrary-util.js
+++ b/tests/testcafe/publiclibrary-util.js
@@ -1,7 +1,7 @@
 import { Selector, ClientFunction } from 'testcafe';
 
 import { escapeID } from '../../client/js/domhelpers.js';
-import { compareState, prepareClient, setName } from './test-util.js';
+import { compareState, prepareClient, setName, waitForStableState } from './test-util.js';
 
 const tabHasActive = ClientFunction((index) => {
   const btns = document.querySelectorAll('.libraryTypeTabs button');
@@ -36,7 +36,23 @@ export function publicLibraryButtons(game, variant, md5, tests) {
             await t.click(`#w_${escapeID(b)}`);
           }
         } else {
-          await t.dragToElement(b[0](), b[1](), { speed:0.5 });
+          // A drag usually depends on the state the previous interaction left behind
+          // (whose turn it is, which squares are legal targets, ...), so let the game
+          // finish evaluating that one before dropping the next piece - otherwise the
+          // drop can be rejected and the test fails with an unrelated-looking hash.
+          await waitForStableState();
+
+          const [ from, to, expectDrop ] = b;
+          await t.dragToElement(`#w_${escapeID(from)}`, `#w_${escapeID(to)}`, { speed:0.5 });
+
+          // Some games reject a drop and send the piece back. Where the test knows
+          // whether the drop is supposed to be accepted, check it right here so a
+          // wrong result is reported at the drag that caused it instead of surfacing
+          // as an unrelated-looking state hash mismatch at the end of the test.
+          if(expectDrop !== undefined)
+            await t
+              .expect(Selector(`#w_${escapeID(to)}`).find(`#w_${escapeID(from)}`).exists)
+              .eql(expectDrop, `dragging ${from} onto ${to} should ${expectDrop ? '' : 'not '}have been accepted`);
         }
   });
 }

--- a/tests/testcafe/publiclibrary-util.js
+++ b/tests/testcafe/publiclibrary-util.js
@@ -49,10 +49,15 @@ export function publicLibraryButtons(game, variant, md5, tests) {
           // whether the drop is supposed to be accepted, check it right here so a
           // wrong result is reported at the drag that caused it instead of surfacing
           // as an unrelated-looking state hash mismatch at the end of the test.
-          if(expectDrop !== undefined)
+          if(expectDrop !== undefined) {
+            // wait for the game to finish reacting to the drop first - a rejected
+            // drop is only sent back once the game has evaluated it, so asserting
+            // right away would pass even if the piece was wrongly accepted
+            await waitForStableState();
             await t
               .expect(Selector(`#w_${escapeID(to)}`).find(`#w_${escapeID(from)}`).exists)
               .eql(expectDrop, `dragging ${from} onto ${to} should ${expectDrop ? '' : 'not '}have been accepted`);
+          }
         }
   });
 }

--- a/tests/testcafe/test-util.js
+++ b/tests/testcafe/test-util.js
@@ -58,6 +58,25 @@ export async function getState() {
   return await response.text();
 }
 
+// Wait until the room state stops changing, i.e. until every routine triggered by
+// the last interaction has finished. Without this, a test that performs multiple
+// interactions in a row can start the next one while the game is still evaluating
+// the previous one, which makes games that validate moves (like Reversi) reject it.
+export async function waitForStableState(timeout = 10000) {
+  const start = Date.now();
+  let previous = null;
+
+  while(Date.now() - start < timeout) {
+    const state = await getState();
+    if(state === previous)
+      return true;
+    previous = state;
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  return false;
+}
+
 export async function compareState(t, md5) {
   const refFile = `${referenceDir}/${md5}.json`;
   let hash = null;

--- a/tests/testcafe/test-util.js
+++ b/tests/testcafe/test-util.js
@@ -69,12 +69,14 @@ export async function waitForStableState(timeout = 10000) {
   while(Date.now() - start < timeout) {
     const state = await getState();
     if(state === previous)
-      return true;
+      return;
     previous = state;
     await new Promise(resolve => setTimeout(resolve, 100));
   }
 
-  return false;
+  // failing here points at the interaction that never settled instead of letting
+  // the test run on and fail with an unrelated-looking state hash mismatch later
+  throw new Error(`The room state was still changing after ${timeout}ms.`);
 }
 
 export async function compareState(t, md5) {

--- a/tests/testcafe/test-util.js
+++ b/tests/testcafe/test-util.js
@@ -59,24 +59,33 @@ export async function getState() {
 }
 
 // Wait until the room state stops changing, i.e. until every routine triggered by
-// the last interaction has finished. Without this, a test that performs multiple
-// interactions in a row can start the next one while the game is still evaluating
-// the previous one, which makes games that validate moves (like Reversi) reject it.
-export async function waitForStableState(timeout = 10000) {
+// the last interaction has finished, and return that stable state. Without this, a
+// test that performs multiple interactions in a row can start the next one while
+// the game is still evaluating the previous one, which makes games that validate
+// moves (like Reversi) reject it.
+//
+// Pass the state from before an interaction as `differentFrom` to also wait for it
+// to arrive: otherwise "stable" can just mean "the interaction has not reached the
+// server yet", which would make a negative assertion afterwards pass vacuously.
+export async function waitForStableState({ differentFrom = null, timeout = 10000 } = {}) {
   const start = Date.now();
   let previous = null;
+  let changed = differentFrom === null;
 
   while(Date.now() - start < timeout) {
     const state = await getState();
-    if(state === previous)
-      return;
+    if(!changed)
+      changed = state !== differentFrom;
+    else if(state === previous)
+      return state;
     previous = state;
     await new Promise(resolve => setTimeout(resolve, 100));
   }
 
   // failing here points at the interaction that never settled instead of letting
   // the test run on and fail with an unrelated-looking state hash mismatch later
-  throw new Error(`The room state was still changing after ${timeout}ms.`);
+  throw new Error(changed ? `The room state was still changing after ${timeout}ms.`
+                          : `The room state did not change at all within ${timeout}ms.`);
 }
 
 export async function compareState(t, md5) {


### PR DESCRIPTION
`Public library: Reversi (variant 0)` failed roughly **50% of the time** locally (10 runs on `main`: 5 hash mismatches). It is the only public-library test that drags pieces instead of clicking buttons, which is why it is the one that shows this — but the two causes behind it both hit real players as "my piece landed next to where I dropped it" or "the board just ate my piece".

## 1. Mouse events were not serialized

Mouse events are handled by an `async` `inputHandler` that is *not* serialized: `window.addEventListener` fires it for every `mousemove` and for `mouseup`, and each invocation `await`s its way through `move()` (position, `checkParent()`, hover-target hit testing, delta sending). So several handlers are in flight at once and can interleave.

`Widget.moveEnd()` drops the widget onto `this.hoverTarget`, which is whatever the *last fully processed* `move()` computed. Two things go wrong under load:

* `mouseup` can be handled while the final `mousemove` is still being processed, so the drop uses a hover target from somewhere along the drag path.
* A `mousemove` handler that is still pending when `moveEnd()` has already run then calls `move()` afterwards, dragging the piece back out of the square it was just dropped into.

Instrumented failing run:

```
MOVE zpiece19 -> sq35 ... now= {"pieceParent":"w_sq34"}
```

**Fix** (`client/js/mousehandling.js`): queue the per-drag `moveStart()`/`move()` calls on a promise chain stored on the widget's `mouseStatus`, and `await` that chain in the `mouseup` branch before calling `moveEnd()`. Moves are applied in event order and the drop always happens after the last of them. A move that a newer `mousemove` already superseded is skipped, the chain can never stay rejected, `mouseStatus` is deleted synchronously when the drop starts (so a `mousemove` delivered during a slow drop cannot re-enter the drag), and `batchEnd()` runs in a `finally` so a throwing routine can no longer leak a batch and stop the client from syncing.

Skipping a superseded move skips it whole, so the hover side effects it would have had — the `droptarget` highlight, the drop shadow entering and leaving a holder, and therefore that holder's `onEnter`/`enterRoutine` — do not run for it either. The last move of a drag always runs, so the end state is unchanged; a drag that sweeps quickly across a holder can now pass over it without that holder seeing the shadow, which is the same thing a lower pointer sampling rate already produced. Games that hang routines off a holder being hovered are the ones that can notice.

## 2. The drop was resolved against the widget's *rendered* position, which lags a whole mouse event behind

Found while addressing the UI/UX review, which showed a piece bouncing back into the holder on a coarse drag — on `main` as well.

`move()` hit tests the drop target with `document.elementsFromPoint()` at `center(this.domElement)`, i.e. it asks the DOM where the widget is. But every mouse event runs inside `batchStart()`/`batchEnd()` and a batched delta only reaches the DOM when the batch ends (`sendDelta()` does nothing while `batchDepth` is non-zero). So the hit test used the position of the **previous** mouse event:

```
DRAGDBG zpiece15 coord 719,297  center 671,283  hover sq22
DRAGDBG zpiece15 coord 788,314  center 738,299  hover sq22   <- last move: the piece is really at 805,315, on sq23
```

With fine pointer sampling the error stays inside the same holder; once a drag covers more than half a holder between two events it is a different square — the drop then goes to the square the piece has already left, which in Reversi is an illegal move and sends the piece back into the holder.

**Fix** (`client/js/widgets/widget.js`): flush the pending delta before the hit test when the DOM transform is stale — the same fix (and the same reason) `line.js` already uses for its stop geometry.

On top of that, a `mouseup` can arrive at coordinates no `mousemove` ever reported (a fast flick ends that way), and the drop was then resolved for the last reported position rather than for the one the player released over. `moveEnd()` now applies the release coordinates with a `move()` first when they differ, so the drop, the line stop and the final position all belong to where the button was released.

| mousemove events per drag | ≈ px per event | before | after |
|---|---|---|---|
| 25 | ~18px | ✅ `sq23` | ✅ `sq23` |
| 8 | ~69px | ❌ back to `holder0` | ✅ `sq23` |
| 5 | ~111px | ❌ | ✅ |
| 3 / 2 / 1 | ≥184px | ❌ | ✅ |
| release over `sq23` after the last mousemove was over `sq22` | – | ❌ resolved against `sq22` → `holder0` | ✅ `sq23` |

Runnable reproductions: [repro-drag.cjs](https://agent.virtualtabletop.io/reports/pr/1533690562639695985/repro/repro-drag.cjs), [repro-flick.cjs](https://agent.virtualtabletop.io/reports/pr/1533690562639695985/repro/repro-flick.cjs).

## Test changes

* `waitForStableState()` in `test-util.js` — polls the room state until it stops changing, and throws instead of failing silently. `publicLibraryButtons` calls it before each drag so a move is never made while the game is still evaluating the previous one, and before each drop assertion so a rejected drop has actually been evaluated.
* Drag steps are now `{ from, to, sticks }` entries instead of `Selector` thunks, and the test asserts right after the drag whether the piece stayed on the target — so a bad drag is reported where it happened instead of as a mystery hash mismatch at the end. The Reversi list documents that `zpiece72 -> sq12` is deliberately an illegal move.
* Those drags now run at `speed:1`, i.e. with the coarse pointer sampling that triggers cause 2. Without the fix the Reversi test fails 2 out of 3 runs; with it, 5 of 5 pass (and it is ~3× faster).

## Verification

Ran locally (Chromium headless):

* `npm test`: 90/90.
* Reversi: 12/12 with the ordering fix (3/6 and 5/10 on `main`), and 5/5 at `speed:1` with both fixes.
* Full `publiclibrary-1..4`, `editor.js`, `routines.js`: 39/39 pass — no reference hash is changed by the flush or by the release-coordinate move.

## beta label

`client/js/mousehandling.js` and `Widget.move()/moveEnd()` are engine code and this changes the order in which drag events are applied and which holder a drop resolves to, i.e. real engine behaviour, so I have added the `engine` label. It is a strict tightening with no state-format change and the full TestCafe suite passes, so it should be safe for beta once a reviewer agrees.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3092/pr-test (or any other room on that server)

