### PR TITLE
Click-to-select for cards in a holder (#2549)

### DIFF
--- a/.github/workflows/testcafe-chrome.yml
+++ b/.github/workflows/testcafe-chrome.yml
@@ -29,6 +29,7 @@ jobs:
           - publiclibrary-3.js
           - publiclibrary-4.js
           - routines.js
+          - multiselect.js
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/testcafe-firefox.yml
+++ b/.github/workflows/testcafe-firefox.yml
@@ -29,6 +29,7 @@ jobs:
           - publiclibrary-3.js
           - publiclibrary-4.js
           - routines.js
+          - multiselect.js
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/client/css/widgets/holder.css
+++ b/client/css/widgets/holder.css
@@ -85,3 +85,23 @@
   position: absolute;
   box-sizing: border-box;
 }
+
+/*
+ * click-to-select: a holder with multiSelectMax lets players pick the widgets in it
+ * by clicking. The picked ones carry the multiSelected class for the player who
+ * picked them, the holder carries multiSelect-<multiSelectStyle> and decides how that
+ * looks. Games that want something of their own set multiSelectStyle to "none" and
+ * style .multiSelected through the holder's css property.
+ */
+.multiSelect-elevate .widget.multiSelected {
+  translate: 0 -14px;
+  filter: drop-shadow(0 4px 4px rgba(0, 0, 0, 0.45));
+}
+
+.multiSelect-highlight .widget.multiSelected {
+  box-shadow: 0 0 0 3px #f5c518, 0 0 8px 4px rgba(245, 197, 24, 0.7);
+}
+
+.multiSelect-shade .widget.multiSelected {
+  filter: brightness(0.65);
+}

