### PR TITLE
Audio tutorial: show how to pick a bundled sound from the JSON editor's sound picker

### DIFF
--- a/library/tutorials/Functions - AUDIO/0.json
+++ b/library/tutorials/Functions - AUDIO/0.json
@@ -223,5 +223,27 @@
     },
     "text": "This bell has a 'clickSound' linked to an external URL.",
     "movable": false
+  },
+  "pickerSpeaker": {
+    "id": "pickerSpeaker",
+    "x": 1102,
+    "y": 690,
+    "image": "/i/noto-emoji/emoji_u1f50a.svg",
+    "clickSound": "",
+    "movable": false
+  },
+  "i4bj": {
+    "id": "i4bj",
+    "x": 902,
+    "y": 800,
+    "width": 500,
+    "height": 50,
+    "z": 75277,
+    "css": {
+      "font-size": "20px",
+      "color": "black"
+    },
+    "text": "This speaker has an empty 'clickSound' and stays silent. You do not need a sound file of your own: open it in the JSON Editor, put the cursor on the 'clickSound' line and use the 'pick a sound from the sound picker' button in the upper right corner. Preview the bundled sounds with ▶, click one to insert its '/i/audio/...' path, then leave edit mode and click the speaker.",
+    "movable": false
   }
 }

--- a/library/tutorials/Functions - AUDIO/1.json
+++ b/library/tutorials/Functions - AUDIO/1.json
@@ -1170,5 +1170,18 @@
       "font-size": "20px",
       "color": "black"
     }
+  },
+  "bm7j": {
+    "id": "bm7j",
+    "x": 108,
+    "y": 280,
+    "width": 1400,
+    "z": 10018,
+    "movable": false,
+    "text": "The 'source' can be any sound URL, but you do not have to find one yourself. Open the Deal button in the JSON Editor, put the cursor on the 'source' line of its AUDIO function and use the 'pick a sound from the sound picker' button in the upper right corner. Preview the sounds that ship with VTT using ▶, click one to insert its '/i/audio/...' path, then leave edit mode and press Deal to hear it.",
+    "css": {
+      "font-size": "20px",
+      "color": "black"
+    }
   }
 }


### PR DESCRIPTION
Teaches readers of the **Functions - AUDIO** tutorial that they no longer have to hunt down a sound file: both of its variants now point at the *sound picker* that #3047 adds to the JSON editor, so a game creator can browse, preview and insert one of the sound effects bundled with VTT.

Depends on #3047 — the `pick a sound from the sound picker` button and the `/i/audio/...` sounds it inserts only exist once that PR is merged, so this one should land after it.

## What it teaches

- **`clickSound` variant** — a new speaker widget sits opposite the existing bell with an *empty* `clickSound`, so it deliberately stays silent. Its caption walks the reader through filling it in: open the speaker in the JSON Editor, put the cursor on the `clickSound` line, use the *pick a sound from the sound picker* button in the upper right corner, preview with ▶, click a sound to insert its `/i/audio/...` path, leave edit mode and click the speaker to hear it. The reader ends up with a widget they made make a noise themselves.
- **`AUDIO` variant** — a paragraph under the intro explains that `source` takes any sound URL but that the same picker is available on the `source` line of an `AUDIO` function, and points at the existing *Deal* button as the thing to try it on.

## Structure

Both variants of this tutorial are single-screen demo boards: an interactive widget with a plain-language caption underneath. The additions follow that exactly — one caption per variant, `font-size: 20px`, black, mirroring the column layout that is already there — and they were modelled on how **Properties - Icon** (variant *CSS Demo*) describes reaching the symbol picker ("open one in the JSON Editor. Place the cursor … and click the … button that appears in the upper right corner"), so the wording for the two pickers matches.

The diff is additions only: two new widgets in `0.json`, one in `1.json`. No existing widget, id, position or text was changed, and no other tutorial was touched.

| clickSound variant | AUDIO variant |
| --- | --- |
| ![clickSound](https://agent.virtualtabletop.io/reports/pr/1534318949343170802/audio-tutorial-clickSound.png) | ![AUDIO](https://agent.virtualtabletop.io/reports/pr/1534318949343170802/audio-tutorial-AUDIO.png) |

## Assets

None added. The new speaker uses `/i/noto-emoji/emoji_u1f50a.svg`, an icon VTT already ships (the same Noto emoji set the tutorial's existing bell uses), so `_meta.info.attribution` is unchanged.

## Testing

- `node validator/validate_gamefile_node.js "library/tutorials/Functions - AUDIO/0.json"` and `… 1.json` both exit 0 with no output; `node validator/validate_library.js` reports 0 problems.
- Walked both variants end-to-end in a real browser (Playwright, server on a local port, this branch cherry-picked onto #3047):
  - **clickSound variant** — the speaker with `"clickSound": ""` requests nothing when clicked (silent, as the caption says), while the neighbouring dice and bell still fetch their sounds. Putting the cursor on the `clickSound` line shows `pick a sound from the sound picker` right above `upload audio file`; the overlay opens, the search box filters (`card shuffle` → *Cards, Chips & Dice → card-shuffle*), and clicking the entry writes `"clickSound": "/i/audio/casino/card-shuffle.mp3"`. Rejoining the room outside edit mode and clicking the speaker then fetches `/i/audio/casino/card-shuffle.mp3` — the sound plays.
  - **AUDIO variant** — the same button appears on the `source` line of the Deal button's `AUDIO` function, the picker writes `"source": "/i/audio/casino/card-shuffle.mp3"` into the routine, and pressing *Deal* in a fresh tab fetches that file.
- Checked both boards render without overflowing the table; screenshots above are from the running app.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3099/pr-test (or any other room on that server)