### PR TITLE
Size the overlays from the board instead of the window

### DIFF
--- a/client/css/editmode.css
+++ b/client/css/editmode.css
@@ -207,7 +207,7 @@
   height: 100%;
 }
 
-@media only screen and (max-width: 500px) {
+@container roomArea (max-width: 500px) {
   #editJSONoverlay textarea {
     min-height: 100%;
   }

--- a/client/css/editor/deckeditor.css
+++ b/client/css/editor/deckeditor.css
@@ -931,7 +931,9 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   overflow: visible;
 }
 
-@media (max-width: 700px) {
+/* the export dialog is one of the #editorOverlays, which initializeEditMode moves into
+   #roomArea - so it is as wide as the board, not as the window */
+@container roomArea (max-width: 700px) {
   .deckEditorExportOptions {
     grid-template-columns: 1fr;
   }

--- a/client/css/editor/deckeditor.css
+++ b/client/css/editor/deckeditor.css
@@ -931,9 +931,9 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   overflow: visible;
 }
 
-/* the export dialog is one of the #editorOverlays, which initializeEditMode moves into
-   #roomArea - so it is as wide as the board, not as the window */
-@container roomArea (max-width: 700px) {
+/* stays a media query: initializeDOM() re-parents this dialog into #editor, where it is positioned
+   against the viewport - a container query on #roomArea has no container to resolve against there */
+@media (max-width: 700px) {
   .deckEditorExportOptions {
     grid-template-columns: 1fr;
   }

--- a/client/css/editor/sidebar.css
+++ b/client/css/editor/sidebar.css
@@ -245,29 +245,31 @@ body.lightsOff #editorModules {
   color: #f8f8f2;
 }
 
-/* iconify sidebar icons */
-@media (max-width: 1600px) {
-  :root {
-    --editSidebarWidth: 36px;
-  }
-  #editorSidebar button {
-    font-size: 0;
-    padding: 5px;
-  }
-  #editorSidebar button::before {
-    margin: 0;
-  }
-  #editorSidebar button span {
-    font-size: 13px;
-  }
+/* iconify sidebar icons - set by isEditSidebarNarrow() because the window width at which the
+   labels stop being affordable depends on the board's shape, which a media query can't know.
+   It used to be @media (max-width: 1600px), which took them away whenever the window was
+   narrower than a 16:10 board at full height, even where the room is limited by its height
+   and does not get any bigger without them. The module panel layouts below always iconify. */
+body.narrowEditSidebar {
+  --editSidebarWidth: 36px;
+}
+body.narrowEditSidebar #editorSidebar button {
+  font-size: 0;
+  padding: 5px;
+}
+body.narrowEditSidebar #editorSidebar button::before {
+  margin: 0;
+}
+body.narrowEditSidebar #editorSidebar button span {
+  font-size: 13px;
 }
 
 /* module above the room - the classes below are set by calculateEditModuleClasses() because the window
    shape they kick in at depends on the board's shape, which a media query can't know. They used to be two
    media queries in this order, and just like those they can both be active at once - the overlay comes
-   second, so it still wins where they overlap. */
+   second, so it still wins where they overlap. Both imply narrowEditSidebar, which is where the 36px
+   sidebar they leave room for comes from. */
 body.edit.editModulesAbove {
-  --editSidebarWidth: 36px;
   --roomTop: calc(100 * var(--vh) - var(--roomHeight) * var(--scale) / var(--roomZoom) + (1 - var(--roomZoom)) / 2 * var(--roomHeight) * var(--scale) / var(--roomZoom));
 }
 body.editModulesAbove #editorModules {
@@ -282,9 +284,6 @@ body.editModulesAbove #editorModules {
 }
 
 /* module as fullscreen overlay */
-body.edit.editModulesOverlay {
-  --editSidebarWidth: 36px;
-}
 body.editModulesOverlay #editorModules {
   left: 0;
   top: var(--editToolbarHeight);

--- a/client/css/fonts.css
+++ b/client/css/fonts.css
@@ -484,12 +484,12 @@
   display: none;
 }
 
-@media (max-width: 600px), (max-height: 375px) {
+@container roomArea ((max-width: 600px) or (max-height: 375px)) {
   #symbolPickerOverlay {
     padding: 2%;
   }
 }