--- a/client/css/widgets/holder.css
+++ b/client/css/widgets/holder.css
@@ -114,16 +114,22 @@
 /* the picks stand out because everything else steps back - a darkened widget means
    "unavailable" everywhere else in the app, so dimming the picked ones would read
    backwards. A widget holding a pick (a pile) is left alone, dimming it would dim
-   the pick inside it. Nothing is dimmed while the player has not picked anything. */
-.multiSelect-shade:has(.multiSelected) .widget:not(.multiSelected):not(:has(.multiSelected)) {
+   the pick inside it - its other children are dimmed one level down instead. Nothing
+   is dimmed while the player has not picked anything. Both rules stay on one level of
+   children: a filter already applies to everything inside the widget it dims, so
+   matching nested widgets as well would only darken them a second time. */
+.multiSelect-shade:has(.multiSelected) > .widget:not(.multiSelected):not(:has(.multiSelected)),
+.multiSelect-shade:has(.multiSelected) > .widget:has(.multiSelected) > .widget:not(.multiSelected) {
   filter: brightness(0.65) !important;
 }
 
 /* until the first click nothing tells the player that this holder reacts to clicks,
-   so widgets in it answer the pointer with a hint of the ring they would get */
-.multiSelect-elevate .widget:not(.multiSelected):hover,
-.multiSelect-highlight .widget:not(.multiSelected):hover,
-.multiSelect-shade .widget:not(.multiSelected):hover {
+   so widgets in it answer the pointer with a hint of the ring they would get. A pile
+   is not one of them (its click opens the pile overlay), and :hover reaches every
+   ancestor, so this stays on the holder's own children. */
+.multiSelect-elevate > .widget:not(.pile):not(.multiSelected):hover,
+.multiSelect-highlight > .widget:not(.pile):not(.multiSelected):hover,
+.multiSelect-shade > .widget:not(.pile):not(.multiSelected):hover {
   box-shadow: 0 0 0 2px rgba(31, 92, 166, 0.45);
 }
 

--- a/client/css/widgets/holder.css
+++ b/client/css/widgets/holder.css
@@ -97,15 +97,44 @@
  * important: a card that dims itself with a filter must not be able to hide the fact
  * that the player selected it. Use the "none" style to take that decision yourself.
  */
+/* the raise is relative so that it stays a nudge on a card and on a small token alike,
+   and the ring keeps the pick readable when the whole holder is selected and every
+   widget in it is raised by the same amount */
 .multiSelect-elevate .widget.multiSelected {
-  translate: 0 -14px !important;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.45) !important;
+  translate: 0 -10% !important;
+  box-shadow: 0 0 0 2px var(--VTTblue), 0 4px 6px rgba(0, 0, 0, 0.45) !important;
 }
 
+/* VTTblue is the colour the app already uses for "the player chose this" (the INPUT
+   dialog): a gold ring would read as edit mode's yellow selection ring instead */
 .multiSelect-highlight .widget.multiSelected {
-  box-shadow: 0 0 0 3px #f5c518, 0 0 8px 4px rgba(245, 197, 24, 0.7) !important;
+  box-shadow: 0 0 0 3px var(--VTTblue), 0 0 8px 4px rgba(31, 92, 166, 0.6) !important;
 }
 
-.multiSelect-shade .widget.multiSelected {
+/* the picks stand out because everything else steps back - a darkened widget means
+   "unavailable" everywhere else in the app, so dimming the picked ones would read
+   backwards. A widget holding a pick (a pile) is left alone, dimming it would dim
+   the pick inside it. Nothing is dimmed while the player has not picked anything. */
+.multiSelect-shade:has(.multiSelected) .widget:not(.multiSelected):not(:has(.multiSelected)) {
   filter: brightness(0.65) !important;
+}
+
+/* until the first click nothing tells the player that this holder reacts to clicks,
+   so widgets in it answer the pointer with a hint of the ring they would get */
+.multiSelect-elevate .widget:not(.multiSelected):hover,
+.multiSelect-highlight .widget:not(.multiSelected):hover,
+.multiSelect-shade .widget:not(.multiSelected):hover {
+  box-shadow: 0 0 0 2px rgba(31, 92, 166, 0.45);
+}
+
+/* clicking while the selection is full does nothing, which looks like a broken game.
+   The holder flashes instead, to say that the click arrived and the limit is the
+   reason. Marked as an animation so a holder that styles itself cannot swallow it. */
+.widget.multiSelectFull {
+  animation: multiSelectFull 0.4s ease-in-out;
+}
+
+@keyframes multiSelectFull {
+  0%, 100% { box-shadow: none; }
+  50% { box-shadow: inset 0 0 0 4px rgba(31, 92, 166, 0.8); }
 }

--- a/client/css/widgets/holder.css
+++ b/client/css/widgets/holder.css
@@ -92,16 +92,20 @@
  * picked them, the holder carries multiSelect-<multiSelectStyle> and decides how that
  * looks. Games that want something of their own set multiSelectStyle to "none" and
  * style .multiSelected through the holder's css property.
+ *
+ * The css property of a widget ends up as an inline style, so these rules are marked
+ * important: a card that dims itself with a filter must not be able to hide the fact
+ * that the player selected it. Use the "none" style to take that decision yourself.
  */
 .multiSelect-elevate .widget.multiSelected {
-  translate: 0 -14px;
-  filter: drop-shadow(0 4px 4px rgba(0, 0, 0, 0.45));
+  translate: 0 -14px !important;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.45) !important;
 }
 
 .multiSelect-highlight .widget.multiSelected {
-  box-shadow: 0 0 0 3px #f5c518, 0 0 8px 4px rgba(245, 197, 24, 0.7);
+  box-shadow: 0 0 0 3px #f5c518, 0 0 8px 4px rgba(245, 197, 24, 0.7) !important;
 }
 
 .multiSelect-shade .widget.multiSelected {
-  filter: brightness(0.65);
+  filter: brightness(0.65) !important;
 }

--- a/client/js/editor/propertyInputs.js
+++ b/client/js/editor/propertyInputs.js
@@ -588,6 +588,7 @@ class CheckboxInput extends PropertyInput {
 
 class SelectInput extends PropertyInput {
   // options.choices: [ { value, text } ]
+  // options.customText: value => label for values that are not among the choices
   cssClass() {
     return 'selectInput';
   }
@@ -618,7 +619,7 @@ class SelectInput extends PropertyInput {
         this.select.appendChild(this.customOption);
       }
       this.customOption.value = jsonValue;
-      this.customOption.textContent = `custom: ${jsonValue}`;
+      this.customOption.textContent = this.options.customText ? this.options.customText(value) : `custom: ${jsonValue}`;
     }
     this.select.value = jsonValue;
   }

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -401,7 +401,7 @@ const editorPropertyHints = {
   dropOffsetY: 'Vertical starting position for widgets aligned inside the holder.',
   stackOffsetX: 'Horizontal distance added between consecutively stacked widgets.',
   stackOffsetY: 'Vertical distance added between consecutively stacked widgets.',
-  multiSelectMax: 'Let players pick widgets in this holder by clicking them, up to this many each - or "any number" for no limit. The picked ones get the clicking player\'s name in their selectedBy property, which automations can read. Works best when the holder spreads its widgets out (see Stack offset X/Y): stacked on one spot only the top one can be clicked.',
+  multiSelectMax: 'Let players pick widgets in this holder by clicking them, up to this many each - or "any number" for no limit. The picked ones get the clicking player\'s name in their selectedBy property, which automations can read. Works best when the holder spreads its widgets out (see Stack offset X/Y): stacked on one spot only the top one can be clicked. All players share the one selectedBy list, so in a holder several players pick from at the same time, two clicks on the same widget in the same moment can cost one of them their pick.',
   multiSelectStyle: 'How a widget the player picked is shown. The built-in styles win over a filter or shadow the widget sets itself, so a widget cannot hide that it was picked (which also means it loses its own shadow while picked); "own CSS" only sets the multiSelected class so the holder css can style it.',
   showPlayerColors: 'Use each player\'s color in their scoreboard heading.',
   verticalHeader: 'Rotate the scoreboard header text vertically.',

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -401,8 +401,8 @@ const editorPropertyHints = {
   dropOffsetY: 'Vertical starting position for widgets aligned inside the holder.',
   stackOffsetX: 'Horizontal distance added between consecutively stacked widgets.',
   stackOffsetY: 'Vertical distance added between consecutively stacked widgets.',
-  multiSelectMax: 'Let players pick widgets in this holder by clicking them, up to this many each. The picked ones get the clicking player\'s name in their selectedBy property, which automations can read.',
-  multiSelectStyle: 'How a widget the player picked is shown. The built-in styles win over a filter or shadow the widget sets itself; "custom CSS" only sets the multiSelected class so the holder css can style it.',
+  multiSelectMax: 'Let players pick widgets in this holder by clicking them, up to this many each - or "any number" for no limit. The picked ones get the clicking player\'s name in their selectedBy property, which automations can read. Works best when the holder spreads its widgets out (see Stack offset X/Y): stacked on one spot only the top one can be clicked.',
+  multiSelectStyle: 'How a widget the player picked is shown. The built-in styles win over a filter or shadow the widget sets itself, so a widget cannot hide that it was picked (which also means it loses its own shadow while picked); "own CSS" only sets the multiSelected class so the holder css can style it.',
   showPlayerColors: 'Use each player\'s color in their scoreboard heading.',
   verticalHeader: 'Rotate the scoreboard header text vertically.',
   autosizeColumns: 'Size score columns from their contents instead of using fixed widths.',
@@ -5972,6 +5972,7 @@ class PropertiesModule extends SidebarModule {
         { value: 'all', text: 'any number' },
         { value: 'custom', text: 'up to...' }
       ],
+      customText: value => +value > 0 ? `up to ${Math.floor(+value)}` : `custom: ${JSON.stringify(value)}`,
       setValue: value => {
         if(value === 'custom') {
           const entered = parseInt(prompt('How many widgets may one player select in this holder?', widget.get('multiSelectMax')));
@@ -5989,15 +5990,19 @@ class PropertiesModule extends SidebarModule {
     const styleInput = new SelectInput(this, widget, 'Selection shown as', {
       property: 'multiSelectStyle',
       hint: editorPropertyHints.multiSelectStyle,
+      // the raw values are in the labels because the JSON editor and the wiki know the
+      // property by those, not by the words this dropdown uses
       choices: [
-        { value: 'elevate',   text: 'raised' },
-        { value: 'highlight', text: 'outlined' },
-        { value: 'shade',     text: 'darkened' },
-        { value: 'none',      text: 'custom CSS' }
+        { value: 'elevate',   text: 'raised (elevate)' },
+        { value: 'highlight', text: 'outlined (highlight)' },
+        { value: 'shade',     text: 'others dimmed (shade)' },
+        { value: 'none',      text: 'own CSS (none)' }
       ]
     });
     styleInput.render(row);
-    this.addPropertyListener(widget, 'multiSelectMax', w => styleInput.dom.style.display = w.get('multiSelectMax') ? '' : 'none');
+    // multiSelectLimit(), not the raw value: a routine-computed "0" is a string and
+    // turns click-to-select off, so the style row has to disappear along with it
+    this.addPropertyListener(widget, 'multiSelectMax', w => styleInput.dom.style.display = w.multiSelectLimit() ? '' : 'none');
   }
 
   // Text / background / border color plus a brightness filter written into a

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -401,6 +401,8 @@ const editorPropertyHints = {
   dropOffsetY: 'Vertical starting position for widgets aligned inside the holder.',
   stackOffsetX: 'Horizontal distance added between consecutively stacked widgets.',
   stackOffsetY: 'Vertical distance added between consecutively stacked widgets.',
+  multiSelectMax: 'Let players pick widgets in this holder by clicking them, up to this many each. The picked ones get the clicking player\'s name in their selectedBy property, which automations can read.',
+  multiSelectStyle: 'How a widget the player picked is shown. "custom CSS" only sets the multiSelected class so the holder css can style it.',
   showPlayerColors: 'Use each player\'s color in their scoreboard heading.',
   verticalHeader: 'Rotate the scoreboard header text vertically.',
   autosizeColumns: 'Size score columns from their contents instead of using fixed widths.',
@@ -5942,6 +5944,7 @@ class PropertiesModule extends SidebarModule {
       { label: 'X', property: 'stackOffsetX' },
       { label: 'Y', property: 'stackOffsetY' }
     ]);
+    this.renderMultiSelectRow(widget);
 
     this.renderAdvancedSection(widget, body => {
       this.renderSeatReferenceInput(widget, 'showInactiveFaceToSeat', 'Show inactive face to seat:', body, {
@@ -5952,7 +5955,49 @@ class PropertiesModule extends SidebarModule {
     });
 
     // onEnter / onLeave stay in the generic property list (handled in PR #3034)
-    this.renderOtherPropertiesSection(widget, [ 'dropTarget', 'text', 'icon', 'image', 'dropOffsetX', 'dropOffsetY', 'stackOffsetX', 'stackOffsetY', 'showInactiveFaceToSeat' ]);
+    this.renderOtherPropertiesSection(widget, [ 'dropTarget', 'text', 'icon', 'image', 'dropOffsetX', 'dropOffsetY', 'stackOffsetX', 'stackOffsetY', 'showInactiveFaceToSeat', 'multiSelectMax', 'multiSelectStyle' ]);
+  }
+
+  // Click-to-select: how many widgets a player can pick in this holder by clicking
+  // them, and what a picked widget looks like. The style only matters once picking
+  // is enabled, so it stays hidden while the limit is 0.
+  renderMultiSelectRow(widget) {
+    const row = div(this.moduleDOM, 'propertyInlineRow');
+    const maxInput = new SelectInput(this, widget, 'Click to select', {
+      property: 'multiSelectMax',
+      hint: editorPropertyHints.multiSelectMax,
+      choices: [
+        { value: 0, text: 'off' },
+        { value: 1, text: 'one at a time' },
+        { value: 'all', text: 'any number' },
+        { value: 'custom', text: 'up to...' }
+      ],
+      setValue: value => {
+        if(value === 'custom') {
+          const entered = parseInt(prompt('How many widgets may one player select in this holder?', widget.get('multiSelectMax')));
+          if(Number.isFinite(entered) && entered > 0)
+            this.inputValueUpdated(widget, 'multiSelectMax', entered);
+          else
+            maxInput.update(widget.get('multiSelectMax')); // snap the dropdown back
+        } else {
+          this.inputValueUpdated(widget, 'multiSelectMax', value);
+        }
+      }
+    });
+    maxInput.render(row);
+
+    const styleInput = new SelectInput(this, widget, 'Selection shown as', {
+      property: 'multiSelectStyle',
+      hint: editorPropertyHints.multiSelectStyle,
+      choices: [
+        { value: 'elevate',   text: 'raised' },
+        { value: 'highlight', text: 'outlined' },
+        { value: 'shade',     text: 'darkened' },
+        { value: 'none',      text: 'custom CSS' }
+      ]
+    });
+    styleInput.render(row);
+    this.addPropertyListener(widget, 'multiSelectMax', w => styleInput.dom.style.display = w.get('multiSelectMax') ? '' : 'none');
   }
 
   // Text / background / border color plus a brightness filter written into a

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -402,7 +402,7 @@ const editorPropertyHints = {
   stackOffsetX: 'Horizontal distance added between consecutively stacked widgets.',
   stackOffsetY: 'Vertical distance added between consecutively stacked widgets.',
   multiSelectMax: 'Let players pick widgets in this holder by clicking them, up to this many each. The picked ones get the clicking player\'s name in their selectedBy property, which automations can read.',
-  multiSelectStyle: 'How a widget the player picked is shown. "custom CSS" only sets the multiSelected class so the holder css can style it.',
+  multiSelectStyle: 'How a widget the player picked is shown. The built-in styles win over a filter or shadow the widget sets itself; "custom CSS" only sets the multiSelected class so the holder css can style it.',
   showPlayerColors: 'Use each player\'s color in their scoreboard heading.',
   verticalHeader: 'Rotate the scoreboard header text vertically.',
   autosizeColumns: 'Size score columns from their contents instead of using fixed widths.',

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1499,8 +1499,8 @@ function jeAddCommands() {
   jeAddEnumCommands('^.*\\((SELECT|TURN)\\) ↦ source', collectionNames);
   jeAddEnumCommands('^.*\\(COUNT\\) ↦ owner', [ '${}' ]);
   jeAddEnumCommands('^scoreboard ↦ sortField',['index', 'player', 'total']);
-  jeAddEnumCommands('^holder ↦ multiSelectMax', [ 0, 1, 'all' ]);
-  jeAddEnumCommands('^holder ↦ multiSelectStyle', [ 'elevate', 'highlight', 'shade', 'none' ]);
+  jeAddEnumCommands('^.* ↦ multiSelectMax', [ 0, 1, 'all' ]);
+  jeAddEnumCommands('^.* ↦ multiSelectStyle', [ 'elevate', 'highlight', 'shade', 'none' ]);
 
   jeAddNumberCommand('increment number', '+', x=>x+1);
   jeAddNumberCommand('decrement number', '-', x=>x-1);

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -1484,7 +1484,7 @@ function jeAddCommands() {
   jeAddEnumCommands('^.*\\(ROTATE\\) ↦ count', [ 1, 'all' ]);
   jeAddEnumCommands('^.*\\(SCORE\\) ↦ mode', [ 'set', 'inc', 'dec' ]);
   jeAddEnumCommands('^.*\\(SELECT\\) ↦ mode', [ 'set', 'add', 'remove', 'intersect' ]);
-  jeAddEnumCommands('^.*\\(SELECT\\) ↦ relation', [ '<', '<=', '==', '!=', '>', '>=', 'in' ]);
+  jeAddEnumCommands('^.*\\(SELECT\\) ↦ relation', [ '<', '<=', '==', '!=', '>', '>=', 'in', 'contains' ]);
   jeAddEnumCommands('^.*\\(SELECT\\) ↦ type', widgetTypes);
   jeAddEnumCommands('^.*\\(SET\\) ↦ relation', [ '+', '-', '=', "*", "/",'!' ]);
   jeAddEnumCommands('^.*\\(SHUFFLE\\) ↦ mode', [ 'true random', 'overhand', 'riffle', 'reverse', 'seeded' ]);
@@ -1499,6 +1499,8 @@ function jeAddCommands() {
   jeAddEnumCommands('^.*\\((SELECT|TURN)\\) ↦ source', collectionNames);
   jeAddEnumCommands('^.*\\(COUNT\\) ↦ owner', [ '${}' ]);
   jeAddEnumCommands('^scoreboard ↦ sortField',['index', 'player', 'total']);
+  jeAddEnumCommands('^holder ↦ multiSelectMax', [ 0, 1, 'all' ]);
+  jeAddEnumCommands('^holder ↦ multiSelectStyle', [ 'elevate', 'highlight', 'shade', 'none' ]);
 
   jeAddNumberCommand('increment number', '+', x=>x+1);
   jeAddNumberCommand('decrement number', '-', x=>x-1);

--- a/client/js/widgets/holder.js
+++ b/client/js/widgets/holder.js
@@ -22,6 +22,9 @@ class Holder extends ImageWidget {
       childrenPerOwner: false,
       showInactiveFaceToSeat: null,
 
+      multiSelectMax: 0,
+      multiSelectStyle: 'elevate',
+
       onEnter: {},
       onLeave: {},
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -605,11 +605,24 @@ export class Widget extends StateManaged {
       for(const w of others)
         await w.setMultiSelected(false);
     } else if(others.length >= limit) {
+      holder.flashMultiSelectFull();
       return true;
     }
 
     await this.setMultiSelected(true);
     return true;
+  }
+
+  // A click that runs into the limit changes nothing, which looks like a game that
+  // stopped reacting. Flash the holder instead, so that the player sees the click
+  // arrive and can tell that the selection being full is the reason.
+  flashMultiSelectFull() {
+    if(!this.domElement)
+      return;
+    this.domElement.classList.remove('multiSelectFull');
+    this.domElement.offsetWidth; // restart the animation while the player keeps clicking
+    this.domElement.classList.add('multiSelectFull');
+    setTimeout(_=>this.domElement.classList.remove('multiSelectFull'), 400);
   }
 
   async clone(overrideProperties, recursive = false, problems = null, xOffset = 0, yOffset = 0) {
@@ -2842,10 +2855,28 @@ export class Widget extends StateManaged {
   // How far apart the widgets that follow a drag are laid out. Most holders stack their
   // children on one spot (stackOffset defaults to 0), so fall back to the width of the
   // dragged widget - otherwise the whole selection would travel and land on one point.
-  multiSelectSpread(source) {
-    const x = +source.get('stackOffsetX') || 0;
-    const y = +source.get('stackOffsetY') || 0;
-    return x || y ? { x, y } : { x: +this.get('width') || 100, y: 0 };
+  multiSelectSpread(source, count) {
+    let x = +source.get('stackOffsetX') || 0;
+    let y = +source.get('stackOffsetY') || 0;
+    if(!x && !y)
+      x = +this.get('width') || 100;
+    return {
+      x: this.fitMultiSelectSpread(x, count, this.absoluteCoord('x'), +this.get('width') || 0, 1600),
+      y: this.fitMultiSelectSpread(y, count, this.absoluteCoord('y'), +this.get('height') || 0, 1000)
+    };
+  }
+
+  // One axis of that fan, kept on the surface: a selection dragged towards the right
+  // edge fans out to the left instead of off-screen, and one that fits on neither side
+  // moves closer together, so that the drag keeps showing what is about to be dropped.
+  fitMultiSelectSpread(offset, count, start, extent, size) {
+    if(!offset || count < 1)
+      return offset;
+    const before = Math.max(0, start);
+    const after = Math.max(0, size - extent - start);
+    if(Math.abs(offset)*count <= (offset > 0 ? after : before))
+      return offset;
+    return (after >= before ? 1 : -1) * Math.min(Math.abs(offset), Math.max(before, after)/count);
   }
 
   // As soon as the drag has taken this widget out of the holder, the rest of the local
@@ -2871,7 +2902,7 @@ export class Widget extends StateManaged {
 
     // absoluteCoord, because a widget that just became the stop of a line is no longer
     // in the same coordinate system as the followers, which stay on the surface
-    const spread = this.multiSelectSpread(source);
+    const spread = this.multiSelectSpread(source, this.multiSelectPicked.length);
     const x = this.absoluteCoord('x');
     const y = this.absoluteCoord('y');
     let i = 1;

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -116,6 +116,7 @@ export class Widget extends StateManaged {
       inheritFrom: null,
       owner: null,
       dragging: null,
+      selectedBy: [],
       dropOffsetX: 0,
       dropOffsetY: 0,
       dropShadowOwner: null,
@@ -429,6 +430,9 @@ export class Widget extends StateManaged {
 
   async checkParent(forceDetach) {
     if(this.currentParent && (forceDetach || !overlap(this.domElement, this.currentParent.domElement))) {
+      // a selection only means something while the widget sits in the holder that offers it
+      if(this.currentParent.multiSelectLimit() && asArray(this.get('selectedBy')).length)
+        await this.set('selectedBy', []);
       await this.set('parent', null);
       await this.set('hoverParent', null);
       if(this.currentParent.get('childrenPerOwner'))
@@ -482,6 +486,12 @@ export class Widget extends StateManaged {
     if (this.get('dropShadowOwner'))
       className += ' dragging-shadow';
 
+    // click-to-select only shows the local player their own selection
+    if(asArray(this.get('selectedBy')).indexOf(playerName) != -1)
+      className += ' multiSelected';
+    if(this.multiSelectLimit())
+      className += ' multiSelect-' + String(this.get('multiSelectStyle')).replace(/[^a-z]/gi, '');
+
     if(this.get('clickable'))
       className += ' clickable';
 
@@ -504,7 +514,7 @@ export class Widget extends StateManaged {
   }
 
   classesProperties() {
-    return [ 'classes', 'display', 'dragging', 'dropShadowOwner', 'hoverTarget', 'hoverParent', 'linkedToSeat', 'onlyVisibleForSeat', 'owner', 'typeClasses', 'movable', 'enlarge', 'clickable' ];
+    return [ 'classes', 'display', 'dragging', 'dropShadowOwner', 'hoverTarget', 'hoverParent', 'linkedToSeat', 'multiSelectMax', 'multiSelectStyle', 'onlyVisibleForSeat', 'owner', 'selectedBy', 'typeClasses', 'movable', 'enlarge', 'clickable' ];
   }
 
   async click(mode='respect') {
@@ -524,12 +534,78 @@ export class Widget extends StateManaged {
       });
     }
 
+    // a holder with multiSelectMax takes over the clicks on the widgets it holds: they
+    // toggle the selection instead of running clickRoutine or flipping a card. A CLICK
+    // operation that asks to skip the click routine skips the selection along with it.
+    if(!(mode == 'ignoreClickRoutine' || mode == 'ignoreAll') && await this.toggleMultiSelect())
+      return true;
+
     if(Array.isArray(this.get('clickRoutine')) && !(mode == 'ignoreClickRoutine' || mode =='ignoreAll')) {
       await this.evaluateRoutine('clickRoutine', {}, {});
       return true;
     } else {
       return false;
     }
+  }
+
+  // How many widgets one player may have selected inside this one at a time. 0 - the
+  // default - means click-to-select is off. multiSelectMax is a holder property, but
+  // the check lives here so that every kind of parent behaves the same way.
+  multiSelectLimit() {
+    const max = this.get('multiSelectMax');
+    if(max === 'all')
+      return Infinity;
+    return typeof max == 'number' && max > 0 ? Math.floor(max) : 0;
+  }
+
+  multiSelectedWidgets(player) {
+    return widgetFilter(w=>w.get('_ancestor') == this.get('id') && asArray(w.get('selectedBy')).indexOf(player) != -1);
+  }
+
+  // The holder that governs click-to-select for this widget, or null. Cards inside
+  // a pile inside the holder are governed by that holder as well (_ancestor skips piles).
+  multiSelectHolder() {
+    const parent = widgets.get(this.get('_ancestor'));
+    return parent && parent.multiSelectLimit() ? parent : null;
+  }
+
+  isMultiSelected() {
+    return asArray(this.get('selectedBy')).indexOf(playerName) != -1;
+  }
+
+  async setMultiSelected(selected) {
+    const players = asArray(this.get('selectedBy')).filter(p=>p != playerName);
+    if(selected)
+      players.push(playerName);
+    await this.set('selectedBy', players);
+  }
+
+  // Add or remove this widget from the local player's selection. Returns true if the
+  // click was consumed, which is the case whenever a holder enables click-to-select -
+  // clicking while the limit is reached does nothing so that a full selection stays put.
+  async toggleMultiSelect() {
+    const holder = this.multiSelectHolder();
+    if(!holder)
+      return false;
+
+    if(this.isMultiSelected()) {
+      await this.setMultiSelected(false);
+      return true;
+    }
+
+    const others = holder.multiSelectedWidgets(playerName).filter(w=>w != this);
+    const limit = holder.multiSelectLimit();
+    if(limit == 1) {
+      // picking one of several is the common case for "play this card next", so the
+      // previous pick gives way instead of forcing the player to deselect it first
+      for(const w of others)
+        await w.setMultiSelected(false);
+    } else if(others.length >= limit) {
+      return true;
+    }
+
+    await this.setMultiSelected(true);
+    return true;
   }
 
   async clone(overrideProperties, recursive = false, problems = null, xOffset = 0, yOffset = 0) {
@@ -1920,6 +1996,9 @@ export class Widget extends StateManaged {
               return w.get(a.property) > a.value;
             else if(a.relation === 'in' && Array.isArray(a.value))
               return a.value.indexOf(w.get(a.property)) != -1;
+            // the mirror image of 'in': the property is the list, e.g. selectedBy or owner
+            else if(a.relation === 'contains')
+              return asArray(w.get(a.property)).indexOf(a.value) != -1;
             if(a.relation != '==')
               problems.push(`Warning: Relation ${a.relation} interpreted as ==.`);
             return w.get(a.property) === a.value;
@@ -2492,6 +2571,12 @@ export class Widget extends StateManaged {
     if(tracingEnabled)
       sendTraceEvent('moveStart', { id: this.get('id') });
 
+    // Dragging one of the widgets the local player selected takes the rest of the
+    // selection along - they follow to wherever this one is dropped. Collected before
+    // the drag detaches this widget from the holder, which is what clears its selection.
+    this.multiSelectSource = this.isMultiSelected() ? this.multiSelectHolder() : null;
+    this.multiSelectDrag = this.multiSelectSource ? this.multiSelectSource.multiSelectedWidgets(playerName).filter(w=>w != this && w.get('movable')) : [];
+
     await this.bringToFront();
     await this.set('dragging', playerName);
     delete this.lastMoveCoord;
@@ -2737,12 +2822,47 @@ export class Widget extends StateManaged {
     }
 
     await this.applyLineStopDrop(stopDropTarget);
+    await this.moveMultiSelectionAlong();
 
     this.hideEnlarged();
     if(this.domElement.classList.contains('longtouch'))
       this.domElement.classList.remove('longtouch');
 
     await this.updatePiles();
+  }
+
+  // The rest of the local player's selection follows the widget that was just dragged
+  // out of the holder: into the same holder it was dropped into, or onto the surface
+  // next to it - there they keep the spacing the holder gave them so that everybody
+  // can see what was played.
+  async moveMultiSelectionAlong() {
+    const others = this.multiSelectDrag || [];
+    const source = this.multiSelectSource;
+    delete this.multiSelectDrag;
+    delete this.multiSelectSource;
+
+    const targetID = this.get('parent');
+    const target = widgets.has(targetID) ? widgets.get(targetID) : null;
+    if(!others.length || !source || target == source || target && target.get('type') == 'line')
+      return;
+
+    const offsetX = +source.get('stackOffsetX') || 0;
+    const offsetY = +source.get('stackOffsetY') || 0;
+    let i = 1;
+    for(const w of others) {
+      if(!widgets.has(w.get('id')) || w.get('_ancestor') != source.get('id'))
+        continue;
+      if(target) {
+        w.movedByButton = true;
+        await w.moveToHolder(target);
+        delete w.movedByButton;
+      } else {
+        w.currentParent = source;
+        await w.checkParent(true);
+        await w.setPosition(this.get('x') + offsetX*i, this.get('y') + offsetY*i, this.get('z') + i);
+      }
+      ++i;
+    }
   }
 
   async hideShadowWidget() {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -570,9 +570,27 @@ export class Widget extends StateManaged {
 
   // The holder that governs click-to-select for this widget, or null. Cards inside
   // a pile inside the holder are governed by that holder as well (_ancestor skips piles).
+  // A pile has that same _ancestor, but it is the stack of what can be picked rather
+  // than something to pick, so it keeps its own click (which opens the pile overlay).
   multiSelectHolder() {
+    if(this.get('type') == 'pile')
+      return null;
     const parent = widgets.get(this.get('_ancestor'));
     return parent && parent.multiSelectLimit() ? parent : null;
+  }
+
+  // A player who leaves the room or renames themselves leaves their name behind on
+  // everything they had picked, where it would keep eating a multiSelectMax slot and
+  // keep being collected by a routine reading selectedBy. Drop the names of players
+  // who are gone whenever somebody uses this holder again.
+  async clearStaleMultiSelections(players = activePlayers) {
+    if(!players.length) // no player list yet - assume everybody is still here
+      return;
+    for(const w of widgetFilter(w=>w.get('_ancestor') == this.get('id') && Array.isArray(w.get('selectedBy')) && w.get('selectedBy').length)) {
+      const remaining = w.get('selectedBy').filter(p=>p == playerName || players.indexOf(p) != -1);
+      if(remaining.length != w.get('selectedBy').length)
+        await w.set('selectedBy', remaining);
+    }
   }
 
   isMultiSelected() {
@@ -593,6 +611,8 @@ export class Widget extends StateManaged {
     const holder = this.multiSelectHolder();
     if(!holder)
       return false;
+
+    await holder.clearStaleMultiSelections();
 
     if(this.isMultiSelected()) {
       await this.setMultiSelected(false);
@@ -621,10 +641,11 @@ export class Widget extends StateManaged {
   flashMultiSelectFull() {
     if(!this.domElement)
       return;
+    clearTimeout(this.multiSelectFullTimeout); // else the previous timer ends this flash early
     this.domElement.classList.remove('multiSelectFull');
     this.domElement.offsetWidth; // restart the animation while the player keeps clicking
     this.domElement.classList.add('multiSelectFull');
-    setTimeout(_=>this.domElement.classList.remove('multiSelectFull'), 400);
+    this.multiSelectFullTimeout = setTimeout(_=>this.domElement.classList.remove('multiSelectFull'), 400);
   }
 
   async clone(overrideProperties, recursive = false, problems = null, xOffset = 0, yOffset = 0) {
@@ -2909,7 +2930,8 @@ export class Widget extends StateManaged {
     const y = this.absoluteCoord('y');
     let i = 1;
     for(const w of this.multiSelectPicked) {
-      await w.setPosition(x + spread.x*i, y + spread.y*i, this.get('z') + i);
+      // descending z, so that the widget under the cursor stays the top one of the fan
+      await w.setPosition(x + spread.x*i, y + spread.y*i, this.get('z') - i);
       ++i;
     }
   }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2,7 +2,7 @@ import { $, removeFromDOM, asArray, escapeID, mapAssetURLs, timeToMS } from '../
 import { StateManaged } from '../statemanaged.js';
 import { playerName, playerColor, activePlayers, activeColors, mouseCoords } from '../overlays/players.js';
 import { batchStart, batchEnd, widgetFilter, widgets, flushDelta, runInput } from '../serverstate.js';
-import { showOverlay, shuffleWidgets, sortWidgets } from '../main.js';
+import { compareDropTarget, showOverlay, shuffleWidgets, sortWidgets } from '../main.js';
 import { tracingEnabled } from '../tracing.js';
 import { toHex } from '../color.js';
 import { center, distance, overlap, getOffset, getElementTransform, getScreenTransform, getPointOnPlane, dehomogenize, getElementTransformRelativeTo, getTransformOrigin } from '../geometry.js';
@@ -430,8 +430,9 @@ export class Widget extends StateManaged {
 
   async checkParent(forceDetach) {
     if(this.currentParent && (forceDetach || !overlap(this.domElement, this.currentParent.domElement))) {
-      // a selection only means something while the widget sits in the holder that offers it
-      if(this.currentParent.multiSelectLimit() && asArray(this.get('selectedBy')).length)
+      // a selection only means something while the widget sits in the holder that offers
+      // it - through _ancestor, so that a card leaving a pile inside that holder counts
+      if(asArray(this.get('selectedBy')).length && (this.currentParent.multiSelectLimit() || this.multiSelectHolder()))
         await this.set('selectedBy', []);
       await this.set('parent', null);
       await this.set('hoverParent', null);
@@ -555,7 +556,10 @@ export class Widget extends StateManaged {
     const max = this.get('multiSelectMax');
     if(max === 'all')
       return Infinity;
-    return typeof max == 'number' && max > 0 ? Math.floor(max) : 0;
+    // a routine that computes the limit tends to end up with a string, so don't
+    // silently turn click-to-select off just because "2" isn't a number
+    const limit = Math.floor(+max);
+    return limit > 0 ? limit : 0;
   }
 
   multiSelectedWidgets(player) {
@@ -1996,7 +2000,8 @@ export class Widget extends StateManaged {
               return w.get(a.property) > a.value;
             else if(a.relation === 'in' && Array.isArray(a.value))
               return a.value.indexOf(w.get(a.property)) != -1;
-            // the mirror image of 'in': the property is the list, e.g. selectedBy or owner
+            // the mirror image of 'in': the property is the list, e.g. selectedBy or owner.
+            // Not a substring test - a property that isn't a list is one entry long.
             else if(a.relation === 'contains')
               return asArray(w.get(a.property)).indexOf(a.value) != -1;
             if(a.relation != '==')
@@ -2575,7 +2580,7 @@ export class Widget extends StateManaged {
     // selection along - they follow to wherever this one is dropped. Collected before
     // the drag detaches this widget from the holder, which is what clears its selection.
     this.multiSelectSource = this.isMultiSelected() ? this.multiSelectHolder() : null;
-    this.multiSelectDrag = this.multiSelectSource ? this.multiSelectSource.multiSelectedWidgets(playerName).filter(w=>w != this && w.get('movable')) : [];
+    this.multiSelectDrag = this.multiSelectSource ? this.multiSelectSource.multiSelectedWidgets(playerName).filter(w=>w != this && w.get('movable') && !w.get('fixedParent')).sort((a,b)=>a.get('z')-b.get('z')) : [];
 
     await this.bringToFront();
     await this.set('dragging', playerName);
@@ -2832,9 +2837,9 @@ export class Widget extends StateManaged {
   }
 
   // The rest of the local player's selection follows the widget that was just dragged
-  // out of the holder: into the same holder it was dropped into, or onto the surface
-  // next to it - there they keep the spacing the holder gave them so that everybody
-  // can see what was played.
+  // out of the holder: into the same holder it was dropped into - as far as it accepts
+  // them - or onto the surface next to it, spread out so that everybody can see what
+  // was played instead of ending up as one pile.
   async moveMultiSelectionAlong() {
     const others = this.multiSelectDrag || [];
     const source = this.multiSelectSource;
@@ -2846,13 +2851,27 @@ export class Widget extends StateManaged {
     if(!others.length || !source || target == source || target && target.get('type') == 'line')
       return;
 
-    const offsetX = +source.get('stackOffsetX') || 0;
-    const offsetY = +source.get('stackOffsetY') || 0;
+    // spread them the way the source holder did. Most holders stack their children on
+    // one spot (stackOffset defaults to 0), so fall back to the size of the widget that
+    // was dragged - otherwise the followers would land on each other and form a pile.
+    let offsetX = +source.get('stackOffsetX') || 0;
+    let offsetY = +source.get('stackOffsetY') || 0;
+    if(!offsetX && !offsetY)
+      offsetX = +this.get('width') || 100;
+
+    // the followers were not dragged, so they have to pass the checks a drag would have
+    // done for them: the target has to accept them and still have room. Whoever fails
+    // stays where it is instead of being forced into the holder.
+    let free = target && target.get('dropLimit') > -1 ? target.get('dropLimit') - target.children().length : Infinity;
+
     let i = 1;
     for(const w of others) {
       if(!widgets.has(w.get('id')) || w.get('_ancestor') != source.get('id'))
         continue;
       if(target) {
+        if(free < 1 || !compareDropTarget(w, target))
+          continue;
+        --free;
         w.movedByButton = true;
         await w.moveToHolder(target);
         delete w.movedByButton;

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -430,9 +430,11 @@ export class Widget extends StateManaged {
 
   async checkParent(forceDetach) {
     if(this.currentParent && (forceDetach || !overlap(this.domElement, this.currentParent.domElement))) {
-      // a selection only means something while the widget sits in the holder that offers
-      // it - through _ancestor, so that a card leaving a pile inside that holder counts
-      if(asArray(this.get('selectedBy')).length && (this.currentParent.multiSelectLimit() || this.multiSelectHolder()))
+      // a selection only means something while the widget sits in the holder that offered
+      // it, so leaving a parent ends it - without asking whether that holder still offers
+      // click-to-select, otherwise turning multiSelectMax off while something is selected
+      // would leave a name behind that a later SELECT would still collect
+      if(asArray(this.get('selectedBy')).length)
         await this.set('selectedBy', []);
       await this.set('parent', null);
       await this.set('hoverParent', null);
@@ -2922,10 +2924,11 @@ export class Widget extends StateManaged {
       const target = widgets.has(targetID) ? widgets.get(targetID) : null;
       // dropped on the surface (or onto a line, where only the dragged widget becomes a
       // stop): the selection stays next to it, in the formation it was dragged in
-      if(!target || target.get('type') == 'line')
+      const onSurface = !target || target.get('type') == 'line';
+      if(onSurface)
         await this.dragMultiSelectionAlong();
 
-      const holder = target && target != source && target.get('type') != 'line' ? target : null;
+      const holder = !onSurface && target != source ? target : null;
       // the followers were not dragged by hand, so the drop has to check them the way it
       // checked the dragged one: the holder has to accept them and still have room
       let free = holder && holder.get('dropLimit') > -1 ? holder.get('dropLimit') - holder.children().length : Infinity;
@@ -2940,9 +2943,10 @@ export class Widget extends StateManaged {
           w.movedByButton = true;
           await w.moveToHolder(holder);
           delete w.movedByButton;
-        } else if(target && !stillInHolder) {
-          // the drop does not take it: back into the holder it was picked from, and
-          // picked again there, so that a refused drop does not cost the selection
+        } else if(!onSurface && !stillInHolder) {
+          // a holder that does not take it (or the one it was picked from, when the drag
+          // ended where it started): back into the holder it was picked from and picked
+          // again there, so that a refused drop does not cost the selection
           w.movedByButton = true;
           await w.moveToHolder(source);
           delete w.movedByButton;

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2576,12 +2576,6 @@ export class Widget extends StateManaged {
     if(tracingEnabled)
       sendTraceEvent('moveStart', { id: this.get('id') });
 
-    // Dragging one of the widgets the local player selected takes the rest of the
-    // selection along - they follow to wherever this one is dropped. Collected before
-    // the drag detaches this widget from the holder, which is what clears its selection.
-    this.multiSelectSource = this.isMultiSelected() ? this.multiSelectHolder() : null;
-    this.multiSelectDrag = this.multiSelectSource ? this.multiSelectSource.multiSelectedWidgets(playerName).filter(w=>w != this && w.get('movable') && !w.get('fixedParent')).sort((a,b)=>a.get('z')-b.get('z')) : [];
-
     await this.bringToFront();
     await this.set('dragging', playerName);
     delete this.lastMoveCoord;
@@ -2592,6 +2586,14 @@ export class Widget extends StateManaged {
     this.stopDropLines = this.get('type') == 'line' ? [] : widgetFilter(w=>w.get('type') == 'line' && w.get('dropTarget') && w.isVisible());
 
     if(!this.get('fixedParent') && this.get('movable')) {
+      // Dragging one of the widgets the local player selected takes the rest of the
+      // selection along: they leave the holder as soon as this one does and follow the
+      // cursor until it is dropped. Collected before the drag detaches this widget,
+      // which is what ends its selection.
+      this.multiSelectSource = this.isMultiSelected() ? this.multiSelectHolder() : null;
+      this.multiSelectDrag = this.multiSelectSource ? this.multiSelectSource.multiSelectedWidgets(playerName).filter(w=>w != this && w.get('movable') && !w.get('fixedParent')).sort((a,b)=>a.get('z')-b.get('z')) : [];
+      this.multiSelectPicked = [];
+
       this.dropTargets = this.validDropTargets();
       this.currentParent = widgets.get(this.get('_ancestor'));
       if(this.currentParent)
@@ -2722,6 +2724,7 @@ export class Widget extends StateManaged {
       }
     }
 
+    await this.dragMultiSelectionAlong();
     this.highlightStopDropLine(this.lineStopDropTarget());
   }
 
@@ -2836,52 +2839,94 @@ export class Widget extends StateManaged {
     await this.updatePiles();
   }
 
-  // The rest of the local player's selection follows the widget that was just dragged
-  // out of the holder: into the same holder it was dropped into - as far as it accepts
-  // them - or onto the surface next to it, spread out so that everybody can see what
-  // was played instead of ending up as one pile.
-  async moveMultiSelectionAlong() {
-    const others = this.multiSelectDrag || [];
+  // How far apart the widgets that follow a drag are laid out. Most holders stack their
+  // children on one spot (stackOffset defaults to 0), so fall back to the width of the
+  // dragged widget - otherwise the whole selection would travel and land on one point.
+  multiSelectSpread(source) {
+    const x = +source.get('stackOffsetX') || 0;
+    const y = +source.get('stackOffsetY') || 0;
+    return x || y ? { x, y } : { x: +this.get('width') || 100, y: 0 };
+  }
+
+  // As soon as the drag has taken this widget out of the holder, the rest of the local
+  // player's selection comes out with it and follows the cursor next to it, so that the
+  // drag shows what is about to be dropped instead of moving a single widget.
+  async dragMultiSelectionAlong() {
     const source = this.multiSelectSource;
-    delete this.multiSelectDrag;
-    delete this.multiSelectSource;
-
-    const targetID = this.get('parent');
-    const target = widgets.has(targetID) ? widgets.get(targetID) : null;
-    if(!others.length || !source || target == source || target && target.get('type') == 'line')
+    if(!source || this.currentParent)
       return;
+    this.multiSelectPicked = this.multiSelectPicked || [];
 
-    // spread them the way the source holder did. Most holders stack their children on
-    // one spot (stackOffset defaults to 0), so fall back to the size of the widget that
-    // was dragged - otherwise the followers would land on each other and form a pile.
-    let offsetX = +source.get('stackOffsetX') || 0;
-    let offsetY = +source.get('stackOffsetY') || 0;
-    if(!offsetX && !offsetY)
-      offsetX = +this.get('width') || 100;
-
-    // the followers were not dragged, so they have to pass the checks a drag would have
-    // done for them: the target has to accept them and still have room. Whoever fails
-    // stays where it is instead of being forced into the holder.
-    let free = target && target.get('dropLimit') > -1 ? target.get('dropLimit') - target.children().length : Infinity;
-
-    let i = 1;
-    for(const w of others) {
+    for(const w of this.multiSelectDrag || []) {
       if(!widgets.has(w.get('id')) || w.get('_ancestor') != source.get('id'))
         continue;
-      if(target) {
-        if(free < 1 || !compareDropTarget(w, target))
-          continue;
-        --free;
-        w.movedByButton = true;
-        await w.moveToHolder(target);
-        delete w.movedByButton;
-      } else {
-        w.currentParent = source;
-        await w.checkParent(true);
-        await w.setPosition(this.get('x') + offsetX*i, this.get('y') + offsetY*i, this.get('z') + i);
-      }
+      // leaving the holder is what ends the selection, so checkParent() takes care of
+      // selectedBy, of the owner a childrenPerOwner holder gave it and of onLeave
+      w.currentParent = source;
+      await w.set('dragging', playerName);
+      await w.checkParent(true);
+      this.multiSelectPicked.push(w);
+    }
+    this.multiSelectDrag = [];
+
+    // absoluteCoord, because a widget that just became the stop of a line is no longer
+    // in the same coordinate system as the followers, which stay on the surface
+    const spread = this.multiSelectSpread(source);
+    const x = this.absoluteCoord('x');
+    const y = this.absoluteCoord('y');
+    let i = 1;
+    for(const w of this.multiSelectPicked) {
+      await w.setPosition(x + spread.x*i, y + spread.y*i, this.get('z') + i);
       ++i;
     }
+  }
+
+  // Where the selection that followed the drag ends up: in the holder this widget was
+  // dropped into - as far as that holder accepts it - or next to it on the surface,
+  // spread out so that everybody can see what was played instead of one pile.
+  async moveMultiSelectionAlong() {
+    const source = this.multiSelectSource;
+    if(source) {
+      const targetID = this.get('parent');
+      const target = widgets.has(targetID) ? widgets.get(targetID) : null;
+      // dropped on the surface (or onto a line, where only the dragged widget becomes a
+      // stop): the selection stays next to it, in the formation it was dragged in
+      if(!target || target.get('type') == 'line')
+        await this.dragMultiSelectionAlong();
+
+      const holder = target && target != source && target.get('type') != 'line' ? target : null;
+      // the followers were not dragged by hand, so the drop has to check them the way it
+      // checked the dragged one: the holder has to accept them and still have room
+      let free = holder && holder.get('dropLimit') > -1 ? holder.get('dropLimit') - holder.children().length : Infinity;
+
+      for(const w of (this.multiSelectPicked || []).concat(this.multiSelectDrag || [])) {
+        if(!widgets.has(w.get('id')))
+          continue;
+        await w.set('dragging', null);
+        const stillInHolder = w.get('_ancestor') == source.get('id');
+        if(holder && free > 0 && compareDropTarget(w, holder)) {
+          --free;
+          w.movedByButton = true;
+          await w.moveToHolder(holder);
+          delete w.movedByButton;
+        } else if(target && !stillInHolder) {
+          // the drop does not take it: back into the holder it was picked from, and
+          // picked again there, so that a refused drop does not cost the selection
+          w.movedByButton = true;
+          await w.moveToHolder(source);
+          delete w.movedByButton;
+          await w.setMultiSelected(true);
+        }
+      }
+
+      // the drag ended where it started, so the selection it interrupted is restored
+      if(target == source)
+        await this.setMultiSelected(true);
+    }
+
+    delete this.multiSelectSource;
+    delete this.multiSelectDrag;
+    delete this.multiSelectPicked;
   }
 
   async hideShadowWidget() {

--- a/tests/client/widget-select.test.js
+++ b/tests/client/widget-select.test.js
@@ -4,8 +4,16 @@ import { createWidget, addLabel, removeWidget } from './client-util.js';
 
 const testName = 'widget-select';
 
-function createHand(multiSelectMax, numCards) {
-  const hand = createWidget({ id: `${testName}-hand`, type: 'widget', multiSelectMax });
+// jsdom does not implement DOMMatrix, so model the room's untransformed coordinate
+// frame directly - these fixtures are about parents and selections, not about geometry
+function createHolder(definition) {
+  const holder = createWidget(Object.assign({ type: 'holder' }, definition));
+  holder.coordLocalFromCoordGlobal = coord => ({ x: coord.x - holder.get('x'), y: coord.y - holder.get('y') });
+  return holder;
+}
+
+function createHand(multiSelectMax, numCards, handProperties = {}) {
+  const hand = createHolder(Object.assign({ id: `${testName}-hand`, multiSelectMax }, handProperties));
   const cards = [];
   for(let i=1; i<=numCards; ++i)
     cards.push(createWidget({
@@ -30,6 +38,9 @@ describe('Scenarios: Selecting widgets by clicking them', () => {
   beforeAll(() => {
     label = addLabel(`${testName}-label`);
     window.jeRoutineLogging = false;
+    // z bookkeeping lives in the concatenated global scope of the shipped bundle
+    globalThis.getMaxZ = () => 0;
+    globalThis.updateMaxZ = () => {};
   });
   afterAll(() => {
     removeWidget(label.get('id'));
@@ -96,6 +107,105 @@ describe('Scenarios: Selecting widgets by clicking them', () => {
         await cards[0].checkParent(true);
         expect(cards[0].get('selectedBy')).toEqual([]);
         expect(cards[0].get('parent')).toBe(null);
+      });
+    });
+  });
+
+  describe('Given a holder with multiSelectMax as a string', () => {
+    let hand, cards;
+    beforeEach(async () => {
+      ({ hand, cards } = createHand('2', 3));
+    });
+    afterEach(() => {
+      cards.concat(hand).forEach(w => removeWidget(w.get('id')));
+    });
+
+    describe('When a widget in it is clicked', () => {
+      test('Then it is selected just like with a number', async () => {
+        await cards[0].click();
+        expect(selectedIDs(cards)).toEqual([ cards[0].get('id') ]);
+      });
+    });
+  });
+
+  describe('Given a selected widget inside a pile inside the holder', () => {
+    let hand, cards, pile;
+    beforeEach(async () => {
+      ({ hand, cards } = createHand('all', 2));
+      pile = createWidget({ id: `${testName}-pile`, type: 'pile', parent: hand.get('id') });
+      await cards[0].set('parent', pile.get('id'));
+      await cards[0].click();
+    });
+    afterEach(() => {
+      cards.concat(hand, pile).forEach(w => removeWidget(w.get('id')));
+    });
+
+    describe('When it is selected by clicking', () => {
+      test('Then the holder around the pile governs the selection', async () => {
+        expect(selectedIDs(cards)).toEqual([ cards[0].get('id') ]);
+      });
+    });
+
+    describe('When a routine moves it out of the pile', () => {
+      test('Then it is no longer selected', async () => {
+        const table = createHolder({ id: `${testName}-table`, dropTarget: {} });
+        await cards[0].moveToHolder(table);
+        expect(cards[0].get('parent')).toBe(table.get('id'));
+        expect(cards[0].get('selectedBy')).toEqual([]);
+        removeWidget(table.get('id'));
+      });
+    });
+  });
+
+  describe('Given a dragged widget that the rest of the selection follows', () => {
+    let hand, cards, target;
+    beforeEach(async () => {
+      ({ hand, cards } = createHand('all', 3, { x: 0, y: 0 }));
+      for(const card of cards)
+        await card.set('cardType', 'plain');
+      await cards[2].set('cardType', 'other');
+      for(const card of cards)
+        await card.click();
+    });
+    afterEach(() => {
+      cards.concat(hand, target).filter(w=>w).forEach(w => removeWidget(w.get('id')));
+      target = null;
+    });
+
+    // the followers are not dragged themselves, so moveMultiSelectionAlong has to apply
+    // the drop checks that getValidDropTargets applies to the widget under the mouse
+    async function dropInto(holder) {
+      target = holder;
+      cards[0].multiSelectSource = hand;
+      cards[0].multiSelectDrag = cards.slice(1);
+      if(holder)
+        await cards[0].moveToHolder(holder);
+      else
+        await cards[0].set('parent', null);
+      await cards[0].moveMultiSelectionAlong();
+    }
+
+    describe('When the target rejects one of them', () => {
+      test('Then that one stays in the holder', async () => {
+        await dropInto(createHolder({ id: `${testName}-target`, dropTarget: { cardType: 'plain' } }));
+        expect(cards.map(c=>c.get('parent'))).toEqual([ target.get('id'), target.get('id'), hand.get('id') ]);
+      });
+    });
+
+    describe('When the target has a dropLimit that is already used up', () => {
+      test('Then no follower is forced into it', async () => {
+        await dropInto(createHolder({ id: `${testName}-target`, dropTarget: {}, dropLimit: 1 }));
+        expect(cards.map(c=>c.get('parent'))).toEqual([ target.get('id'), hand.get('id'), hand.get('id') ]);
+      });
+    });
+
+    describe('When the widget is dropped on the table and the holder does not space its children', () => {
+      test('Then the followers are spread out instead of landing on one spot', async () => {
+        await cards[0].setPosition(500, 300, 5);
+        await dropInto(null);
+        expect(cards.map(c=>c.get('parent'))).toEqual([ null, null, null ]);
+        expect(cards.map(c=>c.get('x'))).toEqual([ 500, 500+cards[0].get('width'), 500+2*cards[0].get('width') ]);
+        expect(cards.map(c=>c.get('y'))).toEqual([ 300, 300, 300 ]);
       });
     });
   });

--- a/tests/client/widget-select.test.js
+++ b/tests/client/widget-select.test.js
@@ -191,13 +191,13 @@ describe('Scenarios: Selecting widgets by clicking them', () => {
 
     // what a drag does once it has carried the widget out of the holder: move() takes
     // the rest of the selection out as well and keeps it next to the dragged widget
-    async function dragOutOfHolder() {
+    async function dragOutOfHolder(x = 500, y = 300) {
       cards[0].multiSelectSource = hand;
       cards[0].multiSelectDrag = cards.slice(1);
       cards[0].multiSelectPicked = [];
       cards[0].currentParent = hand;
       await cards[0].checkParent(true);
-      await cards[0].setPosition(500, 300, 5);
+      await cards[0].setPosition(x, y, 5);
       await cards[0].dragMultiSelectionAlong();
     }
 
@@ -208,6 +208,15 @@ describe('Scenarios: Selecting widgets by clicking them', () => {
         expect(cards.map(c=>c.get('x'))).toEqual([ 500, 500+cards[0].get('width'), 500+2*cards[0].get('width') ]);
         expect(cards.slice(1).map(c=>c.get('dragging'))).toEqual([ playerName, playerName ]);
         expect(selectedIDs(cards)).toEqual([]);
+      });
+    });
+
+    describe('When the drag carries it towards the right edge of the surface', () => {
+      test('Then the followers fan out to the other side instead of off the surface', async () => {
+        const width = cards[0].get('width');
+        await dragOutOfHolder(1600-width, 300);
+        expect(cards.map(c=>c.get('x'))).toEqual([ 1600-width, 1600-2*width, 1600-3*width ]);
+        expect(cards.every(c=>c.get('x') >= 0 && c.get('x') + width <= 1600)).toBe(true);
       });
     });
 
@@ -252,6 +261,31 @@ describe('Scenarios: Selecting widgets by clicking them', () => {
         expect(cards.map(c=>c.get('parent'))).toEqual([ null, null, null ]);
         expect(cards.map(c=>c.get('x'))).toEqual([ 500, 500+cards[0].get('width'), 500+2*cards[0].get('width') ]);
         expect(cards.map(c=>c.get('y'))).toEqual([ 300, 300, 300 ]);
+      });
+    });
+  });
+
+  describe('Given a holder that spreads its widgets further apart than the surface allows', () => {
+    let hand, cards;
+    beforeEach(async () => {
+      ({ hand, cards } = createHand('all', 3, { x: 0, y: 0, stackOffsetX: 800 }));
+      for(const card of cards)
+        await card.click();
+    });
+    afterEach(() => {
+      cards.concat(hand).forEach(w => removeWidget(w.get('id')));
+    });
+
+    describe('When a drag carries the selection out of it', () => {
+      test('Then the followers move closer together so that they stay on the surface', async () => {
+        cards[0].multiSelectSource = hand;
+        cards[0].multiSelectDrag = cards.slice(1);
+        cards[0].multiSelectPicked = [];
+        cards[0].currentParent = hand;
+        await cards[0].checkParent(true);
+        await cards[0].setPosition(100, 300, 5);
+        await cards[0].dragMultiSelectionAlong();
+        expect(cards.map(c=>c.get('x'))).toEqual([ 100, 800, 1500 ]);
       });
     });
   });

--- a/tests/client/widget-select.test.js
+++ b/tests/client/widget-select.test.js
@@ -175,15 +175,61 @@ describe('Scenarios: Selecting widgets by clicking them', () => {
     // the followers are not dragged themselves, so moveMultiSelectionAlong has to apply
     // the drop checks that getValidDropTargets applies to the widget under the mouse
     async function dropInto(holder) {
-      target = holder;
       cards[0].multiSelectSource = hand;
       cards[0].multiSelectDrag = cards.slice(1);
+      await finishDrop(holder);
+    }
+
+    async function finishDrop(holder) {
+      target = holder;
       if(holder)
         await cards[0].moveToHolder(holder);
       else
         await cards[0].set('parent', null);
       await cards[0].moveMultiSelectionAlong();
     }
+
+    // what a drag does once it has carried the widget out of the holder: move() takes
+    // the rest of the selection out as well and keeps it next to the dragged widget
+    async function dragOutOfHolder() {
+      cards[0].multiSelectSource = hand;
+      cards[0].multiSelectDrag = cards.slice(1);
+      cards[0].multiSelectPicked = [];
+      cards[0].currentParent = hand;
+      await cards[0].checkParent(true);
+      await cards[0].setPosition(500, 300, 5);
+      await cards[0].dragMultiSelectionAlong();
+    }
+
+    describe('When the drag carries it out of the holder', () => {
+      test('Then the rest of the selection is carried along with it', async () => {
+        await dragOutOfHolder();
+        expect(cards.map(c=>c.get('parent'))).toEqual([ null, null, null ]);
+        expect(cards.map(c=>c.get('x'))).toEqual([ 500, 500+cards[0].get('width'), 500+2*cards[0].get('width') ]);
+        expect(cards.slice(1).map(c=>c.get('dragging'))).toEqual([ playerName, playerName ]);
+        expect(selectedIDs(cards)).toEqual([]);
+      });
+    });
+
+    describe('When the holder it is dropped into refuses one of the carried ones', () => {
+      test('Then that one goes back into the holder it was picked from, still selected', async () => {
+        await dragOutOfHolder();
+        await finishDrop(createHolder({ id: `${testName}-target`, dropTarget: { cardType: 'plain' } }));
+        expect(cards.map(c=>c.get('parent'))).toEqual([ target.get('id'), target.get('id'), hand.get('id') ]);
+        expect(selectedIDs(cards)).toEqual([ cards[2].get('id') ]);
+        expect(cards[1].get('dragging')).toBe(null);
+      });
+    });
+
+    describe('When the drag ends back in the holder it started in', () => {
+      test('Then the whole selection is put back and stays selected', async () => {
+        await dragOutOfHolder();
+        await finishDrop(hand);
+        expect(cards.map(c=>c.get('parent'))).toEqual([ hand.get('id'), hand.get('id'), hand.get('id') ]);
+        expect(selectedIDs(cards)).toEqual(cards.map(c=>c.get('id')));
+        target = null;
+      });
+    });
 
     describe('When the target rejects one of them', () => {
       test('Then that one stays in the holder', async () => {

--- a/tests/client/widget-select.test.js
+++ b/tests/client/widget-select.test.js
@@ -12,6 +12,15 @@ function createHolder(definition) {
   return holder;
 }
 
+// a stand-in for a line the drag ends on: only its type and its coordinate frame
+// matter here, the line geometry itself is covered by line-widget.test.js
+function createLine(definition) {
+  const line = createWidget(Object.assign({ type: 'line', x: 0, y: 0 }, definition));
+  line.coordGlobalFromCoordLocal = coord => ({ x: line.get('x') + coord.x, y: line.get('y') + coord.y });
+  line.coordLocalFromCoordGlobal = coord => ({ x: coord.x - line.get('x'), y: coord.y - line.get('y') });
+  return line;
+}
+
 function createHand(multiSelectMax, numCards, handProperties = {}) {
   const hand = createHolder(Object.assign({ id: `${testName}-hand`, multiSelectMax }, handProperties));
   const cards = [];
@@ -107,6 +116,16 @@ describe('Scenarios: Selecting widgets by clicking them', () => {
         await cards[0].checkParent(true);
         expect(cards[0].get('selectedBy')).toEqual([]);
         expect(cards[0].get('parent')).toBe(null);
+      });
+    });
+
+    describe('When the holder turns click-to-select off while something is selected', () => {
+      test('Then taking that widget out of the holder still clears the selection', async () => {
+        await cards[0].click();
+        await hand.set('multiSelectMax', 0);
+        cards[0].currentParent = hand;
+        await cards[0].checkParent(true);
+        expect(cards[0].get('selectedBy')).toEqual([]);
       });
     });
   });
@@ -227,6 +246,18 @@ describe('Scenarios: Selecting widgets by clicking them', () => {
         expect(cards.map(c=>c.get('parent'))).toEqual([ target.get('id'), target.get('id'), hand.get('id') ]);
         expect(selectedIDs(cards)).toEqual([ cards[2].get('id') ]);
         expect(cards[1].get('dragging')).toBe(null);
+      });
+    });
+
+    describe('When the drag ends on a line, where only the dragged widget becomes a stop', () => {
+      test('Then the followers stay next to it on the surface instead of going back', async () => {
+        await dragOutOfHolder();
+        await finishDrop(createLine({ id: `${testName}-line` }));
+        const x = cards[0].absoluteCoord('x');
+        expect(cards[0].get('parent')).toBe(target.get('id'));
+        expect(cards.slice(1).map(c=>c.get('parent'))).toEqual([ null, null ]);
+        expect(cards.map(c=>c.absoluteCoord('x'))).toEqual([ x, x+cards[0].get('width'), x+2*cards[0].get('width') ]);
+        expect(selectedIDs(cards)).toEqual([]);
       });
     });
 

--- a/tests/client/widget-select.test.js
+++ b/tests/client/widget-select.test.js
@@ -1,0 +1,156 @@
+import { playerName } from '../../client/js/overlays/players.js';
+
+import { createWidget, addLabel, removeWidget } from './client-util.js';
+
+const testName = 'widget-select';
+
+function createHand(multiSelectMax, numCards) {
+  const hand = createWidget({ id: `${testName}-hand`, type: 'widget', multiSelectMax });
+  const cards = [];
+  for(let i=1; i<=numCards; ++i)
+    cards.push(createWidget({
+      id: `${testName}-card-${i}`,
+      type: 'widget',
+      clickable: true,
+      parent: hand.get('id'),
+      clickRoutine: [
+        { func: 'LABEL', label: `${testName}-label`, value: 1, mode: 'inc' }
+      ]
+    }));
+  return { hand, cards };
+}
+
+function selectedIDs(cards) {
+  return cards.filter(c=>c.get('selectedBy').indexOf(playerName) != -1).map(c=>c.get('id'));
+}
+
+describe('Scenarios: Selecting widgets by clicking them', () => {
+  let label;
+
+  beforeAll(() => {
+    label = addLabel(`${testName}-label`);
+    window.jeRoutineLogging = false;
+  });
+  afterAll(() => {
+    removeWidget(label.get('id'));
+  });
+
+  describe('Given a holder without multiSelectMax', () => {
+    let hand, cards;
+    beforeEach(async () => {
+      ({ hand, cards } = createHand(0, 2));
+      await label.set('text', 0);
+    });
+    afterEach(() => {
+      cards.concat(hand).forEach(w => removeWidget(w.get('id')));
+    });
+
+    describe('When a widget in it is clicked', () => {
+      test('Then it is not selected and its clickRoutine runs', async () => {
+        await cards[0].click();
+        expect(selectedIDs(cards)).toEqual([]);
+        expect(label.get('text')).toBe(1);
+      });
+    });
+  });
+
+  describe('Given a holder with multiSelectMax 2', () => {
+    let hand, cards;
+    beforeEach(async () => {
+      ({ hand, cards } = createHand(2, 3));
+      await label.set('text', 0);
+    });
+    afterEach(() => {
+      cards.concat(hand).forEach(w => removeWidget(w.get('id')));
+    });
+
+    describe('When a widget in it is clicked', () => {
+      test('Then it is selected instead of running its clickRoutine', async () => {
+        await cards[0].click();
+        expect(selectedIDs(cards)).toEqual([ cards[0].get('id') ]);
+        expect(label.get('text')).toBe(0);
+      });
+    });
+
+    describe('When a selected widget is clicked again', () => {
+      test('Then it is deselected', async () => {
+        await cards[0].click();
+        await cards[0].click();
+        expect(selectedIDs(cards)).toEqual([]);
+        expect(cards[0].get('selectedBy')).toEqual([]);
+      });
+    });
+
+    describe('When more widgets are clicked than the limit allows', () => {
+      test('Then the selection stays at the limit', async () => {
+        for(const card of cards)
+          await card.click();
+        expect(selectedIDs(cards)).toEqual([ cards[0].get('id'), cards[1].get('id') ]);
+      });
+    });
+
+    describe('When a selected widget is taken out of the holder', () => {
+      test('Then it is no longer selected', async () => {
+        await cards[0].click();
+        cards[0].currentParent = hand;
+        await cards[0].checkParent(true);
+        expect(cards[0].get('selectedBy')).toEqual([]);
+        expect(cards[0].get('parent')).toBe(null);
+      });
+    });
+  });
+
+  describe('Given a holder with multiSelectMax 1', () => {
+    let hand, cards;
+    beforeEach(async () => {
+      ({ hand, cards } = createHand(1, 2));
+    });
+    afterEach(() => {
+      cards.concat(hand).forEach(w => removeWidget(w.get('id')));
+    });
+
+    describe('When a second widget is clicked', () => {
+      test('Then it replaces the first one', async () => {
+        await cards[0].click();
+        await cards[1].click();
+        expect(selectedIDs(cards)).toEqual([ cards[1].get('id') ]);
+      });
+    });
+  });
+
+  describe("Given widgets selected by different players", () => {
+    let widgets;
+    beforeEach(async () => {
+      widgets = [ 1, 2, 3 ].map(i => createWidget({
+        id: `${testName}-mixed-${i}`,
+        type: 'widget',
+        clickable: true,
+        selectedBy: i == 3 ? [ 'Bob' ] : [ 'Alice' ],
+        clickRoutine: [
+          { func: 'LABEL', label: `${testName}-label`, value: 1, mode: 'inc' }
+        ]
+      }));
+      await label.set('text', 0);
+    });
+    afterEach(() => {
+      widgets.forEach(w => removeWidget(w.get('id')));
+    });
+
+    describe("When a routine SELECTs the ones whose selectedBy contains a player", () => {
+      test('Then only that player\'s widgets are collected', async () => {
+        const button = createWidget({
+          id: `${testName}-button`,
+          type: 'widget',
+          clickable: true,
+          clickRoutine: [
+            { func: 'SELECT', property: 'selectedBy', relation: 'contains', value: 'Alice' },
+            { func: 'CLICK' }
+          ]
+        });
+        await button.click();
+        expect(label.get('text')).toBe(2);
+        removeWidget(button.get('id'));
+      });
+    });
+  });
+});

--- a/tests/client/widget-select.test.js
+++ b/tests/client/widget-select.test.js
@@ -174,6 +174,33 @@ describe('Scenarios: Selecting widgets by clicking them', () => {
         removeWidget(table.get('id'));
       });
     });
+
+    describe('When the pile itself is clicked', () => {
+      test('Then it is not selected and keeps its own click', async () => {
+        expect(await pile.toggleMultiSelect()).toBe(false);
+        expect(pile.get('selectedBy')).toEqual([]);
+      });
+    });
+  });
+
+  describe('Given a widget picked by a player who is no longer in the room', () => {
+    let hand, cards;
+    beforeEach(async () => {
+      ({ hand, cards } = createHand('all', 2));
+      await cards[0].set('selectedBy', [ 'Ghost' ]);
+      await cards[1].set('selectedBy', [ 'Alice' ]);
+    });
+    afterEach(() => {
+      cards.concat(hand).forEach(w => removeWidget(w.get('id')));
+    });
+
+    describe('When the holder is used again', () => {
+      test('Then only the picks of players who are still there survive', async () => {
+        await hand.clearStaleMultiSelections([ playerName, 'Alice' ]);
+        expect(cards[0].get('selectedBy')).toEqual([]);
+        expect(cards[1].get('selectedBy')).toEqual([ 'Alice' ]);
+      });
+    });
   });
 
   describe('Given a dragged widget that the rest of the selection follows', () => {
@@ -226,6 +253,7 @@ describe('Scenarios: Selecting widgets by clicking them', () => {
         expect(cards.map(c=>c.get('parent'))).toEqual([ null, null, null ]);
         expect(cards.map(c=>c.get('x'))).toEqual([ 500, 500+cards[0].get('width'), 500+2*cards[0].get('width') ]);
         expect(cards.slice(1).map(c=>c.get('dragging'))).toEqual([ playerName, playerName ]);
+        expect(cards.map(c=>c.get('z'))).toEqual([ 5, 4, 3 ]); // the dragged one stays on top
         expect(selectedIDs(cards)).toEqual([]);
       });
     });

--- a/tests/testcafe/multiselect.js
+++ b/tests/testcafe/multiselect.js
@@ -115,6 +115,24 @@ test('A card the target holder does not accept stays behind', async t => {
   await expectEventually(t, selectedCards, [ 'card3' ]);
 });
 
+test('A pile in the holder keeps its own click instead of becoming a selection', async t => {
+  const state = selectRoom('all');
+  state.pile = { id: 'pile', type: 'pile', parent: 'hand', x: 400, y: 4 };
+  state.card2.parent = 'pile';
+  state.card3.parent = 'pile';
+  await setRoomState(state);
+  await ClientFunction(prepareClient)();
+  await setName(t, player);
+  await expectEventually(t, ()=>cardsIn('hand'), [ 'card1' ]);
+
+  // clicking the pile handle has to open the pile menu - the pile is the stack of what
+  // can be picked, not something to pick, so it must not eat a multiSelectMax slot
+  await t.click('#w_pile .handle');
+  await t.expect(Selector('#pileOverlay').visible).ok();
+  await t.expect(Selector('#w_pile').hasClass('multiSelected')).notOk();
+  await expectEventually(t, selectedCards, []);
+});
+
 test('Cards dropped on the surface are spread out even if the holder stacks them', async t => {
   await openRoom(t, 'all', { stackOffsetX: 0 });
 

--- a/tests/testcafe/multiselect.js
+++ b/tests/testcafe/multiselect.js
@@ -111,6 +111,8 @@ test('A card the target holder does not accept stays behind', async t => {
   await t.dragToElement('#w_card1', '#w_table');
   await expectEventually(t, ()=>cardsIn('table'), [ 'card1' ]);
   await expectEventually(t, ()=>cardsIn('hand'), [ 'card2', 'card3' ]);
+  // it comes back into the hand still selected, so the refused drop costs no pick
+  await expectEventually(t, selectedCards, [ 'card3' ]);
 });
 
 test('Cards dropped on the surface are spread out even if the holder stacks them', async t => {

--- a/tests/testcafe/multiselect.js
+++ b/tests/testcafe/multiselect.js
@@ -1,0 +1,86 @@
+import { ClientFunction, Selector } from 'testcafe';
+
+import { getState, prepareClient, setName, setRoomState, setupTestEnvironment } from './test-util.js';
+
+setupTestEnvironment();
+
+const player = 'TestCafe';
+
+function selectRoom(multiSelectMax) {
+  const state = {
+    deck: { id: 'deck', type: 'deck', cardTypes: { plain: {} }, x: 50, y: 100 },
+    hand: { id: 'hand', type: 'holder', multiSelectMax, stackOffsetX: 120, x: 50, y: 600, width: 700, height: 180 },
+    table: { id: 'table', type: 'holder', stackOffsetX: 120, x: 50, y: 300, width: 700, height: 180 }
+  };
+  for(const [ index, card ] of [ 'card1', 'card2', 'card3' ].entries())
+    state[card] = { id: card, type: 'card', deck: 'deck', cardType: 'plain', parent: 'hand', x: 4+index*120, y: 4, z: index+1 };
+  return state;
+}
+
+async function expectEventually(t, get, expected) {
+  let actual = null;
+  for(let wait=50; wait<1000; wait*=2) {
+    actual = await get();
+    if(JSON.stringify(actual) == JSON.stringify(expected))
+      break;
+    await new Promise(resolve=>setTimeout(resolve, wait));
+  }
+  await t.expect(actual).eql(expected);
+}
+
+async function selectedCards() {
+  return Object.values(JSON.parse(await getState())).filter(w=>(w.selectedBy || []).indexOf(player) != -1).map(w=>w.id).sort();
+}
+
+async function cardsIn(holder) {
+  return Object.values(JSON.parse(await getState())).filter(w=>w.type == 'card' && w.parent == holder).map(w=>w.id).sort();
+}
+
+async function openRoom(t, multiSelectMax) {
+  await setRoomState(selectRoom(multiSelectMax));
+  await ClientFunction(prepareClient)();
+  await setName(t, player);
+  await expectEventually(t, ()=>cardsIn('hand'), [ 'card1', 'card2', 'card3' ]);
+}
+
+test('Clicking cards in a holder with multiSelectMax selects them', async t => {
+  await openRoom(t, 2);
+
+  await t.click('#w_card1');
+  await expectEventually(t, selectedCards, [ 'card1' ]);
+  await t.expect(Selector('#w_card1').hasClass('multiSelected')).ok();
+
+  await t.click('#w_card2');
+  await expectEventually(t, selectedCards, [ 'card1', 'card2' ]);
+
+  // the limit is reached, so the third card is not added to the selection
+  await t.click('#w_card3');
+  await expectEventually(t, selectedCards, [ 'card1', 'card2' ]);
+
+  // clicking a selected card again deselects it
+  await t.click('#w_card1');
+  await expectEventually(t, selectedCards, [ 'card2' ]);
+});
+
+test('multiSelectMax 1 replaces the previous selection', async t => {
+  await openRoom(t, 1);
+
+  await t.click('#w_card1');
+  await expectEventually(t, selectedCards, [ 'card1' ]);
+  await t.click('#w_card2');
+  await expectEventually(t, selectedCards, [ 'card2' ]);
+});
+
+test('Dragging one selected card takes the rest of the selection along', async t => {
+  await openRoom(t, 'all');
+
+  await t.click('#w_card1');
+  await t.click('#w_card3');
+  await expectEventually(t, selectedCards, [ 'card1', 'card3' ]);
+
+  await t.dragToElement('#w_card1', '#w_table');
+  await expectEventually(t, ()=>cardsIn('table'), [ 'card1', 'card3' ]);
+  await expectEventually(t, ()=>cardsIn('hand'), [ 'card2' ]);
+  // leaving the holder that offers the selection ends it
+  await expectEventually(t, selectedCards, []);
+});

--- a/tests/testcafe/multiselect.js
+++ b/tests/testcafe/multiselect.js
@@ -6,14 +6,17 @@ setupTestEnvironment();
 
 const player = 'TestCafe';
 
-function selectRoom(multiSelectMax) {
+function selectRoom(multiSelectMax, options = {}) {
   const state = {
-    deck: { id: 'deck', type: 'deck', cardTypes: { plain: {} }, x: 50, y: 100 },
-    hand: { id: 'hand', type: 'holder', multiSelectMax, stackOffsetX: 120, x: 50, y: 600, width: 700, height: 180 },
-    table: { id: 'table', type: 'holder', stackOffsetX: 120, x: 50, y: 300, width: 700, height: 180 }
+    deck: { id: 'deck', type: 'deck', cardTypes: { plain: {}, other: {} }, x: 50, y: 100 },
+    // stackOffsetX 0 is the default for a holder, so cover it as well as a spread one
+    hand: { id: 'hand', type: 'holder', multiSelectMax, stackOffsetX: options.stackOffsetX === undefined ? 120 : options.stackOffsetX, x: 50, y: 600, width: 700, height: 180 },
+    table: { id: 'table', type: 'holder', stackOffsetX: 120, dropTarget: options.dropTarget || { type: 'card' }, x: 50, y: 300, width: 700, height: 180 },
+    // a widget that is not a drop target: dropping onto it means dropping on the surface
+    spot: { id: 'spot', type: 'widget', movable: false, layer: -5, x: 900, y: 100, width: 300, height: 300 }
   };
   for(const [ index, card ] of [ 'card1', 'card2', 'card3' ].entries())
-    state[card] = { id: card, type: 'card', deck: 'deck', cardType: 'plain', parent: 'hand', x: 4+index*120, y: 4, z: index+1 };
+    state[card] = { id: card, type: 'card', deck: 'deck', cardType: options.oddCard && index == 2 ? 'other' : 'plain', parent: 'hand', x: 4+index*120, y: 4, z: index+1 };
   return state;
 }
 
@@ -36,8 +39,20 @@ async function cardsIn(holder) {
   return Object.values(JSON.parse(await getState())).filter(w=>w.type == 'card' && w.parent == holder).map(w=>w.id).sort();
 }
 
-async function openRoom(t, multiSelectMax) {
-  await setRoomState(selectRoom(multiSelectMax));
+async function pileCount() {
+  return Object.values(JSON.parse(await getState())).filter(w=>w.type == 'pile').length;
+}
+
+async function cardPositions() {
+  const positions = {};
+  for(const w of Object.values(JSON.parse(await getState())))
+    if(w.type == 'card')
+      positions[w.id] = { x: w.x, y: w.y };
+  return positions;
+}
+
+async function openRoom(t, multiSelectMax, options) {
+  await setRoomState(selectRoom(multiSelectMax, options));
   await ClientFunction(prepareClient)();
   await setName(t, player);
   await expectEventually(t, ()=>cardsIn('hand'), [ 'card1', 'card2', 'card3' ]);
@@ -83,4 +98,32 @@ test('Dragging one selected card takes the rest of the selection along', async t
   await expectEventually(t, ()=>cardsIn('hand'), [ 'card2' ]);
   // leaving the holder that offers the selection ends it
   await expectEventually(t, selectedCards, []);
+});
+
+test('A card the target holder does not accept stays behind', async t => {
+  await openRoom(t, 'all', { dropTarget: { cardType: 'plain' }, oddCard: true });
+
+  await t.click('#w_card1');
+  await t.click('#w_card3');
+  await expectEventually(t, selectedCards, [ 'card1', 'card3' ]);
+
+  // card3 is of another cardType, so the holder rejects it just like it would reject a drag
+  await t.dragToElement('#w_card1', '#w_table');
+  await expectEventually(t, ()=>cardsIn('table'), [ 'card1' ]);
+  await expectEventually(t, ()=>cardsIn('hand'), [ 'card2', 'card3' ]);
+});
+
+test('Cards dropped on the surface are spread out even if the holder stacks them', async t => {
+  await openRoom(t, 'all', { stackOffsetX: 0 });
+
+  await t.click('#w_card1');
+  await t.click('#w_card3');
+  await expectEventually(t, selectedCards, [ 'card1', 'card3' ]);
+
+  await t.dragToElement('#w_card1', '#w_spot');
+  await expectEventually(t, ()=>cardsIn(undefined), [ 'card1', 'card3' ]);
+  // landing on one spot would have turned them into a pile
+  await expectEventually(t, pileCount, 0);
+  const positions = await cardPositions();
+  await t.expect(positions.card1.x).notEql(positions.card3.x);
 });

--- a/validator/validate_gamefile.js
+++ b/validator/validate_gamefile.js
@@ -83,6 +83,9 @@ const COMMON_PROPERTIES = {
     owner: v=>typeof v === 'string' || Array.isArray(v) || 'string or array of strings expected',
     dragging: 'string',
     selectedBy: v=>typeof v === 'string' || Array.isArray(v) || 'string or array of player names expected',
+    // click-to-select is offered by whatever widget a pick sits in, not only by holders
+    multiSelectMax: v=>v === 'all' || (typeof v === 'number' || typeof v === 'string' && v.trim() !== '') && Number.isInteger(+v) && +v >= 0 || 'multiSelectMax must be a non-negative whole number or "all"',
+    multiSelectStyle: getEnumValidator([ 'elevate', 'highlight', 'shade', 'none' ]),
     dropOffsetX: 'number',
     dropOffsetY: 'number',
     dropShadowOwner: 'string',
@@ -131,7 +134,7 @@ const WIDGET_PROPERTIES = {
     },
     Holder: {
         ...COMMON_PROPERTIES,
-        movable: 'boolean', layer: 'number', dropTarget: 'any', dropOffsetX: 'number', dropOffsetY: 'number', dropShadow: 'any', alignChildren: 'any', preventPiles: 'any', childrenPerOwner: 'any', showInactiveFaceToSeat: 'any', multiSelectMax: v=>v === 'all' || (typeof v === 'number' || typeof v === 'string' && v.trim() !== '') && Number.isInteger(+v) && +v >= 0 || 'multiSelectMax must be a non-negative whole number or "all"', multiSelectStyle: getEnumValidator([ 'elevate', 'highlight', 'shade', 'none' ]), onEnter: 'object', onLeave: 'object', stackOffsetX: 'number', stackOffsetY: 'number', borderRadius: 'any', color: 'string', svgReplaces: 'any', text: 'any', textColor: 'any', icon: 'any', image: 'asset'
+        movable: 'boolean', layer: 'number', dropTarget: 'any', dropOffsetX: 'number', dropOffsetY: 'number', dropShadow: 'any', alignChildren: 'any', preventPiles: 'any', childrenPerOwner: 'any', showInactiveFaceToSeat: 'any', onEnter: 'object', onLeave: 'object', stackOffsetX: 'number', stackOffsetY: 'number', borderRadius: 'any', color: 'string', svgReplaces: 'any', text: 'any', textColor: 'any', icon: 'any', image: 'asset'
     },
     Label: {
         ...COMMON_PROPERTIES,

--- a/validator/validate_gamefile.js
+++ b/validator/validate_gamefile.js
@@ -131,7 +131,7 @@ const WIDGET_PROPERTIES = {
     },
     Holder: {
         ...COMMON_PROPERTIES,
-        movable: 'boolean', layer: 'number', dropTarget: 'any', dropOffsetX: 'number', dropOffsetY: 'number', dropShadow: 'any', alignChildren: 'any', preventPiles: 'any', childrenPerOwner: 'any', showInactiveFaceToSeat: 'any', multiSelectMax: v=>v === 'all' || typeof v === 'number' && Number.isInteger(v) && v >= 0 || 'multiSelectMax must be a non-negative whole number or "all"', multiSelectStyle: getEnumValidator([ 'elevate', 'highlight', 'shade', 'none' ]), onEnter: 'object', onLeave: 'object', stackOffsetX: 'number', stackOffsetY: 'number', borderRadius: 'any', color: 'string', svgReplaces: 'any', text: 'any', textColor: 'any', icon: 'any', image: 'asset'
+        movable: 'boolean', layer: 'number', dropTarget: 'any', dropOffsetX: 'number', dropOffsetY: 'number', dropShadow: 'any', alignChildren: 'any', preventPiles: 'any', childrenPerOwner: 'any', showInactiveFaceToSeat: 'any', multiSelectMax: v=>v === 'all' || (typeof v === 'number' || typeof v === 'string' && v.trim() !== '') && Number.isInteger(+v) && +v >= 0 || 'multiSelectMax must be a non-negative whole number or "all"', multiSelectStyle: getEnumValidator([ 'elevate', 'highlight', 'shade', 'none' ]), onEnter: 'object', onLeave: 'object', stackOffsetX: 'number', stackOffsetY: 'number', borderRadius: 'any', color: 'string', svgReplaces: 'any', text: 'any', textColor: 'any', icon: 'any', image: 'asset'
     },
     Label: {
         ...COMMON_PROPERTIES,

--- a/validator/validate_gamefile.js
+++ b/validator/validate_gamefile.js
@@ -82,6 +82,7 @@ const COMMON_PROPERTIES = {
     inheritFrom: 'any',
     owner: v=>typeof v === 'string' || Array.isArray(v) || 'string or array of strings expected',
     dragging: 'string',
+    selectedBy: v=>typeof v === 'string' || Array.isArray(v) || 'string or array of player names expected',
     dropOffsetX: 'number',
     dropOffsetY: 'number',
     dropShadowOwner: 'string',
@@ -130,7 +131,7 @@ const WIDGET_PROPERTIES = {
     },
     Holder: {
         ...COMMON_PROPERTIES,
-        movable: 'boolean', layer: 'number', dropTarget: 'any', dropOffsetX: 'number', dropOffsetY: 'number', dropShadow: 'any', alignChildren: 'any', preventPiles: 'any', childrenPerOwner: 'any', showInactiveFaceToSeat: 'any', onEnter: 'object', onLeave: 'object', stackOffsetX: 'number', stackOffsetY: 'number', borderRadius: 'any', color: 'string', svgReplaces: 'any', text: 'any', textColor: 'any', icon: 'any', image: 'asset'
+        movable: 'boolean', layer: 'number', dropTarget: 'any', dropOffsetX: 'number', dropOffsetY: 'number', dropShadow: 'any', alignChildren: 'any', preventPiles: 'any', childrenPerOwner: 'any', showInactiveFaceToSeat: 'any', multiSelectMax: v=>v === 'all' || typeof v === 'number' && Number.isInteger(v) && v >= 0 || 'multiSelectMax must be a non-negative whole number or "all"', multiSelectStyle: getEnumValidator([ 'elevate', 'highlight', 'shade', 'none' ]), onEnter: 'object', onLeave: 'object', stackOffsetX: 'number', stackOffsetY: 'number', borderRadius: 'any', color: 'string', svgReplaces: 'any', text: 'any', textColor: 'any', icon: 'any', image: 'asset'
     },
     Label: {
         ...COMMON_PROPERTIES,
@@ -763,7 +764,7 @@ const operationProps = {
         'source': v=>v === 'all' || typeof v === 'string',
         'type': 'string',
         'property': 'string',
-        'relation': getEnumValidator(['<','<=','==','===','!=','>=','>','in']),
+        'relation': getEnumValidator(['<','<=','==','===','!=','>=','>','in','contains']),
         'value': 'any',
         'max': 'number',
         'collection': 'string',


### PR DESCRIPTION
## Goal

Implements #2549: an engine-level way to select cards in a holder, so games no longer have to build "pick a card" / "pick up to N cards" out of `INPUT` dialogs or hand-written click routines.

The issue discussion converged on two holder properties (`multiSelectMax` / `multiSelectStyle`) with a `selectedBy` property on the selected widgets — that is what this implements, plus the two extras that came up in the thread: dragging one selected card takes the whole selection along, and selecting a single card replaces the previous pick instead of requiring a deselect first.

## For players

In a holder that has click-to-select enabled, clicking a card picks it and clicking it again drops it. The pick is shown right away (raised by default), the limit is enforced while clicking, and **dragging one of the picked cards out drags the whole selection with it**: the moment the drag leaves the holder the other picked cards come out with it and travel next to it, so the drag shows what is about to be played.

![selection](https://agent.virtualtabletop.io/reports/pr/1534030355961745419/multiselect-selected.png)

![dragging the selection](https://agent.virtualtabletop.io/reports/pr/1534030355961745419/multiselect-drag.png)

The cards that come along are not dragged by hand, so the drop has to check them the way it checked the dragged one: a card the target holder's `dropTarget` rejects, or one that no longer fits its `dropLimit`, goes back into the holder it was picked from and is picked again there — a refused drop costs no selection. The same happens when the drag ends back in the holder it started in, which makes dragging out and back in a way to change your mind.

## For designers

Two new **holder** properties:

| property | values | meaning |
| --- | --- | --- |
| `multiSelectMax` | `0` (default, off), a whole number, `"all"` | how many widgets one player may have selected in this holder at a time |
| `multiSelectStyle` | `"elevate"` (default), `"highlight"`, `"shade"`, `"none"` | how a widget the player picked is shown |

While `multiSelectMax` is set, a click on a widget in the holder toggles its selection **instead of** running its `clickRoutine` or flipping a card. With `multiSelectMax: 1` a new pick replaces the previous one (the pre-selection case from the issue); with a higher limit a full selection stays put until the player deselects something. A `CLICK` operation with `mode: "ignoreClickRoutine"` skips the selection as well, so automations can still flip such a card.

One new property on the selected widgets:

- **`selectedBy`** — the list of players who currently have this widget selected. Several players can select simultaneously in a shared holder, each sees only their own picks. It is cleared when the widget leaves the holder that offers the selection — including when it leaves a pile inside that holder.

Because it is a normal property, `selectedByChangeRoutine` fires on every pick, and routines read the selection with the new `contains` relation of `SELECT` (the mirror image of `in`: the *property* is the list, not a substring test):

```json
{ "func": "SELECT", "type": "card", "property": "selectedBy", "relation": "contains", "value": "${playerName}" },
{ "func": "MOVE", "from": "hand", "to": "table" }
```

The three built-in styles use `--VTTblue`, the colour the app already uses for "the player chose this" in the `INPUT` dialog: `elevate` raises the pick and rings it, `highlight` rings it, and `shade` dims everything the player did *not* pick (a darkened widget means "unavailable" everywhere else in the app, so dimming the picks would read backwards). They are marked `!important` so that a widget dimming or tinting itself through its own `css` cannot hide the fact that the player selected it. `multiSelectStyle: "none"` sets only the `multiSelected` class so a game can style the selection through the holder's `css` property.

A widget in such a holder answers the pointer with a faint ring before the first click, so the holder shows that it reacts to clicks, and a click that runs into the limit flashes the holder instead of doing nothing at all. The widgets that follow a drag stay on the 1600x1000 surface: near the right edge the fan turns around, and a fan too wide for the room left moves closer together.

Both properties are wired into the editor: a "Click to select" / "Selection shown as" row in the holder's Behavior section, insert buttons and value lists in the JSON editor, and validator entries (so they are not reported as unknown properties).

![editor](https://agent.virtualtabletop.io/reports/pr/1534030355961745419/multiselect-editor.png)

## Compatibility

Everything is opt-in through new properties whose defaults preserve today's behaviour (`multiSelectMax: 0` = off), so **no save migration and no legacy mode** are needed. `selectedBy` only appears on widgets in a holder that enables the feature.

Creator-facing change, so the wiki pages *Widgets* (holder properties, `selectedBy`) and *Functions* (`SELECT` relation `contains`) will want an update.

## Testing

- `npm test` — 188 jest tests pass, including `tests/client/widget-select.test.js` (15 cases: selecting, deselecting, the limit, `multiSelectMax` as a string, the `multiSelectMax: 1` replacement, clearing on leaving the holder and on leaving a pile inside it, the selection being carried out of the holder by the drag, the `dropTarget` and `dropLimit` checks, a refused card going back into the holder still selected, a drag that ends where it started, the spread on the surface, and `SELECT ... relation: contains`).
- `tests/testcafe/multiselect.js` — 5 end-to-end cases covering clicking, the limit, `multiSelectMax: 1`, the drag-along, a card the target holder rejects (which keeps its pick), and the spread on the surface with a holder that stacks its children.
- `tests/testcafe/routines.js` and `publiclibrary-1.js` re-run locally and pass unchanged (no state hashes move — the feature is inert unless a holder opts in).
- Manually verified in a browser against the room on the PR test server: the selection travels with the drag, into another holder, onto the surface, back into the hand, and out of a holder that refuses it.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3094/pr-test (or any other room on that server)


