### PR TITLE
Close editor popups when the editor moves on to another widget

### DIFF
--- a/client/css/editor/controls/popup.css
+++ b/client/css/editor/controls/popup.css
@@ -30,8 +30,11 @@
   transition: opacity 1s;
 }
 
+/* a note nobody can see any more must not take the click that was aimed at what
+   is behind it - the strip hangs over the play area on a narrow window */
 .editorNote.editorNoteFading {
   opacity: 0;
+  pointer-events: none;
 }
 
 /* the control a popup is open for, in its own color (a chip of the routine is

--- a/client/css/editor/controls/popup.css
+++ b/client/css/editor/controls/popup.css
@@ -1,5 +1,53 @@
+/* A line of feedback about something that happened where the user is not
+   looking - a value written to the widget the editor has just left, a mode that
+   ended on its own. In the corner of the module panel, above the popups (whose
+   closing is what it is usually about), fading on its own so it never becomes
+   part of the layout. */
+#editorNotes {
+  position: absolute;
+  right: calc(var(--editSidebarWidth) + 10px);
+  bottom: 10px;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  pointer-events: none; /* the gaps between the notes stay clickable */
+}
+
+.editorNote {
+  pointer-events: auto;
+  cursor: pointer;
+  max-width: min(360px, 80vw);
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: var(--backgroundColor);
+  color: var(--textColor);
+  border: 1px solid var(--backgroundHighlightColor1);
+  border-left: 3px solid var(--VTTblue);
+  box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.4);
+  font-size: 13px;
+  transition: opacity 1s;
+}
+
+.editorNote.editorNoteFading {
+  opacity: 0;
+}
+
+/* the control a popup is open for, in its own color (a chip of the routine is
+   colored by what it holds): the popup is that control opened up, so it says
+   which one - and where the popup went when it goes away with it */
+.popupSource {
+  outline: 2px solid currentColor;
+  outline-offset: 1px;
+}
+
 .inline-popup {
   position: fixed;
+  /* the popup is placed by its outer size, so the max-width/max-height it is
+     placed with have to be the outer size as well - with the padding and the
+     border on top of them it overshoots the space it was fitted into by 22px */
+  box-sizing: border-box;
   background: var(--backgroundColor);
   color: var(--textColor);
   z-index: 9;
@@ -68,9 +116,13 @@
   margin-top: 0;
 }
 
+/* the name next to a value is quieter than the value, but a fixed gray is only
+   readable in one of the two themes - this is the text color turned down, the
+   way the popup title does it */
 .inline-popup .popup-property-label {
   flex: 0 0 auto;
-  color: gray;
+  color: var(--textColor);
+  opacity: 0.7;
 }
 
 .inline-popup .popup-property-row .propertyExpandButton {
@@ -424,7 +476,8 @@ body.edit.darkMode .inline-popup button.primary:hover {
 }
 
 .inline-popup .popup-property-empty {
-  color: gray;
+  color: var(--textColor);
+  opacity: 0.7;
   font-style: italic;
   margin: 4px 2px;
 }

--- a/client/js/editor/controls/popup.js
+++ b/client/js/editor/controls/popup.js
@@ -249,6 +249,19 @@ class Popup {
   }
 }
 
+// Every popup of the editor belongs to the widget that is being edited: it hangs
+// off a control (a chip of a routine, the button that adds one) that is thrown
+// away as soon as the editor moves on to another widget, so it would be left
+// floating over the new one with nothing behind it. A click outside dismisses a
+// popup, but a click that selects another widget in the room is not one for the
+// popups that read the room - the widget pickers take the clicks in there - and
+// a selection also changes without any click at all: deleting the widget, an
+// undo, or a new state arriving from the server.
+function closeEditorPopups() {
+  for(const popup of [ ...openPopups ])
+    popup.hide();
+}
+
 // what a tutorial is called in words: the title of the popup it is offered from
 // where there is one ("SELECT - Pick the widgets…" is a SELECT tutorial), and
 // otherwise the file name without the part every one of them starts with

--- a/client/js/editor/controls/popup.js
+++ b/client/js/editor/controls/popup.js
@@ -22,6 +22,14 @@ document.addEventListener('mousedown', e=>{
   popupMouseDownTarget = e.target;
 }, true);
 
