### PR TITLE
Remove the split-session buttons and make Add player a row of the players table

### DIFF
--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -462,7 +462,7 @@ body.aspectTooGood.hiddenToolbar {
     }
 
     #playersButton::before {
-      content: '[users_settings]';
+      content: '[people]';
     }
 
     #editButton::before {

--- a/client/css/overlays/players.css
+++ b/client/css/overlays/players.css
@@ -46,17 +46,6 @@
   font-size: 0.8rem;
 }
 
-#playersTable .sessionCellContent {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-/* the session cell is only as wide as its widest label, so this aligns the buttons without a large gap */
-#playersTable .sessionCellContent button {
-  margin-left: auto;
-}
-
 #playersTable button[icon] {
   display: inline-flex;
   padding: 5px;
@@ -156,6 +145,19 @@
   font-size: 1.2rem;
 }
 
+/* the row that adds a local player: same layout as a player row, but nothing exists yet */
+#addPlayerRow .playerColorCell .material-symbols {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2em;
+  height: 2em;
+  opacity: 0.6;
+}
+#addPlayerRow .playerName {
+  font-weight: normal;
+}
+
 #playersLegend {
   display: flex;
   flex-wrap: wrap;
@@ -180,26 +182,16 @@
   margin: 1rem auto 0 auto;
 }
 
-#playerAdd {
+#playerInvite {
   max-width: 40rem;
   margin: 1rem auto;
 }
-#playerAdd h1 {
+#playerInvite h1 {
   text-align: left;
 }
-#playerAdd .material-symbols {
+#playerInvite .material-symbols {
   font-size: 1em;
   vertical-align: text-bottom;
-}
-#addLocalPlayer {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  margin: 0.5rem 0;
-}
-#localPlayerName {
-  font-size: 1rem;
-  padding: 5px;
 }
 
 .overlay .heading{

--- a/client/css/overlays/players.css
+++ b/client/css/overlays/players.css
@@ -146,12 +146,9 @@
 }
 
 /* the rows that add a local player and invite remote ones: same layout as a player row, but no player of their own */
-#playersTable tfoot .playerColorCell .material-symbols {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2em;
-  height: 2em;
+/* they reuse the wrap of the color circle so their icon sits in a box of the same size */
+#playersTable tfoot .teamColorWrap .material-symbols {
+  font-size: 1.5em;
   opacity: 0.6;
 }
 #addPlayerRow .playerName {

--- a/client/css/overlays/players.css
+++ b/client/css/overlays/players.css
@@ -242,14 +242,26 @@
   padding: 0;
   list-style: none;
 }
+/* the button list uses the icon column of the topics above so that both sections indent
+   their text by the same amount - only the icons themselves are smaller */
+.playersHelp li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
 .playersHelp li + li {
-  margin-top: 0.25rem;
+  margin-top: 0.5rem;
+}
+.playersHelp li > .material-symbols {
+  font-size: 20px;
+  flex: 0 0 32px;
+  text-align: center;
+  color: var(--VTTblue);
 }
 /* an inline icon is placed by its own box instead of by text-bottom: with a fixed height and a
    hidden overflow its baseline is the bottom edge of that box, so the offset below the text
    baseline is a plain length and no longer depends on how a browser reads the font metrics */
-.playersHelp p .material-symbols,
-.playersHelp li .material-symbols {
+.playersHelp p .material-symbols {
   font-size: 1em;
   height: 1em;
   line-height: 1em;

--- a/client/css/overlays/players.css
+++ b/client/css/overlays/players.css
@@ -181,7 +181,6 @@
 /* the room URL is text to read out or select, not a link - clicking it would only reload the room.
    breaking it anywhere keeps it fully readable without widening the table on narrow screens */
 #playerInviteURL {
-  font-weight: bold;
   overflow-wrap: anywhere;
 }
 /* the share button lines up with the row action buttons and has no room for a label,

--- a/client/css/overlays/players.css
+++ b/client/css/overlays/players.css
@@ -46,6 +46,14 @@
   font-size: 0.8rem;
 }
 
+/* on a phone the session labels are what pushes the table past the viewport, so let them
+   wrap there rather than making the whole overlay scroll sideways */
+@media (max-width: 530px) {
+  #playersTable .playerSessionCell {
+    white-space: normal;
+  }
+}
+
 #playersTable button[icon] {
   display: inline-flex;
   padding: 5px;
@@ -151,31 +159,34 @@
   font-size: 1.5em;
   opacity: 0.6;
 }
+/* an empty input has no value to read, so unlike the player names it needs to look like a field */
 #addPlayerRow .playerName {
   font-weight: normal;
+  box-sizing: border-box;
+  min-width: 0;
+  border-bottom: 1px solid var(--VTTblueLight);
+}
+#addPlayerRow .playerName:invalid {
+  border-bottom-color: darkred;
 }
 #invitePlayerRow .playerNameCell {
   font-size: 0.9rem;
 }
-/* the share button lines up with the row action buttons, so the progress text that
-   progressButton writes into it has to stay out of the layout - its icon shows the state */
-#playersShareButton {
-  font-size: 0;
+/* breaking the URL anywhere keeps it fully readable without widening the table on narrow screens */
+#playerInviteURL {
+  overflow-wrap: anywhere;
 }
-
-#playersLegend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem 1.5rem;
-  max-width: 40rem;
-  margin: 0 auto;
-  font-size: 0.8rem;
-  opacity: 0.8;
+/* the share button lines up with the row action buttons and has no room for a label,
+   so the result of sharing replaces the invite text of the row */
+#playerInviteStatus,
+#invitePlayerRow.showStatus #playerInviteText {
+  display: none;
 }
-#playersLegend .material-symbols {
-  font-size: 1.2em;
-  vertical-align: text-bottom;
-  margin-right: 0.25rem;
+#invitePlayerRow.showStatus #playerInviteStatus {
+  display: inline;
+}
+#playerInviteStatus.error {
+  color: darkred;
 }
 
 #playersHelp {
@@ -205,14 +216,24 @@
 #playersHelp p {
   margin: 0;
 }
-#playersHelp p .material-symbols {
+#playersHelp ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+#playersHelp li {
+  margin-top: 0.25rem;
+}
+#playersHelp p .material-symbols,
+#playersHelp li .material-symbols {
   font-size: 1em;
   vertical-align: text-bottom;
+  margin-right: 0.25rem;
 }
 
 .overlay .heading{
   width: 100%;
-  max-width: 40rem; /* same width as the table, legend and invite block below */
+  max-width: 40rem; /* same width as the table and the help section below */
   margin: 0 auto;
 }
 .overlay .heading h1{

--- a/client/css/overlays/players.css
+++ b/client/css/overlays/players.css
@@ -145,8 +145,8 @@
   font-size: 1.2rem;
 }
 
-/* the row that adds a local player: same layout as a player row, but nothing exists yet */
-#addPlayerRow .playerColorCell .material-symbols {
+/* the rows that add a local player and invite remote ones: same layout as a player row, but no player of their own */
+#playersTable tfoot .playerColorCell .material-symbols {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -156,6 +156,14 @@
 }
 #addPlayerRow .playerName {
   font-weight: normal;
+}
+#invitePlayerRow .playerNameCell {
+  font-size: 0.9rem;
+}
+/* the share button lines up with the row action buttons, so the progress text that
+   progressButton writes into it has to stay out of the layout - its icon shows the state */
+#playersShareButton {
+  font-size: 0;
 }
 
 #playersLegend {