-@media (max-width: 300px), (max-height: 187px) {
+@container roomArea ((max-width: 300px) or (max-height: 187px)) {
   #symbolPickerOverlay {
     padding: 0;
   }
@@ -519,7 +519,7 @@ p[icon]::before {
   position: absolute;
   left: -40px;
 }
-@media (max-width: 600px), (max-height: 375px) {
+@container roomArea ((max-width: 600px) or (max-height: 375px)) {
   p[icon] {
     margin: 10px;
     margin-left: 40px;

--- a/client/css/fonts.css
+++ b/client/css/fonts.css
@@ -490,6 +490,14 @@
   #symbolPickerOverlay {
     padding: 2%;
   }
+  #symbolPickerOverlay p[icon] {
+    margin: 10px;
+    margin-left: 40px;
+  }
+  #symbolPickerOverlay p[icon]::before {
+    font-size: 150%;
+    left: -30px;
+  }
 }
 @media (max-width: 300px), (max-height: 187px) {
   #symbolPickerOverlay {
@@ -521,7 +529,10 @@ p[icon]::before {
   position: absolute;
   left: -40px;
 }
-@media (max-width: 600px), (max-height: 375px) {
+/* the other one of these is the welcome overlay's user-generated-content warning, which is laid
+   out inside the board - the symbol picker's copy is handled by the media query above, since that
+   overlay is not always in the room */
+@container roomArea ((max-width: 600px) or (max-height: 375px)) {
   p[icon] {
     margin: 10px;
     margin-left: 40px;

--- a/client/css/fonts.css
+++ b/client/css/fonts.css
@@ -484,12 +484,14 @@
   display: none;
 }
 
-@container roomArea ((max-width: 600px) or (max-height: 375px)) {
+/* stay media queries: the deck editor moves the symbol picker out of the room overlays into #editor
+   or #deckEditorMainCol, so there is no #roomArea container to query while it is open there */
+@media (max-width: 600px), (max-height: 375px) {
   #symbolPickerOverlay {
     padding: 2%;
   }
 }
-@container roomArea ((max-width: 300px) or (max-height: 187px)) {
+@media (max-width: 300px), (max-height: 187px) {
   #symbolPickerOverlay {
     padding: 0;
   }
@@ -519,7 +521,7 @@ p[icon]::before {
   position: absolute;
   left: -40px;
 }
-@container roomArea ((max-width: 600px) or (max-height: 375px)) {
+@media (max-width: 600px), (max-height: 375px) {
   p[icon] {
     margin: 10px;
     margin-left: 40px;

--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -49,7 +49,13 @@ body.loadingEditMode * {
   cursor: wait;
 }
 
+/* the overlays are children of #roomArea, so their size is the board's, not the window's.
+   Their breakpoints are container queries against this box: as media queries they measured
+   the window, which only said something about how much room an overlay has back when every
+   board was 1600x1000. A square or portrait board now leaves a much smaller overlay in the
+   same window and would still have gotten the layout of a wide one. */
 #roomArea {
+  container: roomArea / size;
   position: fixed;
   overflow: clip;
   width: calc(var(--roomWidth) * var(--scale));

--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -53,7 +53,10 @@ body.loadingEditMode * {
    Their breakpoints are container queries against this box: as media queries they measured
    the window, which only said something about how much room an overlay has back when every
    board was 1600x1000. A square or portrait board now leaves a much smaller overlay in the
-   same window and would still have gotten the layout of a wide one. */
+   same window and would still have gotten the layout of a wide one.
+   Only for overlays that stay in here: an element the deck editor re-parents into #editor (the
+   symbol picker, its own dialogs) has no roomArea container left, and a @container rule on it
+   silently stops matching at any size - those keep their media queries. */
 #roomArea {
   container: roomArea / size;
   position: fixed;

--- a/client/css/overlays/misc.css
+++ b/client/css/overlays/misc.css
@@ -17,13 +17,13 @@
     margin: 0 auto;
   }
 
-  @media (max-width: 500px), (max-height: 312px) {
+  @container roomArea ((max-width: 500px) or (max-height: 312px)) {
     #confirmOverlay {
       justify-content: unset;
     }
   }
 
-  @media (max-width: 340px), (max-height: 212px) {
+  @container roomArea ((max-width: 340px) or (max-height: 212px)) {
     #confirmOverlay {
       padding: 0;
     }

--- a/client/css/overlays/states.css
+++ b/client/css/overlays/states.css
@@ -147,19 +147,19 @@
   overflow: auto;
 }
 
-@media (max-width: 600px), (max-height: 375px) {
+@container roomArea ((max-width: 600px) or (max-height: 375px)) {
   #statesList { overflow: unset; }
   #statesOverlay { overflow: auto; }
 }
 
-@media (max-width: 2260px), (max-height: 1412px) { #statesOverlay { --columns: 9; } }
-@media (max-width: 2000px), (max-height: 1250px) { #statesOverlay { --columns: 8; } }
-@media (max-width: 1700px), (max-height: 1062px) { #statesOverlay { --columns: 7; } }
-@media (max-width: 1420px), (max-height:  887px) { #statesOverlay { --columns: 6; } }
-@media (max-width: 1120px), (max-height:  700px) { #statesOverlay { --columns: 5; } }
-@media (max-width:  800px), (max-height:  500px) { #statesOverlay { --columns: 4; } }
-@media (max-width:  680px), (max-height:  425px) { #statesOverlay { --columns: 3; } }
-@media (max-width:  520px), (max-height:  325px) { #statesOverlay { --columns: 2; } }
+@container roomArea ((max-width: 2260px) or (max-height: 1412px)) { #statesOverlay { --columns: 9; } }
+@container roomArea ((max-width: 2000px) or (max-height: 1250px)) { #statesOverlay { --columns: 8; } }
+@container roomArea ((max-width: 1700px) or (max-height: 1062px)) { #statesOverlay { --columns: 7; } }
+@container roomArea ((max-width: 1420px) or (max-height:  887px)) { #statesOverlay { --columns: 6; } }
+@container roomArea ((max-width: 1120px) or (max-height:  700px)) { #statesOverlay { --columns: 5; } }
+@container roomArea ((max-width:  800px) or (max-height:  500px)) { #statesOverlay { --columns: 4; } }
+@container roomArea ((max-width:  680px) or (max-height:  425px)) { #statesOverlay { --columns: 3; } }
+@container roomArea ((max-width:  520px) or (max-height:  325px)) { #statesOverlay { --columns: 2; } }
 
 #statesList .title {
   border-top: 1px solid black;
@@ -412,7 +412,7 @@ div:nth-of-type(2) > .list > .roomState .star {
 }
 
 
-@media (max-width: 600px), (max-height: 375px) {
+@container roomArea ((max-width: 600px) or (max-height: 375px)) {
   #statesOverlay h2.title {
     position: unset;
     margin:  0 !important;
@@ -434,7 +434,7 @@ div:nth-of-type(2) > .list > .roomState .star {
     clear: both;
   }
 }
-@media (max-width: 320px), (max-height: 200px) {
+@container roomArea ((max-width: 320px) or (max-height: 200px)) {
   #filterOverflow > div {
     padding: 2px;
   }
@@ -940,7 +940,7 @@ div:nth-of-type(2) > .list > .roomState .star {
   margin-bottom: 6px;
 }
 
-@media (max-width: 1260px), (max-height: 787px), (min-width: 1421px) and (min-height: 888px) {
+@container roomArea ((max-width: 1260px) or (max-height: 787px) or ((min-width: 1421px) and (min-height: 888px))) {
   #stateDetailsOverlay {
     --mainDetailsHeight: 200px;
     --similarDetailsHeight: 160px;
@@ -963,12 +963,12 @@ div:nth-of-type(2) > .list > .roomState .star {
     display: none;
   }
 }
-@media (max-width: 1040px), (max-height: 650px), (min-width: 1421px) and (min-height: 888px) {
+@container roomArea ((max-width: 1040px) or (max-height: 650px) or ((min-width: 1421px) and (min-height: 888px))) {
   .variant {
     padding: .11rem .5rem;
   }
 }
-@media (max-width: 957px), (max-height: 600px), (max-width: 1000px) and (max-height: 643px), (min-width: 1421px) and (min-height: 888px) {
+@container roomArea ((max-width: 957px) or (max-height: 600px) or ((max-width: 1000px) and (max-height: 643px)) or ((min-width: 1421px) and (min-height: 888px))) {
   #stateDetailsOverlay {
     --mainDetailsHeight: 150px;
     --similarDetailsHeight: 150px;
@@ -1035,7 +1035,7 @@ div:nth-of-type(2) > .list > .roomState .star {
     padding: 0 20px 20px 20px;
   }
 }
-@media (max-width: 500px), (max-height: 312px) {
+@container roomArea ((max-width: 500px) or (max-height: 312px)) {
   #stateDetailsOverlay {
     --mainDetailsHeight: 50px;
     --similarDetailsHeight: 50px;
@@ -1109,7 +1109,7 @@ div:nth-of-type(2) > .list > .roomState .star {
     margin: 10px 0;
   }
 }
-@media (max-width: 270px), (max-height: 168px) {
+@container roomArea ((max-width: 270px) or (max-height: 168px)) {
   #stateDetailsOverlay.editing #mainDetails {
     margin-top: 0;
   }
@@ -1121,7 +1121,7 @@ div:nth-of-type(2) > .list > .roomState .star {
     position: unset;
   }
 }
-@media (min-width: 1421px) and (min-height: 888px) { /* sidebar */
+@container roomArea ((min-width: 1421px) and (min-height: 888px)) { /* sidebar */
   #statesOverlay.withDetails {
     padding-right: calc((var(--size) + 22px) * 3);
   }
@@ -1188,7 +1188,7 @@ div:nth-of-type(2) > .list > .roomState .star {
 #stateAddOverlay > div > div:nth-of-type(1), #variantAddOverlay > div > div:nth-of-type(1) {
   grid-column: 1 / span 2;
 }
-@media (max-width: 880px), (max-height: 550px) {
+@container roomArea ((max-width: 880px) or (max-height: 550px)) {
   #stateAddOverlay, #variantAddOverlay {
     justify-content: unset;
   }
@@ -1196,7 +1196,7 @@ div:nth-of-type(2) > .list > .roomState .star {
     margin-top: 20px;
   }
 }
-@media (max-width: 600px), (max-height: 375px) {
+@container roomArea ((max-width: 600px) or (max-height: 375px)) {
   #stateAddOverlay, #variantAddOverlay {
     padding: 0;
   }
@@ -1204,7 +1204,7 @@ div:nth-of-type(2) > .list > .roomState .star {
     grid-column: unset;
   }
 }
-@media (max-width: 300px), (max-height: 187px) {
+@container roomArea ((max-width: 300px) or (max-height: 187px)) {
   #stateAddOverlay .titleWithCloseButton, #variantAddOverlay .titleWithCloseButton {
     margin-top: 10px;
   }
@@ -1261,13 +1261,13 @@ div:nth-of-type(2) > .list > .roomState .star {
   margin: 0 auto;
 }
 
-@media (max-width: 500px), (max-height: 312px) {
+@container roomArea ((max-width: 500px) or (max-height: 312px)) {
   #stateSaveOverlay {
     justify-content: unset;
   }
 }
 
-@media (max-width: 300px), (max-height: 187px) {
+@container roomArea ((max-width: 300px) or (max-height: 187px)) {
   #stateSaveOverlay {
     padding: 0;
   }
@@ -1325,13 +1325,13 @@ div:nth-of-type(2) > .list > .roomState .star {
   margin: 0 auto;
 }
 
-@media (max-width: 800px), (max-height: 500px) {
+@container roomArea ((max-width: 800px) or (max-height: 500px)) {
   #shareLinkOverlay {
     justify-content: unset;
   }
 }
 
-@media (max-width: 400px), (max-height: 250px) {
+@container roomArea ((max-width: 400px) or (max-height: 250px)) {
   #shareLinkOverlay {
     padding: 0;
   }
@@ -1408,7 +1408,7 @@ div:nth-of-type(2) > .list > .roomState .star {
 }
 
 
-@media (max-width: 1000px), (max-height: 625px) {
+@container roomArea ((max-width: 1000px) or (max-height: 625px)) {
   #updateImageOverlay {
     padding: 10px;
   }
@@ -1422,12 +1422,12 @@ div:nth-of-type(2) > .list > .roomState .star {
     margin-left: 4px;
   }
 }
-@media (max-width: 800px), (max-height: 500px) {
+@container roomArea ((max-width: 800px) or (max-height: 500px)) {
   #updateImageOverlay h1 {
     display: none;
   }
 }
-@media (max-width: 600px), (max-height: 375px) {
+@container roomArea ((max-width: 600px) or (max-height: 375px)) {
   #updateImageOverlay > div:nth-child(2) {
     flex-direction: column;
   }
@@ -1441,12 +1441,12 @@ div:nth-of-type(2) > .list > .roomState .star {
     max-height: 400px;
   }
 }
-@media (max-width: 400px), (max-height: 250px) {
+@container roomArea ((max-width: 400px) or (max-height: 250px)) {
   #updateButtonBar {
     flex-direction: column;
   }
 }
-@media (max-width: 300px), (max-height: 187px) {
+@container roomArea ((max-width: 300px) or (max-height: 187px)) {
   #updateImageOverlay h2 {
     height: unset;
   }

--- a/client/css/overlays/welcome.css
+++ b/client/css/overlays/welcome.css
@@ -172,14 +172,14 @@
 }
 
 
-@media (min-width: 1400px) and (min-height: 875px) {
+@container roomArea ((min-width: 1400px) and (min-height: 875px)) {
   #linkDetailsOverlay {
     justify-content: center;
   }
 }
 
 
-@media (max-width: 960px), (max-height: 600px) {
+@container roomArea ((max-width: 960px) or (max-height: 600px)) {
   #linkDetailsOverlay {
     --mainDetailsHeight: 200px;
   }
@@ -201,7 +201,7 @@
 }
 
 
-@media (max-width: 660px), (max-height: 412px) {
+@container roomArea ((max-width: 660px) or (max-height: 412px)) {
   #linkDetailsOverlay {
     --mainDetailsHeight: 150px;
     padding: 0;
@@ -245,7 +245,7 @@
 }
 
 
-@media (max-width: 500px), (max-height: 312px) {
+@container roomArea ((max-width: 500px) or (max-height: 312px)) {
   #linkDetailsOverlay {
     --mainDetailsHeight: 50px;
   }
@@ -280,7 +280,7 @@
 }
 
 
-@media (max-width: 360px), (max-height: 225px) {
+@container roomArea ((max-width: 360px) or (max-height: 225px)) {
   #linkDetailsOverlay .welcomeInput {
     margin: 0;
   }

--- a/client/js/calculateLayout.js
+++ b/client/js/calculateLayout.js
@@ -3,6 +3,10 @@ const TOOLBAR_SIZE = 44;
 const WIDE_TOOLBAR_SIZE = 200;
 // the window width below which edit mode stops keeping the module panel beside the room
 const NARROW_WINDOW_SIZE = 1000;
+// Mirror editor/sidebar.css and editor/toolbar.css: the width of the editor sidebar with its
+// button labels and the height of the editor toolbar above the room.
+const EDIT_SIDEBAR_WIDTH = 128;
+const EDIT_TOOLBAR_HEIGHT = 36;
 
 export const DEFAULT_VIEWPORT = { targetWidth: 1600, targetHeight: 1000 };
 export const MIN_BOARD_SIZE = 100;
@@ -133,4 +137,28 @@ export function calculateEditModuleClasses(windowWidth, windowHeight, viewport) 
   if(windowWidth <= NARROW_WINDOW_SIZE && windowAspect >= halfBoardAspect)
     classes.push('editModulesOverlay');
   return classes;
+}
+
+/**
+ * Whether the editor sidebar has to drop its button labels and show icons only. It is
+ * 128px wide with them and 36px without, and those 92px come out of the room - but only
+ * while the room is what is limited by the window's width. A portrait board fills the
+ * height long before it runs out of width, so it can keep the labels in a window where
+ * the default board can't, and a wide board loses them in one where it could.
+ *
+ * This used to be `@media (max-width: 1600px)`, which is roughly the window a 16:10 board
+ * needs at full height - the same number for every board, and one that took the labels
+ * away on e.g. 1600x900 even though the room there is limited by its height and does not
+ * get one pixel bigger without them.
+ *
+ * @param {number} windowWidth
+ * @param {number} windowHeight
+ * @param {Object} viewport - { targetWidth, targetHeight }
+ * @returns {boolean}
+ */
+export function isEditSidebarNarrow(windowWidth, windowHeight, viewport) {
+  // the module panel layouts put the panel where the sidebar's labels would be
+  if(calculateEditModuleClasses(windowWidth, windowHeight, viewport).length)
+    return true;
+  return (windowWidth - EDIT_SIDEBAR_WIDTH)/viewport.targetWidth < (windowHeight - EDIT_TOOLBAR_HEIGHT)/viewport.targetHeight;
 }

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -1,6 +1,6 @@
 import { $, $a, onLoad, selectFile, asArray, toggleClass } from './domhelpers.js';
 import { startWebSocket, toServer } from './connection.js';
-import { calculateLayout, calculateEditModuleClasses, isOrientationMismatch, viewportConfig, DEFAULT_VIEWPORT, LAYOUT_CLASSES, MIN_BOARD_SIZE, MAX_BOARD_SIZE } from './calculateLayout.js';
+import { calculateLayout, calculateEditModuleClasses, isEditSidebarNarrow, isOrientationMismatch, viewportConfig, DEFAULT_VIEWPORT, LAYOUT_CLASSES, MIN_BOARD_SIZE, MAX_BOARD_SIZE } from './calculateLayout.js';
 
 export let scale = 1;
 let roomRectangle;
@@ -203,11 +203,14 @@ function setScale() {
 
   const layoutOptions = { toolbarHidden: $('body').className.match(/hiddenToolbar/) != null };
 
-  // set before measuring below - they decide where the module panel sits and so how much room is
-  // left. Only in edit mode: in play mode there is no module panel and game CSS shouldn't see them.
-  $('body').classList.remove('editModulesAbove', 'editModulesOverlay');
-  if(edit || jeEnabled)
+  // set before measuring below - they decide where the module panel sits and how wide the sidebar
+  // is, and so how much room is left. Only in edit mode: in play mode there is neither a module
+  // panel nor a sidebar and game CSS shouldn't see them.
+  $('body').classList.remove('editModulesAbove', 'editModulesOverlay', 'narrowEditSidebar');
+  if(edit || jeEnabled) {
     $('body').classList.add(...calculateEditModuleClasses(w, h, viewportConfig));
+    toggleClass($('body'), 'narrowEditSidebar', isEditSidebarNarrow(w, h, viewportConfig));
+  }
 
   if(edit || jeEnabled) {
     const targetWidth = targetW / zoom;

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -244,6 +244,7 @@ function setScale() {
   document.documentElement.style.setProperty('--scale', scale);
   updateToolbarLayout();
   roomRectangle = $('#roomArea').getBoundingClientRect();
+  setSidebar(); // the game details sidebar is a container query on the board, so it flips with it
   if(edit)
     scaleHasChanged(scale);
   refreshIgnoreZoomWidgets();

--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -1078,10 +1078,16 @@ function fillStateDetails(states, state, dom) {
   };
 }
 
+// Whether the game details are shown as a sidebar next to the shelf instead of as an overlay of
+// their own. What that sidebar looks like comes from `@container roomArea ((min-width: 1421px) and
+// (min-height: 888px))` in states.css, so this has to measure the same box with the same numbers:
+// measuring the window instead claims a sidebar the CSS never gives a `display` in the band where
+// the board is smaller than the window, and clicking a game there does nothing at all.
+// Called from setScale(), i.e. every time the board is laid out - including when a game brings its
+// own board size along, which changes the container without any window resize.
 function setSidebar() {
-  const vw = Math.max(document.documentElement.clientWidth  || 0, window.innerWidth  || 0)
-  const vh = Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0)
-  const bigEnough = vw >= 1421 && vh >= 888;
+  const board = $('#roomArea').getBoundingClientRect();
+  const bigEnough = board.width >= 1421 && board.height >= 888;
 
   if(detailsInSidebar != bigEnough) {
     detailsInSidebar = bigEnough;
@@ -1232,10 +1238,9 @@ onLoad(function() {
       alert('Please enter a link.');
   });
 
-  window.addEventListener('resize', function() {
-    setSidebar();
-    updateFilterOverflow();
-  });
+  // setSidebar() is not called here: a resize reaches this listener before setScale() has given the
+  // board its new size, so it would decide on the old one - setScale() calls it itself instead.
+  window.addEventListener('resize', updateFilterOverflow);
   document.addEventListener('dragover', function(e) {
     if($('#statesOverlay').style.display == 'flex' && e.dataTransfer.types.includes('Files')) {
       e.preventDefault();

--- a/tests/calculateLayout.test.js
+++ b/tests/calculateLayout.test.js
@@ -1,4 +1,4 @@
-import { calculateLayout, calculateEditModuleClasses, isOrientationMismatch, DEFAULT_VIEWPORT, normalizeBoardSize, setViewportSize, viewportConfig } from '../client/js/calculateLayout.js';
+import { calculateLayout, calculateEditModuleClasses, isEditSidebarNarrow, isOrientationMismatch, DEFAULT_VIEWPORT, normalizeBoardSize, setViewportSize, viewportConfig } from '../client/js/calculateLayout.js';
 
 describe('calculateLayout', () => {
   const viewport16x10 = { targetWidth: 1600, targetHeight: 1000 };
@@ -132,6 +132,37 @@ describe('calculateEditModuleClasses', () => {
     const wide = { targetWidth: 3200, targetHeight: 1000 };
     expect(calculateEditModuleClasses(1400, 1200, viewport16x10)).toEqual([]);
     expect(calculateEditModuleClasses(1400, 1200, wide)).toEqual([ 'editModulesAbove' ]);
+  });
+});
+
+// replaces `@media (max-width: 1600px)` on the editor sidebar: the labels may stay as long as
+// the 92px they cost are not what the room is short of
+describe('isEditSidebarNarrow', () => {
+  const viewport16x10 = { targetWidth: 1600, targetHeight: 1000 };
+  const portraitBoard = { targetWidth: 1000, targetHeight: 1600 };
+  const wideBoard     = { targetWidth: 3200, targetHeight: 1000 };
+
+  test('keeps the labels while the room is limited by the window height', () => {
+    expect(isEditSidebarNarrow(1920, 1080, viewport16x10)).toBe(false);
+    // the media query took them away here even though the room is 90px short of the sidebar
+    expect(isEditSidebarNarrow(1600, 900, viewport16x10)).toBe(false);
+  });
+
+  test('drops them once they would make the board smaller', () => {
+    expect(isEditSidebarNarrow(1280, 800, viewport16x10)).toBe(true);
+    // a wide board runs out of width in a window the default board has plenty of room in
+    expect(isEditSidebarNarrow(1920, 1080, wideBoard)).toBe(true);
+  });
+
+  test('lets a portrait board keep them in a window the default board loses them in', () => {
+    expect(isEditSidebarNarrow(1280, 800, portraitBoard)).toBe(false);
+  });
+
+  test('is implied by both module panel layouts, which need the room the sidebar has', () => {
+    expect(calculateEditModuleClasses(1900, 1900, portraitBoard)).toEqual([ 'editModulesAbove' ]);
+    expect(isEditSidebarNarrow(1900, 1900, portraitBoard)).toBe(true);
+    expect(calculateEditModuleClasses(900, 900, viewport16x10)).toEqual([ 'editModulesOverlay' ]);
+    expect(isEditSidebarNarrow(900, 900, viewport16x10)).toBe(true);
   });
 });
 

--- a/tests/testcafe/boardsize.js
+++ b/tests/testcafe/boardsize.js
@@ -31,6 +31,14 @@ async function loadGameWithBoardSize(boardSize) {
 const defaultBoard  = { roomWidth: '1600px', roomHeight: '1000px', renderedAspect: '1.600' };
 const portraitBoard = { roomWidth: '1000px', roomHeight: '1600px', renderedAspect: '0.625' };
 
+// How wide one game tile in the shelf ends up. The overlays are children of #roomArea, so what
+// they have to work with is the rendered board, not the window - --columns comes out of the
+// container queries in states.css and the grid divides the shelf's width by it.
+const shelfTiles = ClientFunction(() => {
+  const columns = +getComputedStyle(document.querySelector('#statesOverlay')).getPropertyValue('--columns');
+  return { columns, tileWidth: document.querySelector('#roomArea').getBoundingClientRect().width/columns };
+});
+
 test('Loading a game with its own board size re-lays out a client that is already in the room', async t => {
   await loadGameWithBoardSize(null);
   await ClientFunction(prepareClient)();
@@ -62,6 +70,27 @@ test('An unusable board size in a game file is normalized instead of being store
   // what everybody renders and what is stored in the game file have to be the same board
   await t.expect(boardLayout()).eql({ roomWidth: '100px', roomHeight: '10000px', renderedAspect: '0.010' });
   await t.expect((await getMeta()).gameSettings.boardSize).eql({ width: 100, height: 10000 });
+
+  await loadGameWithBoardSize(null);
+});
+
+// A portrait board leaves the game shelf a fraction of the width the window has, so it has to
+// drop columns to keep the tiles the size they are on the default board. Off the window - which
+// is what a media query measures - it kept every one of them and squeezed unreadable thumbnails
+// into the space of three.
+test('The game shelf sizes its tiles from the board, not from the window', async t => {
+  await t.resizeWindow(1280, 800);
+  await loadGameWithBoardSize(null);
+  await ClientFunction(prepareClient)();
+  await t.click('#statesButton');
+  const onDefaultBoard = await shelfTiles();
+
+  await loadGameWithBoardSize({ width: 1000, height: 1600 });
+  const onPortraitBoard = await shelfTiles();
+
+  await t
+    .expect(onPortraitBoard.columns).lt(onDefaultBoard.columns)
+    .expect(onPortraitBoard.tileWidth).gt(onDefaultBoard.tileWidth*0.75);
 
   await loadGameWithBoardSize(null);
 });

--- a/tests/testcafe/boardsize.js
+++ b/tests/testcafe/boardsize.js
@@ -106,11 +106,14 @@ test('The Apply confirmation goes away when somebody else changes the board size
   await loadGameWithBoardSize(null);
 });
 
+// What the editor sidebar is currently wide - 128px with its button labels, 36px without them.
+const editSidebarWidth = ClientFunction(() => getComputedStyle(document.body).getPropertyValue('--editSidebarWidth').trim());
+
 // A portrait board leaves the game shelf a fraction of the width the window has, so it has to
 // drop columns to keep the tiles the size they are on the default board. Off the window - which
 // is what a media query measures - it kept every one of them and squeezed unreadable thumbnails
 // into the space of three.
-// Last in this file on purpose: the window size it sets stays with the browser afterwards.
+// The last two tests in this file on purpose: the window size they set stays with the browser.
 test('The game shelf sizes its tiles from the board, not from the window', async t => {
   await t.resizeWindow(1280, 800);
   await loadGameWithBoardSize(null);
@@ -124,6 +127,23 @@ test('The game shelf sizes its tiles from the board, not from the window', async
   await t
     .expect(onPortraitBoard.columns).lt(onDefaultBoard.columns)
     .expect(onPortraitBoard.tileWidth).gt(onDefaultBoard.tileWidth*0.75);
+
+  await loadGameWithBoardSize(null);
+});
+
+// The editor sidebar trades its button labels for board width, so whether it can afford them
+// depends on the board: this window is too narrow for the default board to keep them, but a
+// portrait board runs out of height long before it runs out of width and has them to spare.
+test('The editor sidebar keeps its labels while the board is not short of the space', async t => {
+  await t.resizeWindow(1280, 800);
+  await loadGameWithBoardSize(null);
+  await ClientFunction(prepareClient)();
+  await t
+    .click('#editButton')
+    .expect(editSidebarWidth()).eql('36px');
+
+  await loadGameWithBoardSize({ width: 1000, height: 1600 });
+  await t.expect(editSidebarWidth()).eql('128px');
 
   await loadGameWithBoardSize(null);
 });

--- a/tests/testcafe/boardsize.js
+++ b/tests/testcafe/boardsize.js
@@ -113,7 +113,8 @@ const editSidebarWidth = ClientFunction(() => getComputedStyle(document.body).ge
 // drop columns to keep the tiles the size they are on the default board. Off the window - which
 // is what a media query measures - it kept every one of them and squeezed unreadable thumbnails
 // into the space of three.
-// The last two tests in this file on purpose: the window size they set stays with the browser.
+// The last three tests in this file resize the window on purpose - they come last because the
+// size they set stays with the browser afterwards.
 test('The game shelf sizes its tiles from the board, not from the window', async t => {
   await t.resizeWindow(1280, 800);
   await loadGameWithBoardSize(null);
@@ -144,6 +145,29 @@ test('The editor sidebar keeps its labels while the board is not short of the sp
 
   await loadGameWithBoardSize({ width: 1000, height: 1600 });
   await t.expect(editSidebarWidth()).eql('128px');
+
+  await loadGameWithBoardSize(null);
+});
+
+// Whether the game details are a sidebar of the shelf or an overlay of their own is a container
+// query on the board, so setSidebar() has to decide it from the board too. While it still measured
+// the window, every window that was bigger than its board - 1460x920 on a default board, any
+// desktop window on a portrait one - moved the details into the shelf, where the CSS never gave
+// them a display: clicking a game did nothing at all, with no way on to the PLAY button.
+test('Clicking a game in the shelf opens its details on every board and window size', async t => {
+  const detailsPlayButton = Selector('#stateDetailsOverlay .variantsList > div > button');
+
+  for(const [ window, boardSize ] of [ [ [ 1460, 920 ], null ], [ [ 1920, 1080 ], { width: 1000, height: 1600 } ] ]) {
+    await t.resizeWindow(...window);
+    await loadGameWithBoardSize(boardSize);
+    await t.navigateTo('./testcafe-testing');
+    await ClientFunction(prepareClient)();
+    await t
+      .click('#statesButton')
+      .click(Selector('.roomState.visible'))
+      .expect(Selector('#stateDetailsOverlay').visible).ok()
+      .expect(detailsPlayButton.visible).ok();
+  }
 
   await loadGameWithBoardSize(null);
 });

--- a/tests/testcafe/boardsize.js
+++ b/tests/testcafe/boardsize.js
@@ -33,10 +33,10 @@ const portraitBoard = { roomWidth: '1000px', roomHeight: '1600px', renderedAspec
 
 // How wide one game tile in the shelf ends up. The overlays are children of #roomArea, so what
 // they have to work with is the rendered board, not the window - --columns comes out of the
-// container queries in states.css and the grid divides the shelf's width by it.
+// container queries in states.css and the tiles divide the board's width by it.
 const shelfTiles = ClientFunction(() => {
   const columns = +getComputedStyle(document.querySelector('#statesOverlay')).getPropertyValue('--columns');
-  return { columns, tileWidth: document.querySelector('#roomArea').getBoundingClientRect().width/columns };
+  return { columns, tileWidth: document.querySelector('.roomState.visible').getBoundingClientRect().width };
 });
 
 test('Loading a game with its own board size re-lays out a client that is already in the room', async t => {
@@ -74,27 +74,6 @@ test('An unusable board size in a game file is normalized instead of being store
   await loadGameWithBoardSize(null);
 });
 
-// A portrait board leaves the game shelf a fraction of the width the window has, so it has to
-// drop columns to keep the tiles the size they are on the default board. Off the window - which
-// is what a media query measures - it kept every one of them and squeezed unreadable thumbnails
-// into the space of three.
-test('The game shelf sizes its tiles from the board, not from the window', async t => {
-  await t.resizeWindow(1280, 800);
-  await loadGameWithBoardSize(null);
-  await ClientFunction(prepareClient)();
-  await t.click('#statesButton');
-  const onDefaultBoard = await shelfTiles();
-
-  await loadGameWithBoardSize({ width: 1000, height: 1600 });
-  const onPortraitBoard = await shelfTiles();
-
-  await t
-    .expect(onPortraitBoard.columns).lt(onDefaultBoard.columns)
-    .expect(onPortraitBoard.tileWidth).gt(onDefaultBoard.tileWidth*0.75);
-
-  await loadGameWithBoardSize(null);
-});
-
 // The confirmation names concrete dimensions, so it may only be shown while the board really is
 // on them - with a second editor in the room, somebody else's board size would otherwise leave
 // this panel affirming a size nobody is playing on anymore.
@@ -123,6 +102,28 @@ test('The Apply confirmation goes away when somebody else changes the board size
   await t
     .expect(Selector('#boardHeight').value).eql('1600')
     .expect(confirmation.exists).notOk();
+
+  await loadGameWithBoardSize(null);
+});
+
+// A portrait board leaves the game shelf a fraction of the width the window has, so it has to
+// drop columns to keep the tiles the size they are on the default board. Off the window - which
+// is what a media query measures - it kept every one of them and squeezed unreadable thumbnails
+// into the space of three.
+// Last in this file on purpose: the window size it sets stays with the browser afterwards.
+test('The game shelf sizes its tiles from the board, not from the window', async t => {
+  await t.resizeWindow(1280, 800);
+  await loadGameWithBoardSize(null);
+  await ClientFunction(prepareClient)();
+  await t.click('#statesButton');
+  const onDefaultBoard = await shelfTiles();
+
+  await loadGameWithBoardSize({ width: 1000, height: 1600 });
+  const onPortraitBoard = await shelfTiles();
+
+  await t
+    .expect(onPortraitBoard.columns).lt(onDefaultBoard.columns)
+    .expect(onPortraitBoard.tileWidth).gt(onDefaultBoard.tileWidth*0.75);
 
   await loadGameWithBoardSize(null);
 });


### PR DESCRIPTION
Follow-up to #3085 (custom viewport aspect ratio).

## The problem

The overlays are children of `#roomArea`, so the space they have to lay themselves out in is the **rendered board**, not the window. Their breakpoints were `@media` queries, which measured the window — the same thing only as long as every board was 1600x1000. Now that a game can pick its own board size, a square or portrait board leaves a much smaller overlay in the very same window and still got the layout of a wide one.

The Game Shelf is the obvious symptom: in a 1600x1000 window, a 800x1200 board gives the shelf a **667px wide** overlay — and the window-keyed media query still put **7 columns** of unreadable, clipped thumbnails into it.

| before | after |
| --- | --- |
| ![before](https://agent.virtualtabletop.io/reports/pr/1534093705814872164/shelf-before-w1600x1000-b800x1200.png) | ![after](https://agent.virtualtabletop.io/reports/pr/1534093705814872164/shelf-after-w1600x1000-b800x1200.png) |

(same window, same 800x1200 board — 7 columns of ~90px tiles vs. 3 columns of ~222px tiles, which is the tile size a default board has always had)

Square board, same window: [before](https://agent.virtualtabletop.io/reports/pr/1534093705814872164/shelf-before-w1600x1000-b1000x1000.png) / [after](https://agent.virtualtabletop.io/reports/pr/1534093705814872164/shelf-after-w1600x1000-b1000x1000.png).

## The change

`#roomArea` becomes a size container (`container: roomArea / size`) and every overlay breakpoint becomes a container query against it.

That translation is one-for-one and mechanical: each of these media queries paired a width with the height at 16:10 (`(max-width: 600px), (max-height: 375px)` — the "whichever of the two the board is limited by" idiom), so `@media (max-width: X), (max-height: X/1.6)` became `@container roomArea ((max-width: X) or (max-height: X/1.6))` with the same numbers. On a default 1600x1000 board the same breakpoints therefore fire in the same order — but the board is always a bit smaller than the window (toolbar strip plus letterboxing), so each one now trips at a slightly larger window than before: the shelf drops a column, and the game details sidebar disappears, a little earlier. Boards with a different shape are where the layout really changes.

Converted: `overlays/states.css` (Game Shelf, game details, add/save game, share link, update image), `overlays/welcome.css` (link details), `overlays/misc.css` (confirm), plus the edit-mode JSON overlay (`editmode.css`), which `initializeEditMode` moves into `#roomArea`. Everything that is *not* laid out inside the board keeps its media queries: the JSON editor pane, and the deck editor's export dialog and the symbol picker — `DeckEditor.initializeDOM()` re-parents those into `#editor`, where they are positioned against the viewport and a `@container roomArea` rule would have no container to match against at all.

`setSidebar()` (`client/js/overlays/states.js`), which decides whether the game details are a sidebar of the shelf or an overlay of their own, measures `#roomArea` instead of the window so that it agrees with the container query that lays that sidebar out - and it is called from `setScale()`, so it also follows a game that brings its own board size along. While the two disagreed, clicking a game in the shelf did nothing at all in the band where the board is smaller than the window.

## Testing

- `npm test` — 199 passed.
- TestCafe (chromium headless): `boardsize.js`, `toolbar.js`, `editor.js`, `publiclibrary-1..4.js` all pass.
- New case in `tests/testcafe/boardsize.js`: *"The game shelf sizes its tiles from the board, not from the window"* — asserts a portrait board drops columns and keeps the tile width comparable to the default board. Verified that it **fails** on `main`'s CSS and passes with this change.
- Checked by hand in a browser that the default 1600x1000 board renders the shelf, the game details sidebar, the players and about overlays as before.

No creator-facing behavior changes, no new widget/routine properties, so no validator or `jeCommands` updates needed.

## Follow-up: the rest of the fixed-pixel media queries

> I'm pretty sure there shouldn't be any fixed pixel media queries anymore because everything is so dynamic. Check, fix and tell me which ones should remain and why.

([Discord](https://discord.com/channels/770758631146782780/1534093705814872164/1534111790814855261))

Swept the whole repo for `@media`. One more was keyed to the wrong box, plus one shared rule that is half in the room and half out.

### The editor sidebar

`@media (max-width: 1600px)` iconified the editor sidebar — 128px with button labels, 36px without. Those 92px come out of the room, but only while the room is what the window's *width* limits. 1600px is roughly what a 16:10 board needs at full height, one number for every board: a portrait board lost its labels in a window with hundreds of pixels of unused board margin next to it, and a wide board kept them in a window where they did cost board size. It also took them away at e.g. 1600x900, where the room is limited by its height and is exactly as big either way.

`isEditSidebarNarrow()` decides it from the board now, the same way `calculateEditModuleClasses()` next to it does. Both module-panel layouts also stop repeating the 36px sidebar width and get it from that class instead — which incidentally fixes them iconifying the sidebar without shrinking the button labels on windows wider than the old breakpoint.

1000x1600 board in a 1280x800 window — the board is 478px wide in both shots, so the labels are free:

| before | after |
| --- | --- |
| ![before](https://agent.virtualtabletop.io/reports/pr/1534093705814872164/sidebar-before-b1000x1600-w1280x800.png) | ![after](https://agent.virtualtabletop.io/reports/pr/1534093705814872164/sidebar-after-b1000x1600-w1280x800.png) |

Default board in a 1600x900 window: [before](https://agent.virtualtabletop.io/reports/pr/1534093705814872164/sidebar-before-default-w1600x900.png) / [after](https://agent.virtualtabletop.io/reports/pr/1534093705814872164/sidebar-after-default-w1600x900.png) (room 1382x864 in both).

### `p[icon]`

Two elements use it: the welcome overlay's user-generated-content warning, which is laid out inside the board (→ container query), and the symbol picker's hint paragraph, which is not always in the room — that one moves into the media query that already handles the rest of that overlay.

### What stays a media query, and why

| where | why |
| --- | --- |
| `fonts.css` — `#symbolPickerOverlay` (2 blocks) | the deck editor re-parents the picker into `#editor` / `#deckEditorMainCol`, where there is no `roomArea` container at all — a container query doesn't fall back, it silently stops matching |
| `editor/deckeditor.css` — export dialog at 700px | same thing: `initializeDOM()` moves it into `#editor`, where it is positioned against the viewport |
| `jsonedit.css` — `#jeLog` at 1000px / 600px | the standalone JSON editor is a top-level element the size of the window with `position: fixed` panes; the log's offsets are against the window and the board isn't involved |
| `validator/validate_library.js` at 768px | that's the standalone HTML validation report page, not the room |
| `editor/deckeditor.js` — `@media screen` in the print sheet | not a size breakpoint (it separates the print preview from the printout) |
| `assets/branding/favicon.svg` — `prefers-color-scheme` | not a size breakpoint |

Not touched here, but the same family: `getAvailableRoomRectangle()` (`client/js/editor/layout.js`) still decides where the room starts from `window.innerWidth < 700` and a window-aspect test rather than from the board.

### Testing (follow-up)

- `npm test` — 203 passed, including four new `isEditSidebarNarrow` cases.
- TestCafe (chromium headless): `boardsize.js`, `editor.js`, `toolbar.js` all pass.
- New case in `tests/testcafe/boardsize.js`: *"The editor sidebar keeps its labels while the board is not short of the space"* — 1280x800 window, iconified on the default board and labelled on a portrait one. Verified that it fails without the CSS change.
- Checked in a browser that a module panel opened next to the now-labelled sidebar still lays out (the panel's left edge, and with it the room, does not depend on the sidebar's width).

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3097/pr-test (or any other room on that server)