+// The lists inside a popup that scroll on their own anyway (the widget ids, the
+// property names, the operations). Where the popup does not fit the room it has,
+// they are what gives way - see fitScrollAreas.
+const popupScrollAreas = '.widgetPickerList, .popup-property-list, .popup-operation-list';
+// three rows or so: a list shorter than that shows less than it takes to scroll
+// it, so the popup scrolls after all instead of shrinking it any further
+const popupScrollAreaMinHeight = 66;
+
 class Popup {
   constructor(source) {
     this.source = source;
@@ -155,6 +163,49 @@ class Popup {
     return height(strip) >= 240 ? strip : limits;
   }
 
+  // A popup that is taller than the room it has scrolls, which puts whatever is
+  // at its bottom out of sight with nothing saying it is there: the button a
+  // section is for is the last thing in it, so "Use these widgets" is exactly
+  // what a too-long list of widget ids pushes below the fold. The lists in a
+  // popup scroll on their own anyway, so the height that is missing is taken
+  // from them rather than from the popup - the list gets shorter, everything
+  // around it stays where it can be seen and reached.
+  fitScrollAreas() {
+    const lists = [ ...$a(popupScrollAreas, this.domElement) ].filter(list=>list.offsetParent !== null);
+    if(!lists.length)
+      return;
+    // start from their full height every time: what does not fit changes with
+    // the section that is open, the search term and the size of the window
+    for(const list of lists)
+      list.style.maxHeight = '';
+    // shrinking a list reflows what is around it, so ask again rather than
+    // assume the popup got shorter by exactly as much as the list did
+    for(let pass=0; pass<3; ++pass) {
+      let missing = this.domElement.scrollHeight - this.domElement.clientHeight;
+      if(missing <= 0)
+        break;
+      let shrank = false;
+      for(const list of lists) {
+        if(missing <= 0)
+          break;
+        const height = list.getBoundingClientRect().height;
+        const shrunk = Math.max(popupScrollAreaMinHeight, height-missing);
+        if(shrunk >= height)
+          continue;
+        list.style.maxHeight = `${shrunk}px`;
+        missing -= height-shrunk;
+        shrank = true;
+      }
+      if(!shrank) // nothing left to give: the popup scrolls after all
+        break;
+    }
+    // the mark that says a list is cut off (a rule and a fade below its last
+    // row) is set when the list is filled, before it is known how tall it may be
+    for(const list of lists)
+      if(list.classList.contains('popup-property-list'))
+        list.classList.toggle('popup-property-list-complete', list.scrollHeight <= list.clientHeight);
+  }
+
   moveIntoView() {
     const limits = this.limitsAroundSource(this.placementLimits());
     // shrink into the available strip instead of hanging out of it
@@ -168,6 +219,8 @@ class Popup {
     // Measured at the left end of the room it may use, it is the width it keeps
     // at every position that fits it, which is every position placed below.
     this.domElement.style.left = `${limits.left+10}px`;
+    // at the width it keeps as well: how tall the content is depends on it
+    this.fitScrollAreas();
     const rect = this.domElement.getBoundingClientRect();
     const fit = (position, size, from, to)=>Math.min(Math.max(position, from+10), Math.max(from+10, to-10-size));
     this.domElement.style.left = `${fit(wanted.left, rect.width, limits.left, limits.right)}px`;

--- a/client/js/editor/controls/popup.js
+++ b/client/js/editor/controls/popup.js
@@ -144,6 +144,15 @@ class Popup {
     return strips[0] || limits; // no strip is usable: covering the room beats being unusable
   }
 
+  // Whether the control the popup hangs off has to stay readable while it is
+  // open. It does where the popup edits that control - a routine chip is the
+  // sentence the parameter belongs to. An info tip is not about its own button:
+  // that button is a 14px glyph with nothing to read on it, while the tip is
+  // prose that wants every line of height it can get.
+  avoidsSource() {
+    return true;
+  }
+
   // The popup is the control it hangs off, opened up: a parameter popup that
   // lands on its own chip hides the sentence it is about (on a phone it swallows
   // the whole routine), and the chip going away with the popup is what says the
@@ -151,7 +160,7 @@ class Popup {
   // control - the roomier of the two - as long as one of them can hold a popup
   // at all; where neither can, being usable still beats being clear of it.
   limitsAroundSource(limits) {
-    if(!this.source || !this.source.isConnected)
+    if(!this.avoidsSource() || !this.source || !this.source.isConnected)
       return limits;
     const source = this.source.getBoundingClientRect();
     if(!source.width && !source.height)
@@ -383,9 +392,30 @@ function closeEditorPopups() {
   }
   closePropertyInfoPopup();
   for(const write of applied)
-    editorNote(write.kept
-      ? `${write.parameter} set to ${write.value} on ${write.widgetID}`
-      : `${write.parameter} was not set to ${write.value}: ${write.widgetID} is gone`);
+    editorNote(writeWords(write));
+}
+
+// Which of the widgets a write goes to are still there to take it, told apart
+// exactly the way the sidebar tells them apart before writing (widgetStillExists
+// in properties.js - the jest harness loads this file without it, so fall back
+// to the identity half of that test there).
+function writtenWidgets(widget) {
+  const exists = typeof widgetStillExists == 'function'
+    ? widgetStillExists
+    : w=>!!w && !w.isBeingRemoved && widgets.get(w.id) === w;
+  const targets = !widget ? [] : (widget.isMulti ? widget.widgets : [ widget ]);
+  return { kept: targets.filter(exists), gone: targets.filter(w=>!exists(w)) };
+}
+
+// What a write that happened off screen reads like. A multi-selection can be
+// half gone, and saying "set" for it would be as wrong as saying "not set": name
+// the widgets it reached and the ones it did not.
+function writeWords(write) {
+  if(!write.goneIDs.length)
+    return `${write.parameter} set to ${write.value} on ${write.widgetID}`;
+  if(!write.keptIDs.length)
+    return `${write.parameter} was not set to ${write.value}: ${write.widgetID} is gone`;
+  return `${write.parameter} set to ${write.value} on ${write.keptIDs.join(', ')}: ${write.goneIDs.join(', ')} is gone`;
 }
 
 // a value in a line of feedback: what was typed for text, the JSON for the rest,
@@ -437,6 +467,12 @@ class InfoPopup extends Popup {
     this.tutorialName = tutorialName;
     this.videoFilename = videoFilename;
     this.title = title;
+  }
+
+  // several paragraphs of prose about a 14px "i": covering that button costs
+  // nothing, halving the height the text may use costs a scrollbar
+  avoidsSource() {
+    return false;
   }
 
   show() {
@@ -574,16 +610,17 @@ class RoutinePopup extends Popup {
     this.applied = true;
     const parameter = this.parameterNames[0];
     const widget = this.widget;
-    // the same identity check the sidebar writes through (widgetStillExists):
-    // where the widget is gone, its write is dropped there rather than saved
-    const stillExists = !!widget && (widget.isMulti
-      ? widget.widgets.some(w=>widgets.get(w.id) === w)
-      : widgets.get(widget.id) === widget);
+    // Exactly the test the write itself goes through, so the note cannot claim
+    // a value the sidebar then drops: a pile that is dissolving is still in
+    // widgets under its own id for the three property changes it takes to get
+    // there, and widgetStillExists is the only thing that knows that.
+    const written = writtenWidgets(widget);
     this.appliedOnHide = {
       parameter: `${(this.operation && this.operation.func) || 'var'} ${parameter}`,
       value: shortValueWords(this.workingValue),
       widgetID: widget && widget.id,
-      kept: stillExists
+      keptIDs: written.kept.map(w=>w.id),
+      goneIDs: written.gone.map(w=>w.id)
     };
     this.notifyChangeListeners({ [parameter]: this.workingValue });
   }

--- a/client/js/editor/controls/popup.js
+++ b/client/js/editor/controls/popup.js
@@ -257,9 +257,15 @@ class Popup {
 // popups that read the room - the widget pickers take the clicks in there - and
 // a selection also changes without any click at all: deleting the widget, an
 // undo, or a new state arriving from the server.
+// Closing is not always a pure dismissal: the pickers that only write their
+// parameter when the popup goes away (color, icon, sound, key/value and string
+// lists) apply what was picked, exactly as they do on a click outside. That
+// write goes to the widget the popup belonged to, which is why this runs after
+// the editor has moved on rather than in the middle of it.
 function closeEditorPopups() {
   for(const popup of [ ...openPopups ])
     popup.hide();
+  closePropertyInfoPopup();
 }
 
 // what a tutorial is called in words: the title of the popup it is offered from

--- a/client/js/editor/controls/popup.js
+++ b/client/js/editor/controls/popup.js
@@ -83,6 +83,8 @@ class Popup {
   hide() {
     if(openPopups.indexOf(this) != -1)
       openPopups.splice(openPopups.indexOf(this), 1);
+    if(this.source && this.source.classList)
+      this.source.classList.remove('popupSource');
     // a popup opened from a button inside this one (the info tip of a section
     // title) belongs to it: every popup is appended to #editor rather than to
     // the one it came from, so without this it stays on screen anchored to an
@@ -94,6 +96,10 @@ class Popup {
     if(this.mutationObserver) {
       this.mutationObserver.disconnect();
       this.mutationObserver = null;
+    }
+    if(this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
     }
     document.removeEventListener('click', this.boundOnOutsideClick);
     document.removeEventListener('keydown', this.boundOnKeyDown, true);
@@ -130,15 +136,45 @@ class Popup {
     return strips[0] || limits; // no strip is usable: covering the room beats being unusable
   }
 
+  // The popup is the control it hangs off, opened up: a parameter popup that
+  // lands on its own chip hides the sentence it is about (on a phone it swallows
+  // the whole routine), and the chip going away with the popup is what says the
+  // editor has moved on. So the popup keeps to the strip above or below that
+  // control - the roomier of the two - as long as one of them can hold a popup
+  // at all; where neither can, being usable still beats being clear of it.
+  limitsAroundSource(limits) {
+    if(!this.source || !this.source.isConnected)
+      return limits;
+    const source = this.source.getBoundingClientRect();
+    if(!source.width && !source.height)
+      return limits;
+    const above = Object.assign({}, limits, { bottom: Math.min(limits.bottom, source.top) });
+    const below = Object.assign({}, limits, { top: Math.max(limits.top, source.bottom) });
+    const height = strip=>strip.bottom-strip.top;
+    const strip = height(below) >= height(above) ? below : above;
+    return height(strip) >= 240 ? strip : limits;
+  }
+
   moveIntoView() {
-    const limits = this.placementLimits();
+    const limits = this.limitsAroundSource(this.placementLimits());
     // shrink into the available strip instead of hanging out of it
     this.domElement.style.maxWidth = `${Math.min(window.innerWidth/2, limits.right-limits.left-20)}px`;
     this.domElement.style.maxHeight = `${Math.min(window.innerHeight-20, limits.bottom-limits.top-20)}px`;
+    const wanted = this.domElement.getBoundingClientRect(); // where it wants to be
+    // How wide the popup lays itself out is limited by how far its left edge is
+    // from the right edge of the screen (it is fixed, with no right), so its
+    // width where it currently sits is not the width it will have where it is
+    // about to be put - and moving it would change the width again, in circles.
+    // Measured at the left end of the room it may use, it is the width it keeps
+    // at every position that fits it, which is every position placed below.
+    this.domElement.style.left = `${limits.left+10}px`;
     const rect = this.domElement.getBoundingClientRect();
     const fit = (position, size, from, to)=>Math.min(Math.max(position, from+10), Math.max(from+10, to-10-size));
-    this.domElement.style.left = `${fit(rect.left, rect.width, limits.left, limits.right)}px`;
-    this.domElement.style.top = `${fit(rect.top, rect.height, limits.top, limits.bottom)}px`;
+    this.domElement.style.left = `${fit(wanted.left, rect.width, limits.left, limits.right)}px`;
+    this.domElement.style.top = `${fit(wanted.top, rect.height, limits.top, limits.bottom)}px`;
+    // the size it was placed with, so that a later resize is only followed when
+    // the content really changed
+    this.placedSize = { width: rect.width, height: rect.height };
   }
 
   notifyChangeListeners(value) {
@@ -225,6 +261,11 @@ class Popup {
 
   show() {
     const sourceRect = this.source.getBoundingClientRect();
+    // which control this popup belongs to, in that control's own color: the
+    // outline appearing and going away is what ties the two together, in
+    // particular when the editor moves on and takes the popup with it
+    if(this.source.classList)
+      this.source.classList.add('popupSource');
     $('#editor').append(this.domElement);
     this.domElement.style.left = `${sourceRect.left}px`;
     this.domElement.style.top = `${sourceRect.bottom}px`;
@@ -246,6 +287,20 @@ class Popup {
       this.mutationObserver = new MutationObserver(_=>this.moveIntoView());
       this.mutationObserver.observe(this.domElement, { childList: true, subtree: true });
     }
+    // The popup also changes size without its content changing - a picker lays
+    // itself out, a swatch grid rewraps once the width is clamped - and the
+    // position computed for the size before that hangs it over the module button
+    // strip or over the control it belongs to. Only a real change of size is
+    // followed, so moveIntoView's own writes (which leave the size as it found
+    // it) cannot feed themselves back in here.
+    if(typeof ResizeObserver != 'undefined' && !this.resizeObserver) {
+      this.resizeObserver = new ResizeObserver(_=>{
+        const rect = this.domElement.getBoundingClientRect();
+        if(!this.placedSize || Math.abs(rect.width-this.placedSize.width) >= 1 || Math.abs(rect.height-this.placedSize.height) >= 1)
+          this.moveIntoView();
+      });
+      this.resizeObserver.observe(this.domElement);
+    }
   }
 }
 
@@ -261,11 +316,56 @@ class Popup {
 // parameter when the popup goes away (color, icon, sound, key/value and string
 // lists) apply what was picked, exactly as they do on a click outside. That
 // write goes to the widget the popup belonged to, which is why this runs after
-// the editor has moved on rather than in the middle of it.
+// the editor has moved on rather than in the middle of it - and why it is said
+// out loud: the widget that was written to is not on screen any more, so "it was
+// saved" and "I lost it" would look exactly the same.
 function closeEditorPopups() {
-  for(const popup of [ ...openPopups ])
+  const applied = [];
+  for(const popup of [ ...openPopups ]) {
     popup.hide();
+    if(popup.appliedOnHide) {
+      applied.push(popup.appliedOnHide);
+      popup.appliedOnHide = null;
+    }
+  }
   closePropertyInfoPopup();
+  for(const write of applied)
+    editorNote(write.kept
+      ? `${write.parameter} set to ${write.value} on ${write.widgetID}`
+      : `${write.parameter} was not set to ${write.value}: ${write.widgetID} is gone`);
+}
+
+// a value in a line of feedback: what was typed for text, the JSON for the rest,
+// cut off where it stops being a line
+function shortValueWords(value) {
+  const text = typeof value == 'string' ? value : JSON.stringify(value);
+  if(typeof text != 'string')
+    return 'nothing';
+  return text.length > 40 ? `${text.slice(0, 39)}…` : text;
+}
+
+// A line of feedback for something the editor did that the user cannot see
+// happening, in the corner of the module panel where the editing is: a write to
+// a widget that has just left the screen, a mode that ended on its own. It says
+// its piece and fades, so it never becomes part of the layout.
+function editorNote(text) {
+  const editor = $('#editor');
+  if(!editor)
+    return;
+  let notes = $('#editorNotes');
+  if(!notes) {
+    notes = div(editor);
+    notes.id = 'editorNotes';
+  }
+  // only the last few, so a burst of them cannot wall off the module panel
+  while(notes.children.length >= 3)
+    notes.firstChild.remove();
+  const note = div(notes, 'editorNote');
+  note.textContent = text;
+  note.title = 'Click to dismiss';
+  note.onclick = _=>note.remove();
+  setTimeout(_=>note.classList.add('editorNoteFading'), 4000);
+  setTimeout(_=>note.remove(), 5000);
 }
 
 // what a tutorial is called in words: the title of the popup it is offered from
@@ -404,6 +504,35 @@ class RoutinePopup extends Popup {
     if(isWidgetPickerActive(null, routineWidgetPickerKey))
       stopWidgetPicker();
     super.hide();
+  }
+
+  // The pickers that keep what is picked in a working value and write it to the
+  // routine only when the popup goes away: a color is picked by dragging and a
+  // list is edited row by row, so there is no single moment to write on before
+  // that. Closing is that moment however the popup is closed - the close button,
+  // a click outside, or the editor moving on to another widget. That last one is
+  // why the write is remembered here: closeEditorPopups() says it out loud,
+  // because the widget it went to is off screen by then.
+  applyWorkingValueOnHide() {
+    // notifyChangeListeners makes newRoutineValues call hide() again, so guard
+    // against re-entering the notify
+    if(!this.workingChanged || this.applied)
+      return;
+    this.applied = true;
+    const parameter = this.parameterNames[0];
+    const widget = this.widget;
+    // the same identity check the sidebar writes through (widgetStillExists):
+    // where the widget is gone, its write is dropped there rather than saved
+    const stillExists = !!widget && (widget.isMulti
+      ? widget.widgets.some(w=>widgets.get(w.id) === w)
+      : widgets.get(widget.id) === widget);
+    this.appliedOnHide = {
+      parameter: `${(this.operation && this.operation.func) || 'var'} ${parameter}`,
+      value: shortValueWords(this.workingValue),
+      widgetID: widget && widget.id,
+      kept: stillExists
+    };
+    this.notifyChangeListeners({ [parameter]: this.workingValue });
   }
 
   // the property builder's widget picker needs the room visible while it is open
@@ -1507,11 +1636,7 @@ class RoutineStringListPopup extends RoutinePopup {
   }
 
   hide() {
-    // the same apply-on-close as the pairs list: several entries in one go
-    if(this.workingChanged && !this.applied) {
-      this.applied = true;
-      this.notifyChangeListeners({ [this.parameterNames[0]]: this.workingValue });
-    }
+    this.applyWorkingValueOnHide(); // several entries in one go
     super.hide();
   }
 
@@ -1621,12 +1746,7 @@ class RoutineKeyValuePopup extends RoutinePopup {
   }
 
   hide() {
-    // the same apply-on-close as the color/icon pickers: notifyChangeListeners
-    // makes newRoutineValues call hide() again, so guard against re-entering it
-    if(this.workingChanged && !this.applied) {
-      this.applied = true;
-      this.notifyChangeListeners({ [this.parameterNames[0]]: this.workingValue });
-    }
+    this.applyWorkingValueOnHide(); // one row of the pairs at a time
     super.hide();
   }
 
@@ -1815,14 +1935,9 @@ class RoutinePickerPopup extends RoutinePopup {
   }
 
   hide() {
-    // apply the picked value on close (before super.hide()'s cancel listener, so
-    // its resolve(undefined) is ignored once we have resolved with the value).
-    // notifyChangeListeners triggers newRoutineValues to call hide() again, so
-    // guard against re-entering the notify.
-    if(this.workingChanged && !this.applied) {
-      this.applied = true;
-      this.notifyChangeListeners({ [this.parameterNames[0]]: this.workingValue });
-    }
+    // before super.hide()'s cancel listener, so its resolve(undefined) is
+    // ignored once we have resolved with the value
+    this.applyWorkingValueOnHide();
     super.hide();
   }
 

--- a/client/js/editor/controls/widgetselection.js
+++ b/client/js/editor/controls/widgetselection.js
@@ -4,9 +4,10 @@
 // routine editor for widget, holder and collection parameters.
 let activeWidgetPicker = null;
 
-function startWidgetPicker(targetWidgetID, onPick, options = {}) {
+function startWidgetPicker(targetWidget, onPick, options = {}) {
   activeWidgetPicker = {
-    targetWidgetID,
+    targetWidget,
+    targetWidgetID: targetWidget.id,
     onPick,
     pickerKey: options.pickerKey || null,
     filter: typeof options.filter === 'function' ? options.filter : null,
@@ -39,6 +40,18 @@ function isWidgetPickerActive(targetWidgetID = null, pickerKey = null) {
   return !!getWidgetPicker(targetWidgetID, pickerKey);
 }
 
+// The widget a running picker belongs to, as long as it still is the widget of
+// that id in the room: a new state from the server replaces every widget, so the
+// same id regularly comes back as a different object - one that has nothing to
+// do with the editor the picker was started from. The editor tells widgets apart
+// by identity everywhere else for the same reason (widgetStillExists).
+function widgetPickerTarget() {
+  if(!activeWidgetPicker)
+    return null;
+  const targetWidget = widgets.get(activeWidgetPicker.targetWidgetID);
+  return targetWidget === activeWidgetPicker.targetWidget ? targetWidget : null;
+}
+
 // A click in the room hits the top-most widget, which is often not the one the
 // picker is looking for - a holder is covered by the cards lying on it. The
 // picker resolves such a click to the widget underneath it that fits.
@@ -60,7 +73,7 @@ function handleWidgetPickerClick(clickedWidget) {
   if(!picker)
     return false;
 
-  const targetWidget = widgets.get(picker.targetWidgetID);
+  const targetWidget = widgetPickerTarget();
   if(!targetWidget) {
     stopWidgetPicker();
     return false;
@@ -89,11 +102,18 @@ function isWidgetPickerRestoringSelection() {
 // Whether a running picker explains a selection change: picking widgets in the
 // room selects them and then restores the selection the picker started from,
 // which is not the editor moving on to another widget. That only holds while the
-// widget the picker belongs to is still there - once it is deleted or dropped by
-// a new state, the change is real and the popup the picker runs from goes along.
+// widget the picker belongs to is still there - once it is deleted or replaced
+// by a new state, the change is real and the popup the picker runs from goes
+// along. Nothing can be picked for a widget that is gone, so the picker ends
+// here rather than on the next click in the room, which would never come: the
+// popup it belongs to is about to be closed.
 function isWidgetPickerChangingSelection() {
-  const picker = getWidgetPicker();
-  return !!picker && widgets.has(picker.targetWidgetID);
+  if(!activeWidgetPicker)
+    return false;
+  if(widgetPickerTarget())
+    return true;
+  stopWidgetPicker();
+  return false;
 }
 
 function handleWidgetPickerSelection(newSelection) {
@@ -104,7 +124,7 @@ function handleWidgetPickerSelection(newSelection) {
   if(!picker)
     return false;
 
-  const targetWidget = widgets.get(picker.targetWidgetID);
+  const targetWidget = widgetPickerTarget();
 
   if(!targetWidget) {
     stopWidgetPicker();
@@ -223,7 +243,7 @@ function renderWidgetSelectPopout(wrap, widget, options = {}) {
       if(isWidgetPickerActive(widget.id, options.pickerKey)) {
         stopWidgetPicker();
       } else {
-        startWidgetPicker(widget.id, (targetWidget, pickedWidgets)=>{
+        startWidgetPicker(widget, (targetWidget, pickedWidgets)=>{
           if(options.multiple)
             options.apply([...new Set(selectedIDs().concat(pickedWidgets.map(w=>w.id)))]);
           else

--- a/client/js/editor/controls/widgetselection.js
+++ b/client/js/editor/controls/widgetselection.js
@@ -86,6 +86,16 @@ function isWidgetPickerRestoringSelection() {
   return restoringWidgetPickerSelection;
 }
 
+// Whether a running picker explains a selection change: picking widgets in the
+// room selects them and then restores the selection the picker started from,
+// which is not the editor moving on to another widget. That only holds while the
+// widget the picker belongs to is still there - once it is deleted or dropped by
+// a new state, the change is real and the popup the picker runs from goes along.
+function isWidgetPickerChangingSelection() {
+  const picker = getWidgetPicker();
+  return !!picker && widgets.has(picker.targetWidgetID);
+}
+
 function handleWidgetPickerSelection(newSelection) {
   if(restoringWidgetPickerSelection)
     return true;

--- a/client/js/editor/controls/widgetselection.js
+++ b/client/js/editor/controls/widgetselection.js
@@ -82,6 +82,10 @@ function handleWidgetPickerClick(clickedWidget) {
 // not be mistaken for the player picking that widget
 let restoringWidgetPickerSelection = false;
 
+function isWidgetPickerRestoringSelection() {
+  return restoringWidgetPickerSelection;
+}
+
 function handleWidgetPickerSelection(newSelection) {
   if(restoringWidgetPickerSelection)
     return true;

--- a/client/js/editor/controls/widgetselection.js
+++ b/client/js/editor/controls/widgetselection.js
@@ -99,30 +99,58 @@ function isWidgetPickerRestoringSelection() {
   return restoringWidgetPickerSelection;
 }
 
-// Whether a running picker explains a selection change: picking widgets in the
-// room selects them and then restores the selection the picker started from,
-// which is not the editor moving on to another widget. That only holds while the
-// widget the picker belongs to is still there - once it is deleted or replaced
-// by a new state, the change is real and the popup the picker runs from goes
-// along. Nothing can be picked for a widget that is gone, so the picker ends
-// here rather than on the next click in the room, which would never come: the
-// popup it belongs to is about to be closed.
+// A rubber band drawn in the room is the one selection change a running picker
+// owns - it is how widgets are picked with a band instead of a click, and the
+// picker puts its own widget back afterwards. Every other route into
+// setSelection (the JSON editor's tree, an "Edit line ..." link, an undo, a new
+// state) is the editor moving on to another widget, armed picker or not: it is
+// the selection the picker itself makes that must not be mistaken for one, not
+// the mere existence of a picker.
+let selectingWidgetsInRoom = false;
+
+function selectWidgetsInRoom(applySelection) {
+  selectingWidgetsInRoom = true;
+  try {
+    return applySelection();
+  } finally {
+    selectingWidgetsInRoom = false;
+  }
+}
+
+// Whether a running picker explains a selection change: it selects what was
+// caught in the room and then restores the selection it started from, which is
+// not the editor moving on to another widget. That only holds for a selection
+// made in the room, and only while the widget the picker belongs to is still
+// there - once it is deleted or replaced by a new state, the change is real and
+// the popup the picker runs from goes along.
 function isWidgetPickerChangingSelection() {
-  if(!activeWidgetPicker)
-    return false;
-  if(widgetPickerTarget())
-    return true;
-  // the crosshair over the room is the only sign that a click in there is being
-  // waited for, so it must not just disappear: say why it did
+  return !!activeWidgetPicker && selectingWidgetsInRoom && !!widgetPickerTarget();
+}
+
+// Nothing can be picked for a widget that is gone, and the click in the room a
+// picker waits for would never come: the popup it runs from is being closed in
+// the same breath. So it ends where its widget does, whichever route the
+// selection change came from - and since the crosshair over the room is the only
+// sign that a click in there is being waited for, it must not just disappear:
+// say why it did.
+function endWidgetPickerWithoutTarget() {
+  if(!activeWidgetPicker || widgetPickerTarget())
+    return;
   const targetWidgetID = activeWidgetPicker.targetWidgetID;
   stopWidgetPicker();
   editorNote(`picking in the room ended: ${targetWidgetID} is gone`);
-  return false;
 }
 
+// Turns a selection into a pick and puts the picker's own widget back
+// afterwards, which is why the sidebar stops there rather than re-rendering for
+// what was picked. Only a selection made in the room is one: taking any other
+// one would put the editor back on the widget the picker belongs to, so a
+// running picker would make the sidebar unable to move on at all.
 function handleWidgetPickerSelection(newSelection) {
   if(restoringWidgetPickerSelection)
     return true;
+  if(!selectingWidgetsInRoom)
+    return false;
 
   const picker = getWidgetPicker();
   if(!picker)

--- a/client/js/editor/controls/widgetselection.js
+++ b/client/js/editor/controls/widgetselection.js
@@ -112,7 +112,11 @@ function isWidgetPickerChangingSelection() {
     return false;
   if(widgetPickerTarget())
     return true;
+  // the crosshair over the room is the only sign that a click in there is being
+  // waited for, so it must not just disappear: say why it did
+  const targetWidgetID = activeWidgetPicker.targetWidgetID;
   stopWidgetPicker();
+  editorNote(`picking in the room ended: ${targetWidgetID} is gone`);
   return false;
 }
 
@@ -229,12 +233,14 @@ function renderWidgetSelectPopout(wrap, widget, options = {}) {
     const buttonBar = div(popout, 'propertyPickerSection widgetPickerRow');
     const pickButton = document.createElement('button');
     pickButton.setAttribute('icon', 'colorize');
-    pickButton.title = `Click this button and then the ${options.multiple ? 'widgets' : 'widget'} on the table. The type filter applies here as well, so with the type set to holder a click on a card selects the holder it lies on.`;
+    pickButton.title = `Click this button and then the ${options.multiple ? 'widgets' : 'widget'} in the room. The type filter applies here as well, so with the type set to holder a click on a card selects the holder it lies on.`;
     buttonBar.appendChild(pickButton);
 
     const updatePickButton = _=>{
       const isSelecting = isWidgetPickerActive(widget.id, options.pickerKey);
-      pickButton.textContent = isSelecting ? `click ${options.multiple ? 'widgets' : 'a widget'}...` : 'Pick in the room';
+      // armed, the button says what to do next rather than what it does, in the
+      // same words as unarmed: one control, one way of speaking
+      pickButton.textContent = isSelecting ? `Click ${options.multiple ? 'widgets' : 'a widget'} in the room…` : 'Pick in the room';
       pickButton.classList.toggle('selected', isSelecting);
     };
     updatePickButton();

--- a/client/js/editor/controls/widgetselection.js
+++ b/client/js/editor/controls/widgetselection.js
@@ -40,6 +40,15 @@ function isWidgetPickerActive(targetWidgetID = null, pickerKey = null) {
   return !!getWidgetPicker(targetWidgetID, pickerKey);
 }
 
+// The widgets a picker's target stands for: itself, or - for the facade of a
+// multi-selection, whose id is the ids of all of them ("h1,h2") and which is not
+// in the room under it - the widgets behind it.
+function targetWidgets(targetWidget) {
+  if(!targetWidget)
+    return [];
+  return targetWidget.isMulti ? targetWidget.widgets : [ targetWidget ];
+}
+
 // The widget a running picker belongs to, as long as it still is the widget of
 // that id in the room: a new state from the server replaces every widget, so the
 // same id regularly comes back as a different object - one that has nothing to
@@ -48,8 +57,11 @@ function isWidgetPickerActive(targetWidgetID = null, pickerKey = null) {
 function widgetPickerTarget() {
   if(!activeWidgetPicker)
     return null;
-  const targetWidget = widgets.get(activeWidgetPicker.targetWidgetID);
-  return targetWidget === activeWidgetPicker.targetWidget ? targetWidget : null;
+  const targetWidget = activeWidgetPicker.targetWidget;
+  const behind = targetWidgets(targetWidget);
+  // all of them: a multi-selection that loses one of its widgets is re-rendered
+  // as a new facade, so the one this picker was started for is stale either way
+  return behind.length && behind.every(w=>widgets.get(w.id) === w) ? targetWidget : null;
 }
 
 // A click in the room hits the top-most widget, which is often not the one the
@@ -136,9 +148,10 @@ function isWidgetPickerChangingSelection() {
 function endWidgetPickerWithoutTarget() {
   if(!activeWidgetPicker || widgetPickerTarget())
     return;
-  const targetWidgetID = activeWidgetPicker.targetWidgetID;
+  const gone = targetWidgets(activeWidgetPicker.targetWidget).filter(w=>widgets.get(w.id) !== w).map(w=>w.id);
+  const goneWords = gone.join(', ') || activeWidgetPicker.targetWidgetID;
   stopWidgetPicker();
-  editorNote(`picking in the room ended: ${targetWidgetID} is gone`);
+  editorNote(`picking in the room ended: ${goneWords} is gone`);
 }
 
 // Turns a selection into a pick and puts the picker's own widget back
@@ -163,12 +176,17 @@ function handleWidgetPickerSelection(newSelection) {
     return false;
   }
 
+  // the widgets the editor is on while the picker runs - one, or all of a
+  // multi-selection
+  const selectedByEditor = targetWidgets(targetWidget);
+  const isSelectedByEditor = widget=>selectedByEditor.some(w=>w.id == widget.id);
+
   const restoreSelection = _=>{
-    if(newSelection.length == 1 && newSelection[0].id == targetWidget.id)
+    if(newSelection.length == selectedByEditor.length && newSelection.every(isSelectedByEditor))
       return;
     restoringWidgetPickerSelection = true;
     try {
-      setSelection([ targetWidget ]);
+      setSelection(selectedByEditor);
     } finally {
       restoringWidgetPickerSelection = false;
     }
@@ -179,10 +197,10 @@ function handleWidgetPickerSelection(newSelection) {
     // the target widget is selected again after every pick, so a selection
     // change to it cannot be told apart from that - clicks on it arrive as a
     // click (handleWidgetPickerClick) instead
-    if(!clickedWidget || clickedWidget.id == targetWidget.id)
+    if(!clickedWidget || isSelectedByEditor(clickedWidget))
       continue;
     const pickedWidget = resolvePickedWidget(clickedWidget, picker);
-    if(!pickedWidget || pickedWidget.id == targetWidget.id)
+    if(!pickedWidget || isSelectedByEditor(pickedWidget))
       continue;
     if(resolved.indexOf(pickedWidget) == -1)
       resolved.push(pickedWidget);
@@ -234,7 +252,11 @@ function renderWidgetSelectPopout(wrap, widget, options = {}) {
     popout.style.display = 'none';
 
   const selectedIDs = _=>options.getSelectedIDs ? options.getSelectedIDs() : [];
-  const excludedIDs = _=>(options.allowSelf ? [] : [ widget.id ]).concat(options.excludeIDs ? options.excludeIDs() : []);
+  // the ids the popout belongs to: for a multi-selection that is every widget in
+  // it, not the "h1,h2" of the facade - which is no widget in the room, so
+  // excluding it would exclude nothing and offer them as their own parent
+  const ownIDs = targetWidgets(widget).map(w=>w.id);
+  const excludedIDs = _=>(options.allowSelf ? [] : ownIDs).concat(options.excludeIDs ? options.excludeIDs() : []);
   // the widget the popout belongs to is the one a routine acts on most often, so
   // the list pins and marks it instead of hiding it among the other ids
   const selfID = options.allowSelf ? widget.id : null;

--- a/client/js/editor/propertyInputs.js
+++ b/client/js/editor/propertyInputs.js
@@ -392,6 +392,16 @@ function searchImageIndex(query, limit=100) {
 
 let activePropertyInfoPopup = null;
 
+// An info tip hangs off a sidebar control that is thrown away whenever the
+// editor re-renders for another widget, so closeEditorPopups() takes it along
+// with the popups of controls/popup.js. Its own outside-click handler only
+// helps when there is a click - a deleted widget, an undo or a new state
+// arriving change the selection without one.
+function closePropertyInfoPopup() {
+  if(activePropertyInfoPopup)
+    activePropertyInfoPopup();
+}
+
 // Info button (design inspired by the routine editor in PR #2439): a small
 // "i" icon that opens a dismissable popup with an explanation. The popup
 // opens on hover or click. Hovered popups close when leaving the icon; clicked

--- a/client/js/editor/selection.js
+++ b/client/js/editor/selection.js
@@ -186,10 +186,10 @@ function setSelection(newSelectedWidgets) {
   // the ones that let widgets be picked in the room ignore clicks in there, so
   // nothing else ever closes them. A widget picker is not the editor moving on:
   // it restores the selection it started from after every pick.
-  if(!isWidgetPickerActive() && !isWidgetPickerRestoringSelection() && selectionChanged(previousSelectedWidgets, newSelectedWidgets)) {
+  const editorMovedOn = !isWidgetPickerChangingSelection() && !isWidgetPickerRestoringSelection()
+                        && selectionChanged(previousSelectedWidgets, newSelectedWidgets);
+  if(editorMovedOn)
     cancelAudioPicker();
-    closeEditorPopups();
-  }
 
   selectedWidgets = newSelectedWidgets;
 
@@ -207,6 +207,13 @@ function setSelection(newSelectedWidgets) {
     module.onSelectionChanged(selectedWidgets, previousSelectedWidgets);
 
   updateDragToolbar();
+
+  // last, once the editor really is on the new selection: closing a popup that
+  // applies on close writes the picked value to the widget it belonged to, and
+  // that delta can come straight back in here (a widget dropping out of the
+  // selection re-enters setSelection) - which must not happen half way through.
+  if(editorMovedOn)
+    closeEditorPopups();
 }
 
 export async function editClick(widget) {

--- a/client/js/editor/selection.js
+++ b/client/js/editor/selection.js
@@ -178,14 +178,18 @@ function selectionChanged(previousSelection, newSelection) {
 function setSelection(newSelectedWidgets) {
   const previousSelectedWidgets = [...selectedWidgets];
 
-  // The sound library is an overlay that outlives the editor it was opened from
-  // (it does not cover the sidebar, and a widget can also be selected without
-  // clicking in the room): whoever opened it edits the widget that was shown
-  // then, so a sound picked in it now would go to a widget that is no longer on
-  // screen. A widget picker is not affected - it restores the selection it
-  // started from after every pick, which is not the editor moving on.
-  if(!isWidgetPickerActive() && selectionChanged(previousSelectedWidgets, newSelectedWidgets))
+  // Whatever the editor has open belongs to the widget that was being edited, so
+  // moving on to another one takes it along: the sound library is an overlay
+  // that outlives the editor it was opened from (it does not cover the sidebar,
+  // and a widget can also be selected without clicking in the room), and the
+  // popups hang off controls this very selection change is about to throw away -
+  // the ones that let widgets be picked in the room ignore clicks in there, so
+  // nothing else ever closes them. A widget picker is not the editor moving on:
+  // it restores the selection it started from after every pick.
+  if(!isWidgetPickerActive() && !isWidgetPickerRestoringSelection() && selectionChanged(previousSelectedWidgets, newSelectedWidgets)) {
     cancelAudioPicker();
+    closeEditorPopups();
+  }
 
   selectedWidgets = newSelectedWidgets;
 

--- a/client/js/editor/selection.js
+++ b/client/js/editor/selection.js
@@ -154,18 +154,22 @@ function applySelectionRectangle(addToSelection) {
   if(newlySelected.length == 1 && handleWidgetPickerClick(newlySelected[0]))
     return;
 
-  if(!addToSelection) {
-    setSelection(newlySelected);
-  } else {
-    let selectionToApply = [...selectedWidgets];
-    for(const widget of newlySelected) {
-      if(selectedWidgets.indexOf(widget) == -1)
-        selectionToApply.push(widget);
-      else
-        selectionToApply = selectionToApply.filter(w=>w!=widget);
+  // a band drawn in the room is the one selection change a running picker owns:
+  // it is how widgets are picked with a band rather than a click
+  selectWidgetsInRoom(_=>{
+    if(!addToSelection) {
+      setSelection(newlySelected);
+    } else {
+      let selectionToApply = [...selectedWidgets];
+      for(const widget of newlySelected) {
+        if(selectedWidgets.indexOf(widget) == -1)
+          selectionToApply.push(widget);
+        else
+          selectionToApply = selectionToApply.filter(w=>w!=widget);
+      }
+      setSelection(selectionToApply);
     }
-    setSelection(selectionToApply);
-  }
+  });
 }
 
 // whether a selection is a different set of widgets than the one before it -
@@ -184,8 +188,12 @@ function setSelection(newSelectedWidgets) {
   // and a widget can also be selected without clicking in the room), and the
   // popups hang off controls this very selection change is about to throw away -
   // the ones that let widgets be picked in the room ignore clicks in there, so
-  // nothing else ever closes them. A widget picker is not the editor moving on:
-  // it restores the selection it started from after every pick.
+  // nothing else ever closes them. Picking widgets in the room is not the editor
+  // moving on: the picker restores the selection it started from after every
+  // pick. Every other way to select another widget is - a picker waiting for a
+  // click in the room does not make the JSON editor's tree or an "Edit line ..."
+  // link something else than the editor moving on, so it ends with its popup.
+  endWidgetPickerWithoutTarget();
   const editorMovedOn = !isWidgetPickerChangingSelection() && !isWidgetPickerRestoringSelection()
                         && selectionChanged(previousSelectedWidgets, newSelectedWidgets);
   if(editorMovedOn)

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1638,8 +1638,11 @@ class PropertiesModule extends SidebarModule {
 
   onEditorClose() {
     super.onEditorClose();
-    this.clearGridPreview();
-    this.clearFaceRowRefresh();
+    // Leaving edit mode is the most complete way of moving on, but it does not
+    // go through onClose(): the editor is only display:none'd, so a popup left
+    // open lives on inside it and an armed picker keeps the crosshair over the
+    // whole page while playing.
+    this.onClose();
   }
 
   onMetaReceivedWhileActive(meta) {

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1612,11 +1612,6 @@ class PropertiesModule extends SidebarModule {
       .filter(deck => deck && deck.get('type') == 'deck');
   }
 
-  onClose() {
-    // this module drives the widget picker, so a pick cannot outlive it
-    stopWidgetPicker();
-  }
-
   onDeltaReceivedWhileActive(delta) {
     for(const widgetID in delta.s)
       if(delta.s[widgetID] && this.inputUpdaters[widgetID])
@@ -1634,6 +1629,11 @@ class PropertiesModule extends SidebarModule {
   onClose() {
     this.clearGridPreview();
     this.clearFaceRowRefresh();
+    // This module is what the popups hang off, and closing it throws away the
+    // controls they are anchored to just like moving on to another widget does -
+    // so they go the same way, and the picks they run in the room with them.
+    stopWidgetPicker();
+    closeEditorPopups();
   }
 
   onEditorClose() {

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -51,7 +51,7 @@ beforeAll(() => {
     'EventsEditor', 'propertyAutomations', 'AddEventPopup', 'cardDefaultRoutines', 'InfoPopup', 'RoutineStringPopup', 'RoutineNumberPopup', 'RoutinePropertyNamePopup',
     'RoutineColorPopup', 'RoutineIconPopup', 'RoutineSoundPopup', 'RoutineJSONPopup', 'RoutineFullOperationJSONPopup', 'RoutineKeyValuePopup', 'RoutineWidgetIDPopup', 'RoutineEnumMenu',
     'renderWidgetSelectPopout', 'startWidgetPicker', 'stopWidgetPicker', 'isWidgetPickerActive',
-    'handleWidgetPickerSelection', 'handleWidgetPickerClick', 'commonInfoTopic', 'parameterInfoLine', 'templateLead', 'leadLabel', 'infoButton',
+    'handleWidgetPickerSelection', 'handleWidgetPickerClick', 'selectWidgetsInRoom', 'commonInfoTopic', 'parameterInfoLine', 'templateLead', 'leadLabel', 'infoButton',
     'structureInfoHTML'
   ];
   // eval in test scope so the plain-script class declarations see the jsdom globals
@@ -2517,6 +2517,13 @@ describe('the shared widget picker', () => {
     return id => widgets.get(id);
   }
 
+  // a band drawn in the room reaches the picker as a selection change, and that
+  // is the only selection it takes: one made anywhere else is the editor moving
+  // on to another widget, waiting picker or not
+  function selectInRoom(selection) {
+    return selectWidgetsInRoom(_=>handleWidgetPickerSelection(selection));
+  }
+
   // renders the popout the properties sidebar and the routine editor share and
   // starts its in-room pick mode
   function pickInRoom(options) {
@@ -2537,7 +2544,7 @@ describe('the shared widget picker', () => {
     let picked = null;
     pickInRoom({ typeFilter: 'holder', apply: id => picked = id });
     // the card covers the holder, so a click on it means the holder underneath
-    handleWidgetPickerSelection([ get('c1') ]);
+    selectInRoom([ get('c1') ]);
     expect(picked).toBe('h1');
   });
 
@@ -2545,26 +2552,38 @@ describe('the shared widget picker', () => {
     const get = room([ 'target', 'button' ], [ 'l1', 'label' ]);
     let picked = null;
     pickInRoom({ typeFilter: 'holder', apply: id => picked = id });
-    handleWidgetPickerSelection([ get('l1') ]);
+    selectInRoom([ get('l1') ]);
     expect(picked).toBeNull();
     expect(isWidgetPickerActive()).toBe(true); // still waiting for a matching click
+  });
+
+  test('a selection made anywhere but in the room is not a pick', () => {
+    const get = room([ 'target', 'button' ], [ 'h1', 'holder' ]);
+    let picked = null;
+    pickInRoom({ typeFilter: 'holder', apply: id => picked = id });
+    // the editor selecting another widget on its own (the JSON editor's tree, a
+    // link in the sidebar) is it moving on: taking that as a pick would both
+    // write it into the parameter and put the editor back on the widget the
+    // picker belongs to, so the sidebar could not move on at all while one runs
+    expect(handleWidgetPickerSelection([ get('h1') ])).toBe(false);
+    expect(picked).toBeNull();
   });
 
   test('without a type filter only resolveCovering pickers look past cards and piles', () => {
     const get = room([ 'target', 'button' ], [ 'h1', 'holder' ], [ 'p1', 'pile', 'h1' ], [ 'c1', 'card', 'p1' ], [ 'c2', 'card' ]);
     let picked = null;
     pickInRoom({ apply: id => picked = id });
-    handleWidgetPickerSelection([ get('c1') ]); // the plain picker takes what was clicked
+    selectInRoom([ get('c1') ]); // the plain picker takes what was clicked
     expect(picked).toBe('c1');
 
     stopWidgetPicker();
     pickInRoom({ resolveCovering: true, apply: id => picked = id });
-    handleWidgetPickerSelection([ get('c1') ]);
+    selectInRoom([ get('c1') ]);
     expect(picked).toBe('h1');
 
     stopWidgetPicker();
     pickInRoom({ resolveCovering: true, apply: id => picked = id });
-    handleWidgetPickerSelection([ get('c2') ]); // a card on the table stays itself
+    selectInRoom([ get('c2') ]); // a card on the table stays itself
     expect(picked).toBe('c2');
   });
 
@@ -2572,7 +2591,7 @@ describe('the shared widget picker', () => {
     const get = room([ 'target', 'button' ], [ 'c1', 'card', 'c2' ], [ 'c2', 'card', 'c1' ]);
     let picked = null;
     pickInRoom({ typeFilter: 'holder', apply: id => picked = id });
-    handleWidgetPickerSelection([ get('c1') ]);
+    selectInRoom([ get('c1') ]);
     expect(picked).toBeNull();
   });
 
@@ -2580,9 +2599,9 @@ describe('the shared widget picker', () => {
     const get = room([ 'target', 'button' ], [ 'h1', 'holder' ], [ 'h2', 'holder' ], [ 'c1', 'card', 'h2' ]);
     let picked = [];
     pickInRoom({ multiple: true, resolveCovering: true, getSelectedIDs: () => picked, apply: ids => picked = ids });
-    handleWidgetPickerSelection([ get('h1') ]);
+    selectInRoom([ get('h1') ]);
     expect(isWidgetPickerActive()).toBe(true);
-    handleWidgetPickerSelection([ get('c1') ]);
+    selectInRoom([ get('c1') ]);
     expect(picked).toEqual([ 'h1', 'h2' ]);
   });
 
@@ -2599,7 +2618,7 @@ describe('the shared widget picker', () => {
 
     // it stays selected while the picker runs, so a click on it never arrives as
     // a selection change - only as a click
-    handleWidgetPickerSelection([ widgets.get('target') ]);
+    selectInRoom([ widgets.get('target') ]);
     expect(picked).toBeNull();
     expect(handleWidgetPickerClick(widgets.get('target'))).toBe(true);
     expect(picked).toBe('target');

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -20,6 +20,7 @@ beforeAll(() => {
   window.widgets = new Map();
   window.roomID = 'testroom'; // the tutorial links of info popups use it
   window.setSelection = () => {};
+  window.closePropertyInfoPopup = () => {}; // the sidebar's own info tips (propertyInputs.js)
   window.editorTypeNames = { basic: 'Widget', button: 'Button', canvas: 'Canvas', card: 'Card', holder: 'Holder', label: 'Label', seat: 'Seat', timer: 'Timer' };
   // the validator tables are part of the editor bundle; the property proposals read them
   window.WIDGET_PROPERTIES = {
@@ -51,7 +52,8 @@ beforeAll(() => {
     'EventsEditor', 'propertyAutomations', 'AddEventPopup', 'cardDefaultRoutines', 'InfoPopup', 'RoutineStringPopup', 'RoutineNumberPopup', 'RoutinePropertyNamePopup',
     'RoutineColorPopup', 'RoutineIconPopup', 'RoutineSoundPopup', 'RoutineJSONPopup', 'RoutineFullOperationJSONPopup', 'RoutineKeyValuePopup', 'RoutineWidgetIDPopup', 'RoutineEnumMenu',
     'renderWidgetSelectPopout', 'startWidgetPicker', 'stopWidgetPicker', 'isWidgetPickerActive',
-    'handleWidgetPickerSelection', 'handleWidgetPickerClick', 'selectWidgetsInRoom', 'commonInfoTopic', 'parameterInfoLine', 'templateLead', 'leadLabel', 'infoButton',
+    'handleWidgetPickerSelection', 'handleWidgetPickerClick', 'selectWidgetsInRoom', 'widgetPickerTarget', 'endWidgetPickerWithoutTarget',
+    'isWidgetPickerChangingSelection', 'closeEditorPopups', 'commonInfoTopic', 'parameterInfoLine', 'templateLead', 'leadLabel', 'infoButton',
     'structureInfoHTML'
   ];
   // eval in test scope so the plain-script class declarations see the jsdom globals
@@ -2679,6 +2681,78 @@ describe('the shared widget picker', () => {
     apply.dispatchEvent(new Event('click'));
     expect(value).toEqual({ from: [ 'h1', 'h2' ] });
     popup.hide();
+  });
+
+  // the facade the properties sidebar renders a multi-selection through
+  // (MultiWidget): its id is the ids of all of them, so no widget in the room
+  // has it - the widgets behind it are what says whether it is still there
+  function multiSelection(...ids) {
+    return { id: ids.join(','), isMulti: true, widgets: ids.map(id => widgets.get(id)) };
+  }
+
+  test('the parent picker of a multi-selection picks in the room', () => {
+    const get = room([ 'h1', 'holder' ], [ 'h2', 'holder' ], [ 'h3', 'holder' ]);
+    let picked = null;
+    startWidgetPicker(multiSelection('h1', 'h2'), (target, pickedWidgets) => picked = pickedWidgets.map(w => w.id));
+    expect(handleWidgetPickerClick(get('h3'))).toBe(true);
+    expect(picked).toEqual([ 'h3' ]);
+  });
+
+  test('a picker of a multi-selection ends when one of its widgets is gone', () => {
+    room([ 'h1', 'holder' ], [ 'h2', 'holder' ]);
+    const facade = multiSelection('h1', 'h2');
+    startWidgetPicker(facade, () => {});
+    expect(widgetPickerTarget()).toBe(facade);
+    // it does not end while they are there - the note used to say "h1,h2 is
+    // gone" about widgets that are both in the room
+    endWidgetPickerWithoutTarget();
+    expect(isWidgetPickerActive()).toBe(true);
+
+    widgets.delete('h1');
+    expect(widgetPickerTarget()).toBeNull();
+    endWidgetPickerWithoutTarget();
+    expect(isWidgetPickerActive()).toBe(false);
+    expect(document.querySelector('#editorNotes').lastChild.textContent).toBe('picking in the room ended: h1 is gone');
+  });
+});
+
+describe('what the editor says about a write it made off screen', () => {
+  // a color is picked by dragging, so the parameter is only written when the
+  // popup closes - which is also what the editor moving on to another widget
+  // does to it
+  function colorPopupWithAPick(widget) {
+    const source = document.createElement('span');
+    document.getElementById('editor').append(source);
+    const popup = new RoutineColorPopup();
+    popup.setSource(source);
+    popup.setOperationDetails({ func: 'CANVAS', color: '#1f5ca6' }, [ 'color' ], widget, [], []);
+    popup.show();
+    popup.applyValueInput('#3cb44b');
+    return popup;
+  }
+
+  const lastNote = () => document.querySelector('#editorNotes').lastChild.textContent;
+
+  beforeEach(() => {
+    widgets.clear();
+    const state = { id: 'button', type: 'button' };
+    widgets.set('button', { id: 'button', state, get: p => state[p], set() {} });
+  });
+
+  test('the write is named with the widget it went to', () => {
+    colorPopupWithAPick(widgets.get('button'));
+    closeEditorPopups();
+    expect(lastNote()).toBe('CANVAS color set to #3cb44b on button');
+  });
+
+  test('a widget that is on its way out of the room does not get credit for the write', () => {
+    // a pile sets isBeingRemoved and then awaits three property changes before
+    // it removes itself, so it is still in widgets under its own id - and the
+    // sidebar drops writes to it for exactly that window (widgetStillExists)
+    widgets.get('button').isBeingRemoved = true;
+    colorPopupWithAPick(widgets.get('button'));
+    closeEditorPopups();
+    expect(lastNote()).toBe('CANVAS color was not set to #3cb44b: button is gone');
   });
 });
 

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -2011,6 +2011,26 @@ test('Enabling the Debug module while a routine waits for INPUT does not abort t
   await compareState(t, 'ae64bb637f9aff6df4fe20773602a8e0');
 });
 
+// drags a selection rectangle around the given widgets - the events go to the
+// window, where the editor listens for them, so they need no element to start
+// from. A rectangle around a single widget is treated like a click on it, which
+// is why the callers put the widget being edited in the band as well.
+const rubberBandOver = ClientFunction(selector => {
+  const from = { x: Infinity, y: Infinity };
+  const to = { x: -Infinity, y: -Infinity };
+  document.querySelectorAll(selector).forEach(element=>{
+    const rect = element.getBoundingClientRect();
+    from.x = Math.min(from.x, rect.left - 20);
+    from.y = Math.min(from.y, rect.top - 20);
+    to.x = Math.max(to.x, rect.right + 20);
+    to.y = Math.max(to.y, rect.bottom + 20);
+  });
+  const at = (type, point)=>document.body.dispatchEvent(new MouseEvent(type, { bubbles: true, button: 0, clientX: point.x, clientY: point.y }));
+  at('mousedown', from);
+  at('mousemove', to);
+  at('mouseup', to);
+});
+
 test('A routine parameter popup goes away with the widget it belongs to', async t => {
   await setRoomState({
     button: { id: 'button', type: 'button', x: 100, y: 100, clickRoutine: [ { func: 'MOVE', from: 'holder1', to: 'holder2' } ] },
@@ -2045,7 +2065,25 @@ test('A routine parameter popup goes away with the widget it belongs to', async 
     .expect(popup.exists).notOk()
     .expect(Selector('#w_holder2').hasClass('selectedInEdit')).ok();
 
+  // A rubber band is the other way to pick in the room, and the only one that
+  // goes through the selection: it selects what it caught, and the picker puts
+  // the widget it belongs to back afterwards - which is not the editor moving on
+  // either. The property builder picks a single widget, so its picker is already
+  // gone by the time that restore arrives.
+  await openFromPopup();
+  const propertySection = popup.find('.accordion-section').withAttribute('data-kind', 'property');
+  await t
+    .click(propertySection.find('h3'))
+    .click(propertySection.find('.propertyExpandButton'))
+    .click(propertySection.find('button[icon=colorize]'));
+  await rubberBandOver('#w_button, #w_holder1');
+  await t
+    .expect(popup.exists).ok()
+    .expect(propertySection.find('.popup-property-widget').value).eql('holder1')
+    .expect(Selector('#w_button').hasClass('selectedInEdit')).ok();
+
   // with the picker armed the same click belongs to the popup, which stays open
+  await t.click(popup.find('.popup-close'));
   await openFromPopup();
   await t
     .click(popup.find('button').withText('Pick in the room'))
@@ -2053,4 +2091,76 @@ test('A routine parameter popup goes away with the widget it belongs to', async 
     .expect(popup.exists).ok()
     .expect(popup.find('.widgetPickerEntry.selected').withText('holder2').exists).ok()
     .expect(Selector('#w_button').hasClass('selectedInEdit')).ok();
+});
+
+test('An editor popup does not outlive the widget it belongs to without a click either', async t => {
+  await setRoomState({
+    button: { id: 'button', type: 'button', x: 100, y: 100, clickRoutine: [ { func: 'CANVAS', mode: 'change', color: '#1f5ca6' } ] },
+    holder: { id: 'holder', type: 'holder', x: 500, y: 100 }
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  const popup = Selector('.inline-popup');
+  const colorChip = Selector('.routine-editor-operation [data-parameter=color]');
+  const routineHeader = Selector('.events-editor-event-header').withText('clickRoutine');
+  const routineColor = ClientFunction(_=>widgets.get('button').get('clickRoutine')[0].color);
+  const openColorPopup = async _=>{
+    await t.click('#w_button');
+    if(await routineHeader.getAttribute('aria-expanded') == 'false')
+      await t.click(routineHeader);
+    await t.click(colorChip).expect(popup.exists).ok();
+  };
+
+  await t
+    .click('#editButton')
+    .click('#editorSidebar [icon=tune]');
+  await openColorPopup();
+
+  // The color, icon and sound pickers only write their parameter when the popup
+  // goes away, so closing it applies what was picked - to the widget the popup
+  // belongs to, exactly as a click outside the popup would.
+  await t
+    .click(popup.find('.propertyColorChip[data-value="#3cb44b"]'))
+    .click('#w_holder')
+    .expect(popup.exists).notOk()
+    .expect(routineColor()).eql('#3cb44b');
+
+  // The routes without any click: the widget being edited is removed, which is
+  // what a delete, an undo and a dissolving pile all arrive as. An armed room
+  // picker keeps the popup through the selection changes it causes itself, but
+  // not through this one - the widget it would write to is gone.
+  await openColorPopup();
+  const propertySection = popup.find('.accordion-section').withAttribute('data-kind', 'property');
+  await t
+    .click(propertySection.find('h3'))
+    .click(propertySection.find('.propertyExpandButton'))
+    .click(propertySection.find('button[icon=colorize]'));
+  await ClientFunction(_=>removeWidgetLocal('button'))();
+  await t
+    .expect(popup.exists).notOk()
+    .expect(ClientFunction(_=>widgets.has('button'))()).notOk();
+});
+
+test('A property info tip goes away with the widget it explains', async t => {
+  await setRoomState({
+    button: { id: 'button', type: 'button', x: 100, y: 100 }
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  const infoTip = Selector('#editor > .inline-popup');
+
+  await t
+    .click('#editButton')
+    .click('#editorSidebar [icon=tune]')
+    .click('#w_button')
+    .click(Selector('#editorModules .collapsibleHeader').withText('CSS').find('.info-button'))
+    .expect(infoTip.exists).ok();
+
+  // An info tip hangs off a sidebar control just like the popups do. Its own
+  // outside-click handler covers every route with a click in it, but not the
+  // selection changing on its own - here the widget it explains is removed.
+  await ClientFunction(_=>removeWidgetLocal('button'))();
+  await t.expect(infoTip.exists).notOk();
 });

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -2193,3 +2193,47 @@ test('A property info tip goes away with the widget it explains', async t => {
   await ClientFunction(_=>removeWidgetLocal('button'))();
   await t.expect(infoTip.exists).notOk();
 });
+
+test('A long list of widget ids shrinks instead of pushing the apply button out of the popup', async t => {
+  await t.resizeWindow(1280, 500);
+  const roomState = {
+    button: { id: 'button', type: 'button', x: 100, y: 100, clickRoutine: [ { func: 'MOVE', from: 'holder1', to: 'holder2' } ] }
+  };
+  // more holders than the list of ids can show, so it wants to be at its tallest
+  for(let i=1; i<=30; ++i)
+    roomState[`holder${i}`] = { id: `holder${i}`, type: 'holder', x: 300+i%6*60, y: 100+Math.floor(i/6)*60 };
+  await setRoomState(roomState);
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  const popup = Selector('.inline-popup');
+  const routineHeader = Selector('.events-editor-event-header').withText('clickRoutine');
+
+  await t
+    .click('#editButton')
+    .click('#editorSidebar [icon=tune]')
+    .click('#w_button');
+  if(await routineHeader.getAttribute('aria-expanded') == 'false')
+    await t.click(routineHeader);
+  await t
+    .click(Selector('.routine-editor-operation [data-parameter=from]'))
+    .expect(popup.exists).ok()
+    .expect(popup.find('.widgetPickerList').exists).ok();
+
+  // The button that applies the picked widgets is the last thing in the section,
+  // so a list of ids that is taller than the popup has room for pushes it out of
+  // sight - and a popup that scrolls says nothing about there being more below
+  // it. The list scrolls anyway, so it is what gives way.
+  const fit = await ClientFunction(_=>{
+    const popup = document.querySelector('.inline-popup');
+    const apply = popup.querySelector('button.primary'); // "Use these widgets"
+    const popupRect = popup.getBoundingClientRect(), applyRect = apply.getBoundingClientRect();
+    const list = popup.querySelector('.widgetPickerList');
+    return {
+      popupScrollsBy: popup.scrollHeight - popup.clientHeight,
+      applyInPopup: applyRect.top >= popupRect.top && applyRect.bottom <= popupRect.bottom + 1,
+      listScrolls: list.scrollHeight > list.clientHeight
+    };
+  })();
+  await t.expect(fit).eql({ popupScrollsBy: 0, applyInPopup: true, listScrolls: true });
+});

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -17,6 +17,10 @@ const setEditorState = ClientFunction(state => {
 
 const moduleWidth = ClientFunction(() => document.querySelector('#editorModules').getBoundingClientRect().width);
 
+// the editor state of a test that wants the properties module open the way the user opens it, rather
+// than as the panel edit mode opens on its own the very first time (which sizes itself to its content)
+const propertiesModuleOpen = { modules: { 'Edit Widgets': 'editorModuleTopLeft' } };
+
 test('Edit mode opens the Edit Widgets module when no module is remembered', async t => {
   await t.resizeWindow(1280, 800);
   await setRoomState({
@@ -2336,12 +2340,14 @@ const rubberBandOver = ClientFunction(selector => {
 });
 
 test('A routine parameter popup goes away with the widget it belongs to', async t => {
+  await t.resizeWindow(1280, 800);
   await setRoomState({
     button: { id: 'button', type: 'button', x: 100, y: 100, clickRoutine: [ { func: 'MOVE', from: 'holder1', to: 'holder2' } ] },
     holder1: { id: 'holder1', type: 'holder', x: 300, y: 100 },
     holder2: { id: 'holder2', type: 'holder', x: 500, y: 100 }
   });
   await ClientFunction(prepareClient)();
+  await setEditorState(propertiesModuleOpen);
   await setName(t);
 
   const popup = Selector('.inline-popup');
@@ -2354,9 +2360,7 @@ test('A routine parameter popup goes away with the widget it belongs to', async 
     await t.click(fromChip).expect(popup.exists).ok();
   };
 
-  await t
-    .click('#editButton')
-    .click('#editorSidebar [icon=tune]');
+  await t.click('#editButton');
   await openFromPopup();
 
   // The popup hangs off a chip of the routine of the widget being edited, so a
@@ -2412,6 +2416,7 @@ test('A routine parameter popup goes away with the widget it belongs to', async 
     .click('#jeShowTree')
     .click(Selector('#jeTree .jeTreeWidget').find('.key').withExactText('holder2'))
     .expect(Selector('#w_holder2').hasClass('selectedInEdit')).ok();
+  await setEditorState(null);
 });
 
 // An armed picker only explains the selection changes it makes itself - a click
@@ -2422,6 +2427,7 @@ test('A routine parameter popup goes away with the widget it belongs to', async 
 // route of its own, so it does not even take another module: a widget attached
 // to a line offers a way back to the line it rides on.
 test('An armed picker does not keep a popup open when the sidebar moves the editor on', async t => {
+  await t.resizeWindow(1280, 800);
   await setRoomState({
     route: {
       id: 'route', type: 'line', lineStart: { x: 100, y: 300 }, lineEnd: { x: 600, y: 300 },
@@ -2435,6 +2441,7 @@ test('An armed picker does not keep a popup open when the sidebar moves the edit
     holder2: { id: 'holder2', type: 'holder', x: 500, y: 100 }
   });
   await ClientFunction(prepareClient)();
+  await setEditorState(propertiesModuleOpen);
   await setName(t);
 
   const popup = Selector('.inline-popup');
@@ -2443,7 +2450,6 @@ test('An armed picker does not keep a popup open when the sidebar moves the edit
 
   await t
     .click('#editButton')
-    .click('#editorSidebar [icon=tune]')
     .click('#w_stop1');
   if(await routineHeader.getAttribute('aria-expanded') == 'false')
     await t.click(routineHeader);
@@ -2479,15 +2485,18 @@ test('An armed picker does not keep a popup open when the sidebar moves the edit
     .expect(Selector('body').hasClass('edit')).notOk()
     .expect(popup.exists).notOk()
     .expect(picking).notOk();
+  await setEditorState(null);
 });
 
 test('An editor popup does not outlive the widget it belongs to without a click either', async t => {
+  await t.resizeWindow(1280, 800);
   const roomState = {
     button: { id: 'button', type: 'button', x: 100, y: 100, clickRoutine: [ { func: 'CANVAS', mode: 'change', color: '#1f5ca6' } ] },
     holder: { id: 'holder', type: 'holder', x: 500, y: 100 }
   };
   await setRoomState(roomState);
   await ClientFunction(prepareClient)();
+  await setEditorState(propertiesModuleOpen);
   await setName(t);
 
   const popup = Selector('.inline-popup');
@@ -2511,9 +2520,7 @@ test('An editor popup does not outlive the widget it belongs to without a click 
       .expect(picking).ok();
   };
 
-  await t
-    .click('#editButton')
-    .click('#editorSidebar [icon=tune]');
+  await t.click('#editButton');
   await openColorPopup();
 
   // The color, icon and sound pickers only write their parameter when the popup
@@ -2557,20 +2564,22 @@ test('An editor popup does not outlive the widget it belongs to without a click 
     .expect(popup.exists).notOk()
     .expect(ClientFunction(_=>widgets.has('button'))()).ok()
     .expect(picking).notOk();
+  await setEditorState(null);
 });
 
 test('A property info tip goes away with the widget it explains', async t => {
+  await t.resizeWindow(1280, 800);
   await setRoomState({
     button: { id: 'button', type: 'button', x: 100, y: 100 }
   });
   await ClientFunction(prepareClient)();
+  await setEditorState(propertiesModuleOpen);
   await setName(t);
 
   const infoTip = Selector('#editor > .inline-popup');
 
   await t
     .click('#editButton')
-    .click('#editorSidebar [icon=tune]')
     .click('#w_button')
     .click(Selector('#editorModules .collapsibleHeader').withText('CSS').find('.info-button'))
     .expect(infoTip.exists).ok();
@@ -2580,6 +2589,7 @@ test('A property info tip goes away with the widget it explains', async t => {
   // selection changing on its own - here the widget it explains is removed.
   await ClientFunction(_=>removeWidgetLocal('button'))();
   await t.expect(infoTip.exists).notOk();
+  await setEditorState(null);
 });
 
 test('A long list of widget ids shrinks instead of pushing the apply button out of the popup', async t => {
@@ -2592,6 +2602,7 @@ test('A long list of widget ids shrinks instead of pushing the apply button out 
     roomState[`holder${i}`] = { id: `holder${i}`, type: 'holder', x: 300+i%6*60, y: 100+Math.floor(i/6)*60 };
   await setRoomState(roomState);
   await ClientFunction(prepareClient)();
+  await setEditorState(propertiesModuleOpen);
   await setName(t);
 
   const popup = Selector('.inline-popup');
@@ -2599,7 +2610,6 @@ test('A long list of widget ids shrinks instead of pushing the apply button out 
 
   await t
     .click('#editButton')
-    .click('#editorSidebar [icon=tune]')
     .click('#w_button');
   if(await routineHeader.getAttribute('aria-expanded') == 'false')
     await t.click(routineHeader);
@@ -2624,4 +2634,5 @@ test('A long list of widget ids shrinks instead of pushing the apply button out 
     };
   })();
   await t.expect(fit).eql({ popupScrollsBy: 0, applyInPopup: true, listScrolls: true });
+  await setEditorState(null);
 });

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -2094,10 +2094,11 @@ test('A routine parameter popup goes away with the widget it belongs to', async 
 });
 
 test('An editor popup does not outlive the widget it belongs to without a click either', async t => {
-  await setRoomState({
+  const roomState = {
     button: { id: 'button', type: 'button', x: 100, y: 100, clickRoutine: [ { func: 'CANVAS', mode: 'change', color: '#1f5ca6' } ] },
     holder: { id: 'holder', type: 'holder', x: 500, y: 100 }
-  });
+  };
+  await setRoomState(roomState);
   await ClientFunction(prepareClient)();
   await setName(t);
 
@@ -2105,11 +2106,20 @@ test('An editor popup does not outlive the widget it belongs to without a click 
   const colorChip = Selector('.routine-editor-operation [data-parameter=color]');
   const routineHeader = Selector('.events-editor-event-header').withText('clickRoutine');
   const routineColor = ClientFunction(_=>widgets.get('button').get('clickRoutine')[0].color);
+  const picking = Selector('body').hasClass('editorWidgetPicking');
   const openColorPopup = async _=>{
     await t.click('#w_button');
     if(await routineHeader.getAttribute('aria-expanded') == 'false')
       await t.click(routineHeader);
     await t.click(colorChip).expect(popup.exists).ok();
+  };
+  const armRoomPicker = async _=>{
+    const propertySection = popup.find('.accordion-section').withAttribute('data-kind', 'property');
+    await t
+      .click(propertySection.find('h3'))
+      .click(propertySection.find('.propertyExpandButton'))
+      .click(propertySection.find('button[icon=colorize]'))
+      .expect(picking).ok();
   };
 
   await t
@@ -2131,15 +2141,27 @@ test('An editor popup does not outlive the widget it belongs to without a click 
   // picker keeps the popup through the selection changes it causes itself, but
   // not through this one - the widget it would write to is gone.
   await openColorPopup();
-  const propertySection = popup.find('.accordion-section').withAttribute('data-kind', 'property');
-  await t
-    .click(propertySection.find('h3'))
-    .click(propertySection.find('.propertyExpandButton'))
-    .click(propertySection.find('button[icon=colorize]'));
+  await armRoomPicker();
   await ClientFunction(_=>removeWidgetLocal('button'))();
   await t
     .expect(popup.exists).notOk()
-    .expect(ClientFunction(_=>widgets.has('button'))()).notOk();
+    .expect(ClientFunction(_=>widgets.has('button'))()).notOk()
+    .expect(picking).notOk();
+
+  // The other route without a click: a new state from the server, which replaces
+  // every widget in the room. It usually brings the same ids back (an undo, the
+  // same game loaded again), so the widget the popup belongs to can only be told
+  // apart from its replacement by identity - going by the id alone would leave
+  // the popup floating over an editor that has nothing selected at all.
+  await setRoomState(roomState);
+  await t.expect(ClientFunction(_=>widgets.has('button'))()).ok();
+  await openColorPopup();
+  await armRoomPicker();
+  await setRoomState(roomState);
+  await t
+    .expect(popup.exists).notOk()
+    .expect(ClientFunction(_=>widgets.has('button'))()).ok()
+    .expect(picking).notOk();
 });
 
 test('A property info tip goes away with the widget it explains', async t => {

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -2010,3 +2010,47 @@ test('Enabling the Debug module while a routine waits for INPUT does not abort t
   await t.expect(Selector('#jeLog .jeLogNote').innerText).contains('could not be recorded');
   await compareState(t, 'ae64bb637f9aff6df4fe20773602a8e0');
 });
+
+test('A routine parameter popup goes away with the widget it belongs to', async t => {
+  await setRoomState({
+    button: { id: 'button', type: 'button', x: 100, y: 100, clickRoutine: [ { func: 'MOVE', from: 'holder1', to: 'holder2' } ] },
+    holder1: { id: 'holder1', type: 'holder', x: 300, y: 100 },
+    holder2: { id: 'holder2', type: 'holder', x: 500, y: 100 }
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  const popup = Selector('.inline-popup');
+  const fromChip = Selector('.routine-editor-operation [data-parameter=from]');
+  const routineHeader = Selector('.events-editor-event-header').withText('clickRoutine');
+  const openFromPopup = async _=>{
+    await t.click('#w_button');
+    if(await routineHeader.getAttribute('aria-expanded') == 'false')
+      await t.click(routineHeader);
+    await t.click(fromChip).expect(popup.exists).ok();
+  };
+
+  await t
+    .click('#editButton')
+    .click('#editorSidebar [icon=tune]');
+  await openFromPopup();
+
+  // The popup hangs off a chip of the routine of the widget being edited, so a
+  // click that moves the editor on to another widget takes it along - without
+  // this it stays on screen over an editor for a widget it has nothing to do
+  // with. Its own "Pick in the room" is what makes a click in the room fill the
+  // parameter instead, which is why nothing else ever closed it.
+  await t
+    .click('#w_holder2')
+    .expect(popup.exists).notOk()
+    .expect(Selector('#w_holder2').hasClass('selectedInEdit')).ok();
+
+  // with the picker armed the same click belongs to the popup, which stays open
+  await openFromPopup();
+  await t
+    .click(popup.find('button').withText('Pick in the room'))
+    .click('#w_holder2')
+    .expect(popup.exists).ok()
+    .expect(popup.find('.widgetPickerEntry.selected').withText('holder2').exists).ok()
+    .expect(Selector('#w_button').hasClass('selectedInEdit')).ok();
+});

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -2107,6 +2107,7 @@ test('An editor popup does not outlive the widget it belongs to without a click 
   const routineHeader = Selector('.events-editor-event-header').withText('clickRoutine');
   const routineColor = ClientFunction(_=>widgets.get('button').get('clickRoutine')[0].color);
   const picking = Selector('body').hasClass('editorWidgetPicking');
+  const notes = Selector('#editorNotes');
   const openColorPopup = async _=>{
     await t.click('#w_button');
     if(await routineHeader.getAttribute('aria-expanded') == 'false')
@@ -2129,12 +2130,15 @@ test('An editor popup does not outlive the widget it belongs to without a click 
 
   // The color, icon and sound pickers only write their parameter when the popup
   // goes away, so closing it applies what was picked - to the widget the popup
-  // belongs to, exactly as a click outside the popup would.
+  // belongs to, exactly as a click outside the popup would. That widget is off
+  // screen by then, so the editor says what it wrote where: without that, having
+  // kept the pick and having thrown it away look exactly the same.
   await t
     .click(popup.find('.propertyColorChip[data-value="#3cb44b"]'))
     .click('#w_holder')
     .expect(popup.exists).notOk()
-    .expect(routineColor()).eql('#3cb44b');
+    .expect(routineColor()).eql('#3cb44b')
+    .expect(notes.innerText).contains('CANVAS color set to #3cb44b on button');
 
   // The routes without any click: the widget being edited is removed, which is
   // what a delete, an undo and a dissolving pile all arrive as. An armed room
@@ -2146,7 +2150,10 @@ test('An editor popup does not outlive the widget it belongs to without a click 
   await t
     .expect(popup.exists).notOk()
     .expect(ClientFunction(_=>widgets.has('button'))()).notOk()
-    .expect(picking).notOk();
+    .expect(picking).notOk()
+    // the crosshair over the room is all there is to see of an armed picker, so
+    // it ending on its own is said out loud as well
+    .expect(notes.innerText).contains('picking in the room ended: button is gone');
 
   // The other route without a click: a new state from the server, which replaces
   // every widget in the room. It usually brings the same ids back (an undo, the

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -20,6 +20,9 @@ const moduleWidth = ClientFunction(() => document.querySelector('#editorModules'
 // the editor state of a test that wants the properties module open the way the user opens it, rather
 // than as the panel edit mode opens on its own the very first time (which sizes itself to its content)
 const propertiesModuleOpen = { modules: { 'Edit Widgets': 'editorModuleTopLeft' } };
+// edit mode imports itself on the first click of the edit button, so waiting for the module the state
+// above restores is what tells "the editor is there" from "the click has not arrived yet"
+const propertiesModule = Selector('#editorModuleTopLeft.tune');
 
 test('Edit mode opens the Edit Widgets module when no module is remembered', async t => {
   await t.resizeWindow(1280, 800);
@@ -2360,7 +2363,7 @@ test('A routine parameter popup goes away with the widget it belongs to', async 
     await t.click(fromChip).expect(popup.exists).ok();
   };
 
-  await t.click('#editButton');
+  await t.click('#editButton').expect(propertiesModule.exists).ok();
   await openFromPopup();
 
   // The popup hangs off a chip of the routine of the widget being edited, so a
@@ -2450,6 +2453,7 @@ test('An armed picker does not keep a popup open when the sidebar moves the edit
 
   await t
     .click('#editButton')
+    .expect(propertiesModule.exists).ok()
     .click('#w_stop1');
   if(await routineHeader.getAttribute('aria-expanded') == 'false')
     await t.click(routineHeader);
@@ -2520,7 +2524,7 @@ test('An editor popup does not outlive the widget it belongs to without a click 
       .expect(picking).ok();
   };
 
-  await t.click('#editButton');
+  await t.click('#editButton').expect(propertiesModule.exists).ok();
   await openColorPopup();
 
   // The color, icon and sound pickers only write their parameter when the popup
@@ -2580,6 +2584,7 @@ test('A property info tip goes away with the widget it explains', async t => {
 
   await t
     .click('#editButton')
+    .expect(propertiesModule.exists).ok()
     .click('#w_button')
     .click(Selector('#editorModules .collapsibleHeader').withText('CSS').find('.info-button'))
     .expect(infoTip.exists).ok();
@@ -2610,6 +2615,7 @@ test('A long list of widget ids shrinks instead of pushing the apply button out 
 
   await t
     .click('#editButton')
+    .expect(propertiesModule.exists).ok()
     .click('#w_button');
   if(await routineHeader.getAttribute('aria-expanded') == 'false')
     await t.click(routineHeader);

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -2091,6 +2091,72 @@ test('A routine parameter popup goes away with the widget it belongs to', async 
     .expect(popup.exists).ok()
     .expect(popup.find('.widgetPickerEntry.selected').withText('holder2').exists).ok()
     .expect(Selector('#w_button').hasClass('selectedInEdit')).ok();
+
+  // The route that reads as a pick least of all: the JSON editor, which selects
+  // widgets in its own tree. Opening it also replaces the module the popup hangs
+  // off, which takes the popup along by itself - either way nothing of the
+  // editor for the other widget is left over the new one.
+  const picking = Selector('body').hasClass('editorWidgetPicking');
+  await t.click(popup.find('.popup-close'));
+  await openFromPopup();
+  await t
+    .click(popup.find('button').withText('Pick in the room'))
+    .expect(picking).ok()
+    .click('#editorSidebar [icon=data_object]')
+    .expect(popup.exists).notOk()
+    .expect(picking).notOk()
+    .click('#jeShowTree')
+    .click(Selector('#jeTree .jeTreeWidget').find('.key').withExactText('holder2'))
+    .expect(Selector('#w_holder2').hasClass('selectedInEdit')).ok();
+});
+
+// An armed picker only explains the selection changes it makes itself - a click
+// or a band in the room. Every other way to select another widget is the editor
+// moving on, waiting picker or not: without that, arming the picker would leave
+// the popup floating over whatever the editor moved on to, with the picker still
+// armed for a widget that is not on screen any more. The sidebar has such a
+// route of its own, so it does not even take another module: a widget attached
+// to a line offers a way back to the line it rides on.
+test('An armed picker does not keep a popup open when the sidebar moves the editor on', async t => {
+  await setRoomState({
+    route: {
+      id: 'route', type: 'line', lineStart: { x: 100, y: 300 }, lineEnd: { x: 600, y: 300 },
+      stops: [ { widget: 'stop1', position: 0.5 } ]
+    },
+    stop1: {
+      id: 'stop1', type: 'basic', parent: 'route', x: 340, y: 290, width: 40, height: 20,
+      clickRoutine: [ { func: 'MOVE', from: 'holder1', to: 'holder2' } ]
+    },
+    holder1: { id: 'holder1', type: 'holder', x: 300, y: 100 },
+    holder2: { id: 'holder2', type: 'holder', x: 500, y: 100 }
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  const popup = Selector('.inline-popup');
+  const picking = Selector('body').hasClass('editorWidgetPicking');
+  const routineHeader = Selector('.events-editor-event-header').withText('clickRoutine');
+
+  await t
+    .click('#editButton')
+    .click('#editorSidebar [icon=tune]')
+    .click('#w_stop1');
+  if(await routineHeader.getAttribute('aria-expanded') == 'false')
+    await t.click(routineHeader);
+  await t
+    .click(Selector('.routine-editor-operation [data-parameter=from]'))
+    .expect(popup.exists).ok()
+    .click(popup.find('button').withText('Pick in the room'))
+    .expect(picking).ok();
+
+  // "Edit line route" in the widget header selects the line - a selection change
+  // that never touches the room, with the widget the picker belongs to still
+  // there. It is the editor moving on all the same.
+  await t
+    .click(Selector('.widgetHeaderLineButton'))
+    .expect(Selector('#w_route').hasClass('selectedInEdit')).ok()
+    .expect(popup.exists).notOk()
+    .expect(picking).notOk();
 });
 
 test('An editor popup does not outlive the widget it belongs to without a click either', async t => {

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -2157,6 +2157,24 @@ test('An armed picker does not keep a popup open when the sidebar moves the edit
     .expect(Selector('#w_route').hasClass('selectedInEdit')).ok()
     .expect(popup.exists).notOk()
     .expect(picking).notOk();
+
+  // Leaving edit mode is the most complete way of moving on, and it goes past
+  // the module being closed: the editor is only hidden, so a popup left open
+  // lives on inside it and an armed picker keeps the crosshair over the whole
+  // page while playing. An armed picker also makes the popup ignore the click on
+  // the edit button itself, so nothing else takes it along.
+  await t.click('#w_stop1');
+  if(await routineHeader.getAttribute('aria-expanded') == 'false')
+    await t.click(routineHeader);
+  await t
+    .click(Selector('.routine-editor-operation [data-parameter=from]'))
+    .expect(popup.exists).ok()
+    .click(popup.find('button').withText('Pick in the room'))
+    .expect(picking).ok()
+    .click('#editorToolbar button[icon=close]')
+    .expect(Selector('body').hasClass('edit')).notOk()
+    .expect(popup.exists).notOk()
+    .expect(picking).notOk();
 });
 
 test('An editor popup does not outlive the widget it belongs to without a click either', async t => {


### PR DESCRIPTION
## What this changes

Popups of the widget editor (the parameter popups of the Automations routine editor, the "Add routine" popup, info popups) are now closed as soon as the editor moves on to a different widget, instead of being left hanging over an editor they no longer belong to.

## Why

A routine parameter that takes a widget — `MOVE from`/`to`, `SELECT`, the "property of a widget" builder, a `TURN` seat, … — opens a popup that offers **Pick in the room**. Because that button makes a click on a widget in the room fill the parameter, those popups deliberately ignore clicks in the play area.

If the user never presses that button and just clicks a widget in the room directly, the editor does what it normally does: it selects that widget and re-renders the whole properties sidebar for it. The popup, however, ignored the click — so it stayed on screen, anchored to a routine chip that had just been thrown away, now floating over the editor of an unrelated widget. Anything picked in it went to the widget that was no longer on screen.

The same stranding happened whenever the selection changed **without** any click at all, which is the "other circumstances" part of the report:

- the edited widget is deleted, or a pile dissolves and drops out of the selection,
- an undo removes it,
- a new state arrives from the server (loading another game clears the selection).

## How

`setSelection()` already cancels the sound library overlay when the selection really changes, for exactly the same reason ("whoever opened it edits the widget that was shown then"). Editor popups are now closed in the same place, so every route into a selection change is covered rather than just the click. The sidebar's info tips (the small "i" next to a property or section title) are a second, hand-rolled popup implementation that is not part of that list, so they are closed alongside it.

Picking widgets in the room is not the editor moving on: the picker selects what is picked and restores the selection it started from afterwards, so it keeps its popup. That is tied to the selection the picker itself makes — a band drawn in the room — rather than to a picker merely being armed: selecting another widget any other way (the JSON editor's tree, an "Edit line …" link in the sidebar) is the editor moving on, waiting picker or not, and the popup goes with it. It also only holds while the widget the picker belongs to still exists — once that one is deleted or replaced by a new state, the popup goes as well and the picker ends itself instead of waiting for a click in the room that will never come. "Still exists" is decided by identity, not by id: a new state rebuilds every widget in the room as a new object and regularly brings the same ids back (an undo, the same game loaded again), so the picker remembers the widget object it was started for — the way the rest of the editor does with `widgetStillExists()`.

Closing the popups is the last thing `setSelection()` does, after the sidebar has been told about the new selection: it is not a pure dismissal (see below), so the write it can cause must see a consistent selection rather than one being changed.

Behaviour that is unchanged: with **Pick in the room** armed, a click in the room still fills the parameter and the popup stays open.

## Behaviour worth knowing about

The pickers that only write their parameter when the popup goes away — color, icon, sound, key/value pairs and string lists — **apply** what was picked when the popup is closed this way, exactly as they do on a click outside the popup. So picking a color on widget A's routine and then clicking widget B writes that color to A's routine rather than dropping it. Where the widget is gone (deleted, undone, replaced by a new state) the write is dropped by the sidebar's existing `widgetStillExists()` guard.


Because the widget that is written to is off screen by then, the editor says so: a line in the corner of the module panel — *"CANVAS color set to #3cb44b on button"* — that fades after a few seconds, or *"… was not set …: button is gone"* where the write was dropped. Without it, having kept the pick and having thrown it away look exactly the same. An armed room picker that ends because its widget is gone says that too, since the crosshair over the room is all there is to see of it.

## Along the way (from the UI/UX review)

- A popup no longer lands on the control it hangs off: it keeps to the strip above or below it, so the routine it is about stays readable (at 390×844 the popup used to swallow the whole routine). Measured at 390×844, 820×1180, 1280×800 and 1920×1080: 0% of the chip covered, down from 100%.
- While a popup is open, the control it belongs to is outlined in that control's own color — the popup *is* that control, opened up, and the outline going away is what says the editor has moved on.
- A popup no longer reaches over the module button strip on the right (36px over it at 1280×800 before). It was placed by a size that did not include its own padding and border, and it can still change size after being placed — both are handled now.
- The picker button reads **Click a widget in the room…** while armed instead of `click a widget...`, and its tooltip says *room* where the button says room (it said *table*).
- The two hard-coded `color: gray` in `popup.css` follow `--textColor` at 0.7 opacity now, like the popup title does, so they stay readable in both themes.
- A popup no longer scrolls where one of its lists can be shorter instead: the height it is missing comes off the list of widget ids (or of property names, or of operations), which scrolls on its own anyway. On a short window that used to push the widget picker’s **Use these widgets** button out of the popup, with nothing saying it was there.
- Picking a parent **in the room** works for a multi-selection now. The facade the sidebar renders one through carries the ids of all of them as its own id (`h1,h2`), which is no widget in the room, so the picker's target looked gone: the first click only ended the picking, and the list of ids offered the selected widgets as their own parent.
- An info popup is no longer kept out of the strip its own 14px "i" sits in - that button has nothing to read on it, while the prose wants the height (475px of usable height at 1280x800, 780px now). Keeping a *parameter* popup off its chip is what that rule is for.
- The "... set to X on Y" note goes through the very check the write goes through (`widgetStillExists`), so it cannot claim a value the sidebar then drops - the window a dissolving pile spends in the room is exactly that case. A note that has faded to nothing no longer eats clicks either.
- Leaving edit mode closes the popups and ends a room pick the same way closing the properties module does: the editor is only hidden, so a popup left open lives on inside it.

## Testing

- `npm test` (jest): 580 passed.
- TestCafe `tests/testcafe/editor.js`: 36 passed, including the tests below; `routines.js` and `toolbar.js` also pass.
- *"A routine parameter popup goes away with the widget it belongs to"* — clicking another widget in the room closes the popup and selects that widget; a rubber band while a picker runs (the only way a pick reaches `setSelection()`) picks the widget and keeps the popup through the selection the picker restores; an armed room picker still takes a plain click and keeps the popup open.
- *"An editor popup does not outlive the widget it belongs to without a click either"* — the color picked on a routine is written to that routine when clicking another widget closes the popup; removing the edited widget closes the popup with no click involved, even with a room picker armed; and a new state from the server carrying the same widget ids does the same, which is the case the id-based check got wrong.
- *"A property info tip goes away with the widget it explains"* — the same for the sidebar's info tips, which have no other way of noticing.
- *“A long list of widget ids shrinks instead of pushing the apply button out of the popup”* — at 1280×500 with 30 holders in the room, the popup does not scroll and “Use these widgets” is inside it; on the old code the button sat 105px below its bottom edge.
- The two new assertions from the review: the acknowledgement after the color is written to the widget that left the screen, and the one for an armed picker that ends because its widget is gone.
- *"An armed picker does not keep a popup open when the sidebar moves the editor on"* — with **Pick in the room** armed, "Edit line …" in the widget header selects the line: the popup goes and the picker is disarmed. The same through the JSON editor, which also replaces the module the popup hangs off. Leaving edit mode altogether with the picker armed does the same.
- jest: *"a widget that is on its way out of the room does not get credit for the write"* (the note reads *"was not set ..."* for a widget with `isBeingRemoved`), *"the parent picker of a multi-selection picks in the room"* and *"a picker of a multi-selection ends when one of its widgets is gone"*.
- Each of them fails without the corresponding part of the change.
- Verified by hand in a browser as well (open `MOVE`'s `from` popup on a button, click a holder in the room → the popup is gone and the holder is being edited).

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3103/pr-test (or any other room on that server)