@@ -180,16 +188,6 @@
   display: block;
   max-width: 40rem;
   margin: 1rem auto 0 auto;
-}
-
-#playerInvite {
-  width: 100%;
-  max-width: 40rem;
-  margin: 1rem auto;
-}
-#playerInvite h1 {
-  text-align: left;
-  margin-bottom: 0.5em;
 }
 
 #playersHelp {

--- a/client/css/overlays/players.css
+++ b/client/css/overlays/players.css
@@ -178,15 +178,6 @@
   margin-right: 0.25rem;
 }
 
-#playersAloneHint {
-  display: none;
-}
-#playersAloneHint.shown {
-  display: block;
-  max-width: 40rem;
-  margin: 1rem auto 0 auto;
-}
-
 #playersHelp {
   width: 100%;
   max-width: 40rem;

--- a/client/css/overlays/players.css
+++ b/client/css/overlays/players.css
@@ -183,38 +183,55 @@
 }
 
 #playerInvite {
+  width: 100%;
   max-width: 40rem;
   margin: 1rem auto;
 }
 #playerInvite h1 {
   text-align: left;
+  margin-bottom: 0.5em;
 }
-#playerInvite .material-symbols {
+
+#playersHelp {
+  width: 100%;
+  max-width: 40rem;
+  margin: 1rem auto;
+}
+#playersHelp > summary {
+  cursor: pointer;
+  font-weight: bold;
+}
+#playersHelp .helpTopic {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+#playersHelp .helpTopic > .material-symbols {
+  font-size: 32px;
+  flex: 0 0 32px;
+  color: var(--VTTblue);
+}
+#playersHelp h2 {
+  margin: 0 0 0.25rem 0;
+  font-size: 1.1rem;
+}
+#playersHelp p {
+  margin: 0;
+}
+#playersHelp p .material-symbols {
   font-size: 1em;
   vertical-align: text-bottom;
 }
 
 .overlay .heading{
-  display: flex;
-  align-items: flex-start;
-  justify-content: flex-start;
   width: 100%;
-  max-width: 40rem; /* same width as the table, legend and add-player block below */
+  max-width: 40rem; /* same width as the table, legend and invite block below */
   margin: 0 auto;
 }
 .overlay .heading h1{
-  margin: 0 0.5em 0 0;
-  padding: 0.25em 0.5em 0.25em 0;
-  border-right: 1px solid rgba(255, 255, 255, 0.5);
-  line-height: 1em;
+  margin: 0;
   text-align: left;
-  max-width: 45%;
-}
-.overlay .heading .instructionalText{
-  display: block;
-  font-size: 16px;
-  text-align: left;
-  padding: 0.9rem 0;
 }
 #playerCursors {
   position: absolute;

--- a/client/css/overlays/players.css
+++ b/client/css/overlays/players.css
@@ -169,6 +169,12 @@
 #addPlayerRow .playerName:invalid {
   border-bottom-color: darkred;
 }
+/* the invite row is a hint of the same kind as the add-player placeholder, so it gets its color
+   (spelled out because browsers disagree on the default placeholder color) */
+#addPlayerRow .playerName::placeholder,
+#invitePlayerRow .playerNameCell {
+  color: #757575;
+}
 #invitePlayerRow .playerNameCell {
   font-size: 0.9rem;
 }
@@ -191,43 +197,57 @@
   color: darkred;
 }
 
-#playersHelp {
+/* framed so that it is obvious where the collapsed section starts and what belongs to it */
+.playersHelp {
   width: 100%;
   max-width: 40rem;
-  margin: 1rem auto;
+  box-sizing: border-box;
+  margin: 0.5rem auto;
+  border: 1px solid var(--VTTblueLight);
+  border-radius: 4px;
 }
-#playersHelp > summary {
+.playersHelp > summary {
   cursor: pointer;
   font-weight: bold;
+  padding: 0.5rem;
+  background: #1f5ca61a;
 }
-#playersHelp .helpTopic {
+.playersHelp[open] > summary {
+  border-bottom: 1px solid var(--VTTblueLight);
+}
+.playersHelp .helpContent {
+  padding: 0.5rem 0.75rem 0.75rem 0.75rem;
+}
+.playersHelp .helpTopic {
   display: flex;
   align-items: flex-start;
   gap: 0.75rem;
+}
+.playersHelp .helpTopic + .helpTopic {
   margin-top: 1rem;
 }
-#playersHelp .helpTopic > .material-symbols {
+.playersHelp .helpTopic > .material-symbols {
   font-size: 32px;
   flex: 0 0 32px;
   color: var(--VTTblue);
 }
-#playersHelp h2 {
+.playersHelp h2 {
   margin: 0 0 0.25rem 0;
   font-size: 1.1rem;
 }
-#playersHelp p {
+.playersHelp p {
   margin: 0;
 }
-#playersHelp ul {
+.playersHelp ul {
   margin: 0;
   padding: 0;
   list-style: none;
 }
-#playersHelp li {
+.playersHelp li + li {
   margin-top: 0.25rem;
 }
-#playersHelp p .material-symbols,
-#playersHelp li .material-symbols {
+.playersHelp p .material-symbols,
+.playersHelp li .material-symbols {
   font-size: 1em;
   vertical-align: text-bottom;
   margin-right: 0.25rem;

--- a/client/css/overlays/players.css
+++ b/client/css/overlays/players.css
@@ -246,10 +246,16 @@
 .playersHelp li + li {
   margin-top: 0.25rem;
 }
+/* an inline icon is placed by its own box instead of by text-bottom: with a fixed height and a
+   hidden overflow its baseline is the bottom edge of that box, so the offset below the text
+   baseline is a plain length and no longer depends on how a browser reads the font metrics */
 .playersHelp p .material-symbols,
 .playersHelp li .material-symbols {
   font-size: 1em;
-  vertical-align: text-bottom;
+  height: 1em;
+  line-height: 1em;
+  overflow: hidden;
+  vertical-align: -0.25em;
   margin-right: 0.25rem;
 }
 

--- a/client/css/overlays/players.css
+++ b/client/css/overlays/players.css
@@ -172,8 +172,10 @@
 #invitePlayerRow .playerNameCell {
   font-size: 0.9rem;
 }
-/* breaking the URL anywhere keeps it fully readable without widening the table on narrow screens */
+/* the room URL is text to read out or select, not a link - clicking it would only reload the room.
+   breaking it anywhere keeps it fully readable without widening the table on narrow screens */
 #playerInviteURL {
