### PR TITLE
Keep a dragged card hidden from the other players until it has left its hand

### DIFF
--- a/.github/workflows/testcafe-chrome.yml
+++ b/.github/workflows/testcafe-chrome.yml
@@ -21,6 +21,7 @@ jobs:
           - editor.js
           - toolbar.js
           - boardsize.js
+          - drag.js
           - compute-1.js
           - compute-2.js
           - compute-3.js

--- a/.github/workflows/testcafe-firefox.yml
+++ b/.github/workflows/testcafe-firefox.yml
@@ -21,6 +21,7 @@ jobs:
           - editor.js
           - toolbar.js
           - boardsize.js
+          - drag.js
           - compute-1.js
           - compute-2.js
           - compute-3.js

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -427,19 +427,21 @@ export class Widget extends StateManaged {
     return this.children().filter(c=>!c.get('owner') || c.get('owner')==playerName);
   }
 
-  async checkParent(forceDetach) {
-    const stillInside = this.currentParent && overlap(this.domElement, this.currentParent.domElement);
-    if(this.currentParent && (forceDetach || !stillInside)) {
+  // keepOwnerWhileInside is used by the drag that is on its way out of a holder: the widget
+  // is detached as soon as another holder becomes the drop target, which is while it is still
+  // completely inside its own holder when that other holder is stacked on top of it. owner
+  // and hoverParent are what keeps the widget out of sight of the other players, so they are
+  // kept until it has really left - otherwise a card is shown to the whole table before it
+  // has even left the hand it is being dragged around in. Leaving itself keeps its timing:
+  // onLeave and leaveRoutine still run right here.
+  async checkParent(forceDetach, keepOwnerWhileInside) {
+    if(!this.currentParent)
+      return;
+    const stillInside = (!forceDetach || keepOwnerWhileInside) && overlap(this.domElement, this.currentParent.domElement);
+    if(forceDetach || !stillInside) {
       await this.set('parent', null);
-      // A forced detach can happen while the widget is still completely inside the holder it
-      // is being dragged out of: a holder stacked on top of that one becomes the drop target
-      // as soon as the widget is dragged over it. owner and hoverParent are what keeps the
-      // widget out of sight of the other players, so they are only cleared once it has
-      // really left - otherwise a card is shown to the whole table before it has even left
-      // the hand it is being dragged around in. Leaving itself keeps its timing: onLeave and
-      // leaveRoutine still run right here.
       this.detachedParent = this.currentParent;
-      await this.checkDetachedParent(!stillInside);
+      await this.checkDetachedParent(!(keepOwnerWhileInside && stillInside));
       if(this.currentParent.dispenseCard)
         await this.currentParent.dispenseCard(this);
       delete this.currentParent;
@@ -2626,7 +2628,7 @@ export class Widget extends StateManaged {
       if (lastHoverTarget != this.hoverTarget) {
         await this.set('hoverTarget', this.hoverTarget ? this.hoverTarget.get('id') : null);
         if(this.hoverTarget != this.currentParent)
-          await this.checkParent(true);
+          await this.checkParent(true, true);
 
         // When the hover target changes we may need to create or remove the shadow widget.
         // Only create a shadow widget if the holder is shared and doesn't already have one in it.

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -427,36 +427,54 @@ export class Widget extends StateManaged {
     return this.children().filter(c=>!c.get('owner') || c.get('owner')==playerName);
   }
 
-  // keepOwnerWhileInside is used by the drag that is on its way out of a holder: the widget
-  // is detached as soon as another holder becomes the drop target, which is while it is still
+  // hideUntilOutside is used by the drag that is on its way out of a holder: the widget is
+  // detached as soon as another holder becomes the drop target, which is while it is still
   // completely inside its own holder when that other holder is stacked on top of it. owner
   // and hoverParent are what keeps the widget out of sight of the other players, so they are
-  // kept until it has really left - otherwise a card is shown to the whole table before it
-  // has even left the hand it is being dragged around in. Leaving itself keeps its timing:
-  // onLeave and leaveRoutine still run right here.
-  async checkParent(forceDetach, keepOwnerWhileInside) {
-    if(!this.currentParent)
-      return;
-    const stillInside = (!forceDetach || keepOwnerWhileInside) && overlap(this.domElement, this.currentParent.domElement);
-    if(forceDetach || !stillInside) {
+  // put back until it has really left - otherwise a card is shown to the whole table before
+  // it has even left the hand it is being dragged around in. Detaching itself is unchanged:
+  // parent, hoverParent and owner are cleared and onLeave / leaveRoutine run in the same
+  // place with the same values as before, so whatever the leave hooks assign is what the
+  // widget gets back once it is outside (see checkDetachedParent).
+  async checkParent(forceDetach, hideUntilOutside) {
+    if(this.currentParent && (forceDetach || !overlap(this.domElement, this.currentParent.domElement))) {
+      const parent = this.currentParent;
+      const hidden = hideUntilOutside && overlap(this.domElement, parent.domElement)
+        ? { hoverParent: this.get('hoverParent'), owner: this.get('owner') } : null;
+
       await this.set('parent', null);
-      this.detachedParent = this.currentParent;
-      await this.checkDetachedParent(!(keepOwnerWhileInside && stillInside));
-      if(this.currentParent.dispenseCard)
-        await this.currentParent.dispenseCard(this);
+      await this.set('hoverParent', null);
+      if(parent.get('childrenPerOwner'))
+        await this.set('owner',  null);
+      if(parent.dispenseCard)
+        await parent.dispenseCard(this);
       delete this.currentParent;
+
+      if(hidden) {
+        this.detachedParent = parent;
+        this.detachedParentState = { hoverParent: this.get('hoverParent'), owner: this.get('owner') };
+        await this.set('hoverParent', hidden.hoverParent);
+        if(parent.get('childrenPerOwner'))
+          await this.set('owner',  hidden.owner);
+      }
     }
   }
 
-  // Clears what checkParent() kept when it detached the widget while it was still inside its
-  // holder. Called on every move so that the widget stops being the owner's as soon as it no
-  // longer overlaps that holder, and with force when the drag ends.
+  // Reveals a widget that checkParent() hid in the holder it was detached from, by restoring
+  // the state the detaching left it in. Called on every move so that the widget becomes
+  // visible to the other players as soon as it no longer overlaps that holder, and with
+  // force when the drag ends, before the drop, so that the holder it lands in has the last
+  // word.
   async checkDetachedParent(force) {
     if(this.detachedParent && (force || !overlap(this.domElement, this.detachedParent.domElement))) {
-      await this.set('hoverParent', null);
-      if(this.detachedParent.get('childrenPerOwner'))
-        await this.set('owner',  null);
+      const parent = this.detachedParent;
+      const state = this.detachedParentState;
       delete this.detachedParent;
+      delete this.detachedParentState;
+
+      await this.set('hoverParent', state.hoverParent);
+      if(parent.get('childrenPerOwner'))
+        await this.set('owner',  state.owner);
     }
   }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2600,8 +2600,14 @@ export class Widget extends StateManaged {
 
       if (lastHoverTarget != this.hoverTarget) {
         await this.set('hoverTarget', this.hoverTarget ? this.hoverTarget.get('id') : null);
+        // A holder that sits on top of the current parent becomes the hover target while the
+        // widget is still completely inside that parent. Leaving the parent right away would
+        // run its onLeave and drop the owner - which reveals a card to everyone before it has
+        // even left the hand it is being dragged around in - so the widget only leaves once it
+        // no longer overlaps its parent. This repeats the check from the top of move() because
+        // the delta flushed above is what gave the widget its current geometry.
         if(this.hoverTarget != this.currentParent)
-          await this.checkParent(true);
+          await this.checkParent();
 
         // When the hover target changes we may need to create or remove the shadow widget.
         // Only create a shadow widget if the holder is shared and doesn't already have one in it.

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -428,14 +428,33 @@ export class Widget extends StateManaged {
   }
 
   async checkParent(forceDetach) {
-    if(this.currentParent && (forceDetach || !overlap(this.domElement, this.currentParent.domElement))) {
+    const stillInside = this.currentParent && overlap(this.domElement, this.currentParent.domElement);
+    if(this.currentParent && (forceDetach || !stillInside)) {
       await this.set('parent', null);
-      await this.set('hoverParent', null);
-      if(this.currentParent.get('childrenPerOwner'))
-        await this.set('owner',  null);
+      // A forced detach can happen while the widget is still completely inside the holder it
+      // is being dragged out of: a holder stacked on top of that one becomes the drop target
+      // as soon as the widget is dragged over it. owner and hoverParent are what keeps the
+      // widget out of sight of the other players, so they are only cleared once it has
+      // really left - otherwise a card is shown to the whole table before it has even left
+      // the hand it is being dragged around in. Leaving itself keeps its timing: onLeave and
+      // leaveRoutine still run right here.
+      this.detachedParent = this.currentParent;
+      await this.checkDetachedParent(!stillInside);
       if(this.currentParent.dispenseCard)
         await this.currentParent.dispenseCard(this);
       delete this.currentParent;
+    }
+  }
+
+  // Clears what checkParent() kept when it detached the widget while it was still inside its
+  // holder. Called on every move so that the widget stops being the owner's as soon as it no
+  // longer overlaps that holder, and with force when the drag ends.
+  async checkDetachedParent(force) {
+    if(this.detachedParent && (force || !overlap(this.domElement, this.detachedParent.domElement))) {
+      await this.set('hoverParent', null);
+      if(this.detachedParent.get('childrenPerOwner'))
+        await this.set('owner',  null);
+      delete this.detachedParent;
     }
   }
 
@@ -2546,6 +2565,8 @@ export class Widget extends StateManaged {
     await this.snapToGrid();
 
     if(!this.get('fixedParent') && this.get('movable')) {
+      await this.checkParent();
+
       const lastHoverTarget = this.hoverTarget;
       // The hit test below asks the DOM where this widget is, but the delta that
       // carries the position set above only reaches the DOM when the batch around
@@ -2557,12 +2578,10 @@ export class Widget extends StateManaged {
       if(this.domElement.style.transform != this.cssTransform())
         flushDelta();
 
-      // A widget stays in its holder until it no longer overlaps it - leaving as soon as the
-      // hover target changes would run the holder's onLeave and drop the owner while the
-      // widget is still inside, which reveals a card to everyone before it has even left the
-      // hand it is being dragged around in. This runs after the flush above so that the
-      // overlap is checked against where the widget is now, not where it was last event.
-      await this.checkParent();
+      // after the flush, so that a widget that was detached while it was still inside its
+      // holder is measured against where it is now: the last mouse event of a drag is the
+      // one that takes the widget out of the holder, and there is no next one to notice it
+      await this.checkDetachedParent();
 
       const myCenter = center(this.domElement);
       const myMinDim = Math.min(this.get('width'), this.get('height')) * this.get('_absoluteScale');
@@ -2606,6 +2625,8 @@ export class Widget extends StateManaged {
 
       if (lastHoverTarget != this.hoverTarget) {
         await this.set('hoverTarget', this.hoverTarget ? this.hoverTarget.get('id') : null);
+        if(this.hoverTarget != this.currentParent)
+          await this.checkParent(true);
 
         // When the hover target changes we may need to create or remove the shadow widget.
         // Only create a shadow widget if the holder is shared and doesn't already have one in it.
@@ -2726,6 +2747,9 @@ export class Widget extends StateManaged {
     delete this.stopDropLines;
 
     await this.set('hoverTarget', null);
+    // the drag is over, so the widget is not on its way out of anything any more - this runs
+    // before the drop below so that a holder taking the widget in still has the last word
+    await this.checkDetachedParent(true);
 
     if(!this.get('fixedParent') && this.get('movable')) {
       for(const t of this.dropTargets)

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2546,8 +2546,6 @@ export class Widget extends StateManaged {
     await this.snapToGrid();
 
     if(!this.get('fixedParent') && this.get('movable')) {
-      await this.checkParent();
-
       const lastHoverTarget = this.hoverTarget;
       // The hit test below asks the DOM where this widget is, but the delta that
       // carries the position set above only reaches the DOM when the batch around
@@ -2558,6 +2556,14 @@ export class Widget extends StateManaged {
       // (or the game rejects the move and sends it back).
       if(this.domElement.style.transform != this.cssTransform())
         flushDelta();
+
+      // A widget stays in its holder until it no longer overlaps it - leaving as soon as the
+      // hover target changes would run the holder's onLeave and drop the owner while the
+      // widget is still inside, which reveals a card to everyone before it has even left the
+      // hand it is being dragged around in. This runs after the flush above so that the
+      // overlap is checked against where the widget is now, not where it was last event.
+      await this.checkParent();
+
       const myCenter = center(this.domElement);
       const myMinDim = Math.min(this.get('width'), this.get('height')) * this.get('_absoluteScale');
       this.hoverTarget = null;
@@ -2600,14 +2606,6 @@ export class Widget extends StateManaged {
 
       if (lastHoverTarget != this.hoverTarget) {
         await this.set('hoverTarget', this.hoverTarget ? this.hoverTarget.get('id') : null);
-        // A holder that sits on top of the current parent becomes the hover target while the
-        // widget is still completely inside that parent. Leaving the parent right away would
-        // run its onLeave and drop the owner - which reveals a card to everyone before it has
-        // even left the hand it is being dragged around in - so the widget only leaves once it
-        // no longer overlaps its parent. This repeats the check from the top of move() because
-        // the delta flushed above is what gave the widget its current geometry.
-        if(this.hoverTarget != this.currentParent)
-          await this.checkParent();
 
         // When the hover target changes we may need to create or remove the shadow widget.
         // Only create a shadow widget if the holder is shared and doesn't already have one in it.

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -444,17 +444,21 @@ export class Widget extends StateManaged {
 
       await this.set('parent', null);
       await this.set('hoverParent', null);
-      if(parent.get('childrenPerOwner'))
+      // remembered with the rest of the state below, so that the reveal restores exactly the
+      // properties that were cleared here even if a leave hook changes the flag mid-drag
+      const perOwner = parent.get('childrenPerOwner');
+      if(perOwner)
         await this.set('owner',  null);
       if(parent.dispenseCard)
         await parent.dispenseCard(this);
       delete this.currentParent;
 
-      if(hidden) {
+      // nothing to hide (and nothing to restore later) if a leave hook just removed the widget
+      if(hidden && !this.isBeingRemoved && !this.inRemovalQueue) {
         this.detachedParent = parent;
-        this.detachedParentState = { hoverParent: this.get('hoverParent'), owner: this.get('owner') };
+        this.detachedParentState = { hoverParent: this.get('hoverParent'), owner: this.get('owner'), perOwner };
         await this.set('hoverParent', hidden.hoverParent);
-        if(parent.get('childrenPerOwner'))
+        if(perOwner)
           await this.set('owner',  hidden.owner);
       }
     }
@@ -467,13 +471,12 @@ export class Widget extends StateManaged {
   // word.
   async checkDetachedParent(force) {
     if(this.detachedParent && (force || !overlap(this.domElement, this.detachedParent.domElement))) {
-      const parent = this.detachedParent;
       const state = this.detachedParentState;
       delete this.detachedParent;
       delete this.detachedParentState;
 
       await this.set('hoverParent', state.hoverParent);
-      if(parent.get('childrenPerOwner'))
+      if(state.perOwner)
         await this.set('owner',  state.owner);
     }
   }
@@ -658,6 +661,9 @@ export class Widget extends StateManaged {
     await this.set('dropShadowWidget', (await shadowWidget.clone({
         'movable': false,
         'dropShadowOwner': playerName,
+        // the dragged widget can still carry the hoverParent of the holder it is on its way
+        // out of - the shadow sits in the target holder and must not inherit that
+        'hoverParent': null,
         'parent': null}, true)).get('id'));
   }
 
@@ -2536,6 +2542,10 @@ export class Widget extends StateManaged {
     await this.bringToFront();
     await this.set('dragging', playerName);
     delete this.lastMoveCoord;
+    // a previous drag that did not reach checkDetachedParent(true) must not restore its state
+    // onto this one
+    delete this.detachedParent;
+    delete this.detachedParentState;
 
     // Lines that take a widget dropped onto their path as a stop. Collected once
     // like the drop targets below, but not restricted to widgets that can be

--- a/tests/testcafe/drag.js
+++ b/tests/testcafe/drag.js
@@ -35,6 +35,19 @@ const dragOnto = ClientFunction(id => {
   window.dragCoords = to;
 });
 
+// Drags straight down until the dragged widget's center sits the given number of card
+// heights below the bottom edge of the given widget - so 0.2 leaves the card overlapping
+// that widget and 0.7 (more than half a card) puts it completely clear of it.
+const dragBelow = ClientFunction((id, cardHeights) => {
+  const bottom = document.querySelector(`#w_${id}`).getBoundingClientRect().bottom;
+  const card = document.querySelector('#w_card').getBoundingClientRect();
+  const from = window.dragCoords;
+  const to = { x: from.x, y: bottom + card.height*cardHeights };
+  for(let step=1; step<=5; ++step)
+    document.body.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, buttons: 1, clientX: to.x, clientY: from.y + (to.y-from.y)*step/5 }));
+  window.dragCoords = to;
+});
+
 const dragEnd = ClientFunction(() => {
   document.body.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, button: 0, clientX: window.dragCoords.x, clientY: window.dragCoords.y }));
 });
@@ -42,18 +55,16 @@ const dragEnd = ClientFunction(() => {
 // the state is read straight from the server so that this sees what the other players see
 async function cardState() {
   const { card } = JSON.parse(await getState());
-  return { owner: card.owner || null, parent: card.parent || null, hoverTarget: card.hoverTarget || null };
+  return { owner: card.owner || null, parent: card.parent || null, hoverParent: card.hoverParent || null, hoverTarget: card.hoverTarget || null };
 }
 
 // the mouse events above return before the drag they trigger has reached the server, so
 // give the state a moment to arrive there instead of waiting a fixed amount of time
 async function expectCardState(t, expected) {
-  let actual = null;
-  for(let wait=50; wait<2000; wait*=2) {
-    actual = await cardState();
-    if(JSON.stringify(actual) == JSON.stringify(expected))
-      break;
+  let actual = await cardState();
+  for(let wait=50; wait<2000 && JSON.stringify(actual) != JSON.stringify(expected); wait*=2) {
     await new Promise(resolve => setTimeout(resolve, wait));
+    actual = await cardState();
   }
   await t.expect(actual).eql(expected);
 }
@@ -69,10 +80,10 @@ test('A card is not revealed while it is dragged over a holder stacked on top of
   // the card is still completely inside the hand, so it still belongs to its owner and
   // the other players do not get to see it - even though the holder on top of the hand
   // is what a drop would go to now
-  await expectCardState(t, { owner: 'TestCafe', parent: null, hoverTarget: 'over' });
+  await expectCardState(t, { owner: 'TestCafe', parent: null, hoverParent: 'hand', hoverTarget: 'over' });
 
   await dragEnd();
-  await expectCardState(t, { owner: null, parent: 'over', hoverTarget: null });
+  await expectCardState(t, { owner: null, parent: 'over', hoverParent: null, hoverTarget: null });
 });
 
 test('A card is revealed as soon as it is dragged out of its hand', async t => {
@@ -83,8 +94,29 @@ test('A card is revealed as soon as it is dragged out of its hand', async t => {
   await dragStart('card');
   await dragOnto('table');
 
-  await expectCardState(t, { owner: null, parent: null, hoverTarget: 'table' });
+  await expectCardState(t, { owner: null, parent: null, hoverParent: null, hoverTarget: 'table' });
 
   await dragEnd();
-  await expectCardState(t, { owner: null, parent: 'table', hoverTarget: null });
+  await expectCardState(t, { owner: null, parent: 'table', hoverParent: null, hoverTarget: null });
+});
+
+test('A card half out of its hand and over no other holder still belongs to its owner', async t => {
+  await setRoomState(stackedHoldersRoom());
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  await dragStart('card');
+
+  // dragged straight down out of the hand, past its bottom edge but not clear of it: the
+  // hover target is gone (there is nothing below the hand) but the card still overlaps
+  // the hand it came from, so it keeps its owner
+  await dragBelow('hand', 0.2);
+  await expectCardState(t, { owner: 'TestCafe', parent: null, hoverParent: 'hand', hoverTarget: null });
+
+  // once it no longer touches the hand at all, it leaves and everyone gets to see it
+  await dragBelow('hand', 0.7);
+  await expectCardState(t, { owner: null, parent: null, hoverParent: null, hoverTarget: null });
+
+  await dragEnd();
+  await expectCardState(t, { owner: null, parent: null, hoverParent: null, hoverTarget: null });
 });

--- a/tests/testcafe/drag.js
+++ b/tests/testcafe/drag.js
@@ -6,11 +6,15 @@ setupTestEnvironment();
 
 // A hand that keeps a separate set of cards per player, with a second holder stacked on
 // top of its right half. The card starts on the left, in the part of the hand that the
-// other holder does not cover, so that it can be picked up at all.
+// other holder does not cover, so that it can be picked up at all. The hand marks the
+// card when it leaves, once through onLeave and once through leaveRoutine, so that the
+// tests can tell when the card left on top of what the other players see of it.
 function stackedHoldersRoom() {
   return {
     deck:  { id: 'deck', type: 'deck', cardTypes: { plain: {} }, x: 1200, y: 50 },
-    hand:  { id: 'hand', type: 'holder', x: 100, y: 400, width: 600, height: 300, childrenPerOwner: true, alignChildren: false },
+    hand:  { id: 'hand', type: 'holder', x: 100, y: 400, width: 600, height: 300, childrenPerOwner: true, alignChildren: false,
+             onLeave: { classes: 'ran' },
+             leaveRoutine: [ { func: 'SET', collection: 'child', property: 'text', value: 'ran' } ] },
     over:  { id: 'over', type: 'holder', x: 400, y: 350, width: 300, height: 400, z: 10 },
     table: { id: 'table', type: 'holder', x: 800, y: 100, width: 300, height: 250 },
     card:  { id: 'card', type: 'card', deck: 'deck', cardType: 'plain', parent: 'hand', x: 30, y: 70, owner: 'TestCafe' }
@@ -52,10 +56,19 @@ const dragEnd = ClientFunction(() => {
   document.body.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, button: 0, clientX: window.dragCoords.x, clientY: window.dragCoords.y }));
 });
 
-// the state is read straight from the server so that this sees what the other players see
+// the state is read straight from the server so that this sees what the other players see.
+// onLeave and leaveRoutine are the marks the hand leaves on the card on its way out - what
+// they say about when the card leaves must not change.
 async function cardState() {
   const { card } = JSON.parse(await getState());
-  return { owner: card.owner || null, parent: card.parent || null, hoverParent: card.hoverParent || null, hoverTarget: card.hoverTarget || null };
+  return {
+    owner:        card.owner       || null,
+    parent:       card.parent      || null,
+    hoverParent:  card.hoverParent || null,
+    hoverTarget:  card.hoverTarget || null,
+    onLeave:      card.classes     || null,
+    leaveRoutine: card.text        || null
+  };
 }
 
 // the mouse events above return before the drag they trigger has reached the server, so
@@ -77,13 +90,13 @@ test('A card is not revealed while it is dragged over a holder stacked on top of
   await dragStart('card');
   await dragOnto('over');
 
-  // the card is still completely inside the hand, so it still belongs to its owner and
-  // the other players do not get to see it - even though the holder on top of the hand
-  // is what a drop would go to now
-  await expectCardState(t, { owner: 'TestCafe', parent: null, hoverParent: 'hand', hoverTarget: 'over' });
+  // the holder on top of the hand is what a drop would go to now, so the card leaves the
+  // hand right here and gets both of its marks - but it is still completely inside the
+  // hand, so it keeps belonging to its owner and the other players do not get to see it
+  await expectCardState(t, { owner: 'TestCafe', parent: null, hoverParent: 'hand', hoverTarget: 'over', onLeave: 'ran', leaveRoutine: 'ran' });
 
   await dragEnd();
-  await expectCardState(t, { owner: null, parent: 'over', hoverParent: null, hoverTarget: null });
+  await expectCardState(t, { owner: null, parent: 'over', hoverParent: null, hoverTarget: null, onLeave: 'ran', leaveRoutine: 'ran' });
 });
 
 test('A card is revealed as soon as it is dragged out of its hand', async t => {
@@ -94,10 +107,10 @@ test('A card is revealed as soon as it is dragged out of its hand', async t => {
   await dragStart('card');
   await dragOnto('table');
 
-  await expectCardState(t, { owner: null, parent: null, hoverParent: null, hoverTarget: 'table' });
+  await expectCardState(t, { owner: null, parent: null, hoverParent: null, hoverTarget: 'table', onLeave: 'ran', leaveRoutine: 'ran' });
 
   await dragEnd();
-  await expectCardState(t, { owner: null, parent: 'table', hoverParent: null, hoverTarget: null });
+  await expectCardState(t, { owner: null, parent: 'table', hoverParent: null, hoverTarget: null, onLeave: 'ran', leaveRoutine: 'ran' });
 });
 
 test('A card half out of its hand and over no other holder still belongs to its owner', async t => {
@@ -108,15 +121,15 @@ test('A card half out of its hand and over no other holder still belongs to its 
   await dragStart('card');
 
   // dragged straight down out of the hand, past its bottom edge but not clear of it: the
-  // hover target is gone (there is nothing below the hand) but the card still overlaps
-  // the hand it came from, so it keeps its owner
+  // card has left the hand and is marked accordingly, but it still overlaps the hand it
+  // came from, so it keeps its owner
   await dragBelow('hand', 0.2);
-  await expectCardState(t, { owner: 'TestCafe', parent: null, hoverParent: 'hand', hoverTarget: null });
+  await expectCardState(t, { owner: 'TestCafe', parent: null, hoverParent: 'hand', hoverTarget: null, onLeave: 'ran', leaveRoutine: 'ran' });
 
-  // once it no longer touches the hand at all, it leaves and everyone gets to see it
+  // once it no longer touches the hand at all, everyone gets to see it
   await dragBelow('hand', 0.7);
-  await expectCardState(t, { owner: null, parent: null, hoverParent: null, hoverTarget: null });
+  await expectCardState(t, { owner: null, parent: null, hoverParent: null, hoverTarget: null, onLeave: 'ran', leaveRoutine: 'ran' });
 
   await dragEnd();
-  await expectCardState(t, { owner: null, parent: null, hoverParent: null, hoverTarget: null });
+  await expectCardState(t, { owner: null, parent: null, hoverParent: null, hoverTarget: null, onLeave: 'ran', leaveRoutine: 'ran' });
 });

--- a/tests/testcafe/drag.js
+++ b/tests/testcafe/drag.js
@@ -1,0 +1,90 @@
+import { ClientFunction } from 'testcafe';
+
+import { getState, prepareClient, setName, setRoomState, setupTestEnvironment } from './test-util.js';
+
+setupTestEnvironment();
+
+// A hand that keeps a separate set of cards per player, with a second holder stacked on
+// top of its right half. The card starts on the left, in the part of the hand that the
+// other holder does not cover, so that it can be picked up at all.
+function stackedHoldersRoom() {
+  return {
+    deck:  { id: 'deck', type: 'deck', cardTypes: { plain: {} }, x: 1200, y: 50 },
+    hand:  { id: 'hand', type: 'holder', x: 100, y: 400, width: 600, height: 300, childrenPerOwner: true, alignChildren: false },
+    over:  { id: 'over', type: 'holder', x: 400, y: 350, width: 300, height: 400, z: 10 },
+    table: { id: 'table', type: 'holder', x: 800, y: 100, width: 300, height: 250 },
+    card:  { id: 'card', type: 'card', deck: 'deck', cardType: 'plain', parent: 'hand', x: 30, y: 70, owner: 'TestCafe' }
+  };
+}
+
+// The mouse events are dispatched one at a time so that the room state can be read while
+// the drag is still going on - t.drag() would only leave the result of the drop behind.
+const dragStart = ClientFunction(id => {
+  const card = document.querySelector(`#w_${id}`).getBoundingClientRect();
+  window.dragCoords = { x: card.left + card.width/2, y: card.top + card.height/2 };
+  document.querySelector(`#w_${id}`).dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0, clientX: window.dragCoords.x, clientY: window.dragCoords.y }));
+});
+
+// Drags onto the center of the given widget in a few steps, like a real pointer would.
+const dragOnto = ClientFunction(id => {
+  const target = document.querySelector(`#w_${id}`).getBoundingClientRect();
+  const from = window.dragCoords;
+  const to = { x: target.left + target.width/2, y: target.top + target.height/2 };
+  for(let step=1; step<=5; ++step)
+    document.body.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, buttons: 1, clientX: from.x + (to.x-from.x)*step/5, clientY: from.y + (to.y-from.y)*step/5 }));
+  window.dragCoords = to;
+});
+
+const dragEnd = ClientFunction(() => {
+  document.body.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, button: 0, clientX: window.dragCoords.x, clientY: window.dragCoords.y }));
+});
+
+// the state is read straight from the server so that this sees what the other players see
+async function cardState() {
+  const { card } = JSON.parse(await getState());
+  return { owner: card.owner || null, parent: card.parent || null, hoverTarget: card.hoverTarget || null };
+}
+
+// the mouse events above return before the drag they trigger has reached the server, so
+// give the state a moment to arrive there instead of waiting a fixed amount of time
+async function expectCardState(t, expected) {
+  let actual = null;
+  for(let wait=50; wait<2000; wait*=2) {
+    actual = await cardState();
+    if(JSON.stringify(actual) == JSON.stringify(expected))
+      break;
+    await new Promise(resolve => setTimeout(resolve, wait));
+  }
+  await t.expect(actual).eql(expected);
+}
+
+test('A card is not revealed while it is dragged over a holder stacked on top of its hand', async t => {
+  await setRoomState(stackedHoldersRoom());
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  await dragStart('card');
+  await dragOnto('over');
+
+  // the card is still completely inside the hand, so it still belongs to its owner and
+  // the other players do not get to see it - even though the holder on top of the hand
+  // is what a drop would go to now
+  await expectCardState(t, { owner: 'TestCafe', parent: null, hoverTarget: 'over' });
+
+  await dragEnd();
+  await expectCardState(t, { owner: null, parent: 'over', hoverTarget: null });
+});
+
+test('A card is revealed as soon as it is dragged out of its hand', async t => {
+  await setRoomState(stackedHoldersRoom());
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  await dragStart('card');
+  await dragOnto('table');
+
+  await expectCardState(t, { owner: null, parent: null, hoverTarget: 'table' });
+
+  await dragEnd();
+  await expectCardState(t, { owner: null, parent: 'table', hoverTarget: null });
+});

--- a/tests/testcafe/drag.js
+++ b/tests/testcafe/drag.js
@@ -8,15 +8,20 @@ setupTestEnvironment();
 // top of its right half. The card starts on the left, in the part of the hand that the
 // other holder does not cover, so that it can be picked up at all. The hand marks the
 // card when it leaves, once through onLeave and once through leaveRoutine, so that the
-// tests can tell when the card left on top of what the other players see of it.
-function stackedHoldersRoom() {
+// tests can tell when the card left on top of what the other players see of it. With
+// keepOwnerOnLeave the leaveRoutine also hands the card to the player who took it out,
+// the way the hands in "4-Letter Words" and "CONTEST" do. spot is not a drop target, it
+// just marks a free place on the table to drop a card onto.
+function stackedHoldersRoom(keepOwnerOnLeave) {
   return {
     deck:  { id: 'deck', type: 'deck', cardTypes: { plain: {} }, x: 1200, y: 50 },
     hand:  { id: 'hand', type: 'holder', x: 100, y: 400, width: 600, height: 300, childrenPerOwner: true, alignChildren: false,
              onLeave: { classes: 'ran' },
-             leaveRoutine: [ { func: 'SET', collection: 'child', property: 'text', value: 'ran' } ] },
+             leaveRoutine: [ { func: 'SET', collection: 'child', property: 'text', value: 'ran' },
+                             ...(keepOwnerOnLeave ? [ { func: 'SET', collection: 'child', property: 'owner', value: '${playerName}' } ] : []) ] },
     over:  { id: 'over', type: 'holder', x: 400, y: 350, width: 300, height: 400, z: 10 },
     table: { id: 'table', type: 'holder', x: 800, y: 100, width: 300, height: 250 },
+    spot:  { id: 'spot', x: 850, y: 550, width: 200, height: 200, movable: false },
     card:  { id: 'card', type: 'card', deck: 'deck', cardType: 'plain', parent: 'hand', x: 30, y: 70, owner: 'TestCafe' }
   };
 }
@@ -132,4 +137,26 @@ test('A card half out of its hand and over no other holder still belongs to its 
 
   await dragEnd();
   await expectCardState(t, { owner: null, parent: null, hoverParent: null, hoverTarget: null, onLeave: 'ran', leaveRoutine: 'ran' });
+});
+
+test('An owner assigned by a leaveRoutine survives the card leaving its hand', async t => {
+  await setRoomState(stackedHoldersRoom(true));
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  await dragStart('card');
+
+  // the card leaves the hand while it is still inside it, so the leaveRoutine hands it to
+  // the player right here - and it is still hidden from the other players
+  await dragOnto('over');
+  await expectCardState(t, { owner: 'TestCafe', parent: null, hoverParent: 'hand', hoverTarget: 'over', onLeave: 'ran', leaveRoutine: 'ran' });
+
+  // being outside the hand only takes back what leaving it did, so the owner the
+  // leaveRoutine assigned stays - the card keeps belonging to the player who took it,
+  // all the way to a drop on the table next to any holder
+  await dragOnto('spot');
+  await expectCardState(t, { owner: 'TestCafe', parent: null, hoverParent: null, hoverTarget: null, onLeave: 'ran', leaveRoutine: 'ran' });
+
+  await dragEnd();
+  await expectCardState(t, { owner: 'TestCafe', parent: null, hoverParent: null, hoverTarget: null, onLeave: 'ran', leaveRoutine: 'ran' });
 });

--- a/tests/testcafe/drag.js
+++ b/tests/testcafe/drag.js
@@ -76,15 +76,27 @@ async function cardState() {
   };
 }
 
+// the preview a dropShadow holder shows while a card is dragged over it, as the other
+// players see it - it is a clone of the card and must not carry anything that would make
+// it look like the hand the card is still hidden in
+async function shadowState() {
+  const shadow = Object.values(JSON.parse(await getState())).filter(w => w && w.dropShadowOwner)[0];
+  return shadow ? { parent: shadow.parent || null, hoverParent: shadow.hoverParent || null } : null;
+}
+
 // the mouse events above return before the drag they trigger has reached the server, so
 // give the state a moment to arrive there instead of waiting a fixed amount of time
-async function expectCardState(t, expected) {
-  let actual = await cardState();
+async function expectState(t, readState, expected) {
+  let actual = await readState();
   for(let wait=50; wait<2000 && JSON.stringify(actual) != JSON.stringify(expected); wait*=2) {
     await new Promise(resolve => setTimeout(resolve, wait));
-    actual = await cardState();
+    actual = await readState();
   }
   await t.expect(actual).eql(expected);
+}
+
+async function expectCardState(t, expected) {
+  await expectState(t, cardState, expected);
 }
 
 test('A card is not revealed while it is dragged over a holder stacked on top of its hand', async t => {
@@ -159,4 +171,23 @@ test('An owner assigned by a leaveRoutine survives the card leaving its hand', a
 
   await dragEnd();
   await expectCardState(t, { owner: 'TestCafe', parent: null, hoverParent: null, hoverTarget: null, onLeave: 'ran', leaveRoutine: 'ran' });
+});
+
+test('The drop shadow of a holder stacked on a hand does not inherit that hand', async t => {
+  const room = stackedHoldersRoom();
+  room.over.dropShadow = true;
+  await setRoomState(room);
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  await dragStart('card');
+  await dragOnto('over');
+
+  // the card is hidden in the hand it has not left yet, but the preview of where it would
+  // land is in the holder on top and belongs to nothing else
+  await expectCardState(t, { owner: 'TestCafe', parent: null, hoverParent: 'hand', hoverTarget: 'over', onLeave: 'ran', leaveRoutine: 'ran' });
+  await expectState(t, shadowState, { parent: 'over', hoverParent: null });
+
+  await dragEnd();
+  await expectState(t, shadowState, null);
 });


### PR DESCRIPTION
<!-- todo-human-input:start -->
## ⏳ To Do — waiting on a human maintainer

- [ ] **Decide on a visual cue at the private→public drag threshold** — Design call: whether an always-on cue should be added (the hook is ready); if yes, here or in a separate PR. ([discussion](https://github.com/ArnoldSmith86/virtualtabletop/pull/3100#issuecomment-5188703210))

<!-- todo-human-input:end -->

A card that is dragged out of a `childrenPerOwner: true` hand stays hidden from the other players until it has actually left that hand, instead of being shown to the whole table as soon as another holder becomes the drop target. That happens with a holder stacked on top of a hand: the card is revealed while it is still being dragged around inside the hand it came from.

Reported on Discord:

> I tested and it seems that the dragged card is revealed before it normally would if another holder is on top of a `childrenPerOwner:true` holder.

(Source: https://discord.com/channels/770758631146782780/793626590848352306/1534420902320541799)

## What went wrong

`Widget.move()` picks the topmost droppable widget under the dragged widget's center as the hover target. If a holder is stacked on top of a hand, that holder wins the hit test while the dragged card is still completely inside the hand. The hover target change then ran `checkParent(true)`, a *forced* detach, which

- clears `owner` (the hand has `childrenPerOwner: true`) and `hoverParent`, and
- applies the hand's `onLeave` and runs its `leaveRoutine`.

`owner` and `hoverParent` are what keeps a card in a hand out of sight of everybody else - a widget owned by another player is not rendered at all, and `hoverParent` is what keeps a card showing its back while it is dragged. Clearing them is what reveals the card, so merely dragging a card across the part of your hand that another holder covers showed it to the whole table.

## The fix

**Leaving the holder keeps the timing it has always had.** `checkParent()` detaches the widget at exactly the same moment as before, clearing `parent`, `hoverParent` and `owner` and running the holder's `onLeave` and `leaveRoutine` in the same place with the same values - routines see the card leave the hand when they always did, and a `leaveRoutine` that assigns an `owner` (as the hands in `4-Letter Words` and `CONTEST` do) still has the last word over the clear.

What is new is a temporary override on top of that: when `checkParent()` detaches a widget that is still inside its holder, it puts `owner` and `hoverParent` back - the pair that hides a card in a hand from the other players - and remembers both the holder and the state the detaching left the widget in. That state is restored once the widget no longer overlaps the holder, or at the latest when the drag ends, before the drop, so that the holder the card lands in still has the last word.

Nothing changes for a widget that is already outside its holder when it is detached, which is every drag that does not involve stacked holders: there nothing is overridden and the same properties are cleared in the same order, in the same call, as before.

Verified in the browser with a hand (`childrenPerOwner: true`) and a second holder stacked on its right half:

| | before | after |
| --- | --- | --- |
| card leaves the hand (`onLeave`, `leaveRoutine`) | when another holder becomes the drop target | unchanged |
| dragging the card inside the hand, over the stacked holder | `owner` and `hoverParent` cleared - card visible to everyone | kept - card stays out of sight |
| dragging it half out of the hand, over nothing else | `owner` cleared - card visible to everyone | kept until the card is clear of the hand |
| dropping it on the stacked holder | `owner` cleared, `parent: over` | `owner` cleared, `parent: over` |

## Tests

New TestCafe fixture `tests/testcafe/drag.js` (added to both TestCafe workflow matrices). The hand in its room marks the card on the way out, once through `onLeave` and once through `leaveRoutine`, and every assertion checks those marks next to `owner`, `parent`, `hoverParent` and `hoverTarget` as the other players see them on the server - so a test fails if the card leaves at a different moment, not only if it is revealed at a different moment.

- a card dragged over a holder stacked on top of its hand leaves the hand right away but keeps its owner until the drop,
- a card dragged half out of its hand, with no other holder involved, keeps its owner until it no longer overlaps the hand,
- a card dragged out of the hand onto another holder loses its owner right away,
- an `owner` that the hand's `leaveRoutine` assigns survives the card leaving the hand, including on the deferred path.

The first two fail on `main`, and their failure there is exactly the `owner`/`hoverParent` pair - the `onLeave` and `leaveRoutine` marks match `main` in every assertion.

`npm test` (jest) plus `drag.js`, `editor.js`, `routines.js`, `boardsize.js`, `toolbar.js` and `publiclibrary-1..4` pass locally in Chromium.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3100/pr-test (or any other room on that server)