+  font-weight: bold;
   overflow-wrap: anywhere;
 }
 /* the share button lines up with the row action buttons and has no room for a label,

--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -64,16 +64,19 @@ export function progressButton(button, clickHandler, disableWhenDone=true) {
   };
 }
 
-async function shareURL(url) {
+// returns how the URL was passed on so callers can tell the user what happened
+export async function shareURL(url) {
   try {
     await navigator.share({ url });
   } catch(e) {
     try {
       await navigator.clipboard.writeText(url);
+      return 'clipboard';
     } catch(e) {
       throw new Error('Could not share or copy URL.');
     }
   }
+  return 'share';
 }
 
 // uses a progressButton with a custom handler that shares a URL

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -680,8 +680,7 @@ onLoad(function() {
     checkedOnce = true;
     let tabSuffix = config.customTab || config.serverName || 'VirtualTabletop.io';
     document.title = `${document.location.pathname.split('/').pop()} - ${tabSuffix}`;
-    const inviteLink = $('#playerInviteURL');
-    inviteLink.href = inviteLink.innerText = location.href;
+    $('#playerInviteURL').innerText = location.href;
   });
 });
 

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -681,7 +681,7 @@ onLoad(function() {
     let tabSuffix = config.customTab || config.serverName || 'VirtualTabletop.io';
     document.title = `${document.location.pathname.split('/').pop()} - ${tabSuffix}`;
     const inviteLink = $('#playerInviteURL');
-    inviteLink.href = inviteLink.title = location.href;
+    inviteLink.href = inviteLink.innerText = location.href;
   });
 });
 

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -680,7 +680,8 @@ onLoad(function() {
     checkedOnce = true;
     let tabSuffix = config.customTab || config.serverName || 'VirtualTabletop.io';
     document.title = `${document.location.pathname.split('/').pop()} - ${tabSuffix}`;
-    $('#playerInviteURL').innerText = location.href;
+    const inviteLink = $('#playerInviteURL');
+    inviteLink.href = inviteLink.title = location.href;
   });
 });
 

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -196,6 +196,10 @@ function fillPlayerList(players, active, sessions) {
     if(player != playerName && activePlayers.indexOf(player) != -1)
       addPlayerCursor(player, players[player]);
   }
+  // with a second tab open as the same player, adding a player also moves this tab to it
+  $('#addLocalPlayerButton').title = (sessionsByPlayer[playerName] || []).length > 1
+    ? 'Add a player and switch this browser tab to them'
+    : 'Add a player who shares this device';
   // somebody who is alone at the table is usually here to find out how to get others in, so
   // the help starts open for them - once there are other players it would just be in the way
   if(!helpDefaultApplied) {
@@ -290,6 +294,13 @@ onLoad(function() {
       input.setCustomValidity(localPlayerName ? 'This player already exists.' : 'Please enter a player name.');
       input.reportValidity();
       return;
+    }
+    // a second tab connected as the same player is somebody who wants to be their own player, so
+    // the new player takes this session over right away instead of waiting for a View click
+    if((lastMetaArgs && lastMetaArgs.sessions || []).filter(s=>s.player == playerName).length > 1) {
+      // renaming a single session creates the player if it does not exist yet
+      toServer('rename', { oldName: playerName, newName: localPlayerName, sessionID: mySessionID });
+      return nextMetaUpdate(args=>(args.sessions || []).some(s=>s.sessionID == mySessionID && s.player == localPlayerName)).then(_=>input.value = '');
     }
     toServer('addLocalPlayer', { player: localPlayerName });
     return nextMetaUpdate(args=>args.meta.players[localPlayerName] !== undefined).then(_=>input.value = '');

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -1,4 +1,4 @@
-import { asArray, onLoad, progressButton, rand } from '../domhelpers.js';
+import { asArray, onLoad, rand } from '../domhelpers.js';
 
 let playerCursors = {};
 let playerCursorsTimeout = {};
@@ -172,16 +172,8 @@ function fillPlayerList(players, active, sessions) {
         // numbering the sessions only carries information for players that actually have more than one
         const label = playerSessions.length > 1 ? `Session ${sessionIndex+1}` : 'connected';
         $('.sessionLabel', sessionCell).textContent = session.sessionID == mySessionID ? `${label} (you)` : label;
-        serverActionButton($('.splitSession', sessionCell), function() {
-          const newName = (prompt(`Enter a new player name for this session of ${player}:`) || '').trim();
-          if(!newName || newName == player)
-            return;
-          toServer('rename', { oldName: player, newName, sessionID: session.sessionID });
-          return nextMetaUpdate(args=>(args.sessions || []).some(s=>s.sessionID == session.sessionID && s.player == newName));
-        });
       } else {
         $('.sessionLabel', sessionCell).textContent = 'not connected';
-        removeFromDOM($('.splitSession', sessionCell));
       }
       row.appendChild(sessionCell);
 
@@ -271,16 +263,19 @@ onLoad(function() {
       widget.updateOwner();
   });
 
-  progressButton($('#addLocalPlayerButton'), async function() {
-    const localPlayerName = $('#localPlayerName').value.trim();
-    if(!localPlayerName)
-      throw new Error('Please enter a player name.');
-    if(lastMetaArgs && lastMetaArgs.meta.players[localPlayerName] !== undefined)
-      throw new Error('This player already exists.');
+  serverActionButton($('#addLocalPlayerButton'), function() {
+    const input = $('#localPlayerName');
+    const localPlayerName = input.value.trim();
+    // the server silently ignores empty and duplicate names, so complain right at the input instead
+    if(!localPlayerName || (lastMetaArgs && lastMetaArgs.meta.players[localPlayerName] !== undefined)) {
+      input.setCustomValidity(localPlayerName ? 'This player already exists.' : 'Please enter a player name.');
+      input.reportValidity();
+      return;
+    }
     toServer('addLocalPlayer', { player: localPlayerName });
-    await nextMetaUpdate(args=>args.meta.players[localPlayerName] !== undefined);
-    $('#localPlayerName').value = '';
+    return nextMetaUpdate(args=>args.meta.players[localPlayerName] !== undefined).then(_=>input.value = '');
   });
+  $('#localPlayerName').addEventListener('input', e=>e.target.setCustomValidity(''));
   $('#localPlayerName').addEventListener('keydown', function(e) {
     if(e.key == 'Enter')
       $('#addLocalPlayerButton').click();

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -62,6 +62,22 @@ function nextMetaUpdate(isApplied, timeout=3000) {
 
 // shows a spinner on the button while a returned promise is pending; the row usually
 // gets replaced by the meta update before the button is restored
+// the widget properties the server looks at before it lets a player be removed, and how to say
+// in the tooltip of the disabled button what is still pointing at that player
+const playerReferences = {
+  owner: 'cards or other widgets in the game belong to them',
+  player: 'they are seated in the game',
+  artist: 'they are credited as an artist'
+};
+
+// a button that cannot do anything here stays visible and says why - removing it silently
+// leaves people wondering why the same row of the table has fewer buttons than the others
+function unavailableButton(button, reason) {
+  button.classList.add('unavailable');
+  button.setAttribute('aria-disabled', 'true');
+  button.title = reason;
+}
+
 function serverActionButton(button, action) {
   button.addEventListener('click', async function() {
     if(button.disabled)
@@ -108,6 +124,11 @@ function fillPlayerList(players, active, sessions) {
   const rank = player=>player == playerName ? 0 : sessionsByPlayer[player] ? 1 : 2;
   const sortedPlayers = Object.keys(players).sort((a,b)=>rank(a)-rank(b) || a.localeCompare(b));
 
+  const widgetList = [...widgets.values()];
+  const referencesTo = player=>Object.keys(playerReferences).filter(p=>widgetList.some(function(w) {
+    return Array.isArray(w.state[p]) ? w.state[p].indexOf(player) != -1 : w.state[p] == player;
+  }));
+
   for(const player of sortedPlayers) {
     const playerSessions = sessionsByPlayer[player] || [ null ];
     const hasMySession = playerSessions.some(s=>s && s.sessionID == mySessionID);
@@ -145,23 +166,25 @@ function fillPlayerList(players, active, sessions) {
           $('.playerName', row).focus();
           $('.playerName', row).select();
         });
-        const isReferencedByWidgets = [...widgets.values()].some(w=>[ w.state.owner, w.state.player, w.state.artist ].some(v=>Array.isArray(v) ? v.indexOf(player) != -1 : v == player));
+        const references = referencesTo(player);
         // viewing a connected player who is part of the game would secretly reveal their hand (the server refuses it too)
         if(player == playerName) {
           removeFromDOM($('.viewPlayer', row));
-        } else if(session && isReferencedByWidgets) {
-          // keep the button visible but explain why it does not work here, otherwise it just silently disappears for some players
-          $('.viewPlayer', row).classList.add('unavailable');
-          $('.viewPlayer', row).setAttribute('aria-disabled', 'true');
-          $('.viewPlayer', row).title = `You cannot view the game as ${player} because they are connected and taking part in the game - it would reveal their hand to you`;
+        } else if(session && references.length) {
+          unavailableButton($('.viewPlayer', row), `You cannot view the game as ${player} because they are connected and taking part in the game - it would reveal their hand to you`);
         } else {
           serverActionButton($('.viewPlayer', row), function() {
             toServer('rename', { oldName: playerName, newName: player, sessionID: mySessionID });
             return nextMetaUpdate(args=>(args.sessions || []).some(s=>s.sessionID == mySessionID && s.player == player));
           });
         }
-        if(session || isReferencedByWidgets) {
+        // a player the game still points at cannot be removed - the sessions column already says
+        // why a connected one cannot, so only the widget references need spelling out
+        if(session) {
           removeFromDOM($('.removePlayer', row));
+        } else if(references.length) {
+          const reasons = references.map(p=>playerReferences[p]);
+          unavailableButton($('.removePlayer', row), `You cannot remove ${player} because ${reasons.join(' and ')}. Rename them to a player who stays, or free what belongs to them, and the button becomes available.`);
         } else {
           serverActionButton($('.removePlayer', row), function() {
             toServer('removeLocalPlayer', { player });

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -311,16 +311,12 @@ onLoad(function() {
       $('#addLocalPlayerButton').click();
   });
 
-  // share URL when clicking the button or the link, which would otherwise just reload the room
+  // the room URL is plain text - clicking it would just reload the room, so sharing it is the button's job
   serverActionButton($('#playersShareButton'), async function() {
     try {
       showInviteStatus(await shareURL(location.href) == 'clipboard' ? 'Room URL copied to clipboard.' : 'Room URL shared.');
     } catch(e) {
       showInviteStatus(e.message, true);
     }
-  });
-  $('#playerInviteURL').addEventListener('click', function(e) {
-    e.preventDefault();
-    $('#playersShareButton').click();
   });
 });

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -213,8 +213,8 @@ function fillPlayerList(players, active, sessions) {
 
       const sessionCell = $('td', domByTemplate('template-playerlist-session', {}, 'tr'));
       if(session) {
-        // numbering the sessions only carries information for players that actually have more than one
-        const label = playerSessions.length > 1 ? `Session ${sessionIndex+1}` : 'connected';
+        // numbering the connections only carries information for players that actually have more than one
+        const label = playerSessions.length > 1 ? `Connection ${sessionIndex+1}` : 'connected';
         $('.sessionLabel', sessionCell).textContent = session.sessionID == mySessionID ? `${label} (you)` : label;
       } else {
         $('.sessionLabel', sessionCell).textContent = 'not connected';

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -265,6 +265,7 @@ onLoad(function() {
 
   serverActionButton($('#addLocalPlayerButton'), function() {
     const input = $('#localPlayerName');
+    input.setCustomValidity('');
     const localPlayerName = input.value.trim();
     // the server silently ignores empty and duplicate names, so complain right at the input instead
     if(!localPlayerName || (lastMetaArgs && lastMetaArgs.meta.players[localPlayerName] !== undefined)) {

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -9,7 +9,6 @@ let activeColors = [];
 let mouseCoords = [];
 let mySessionID = null;
 let metaUpdateResolves = [];
-let helpDefaultApplied = false;
 let inviteStatusTimeout = null;
 localStorage.setItem('playerName', playerName);
 
@@ -200,12 +199,6 @@ function fillPlayerList(players, active, sessions) {
   $('#addLocalPlayerButton').title = (sessionsByPlayer[playerName] || []).length > 1
     ? 'Add a player and switch this browser tab to them'
     : 'Add a player who shares this device';
-  // somebody who is alone at the table is usually here to find out how to get others in, so
-  // the help starts open for them - once there are other players it would just be in the way
-  if(!helpDefaultApplied) {
-    helpDefaultApplied = true;
-    $('#playersHelp').open = sortedPlayers.length < 2;
-  }
   updatePlayerCountDisplay();
 }
 

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -60,10 +60,8 @@ function nextMetaUpdate(isApplied, timeout=3000) {
   });
 }
 
-// shows a spinner on the button while a returned promise is pending; the row usually
-// gets replaced by the meta update before the button is restored
-// the widget properties the server looks at before it lets a player be removed, and how to say
-// in the tooltip of the disabled button what is still pointing at that player
+// the widget properties that can still point at a player after they left, and how to name
+// them in the warning shown before that player is taken off the list
 const playerReferences = {
   owner: 'cards or other widgets in the game belong to them',
   player: 'they are seated in the game',
@@ -78,6 +76,16 @@ function unavailableButton(button, reason) {
   button.title = reason;
 }
 
+// what a removed player leaves behind is invisible in this overlay, so say it before it happens
+async function confirmRemoval(player, references) {
+  const reasons = references.map(p=>playerReferences[p]).join(' and ');
+  const confirmed = await confirmOverlay('Remove player', `${player} is not connected, but ${reasons}.\n\nRemoving them only takes the name off this list - everything that belongs to them stays in the game and is picked up again by a player of the same name.`, 'Remove', 'Keep', 'delete', 'undo', 'red');
+  showOverlay('playerOverlay');
+  return confirmed;
+}
+
+// shows a spinner on the button while a returned promise is pending; the row usually
+// gets replaced by the meta update before the button is restored
 function serverActionButton(button, action) {
   button.addEventListener('click', async function() {
     if(button.disabled)
@@ -178,15 +186,16 @@ function fillPlayerList(players, active, sessions) {
             return nextMetaUpdate(args=>(args.sessions || []).some(s=>s.sessionID == mySessionID && s.player == player));
           });
         }
-        // a player the game still points at cannot be removed - the sessions column already says
-        // why a connected one cannot, so only the widget references need spelling out
+        // only a connected player cannot be taken off the list, and the sessions column of the
+        // same row already says so - anybody else can go, with a warning about what they leave behind
         if(session) {
           removeFromDOM($('.removePlayer', row));
-        } else if(references.length) {
-          const reasons = references.map(p=>playerReferences[p]);
-          unavailableButton($('.removePlayer', row), `You cannot remove ${player} because ${reasons.join(' and ')}. Rename them to a player who stays, or free what belongs to them, and the button becomes available.`);
         } else {
-          serverActionButton($('.removePlayer', row), function() {
+          if(references.length)
+            $('.removePlayer', row).title = `Remove ${player} from the list - ${references.map(p=>playerReferences[p]).join(' and ')}`;
+          serverActionButton($('.removePlayer', row), async function() {
+            if(references.length && !await confirmRemoval(player, references))
+              return;
             toServer('removeLocalPlayer', { player });
             return nextMetaUpdate(args=>args.meta.players[player] === undefined);
           });

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -1,4 +1,4 @@
-import { asArray, onLoad, rand } from '../domhelpers.js';
+import { asArray, onLoad, rand, shareURL } from '../domhelpers.js';
 
 let playerCursors = {};
 let playerCursorsTimeout = {};
@@ -9,6 +9,8 @@ let activeColors = [];
 let mouseCoords = [];
 let mySessionID = null;
 let metaUpdateResolves = [];
+let helpDefaultApplied = false;
+let inviteStatusTimeout = null;
 localStorage.setItem('playerName', playerName);
 
 export {
@@ -79,6 +81,17 @@ function serverActionButton(button, action) {
     button.setAttribute('icon', initialIcon);
     button.classList.remove('working');
   });
+}
+
+// the share button sits in the actions column of the invite row and has no room for a label,
+// so sharing reports its result in the name cell of that row instead
+function showInviteStatus(text, isError) {
+  clearTimeout(inviteStatusTimeout);
+  $('#playerInviteStatus').textContent = text;
+  $('#playerInviteStatus').classList.toggle('error', !!isError);
+  $('#invitePlayerRow').classList.toggle('showStatus', !!text);
+  if(text)
+    inviteStatusTimeout = setTimeout(_=>showInviteStatus(''), 5000);
 }
 
 function fillPlayerList(players, active, sessions) {
@@ -183,6 +196,12 @@ function fillPlayerList(players, active, sessions) {
     if(player != playerName && activePlayers.indexOf(player) != -1)
       addPlayerCursor(player, players[player]);
   }
+  // somebody who is alone at the table is usually here to find out how to get others in, so
+  // the help starts open for them - once there are other players it would just be in the way
+  if(!helpDefaultApplied) {
+    helpDefaultApplied = true;
+    $('#playersHelp').open = sortedPlayers.length < 2;
+  }
   updatePlayerCountDisplay();
 }
 
@@ -281,6 +300,16 @@ onLoad(function() {
       $('#addLocalPlayerButton').click();
   });
 
-  // share URL when clicking button
-  shareButton($('#playersShareButton'), _=>location.href);
+  // share URL when clicking the button or the link, which would otherwise just reload the room
+  serverActionButton($('#playersShareButton'), async function() {
+    try {
+      showInviteStatus(await shareURL(location.href) == 'clipboard' ? 'Room URL copied to clipboard.' : 'Room URL shared.');
+    } catch(e) {
+      showInviteStatus(e.message, true);
+    }
+  });
+  $('#playerInviteURL').addEventListener('click', function(e) {
+    e.preventDefault();
+    $('#playersShareButton').click();
+  });
 });

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -183,7 +183,6 @@ function fillPlayerList(players, active, sessions) {
     if(player != playerName && activePlayers.indexOf(player) != -1)
       addPlayerCursor(player, players[player]);
   }
-  $('#playersAloneHint').classList.toggle('shown', sortedPlayers.length < 2);
   updatePlayerCountDisplay();
 }
 

--- a/client/room.html
+++ b/client/room.html
@@ -84,7 +84,6 @@
     <div id="playerOverlay" class="overlay">
       <div class="heading">
         <h1>Players</h1>
-        <div class="instructionalText">Every connected browser tab is a session of a player. Edit the name and color of any player, view the game as another player or add a local player that shares this device.</div>
       </div>
       <div id="playerList">
         <template id="template-playerlist-player" type="text/template">
@@ -129,10 +128,33 @@
         <div id="playersAloneHint">You are the only player at this table. Share the room URL or add a local player to play with others.</div>
       </div>
       <div id="playerInvite">
-        <h1>Invite</h1>
-        <p>More players can join this game by visiting <span id="playerInviteURL"></span>. Players without their own device can be added in the last row of the table above and take their turns via the <i class="material-symbols">visibility</i> buttons.</p>
+        <h1>Invite players to <a id="playerInviteURL">this room</a></h1>
         <button icon="share" id="playersShareButton">Share room URL</button>
       </div>
+      <details id="playersHelp">
+        <summary>Help: playing together</summary>
+        <div class="helpTopic">
+          <i class="material-symbols">groups</i>
+          <div>
+            <h2>Players and sessions</h2>
+            <p>Every connected browser tab is a session of a player. Edit the name and color of any player, view the game as another player or add a local player that shares this device.</p>
+          </div>
+        </div>
+        <div class="helpTopic">
+          <i class="material-symbols">share</i>
+          <div>
+            <h2>Remote play</h2>
+            <p>Everybody plays on their own device: send them the room URL above and they join this table as soon as they open it. Their browser tab shows up here as a session and they can pick their name and color in the table.</p>
+          </div>
+        </div>
+        <div class="helpTopic">
+          <i class="material-symbols">swap_horizontal_circle</i>
+          <div>
+            <h2>Hotseat</h2>
+            <p>Several people share one device: add each of them in the last row of the table, then use the <i class="material-symbols">visibility</i> button to switch this browser tab to whoever's turn it is. Only your own session changes, the game itself stays untouched.</p>
+          </div>
+        </div>
+      </details>
     </div>
 
     <div id="returnOverlay" class="overlay">

--- a/client/room.html
+++ b/client/room.html
@@ -120,7 +120,7 @@
             </tr>
             <tr id="invitePlayerRow">
               <td class="playerColorCell"><span class="teamColorWrap"><i class="material-symbols">group_add</i></span></td>
-              <td class="playerNameCell"><span id="playerInviteText">Invite players to <a id="playerInviteURL" title="Share the room URL so other players can join"></a></span><span id="playerInviteStatus"></span></td>
+              <td class="playerNameCell"><span id="playerInviteText">Invite players to <span id="playerInviteURL"></span></span><span id="playerInviteStatus"></span></td>
               <td class="playerActionsCell" colspan="2"><button icon="share" id="playersShareButton" title="Share the room URL so other players can join"></button></td>
             </tr>
           </tfoot>

--- a/client/room.html
+++ b/client/room.html
@@ -84,7 +84,7 @@
     <div id="playerOverlay" class="overlay">
       <div class="heading">
         <h1>Players</h1>
-        <div class="instructionalText">Every connected browser tab is a session of a player. Edit the name and color of any player, view the game as another player or split a session off into its own player.</div>
+        <div class="instructionalText">Every connected browser tab is a session of a player. Edit the name and color of any player, view the game as another player or add a local player that shares this device.</div>
       </div>
       <div id="playerList">
         <template id="template-playerlist-player" type="text/template">
@@ -105,10 +105,7 @@
         </template>
         <template id="template-playerlist-session" type="text/template">
           <td class="playerSessionCell">
-            <div class="sessionCellContent">
-              <span class="sessionLabel"></span>
-              <button icon="call_split" class="splitSession" title="Split this session off into its own player: only this session gets renamed and the game stays unchanged"></button>
-            </div>
+            <span class="sessionLabel"></span>
           </td>
         </template>
         <table id="playersTable">
@@ -116,22 +113,24 @@
             <tr><th></th><th>Player</th><th></th><th>Sessions</th></tr>
           </thead>
           <tbody></tbody>
+          <tfoot>
+            <tr id="addPlayerRow">
+              <td class="playerColorCell"><i class="material-symbols">person_add</i></td>
+              <td class="playerNameCell"><input id="localPlayerName" class="playerName" placeholder="Add a local player" /></td>
+              <td class="playerActionsCell" colspan="2"><button icon="add" id="addLocalPlayerButton" title="Add a local player that shares this device"></button></td>
+            </tr>
+          </tfoot>
         </table>
         <div id="playersLegend">
           <span><i class="material-symbols">edit</i>Rename the player everywhere in the game</span>
           <span><i class="material-symbols">visibility</i>View the game as this player - greyed out while they are connected and playing</span>
-          <span><i class="material-symbols">call_split</i>Split this session off into its own player</span>
           <span><i class="material-symbols">delete</i>Remove this player</span>
         </div>
-        <div id="playersAloneHint">You are the only player at this table. Share the room URL or add a local player below to play with others.</div>
+        <div id="playersAloneHint">You are the only player at this table. Share the room URL or add a local player to play with others.</div>
       </div>
-      <div id="playerAdd">
-        <h1>Add player</h1>
-        <p>More players can join this game by visiting <span id="playerInviteURL"></span>. You can also add a local player without its own device and use the <i class="material-symbols">visibility</i> buttons above to pass the turn around on this device.</p>
-        <div id="addLocalPlayer">
-          <input id="localPlayerName" placeholder="Player name" />
-          <button icon="person_add" id="addLocalPlayerButton">Add local player</button>
-        </div>
+      <div id="playerInvite">
+        <h1>Invite</h1>
+        <p>More players can join this game by visiting <span id="playerInviteURL"></span>. Players without their own device can be added in the last row of the table above and take their turns via the <i class="material-symbols">visibility</i> buttons.</p>
         <button icon="share" id="playersShareButton">Share room URL</button>
       </div>
     </div>

--- a/client/room.html
+++ b/client/room.html
@@ -132,7 +132,7 @@
           <i class="material-symbols">groups</i>
           <div>
             <h2>Players and sessions</h2>
-            <p>Every connected browser tab is a session of a player. Edit the name and color of any player, view the game as another player or add a local player that shares this device.</p>
+            <p>Every connected browser tab is a session of a player. Edit the name and color of any player, view the game as another player or add a local player that shares this device. While you have this room open in more than one tab, adding a player switches the current tab to them, so every tab can be its own player.</p>
           </div>
         </div>
         <div class="helpTopic">

--- a/client/room.html
+++ b/client/room.html
@@ -114,12 +114,12 @@
           <tbody></tbody>
           <tfoot>
             <tr id="addPlayerRow">
-              <td class="playerColorCell"><i class="material-symbols">person_add</i></td>
+              <td class="playerColorCell"><span class="teamColorWrap"><i class="material-symbols">person_add</i></span></td>
               <td class="playerNameCell"><input id="localPlayerName" class="playerName" placeholder="Add a local player" /></td>
               <td class="playerActionsCell" colspan="2"><button icon="add" id="addLocalPlayerButton" title="Add a local player that shares this device"></button></td>
             </tr>
             <tr id="invitePlayerRow">
-              <td class="playerColorCell"><i class="material-symbols">link</i></td>
+              <td class="playerColorCell"><span class="teamColorWrap"><i class="material-symbols">link</i></span></td>
               <td class="playerNameCell">Invite players to <a id="playerInviteURL">this room</a></td>
               <td class="playerActionsCell" colspan="2"><button icon="share" id="playersShareButton" title="Share the room URL so other players can join"></button></td>
             </tr>

--- a/client/room.html
+++ b/client/room.html
@@ -126,39 +126,42 @@
           </tfoot>
         </table>
       </div>
-      <details id="playersHelp">
+      <details id="playersHelp" class="playersHelp">
         <summary>Help: playing together</summary>
-        <div class="helpTopic">
-          <i class="material-symbols">groups</i>
-          <div>
-            <h2>Players and sessions</h2>
-            <p>Every connected browser tab is a session of a player. Edit the name and color of any player, view the game as another player or add a local player that shares this device. While you have this room open in more than one tab, adding a player switches the current tab to them, so every tab can be its own player.</p>
+        <div class="helpContent">
+          <div class="helpTopic">
+            <i class="material-symbols">groups</i>
+            <div>
+              <h2>Players and sessions</h2>
+              <p>Every connected browser tab is a session of a player. Edit the name and color of any player, view the game as another player or add a local player that shares this device. While you have this room open in more than one tab, adding a player switches the current tab to them, so every tab can be its own player.</p>
+            </div>
+          </div>
+          <div class="helpTopic">
+            <i class="material-symbols">share</i>
+            <div>
+              <h2>Remote play</h2>
+              <p>Everybody plays on their own device: send them the room URL with the <i class="material-symbols">share</i> button in the table above and they join this table as soon as they open it. Their browser tab shows up here as a session and they can pick their name and color in the table.</p>
+            </div>
+          </div>
+          <div class="helpTopic">
+            <i class="material-symbols">swap_horizontal_circle</i>
+            <div>
+              <h2>Hotseat</h2>
+              <p>Several people share one device: add each of them with the <i class="material-symbols">person_add</i> row of the table, then use the <i class="material-symbols">visibility</i> button to switch this browser tab to whoever's turn it is. Only your own session changes, the game itself stays untouched.</p>
+            </div>
           </div>
         </div>
-        <div class="helpTopic">
-          <i class="material-symbols">share</i>
-          <div>
-            <h2>Remote play</h2>
-            <p>Everybody plays on their own device: send them the room URL with the <i class="material-symbols">share</i> button in the table above and they join this table as soon as they open it. Their browser tab shows up here as a session and they can pick their name and color in the table.</p>
-          </div>
-        </div>
-        <div class="helpTopic">
-          <i class="material-symbols">swap_horizontal_circle</i>
-          <div>
-            <h2>Hotseat</h2>
-            <p>Several people share one device: add each of them with the <i class="material-symbols">person_add</i> row of the table, then use the <i class="material-symbols">visibility</i> button to switch this browser tab to whoever's turn it is. Only your own session changes, the game itself stays untouched.</p>
-          </div>
-        </div>
-        <div class="helpTopic">
-          <i class="material-symbols">smart_button</i>
-          <div>
-            <h2>What the buttons do</h2>
-            <ul>
-              <li><i class="material-symbols">edit</i>Rename the player everywhere in the game</li>
-              <li><i class="material-symbols">visibility</i>View the game as this player - greyed out while they are connected and playing</li>
-              <li><i class="material-symbols">delete</i>Remove this player</li>
-            </ul>
-          </div>
+      </details>
+      <details id="playersButtonHelp" class="playersHelp">
+        <summary>Help: what the buttons do</summary>
+        <div class="helpContent">
+          <ul>
+            <li><i class="material-symbols">edit</i>Rename the player everywhere in the game</li>
+            <li><i class="material-symbols">visibility</i>View the game as this player - greyed out while they are connected and playing</li>
+            <li><i class="material-symbols">delete</i>Remove this player</li>
+            <li><i class="material-symbols">add</i>Add a player who shares this device</li>
+            <li><i class="material-symbols">share</i>Share the room URL so other players can join</li>
+          </ul>
         </div>
       </details>
     </div>

--- a/client/room.html
+++ b/client/room.html
@@ -158,7 +158,7 @@
           <ul>
             <li><i class="material-symbols">edit</i>Rename the player everywhere in the game</li>
             <li><i class="material-symbols">visibility</i>View the game as this player - greyed out while they are connected and playing</li>
-            <li><i class="material-symbols">delete</i>Remove this player from the list - only shown while they are not connected, and greyed out while parts of the game still belong to them</li>
+            <li><i class="material-symbols">delete</i>Remove this player from the list - only shown while they are not connected, and asking first if parts of the game still belong to them</li>
             <li><i class="material-symbols">add</i>Add a player who shares this device</li>
             <li><i class="material-symbols">share</i>Share the room URL so other players can join</li>
           </ul>

--- a/client/room.html
+++ b/client/room.html
@@ -130,7 +130,6 @@
           <span><i class="material-symbols">visibility</i>View the game as this player - greyed out while they are connected and playing</span>
           <span><i class="material-symbols">delete</i>Remove this player</span>
         </div>
-        <div id="playersAloneHint">You are the only player at this table. Share the room URL or add a local player to play with others.</div>
       </div>
       <details id="playersHelp">
         <summary>Help: playing together</summary>

--- a/client/room.html
+++ b/client/room.html
@@ -158,7 +158,7 @@
           <ul>
             <li><i class="material-symbols">edit</i>Rename the player everywhere in the game</li>
             <li><i class="material-symbols">visibility</i>View the game as this player - greyed out while they are connected and playing</li>
-            <li><i class="material-symbols">delete</i>Remove this player</li>
+            <li><i class="material-symbols">delete</i>Remove this player from the list - only shown while they are not connected, and greyed out while parts of the game still belong to them</li>
             <li><i class="material-symbols">add</i>Add a player who shares this device</li>
             <li><i class="material-symbols">share</i>Share the room URL so other players can join</li>
           </ul>

--- a/client/room.html
+++ b/client/room.html
@@ -109,27 +109,22 @@
         </template>
         <table id="playersTable">
           <thead>
-            <tr><th></th><th>Player</th><th></th><th>Sessions</th></tr>
+            <tr><th></th><th>Player</th><th></th><th title="Every connected browser tab is a session of a player">Sessions</th></tr>
           </thead>
           <tbody></tbody>
           <tfoot>
             <tr id="addPlayerRow">
               <td class="playerColorCell"><span class="teamColorWrap"><i class="material-symbols">person_add</i></span></td>
-              <td class="playerNameCell"><input id="localPlayerName" class="playerName" placeholder="Add a local player" /></td>
-              <td class="playerActionsCell" colspan="2"><button icon="add" id="addLocalPlayerButton" title="Add a local player that shares this device"></button></td>
+              <td class="playerNameCell"><input id="localPlayerName" class="playerName" placeholder="Add a player who shares this device" /></td>
+              <td class="playerActionsCell" colspan="2"><button icon="add" id="addLocalPlayerButton" title="Add a player who shares this device"></button></td>
             </tr>
             <tr id="invitePlayerRow">
-              <td class="playerColorCell"><span class="teamColorWrap"><i class="material-symbols">link</i></span></td>
-              <td class="playerNameCell">Invite players to <a id="playerInviteURL">this room</a></td>
+              <td class="playerColorCell"><span class="teamColorWrap"><i class="material-symbols">group_add</i></span></td>
+              <td class="playerNameCell"><span id="playerInviteText">Invite players to <a id="playerInviteURL" title="Share the room URL so other players can join"></a></span><span id="playerInviteStatus"></span></td>
               <td class="playerActionsCell" colspan="2"><button icon="share" id="playersShareButton" title="Share the room URL so other players can join"></button></td>
             </tr>
           </tfoot>
         </table>
-        <div id="playersLegend">
-          <span><i class="material-symbols">edit</i>Rename the player everywhere in the game</span>
-          <span><i class="material-symbols">visibility</i>View the game as this player - greyed out while they are connected and playing</span>
-          <span><i class="material-symbols">delete</i>Remove this player</span>
-        </div>
       </div>
       <details id="playersHelp">
         <summary>Help: playing together</summary>
@@ -152,6 +147,17 @@
           <div>
             <h2>Hotseat</h2>
             <p>Several people share one device: add each of them with the <i class="material-symbols">person_add</i> row of the table, then use the <i class="material-symbols">visibility</i> button to switch this browser tab to whoever's turn it is. Only your own session changes, the game itself stays untouched.</p>
+          </div>
+        </div>
+        <div class="helpTopic">
+          <i class="material-symbols">smart_button</i>
+          <div>
+            <h2>What the buttons do</h2>
+            <ul>
+              <li><i class="material-symbols">edit</i>Rename the player everywhere in the game</li>
+              <li><i class="material-symbols">visibility</i>View the game as this player - greyed out while they are connected and playing</li>
+              <li><i class="material-symbols">delete</i>Remove this player</li>
+            </ul>
           </div>
         </div>
       </details>

--- a/client/room.html
+++ b/client/room.html
@@ -118,6 +118,11 @@
               <td class="playerNameCell"><input id="localPlayerName" class="playerName" placeholder="Add a local player" /></td>
               <td class="playerActionsCell" colspan="2"><button icon="add" id="addLocalPlayerButton" title="Add a local player that shares this device"></button></td>
             </tr>
+            <tr id="invitePlayerRow">
+              <td class="playerColorCell"><i class="material-symbols">link</i></td>
+              <td class="playerNameCell">Invite players to <a id="playerInviteURL">this room</a></td>
+              <td class="playerActionsCell" colspan="2"><button icon="share" id="playersShareButton" title="Share the room URL so other players can join"></button></td>
+            </tr>
           </tfoot>
         </table>
         <div id="playersLegend">
@@ -126,10 +131,6 @@
           <span><i class="material-symbols">delete</i>Remove this player</span>
         </div>
         <div id="playersAloneHint">You are the only player at this table. Share the room URL or add a local player to play with others.</div>
-      </div>
-      <div id="playerInvite">
-        <h1>Invite players to <a id="playerInviteURL">this room</a></h1>
-        <button icon="share" id="playersShareButton">Share room URL</button>
       </div>
       <details id="playersHelp">
         <summary>Help: playing together</summary>
@@ -144,14 +145,14 @@
           <i class="material-symbols">share</i>
           <div>
             <h2>Remote play</h2>
-            <p>Everybody plays on their own device: send them the room URL above and they join this table as soon as they open it. Their browser tab shows up here as a session and they can pick their name and color in the table.</p>
+            <p>Everybody plays on their own device: send them the room URL with the <i class="material-symbols">share</i> button in the table above and they join this table as soon as they open it. Their browser tab shows up here as a session and they can pick their name and color in the table.</p>
           </div>
         </div>
         <div class="helpTopic">
           <i class="material-symbols">swap_horizontal_circle</i>
           <div>
             <h2>Hotseat</h2>
-            <p>Several people share one device: add each of them in the last row of the table, then use the <i class="material-symbols">visibility</i> button to switch this browser tab to whoever's turn it is. Only your own session changes, the game itself stays untouched.</p>
+            <p>Several people share one device: add each of them with the <i class="material-symbols">person_add</i> row of the table, then use the <i class="material-symbols">visibility</i> button to switch this browser tab to whoever's turn it is. Only your own session changes, the game itself stays untouched.</p>
           </div>
         </div>
       </details>

--- a/client/room.html
+++ b/client/room.html
@@ -98,7 +98,7 @@
           </td>
           <td class="playerActionsCell">
             <button icon="edit" class="renamePlayer" title="Rename this player and update all references to it in the game"></button>
-            <button icon="visibility" class="viewPlayer" title="View the game as this player: only your session gets renamed and the game stays unchanged"></button>
+            <button icon="visibility" class="viewPlayer" title="View the game as this player: only this browser tab switches over and the game stays unchanged"></button>
             <button icon="delete" class="removePlayer" title="Remove this player"></button>
           </td>
         </template>
@@ -109,7 +109,7 @@
         </template>
         <table id="playersTable">
           <thead>
-            <tr><th></th><th>Player</th><th></th><th title="Every connected browser tab is a session of a player">Sessions</th></tr>
+            <tr><th></th><th>Player</th><th></th><th title="Every browser tab that has this room open is one connection of a player">Connections</th></tr>
           </thead>
           <tbody></tbody>
           <tfoot>
@@ -132,22 +132,22 @@
           <div class="helpTopic">
             <i class="material-symbols">groups</i>
             <div>
-              <h2>Players and sessions</h2>
-              <p>Every connected browser tab is a session of a player. Edit the name and color of any player, view the game as another player or add a local player that shares this device. While you have this room open in more than one tab, adding a player switches the current tab to them, so every tab can be its own player.</p>
+              <h2>Players and connections</h2>
+              <p>Every browser tab that has this room open is one connection of a player. Edit the name and color of any player, view the game as another player or add a local player that shares this device. While you have this room open in more than one tab, adding a player switches the current tab to them, so every tab can be its own player.</p>
             </div>
           </div>
           <div class="helpTopic">
             <i class="material-symbols">share</i>
             <div>
               <h2>Remote play</h2>
-              <p>Everybody plays on their own device: send them the room URL with the <i class="material-symbols">share</i> button in the table above and they join this table as soon as they open it. Their browser tab shows up here as a session and they can pick their name and color in the table.</p>
+              <p>Everybody plays on their own device: send them the room URL with the <i class="material-symbols">share</i> button in the table above and they join this table as soon as they open it. Their browser tab shows up here as a connection and they can pick their name and color in the table.</p>
             </div>
           </div>
           <div class="helpTopic">
             <i class="material-symbols">swap_horizontal_circle</i>
             <div>
               <h2>Hotseat</h2>
-              <p>Several people share one device: add each of them with the <i class="material-symbols">person_add</i> row of the table, then use the <i class="material-symbols">visibility</i> button to switch this browser tab to whoever's turn it is. Only your own session changes, the game itself stays untouched.</p>
+              <p>Several people share one device: add each of them with the <i class="material-symbols">person_add</i> row of the table, then use the <i class="material-symbols">visibility</i> button to switch this browser tab to whoever's turn it is. Only this browser tab switches over, the game itself stays untouched.</p>
             </div>
           </div>
         </div>

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -854,8 +854,10 @@ export default class Room {
     return Object.values(this.state).some(w=>[ w.owner, w.player, w.artist ].some(v=>Array.isArray(v) ? v.indexOf(playerName) != -1 : v == playerName));
   }
 
+  // a player the game still points at can be removed too - the client warns about what stays
+  // behind, and those widgets pick the name up again as soon as a player uses it
   removeLocalPlayer(removingPlayer, playerName) {
-    if(this.players.filter(p=>p.name == playerName).length || this.playerIsReferencedInWidgets(playerName))
+    if(this.players.filter(p=>p.name == playerName).length)
       return;
     delete this.state._meta.players[playerName];
     this.sendMetaUpdate();


### PR DESCRIPTION
Simplifies the reworked Players overlay from #3013: the per-session **split** button is removed, and *Add player* and *Invite players* become the last two rows of the players table, with everything explanatory folded into one collapsed help section. Based on #3013 (`players-tab-table`), so please merge that first.

## What changed

- **Split buttons removed.** The ⑂ button in every session cell (and its legend entry and the mention in the overlay's intro text) is gone. It duplicated what *View* already does for hotseat play — with the extra cost of a modal `prompt()` — and it is the one action people found hard to tell apart from *View*. The session cell is now just the label, so the column is plain text again.
- **Add player is a table row.** The name input and the add button moved into a `<tfoot>` row of the players table (person icon, *Add a player who shares this device* input, `+` button), so adding a player looks and lines up like every other row instead of living in a separate block underneath. The input carries an underline so it reads as a field.
- Adding an empty or already-existing name now reports the problem directly at the input (`setCustomValidity`/`reportValidity`, plus a red underline) instead of turning the button into a red error label, and the button shows the same inline spinner as the other row actions while the server request is in flight.
- **Adding a player switches to it when you have several tabs open.** While the current player has more than one connection open, adding a player hands the current browser tab over to that player (a single `rename` of this session) instead of only listing the name - that is the case the removed split button covered. With a single connection nothing changes. The add button tooltip and the help say when the switch happens.
- **Invite is a table row too.** Below the add-player row, a second footer row reads *Invite players to* followed by the room URL as plain text to read out or select, and puts the share button in the same column as the row action buttons. That button shares the URL (or copies it to the clipboard), and the result — or the error — is shown in that row instead of inside the icon-sized button.
- **Collapsed help instead of intro text and legend.** The paragraph the overlay used to open with, the explanatory part of the old invite block and the icon legend all moved into two framed collapsible sections below the table: *Help: playing together*, split into three topics that each get a large icon and a title (*Players and connections*, *Remote play*, *Hotseat*), and *Help: what the buttons do*, which lists every button of the table. Both start collapsed and only open when you click them, so the overlay is the table and nothing else until you ask for an explanation.
- **Any disconnected player can be removed.** The server used to refuse the removal while any widget still named the player as `owner`, seat `player` or `artist`, and the client hid the trash button to match — so an old name that only lived on in an invisible seat or artist credit could never be cleared out. Removal is now allowed for everybody who is not connected; when something in the game still points at them, the button asks first and names what will be left behind. Nothing is deleted with the player, so a player of the same name picks those widgets up again. For connected players the button is still hidden, since the connections column of the same row already says why.
- The connection labels wrap below 530px, which keeps the table inside a 390px phone viewport instead of overflowing it.
- **"Sessions" is called "Connections" now.** The word only made sense to people who know what a session is; what the column actually lists is the browser tabs that have this room open. The header, its tooltip and the numbered labels of a player with several tabs (*Connection 1*, *Connection 2*) use "connection", and so does the help text: *Every browser tab that has this room open is one connection of a player.* Nothing about the *View* / hotseat wording talks about sessions any more either.
- **The toolbar icon lost its gear.** The Players tab used `[users_settings]` (a person with a gear, which reads as a settings screen); it is `[people]` now.

The server side is unchanged — `rename` with a `sessionID` is still what *View* uses, so no code became dead.

Alone in a fresh room:

![Players overlay for a first-time visitor](https://agent.virtualtabletop.io/reports/pr/1534579234175979562/players-first-time-collapsed.png)

With other players at the table:

![Players overlay with three players](https://agent.virtualtabletop.io/reports/pr/1534579234175979562/players-collapsed.png)

Every disconnected player has a remove button, and removing one the game still points at asks first:

![Players table with a remove button on every disconnected player](https://agent.virtualtabletop.io/reports/pr/1534579234175979562/players-remove-enabled.png)
![Warning before removing a player who still owns widgets](https://agent.virtualtabletop.io/reports/pr/1534579234175979562/players-remove-warning.png)

The help section expanded, and the result of sharing the room URL:

![Expanded help section](https://agent.virtualtabletop.io/reports/pr/1534579234175979562/players-help-open.png)
![Share result in the invite row](https://agent.virtualtabletop.io/reports/pr/1534579234175979562/players-share-status.png)

The renamed column, with one player who has the room open in two tabs (the screenshots above still show the older *Sessions* header):

![Players table with a Connections column listing Connection 1 and Connection 2](https://agent.virtualtabletop.io/reports/pr/1534579234175979562/connections-two-tabs.png)
![Help section talking about connections](https://agent.virtualtabletop.io/reports/pr/1534579234175979562/connections-help.png)

## Verified

`npm test` (15/15) and the TestCafe editor test (which drives this overlay through `setName`) pass locally. Scripted browser checks confirmed: add local player, duplicate/empty name feedback, view another player, rename with reference updates, no split button left in the DOM, the two-tab add-and-switch behaviour (and that a single session still just adds), both help sections staying collapsed until clicked, removing a player with and without the warning (confirm, cancel, and no dialog at all when nothing points at them), the share status and clipboard content, the invite link not navigating, and the table fitting a 390px viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3102/pr-test (or any other room on that server)








