### PR TITLE
Render the edit-mode "Pick icon" picker as a modal above the room instead of behind it

### DIFF
--- a/client/css/editor/deckeditor.css
+++ b/client/css/editor/deckeditor.css
@@ -474,12 +474,20 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   z-index: 30;
 }
 
-/* The sound picker is opened from the JSON editor, which is reachable while the deck editor covers the play
-   area, so it is moved into #editor as well (see initializeDOM). It has no smaller box to be constrained to
-   there, so float it over the whole editor like the rule above - otherwise #deckEditor (z-index 1) hides it. */
+/* Both pickers are opened from the JSON editor and the properties panel, which stay reachable while the deck
+   editor covers the play area, so they are moved into #editor (see initializeDOM) and the symbol picker is
+   left there when the deck editor closes (see close()) - from then on that is where edit mode opens it. In
+   #editor they have no box and no stacking order of their own, so .overlay's own 100%/100% makes them cover
+   the whole window and #roomArea (position: fixed, z-index 1) paints the board on top of the open picker.
+   Give them the deck editor's box instead - below the toolbar, beside the sidebar - and float them above the
+   sidebar (2), the toolbar (3) and the deck editor's dialogs (20). */
+#editor > #symbolPickerOverlay,
 #editor > #audioPickerOverlay {
   position: fixed;
-  inset: 0;
+  top: var(--editToolbarHeight);
+  right: var(--editSidebarWidth);
+  bottom: 0;
+  left: 0;
   width: auto;
   height: auto;
   z-index: 30;

--- a/client/css/editor/deckeditor.css
+++ b/client/css/editor/deckeditor.css
@@ -462,27 +462,18 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   z-index: 20;
 }
 
-/* Opening the picker from an icon property inside one of the dialogs above parks it next to that dialog
-   (pickSymbolKeepingOverlay), where the rule above no longer applies and it would render behind #deckEditor
-   (z-index 1). Float it over the whole editor instead: above the sidebar (2), the toolbar (3) and the
-   dialog it was opened from (20). */
-#symbolPickerOverlay.symbolPickerAboveEditor {
-  position: fixed;
-  inset: 0;
-  width: auto;
-  height: auto;
-  z-index: 30;
-}
-
 /* Both pickers are opened from the JSON editor and the properties panel, which stay reachable while the deck
    editor covers the play area, so they are moved into #editor (see initializeDOM) and the symbol picker is
-   left there when the deck editor closes (see close()) - from then on that is where edit mode opens it. In
-   #editor they have no box and no stacking order of their own, so .overlay's own 100%/100% makes them cover
-   the whole window and #roomArea (position: fixed, z-index 1) paints the board on top of the open picker.
-   Give them the deck editor's box instead - below the toolbar, beside the sidebar - and float them above the
-   sidebar (2), the toolbar (3) and the deck editor's dialogs (20). */
+   left there when the deck editor closes (see close()) - from then on that is where edit mode opens it.
+   Opening the picker from an icon property inside one of the dialogs above parks it next to that dialog
+   instead (pickSymbolKeepingOverlay, which marks it with .symbolPickerAboveEditor) - same situation.
+   Neither spot gives them a box or a stacking order of their own, so .overlay's own 100%/100% makes them
+   cover the whole window and #roomArea (position: fixed, z-index 1) paints the board on top of the open
+   picker. Give them the deck editor's box instead - below the toolbar, beside the sidebar - and float them
+   above the sidebar (2), the toolbar (3) and the deck editor's dialogs (20). */
 #editor > #symbolPickerOverlay,
-#editor > #audioPickerOverlay {
+#editor > #audioPickerOverlay,
+#symbolPickerOverlay.symbolPickerAboveEditor {
   position: fixed;
   top: var(--editToolbarHeight);
   right: var(--editSidebarWidth);

--- a/client/css/fonts.css
+++ b/client/css/fonts.css
@@ -395,17 +395,29 @@
    the media queries at the end of this block cannot see - so make it a container and query that instead. */
 #symbolPickerOverlay {
   container: symbolPicker / size;
+  /* .overlay's own 5% 10% is a percentage of the WIDTH, in both directions: the wider the host box the more
+     vertical padding the picker gets - ~90px of dead band above the title in #editor at 1920px, while the
+     small boxes that actually need every pixel of height get almost none. The column below is centered and
+     capped at 1000px anyway, so the horizontal padding only matters once the box is narrower than that. */
+  padding: 20px 10px;
 }
 
-/* In a short box the hint is what has to go: it explains the list but costs more height than the list is
-   then left with (114px of a 250px box). Same breakpoint as the media queries below, and the same
-   compensation .fewResults makes when it hides the hint for the same reason. */
-@container symbolPicker (max-height: 375px) {
+/* In a short or a narrow box the hint is what has to go: it explains the list but costs more height than the
+   list is then left with - 114px of a 250px-tall box, and 700px of a 931px-tall one when the box is only
+   204px wide and every line of the hint holds two words. Same breakpoints as the media queries below, and
+   the same compensation .fewResults makes when it hides the hint for the same reason. */
+@container symbolPicker (max-height: 375px), symbolPicker (max-width: 600px) {
   #symbolPickerOverlay p[icon] {
     display: none;
   }
   #symbolPickerOverlay input {
     margin-bottom: 20px;
+  }
+  /* the close button is positioned over the right edge of the title, which the centered "Pick icon" runs
+     into once the box is this narrow */
+  #symbolPickerOverlay h1 {
+    font-size: 20px;
+    margin: 0 40px 10px;
   }
 }
 
@@ -424,6 +436,15 @@
   flex-direction: column;
   flex: 1;
   min-height: 0;
+}
+
+/* div[icon] clips (overflow: hidden, for its rounded corners and its watermark glyph), so squeezing it below
+   what it holds drops the bottom of the list on the floor with nothing left to scroll. Keep it at least as
+   tall as the reduced layout needs - its own padding, the search field, and the list's floor below. The
+   plain wrapper around it does not clip, so a box that cannot afford even this overflows the overlay, which
+   scrolls (.overlay is overflow: auto), instead of losing the rest of the list. */
+#symbolPickerOverlay div[icon] {
+  min-height: 210px;
 }
 
 #symbolPickerOverlay > button {
@@ -462,6 +483,22 @@
 }
 #symbolPickerOverlay.bigPreviews.fewResults #symbolList {
   --symbolSize: 64px;
+}
+
+/* a search that matches nothing left an empty card without saying why - take the list's place instead */
+#symbolNoResults {
+  display: none;
+}
+#symbolPickerOverlay.noResults #symbolList {
+  display: none;
+}
+#symbolPickerOverlay.noResults #symbolNoResults {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  word-wrap: anywhere;
 }
 
 #symbolPickerOverlay h1 {

--- a/client/css/fonts.css
+++ b/client/css/fonts.css
@@ -388,9 +388,25 @@
 
 /* The picker is a dialog, not a document: the title, the search field and the hint stay put and the symbol
    list is the only part that scrolls. The whole overlay scrolling meant that scrolling down to an icon also
-   scrolled the search field and the close button off the top of the screen. */
+   scrolled the search field and the close button off the top of the screen. .overlay's own overflow: auto
+   stays as a fallback for a box too short even for the reduced layout below.
+   How much room the parts have is decided by the picker's own box, not by the window: it is opened in three
+   hosts of very different sizes (the room overlays, the deck editor's card column, #editor), which is what
+   the media queries at the end of this block cannot see - so make it a container and query that instead. */
 #symbolPickerOverlay {
-  overflow: hidden;
+  container: symbolPicker / size;
+}
+
+/* In a short box the hint is what has to go: it explains the list but costs more height than the list is
+   then left with (114px of a 250px box). Same breakpoint as the media queries below, and the same
+   compensation .fewResults makes when it hides the hint for the same reason. */
+@container symbolPicker (max-height: 375px) {
+  #symbolPickerOverlay p[icon] {
+    display: none;
+  }
+  #symbolPickerOverlay input {
+    margin-bottom: 20px;
+  }
 }
 
 /* the title and the list are separate children, so they need the same width to line up - the close button
@@ -440,7 +456,9 @@
   overflow-y: auto;
   word-wrap: anywhere;
   flex: 1;
-  min-height: 0;
+  /* the list takes what is left over, but never less than about four rows: with min-height: 0 whatever sits
+     above it could squeeze it to nothing, and since it is the only scroller that leaves no icon reachable */
+  min-height: 120px;
 }
 #symbolPickerOverlay.bigPreviews.fewResults #symbolList {
   --symbolSize: 64px;

--- a/client/css/fonts.css
+++ b/client/css/fonts.css
@@ -553,15 +553,11 @@
   background: var(--url);
 }
 
+/* every icon and category heading carries data-family=image|font, so the restriction to one of the two
+   families is a single pair of selectors - and symbols.js can count what is left with the same attribute */
 #symbolPickerOverlay .hidden,
-#symbolPickerOverlay.hideImages h2.imageCategory,
-#symbolPickerOverlay.hideImages .emoji-color,
-#symbolPickerOverlay.hideImages .gameicons,
-#symbolPickerOverlay.hideFonts h2.fontCategory,
-#symbolPickerOverlay.hideFonts .symbols,
-#symbolPickerOverlay.hideFonts .material-symbols,
-#symbolPickerOverlay.hideFonts .material-symbols-nofill,
-#symbolPickerOverlay.hideFonts .emoji-monochrome {
+#symbolPickerOverlay.hideImages [data-family=image],
+#symbolPickerOverlay.hideFonts [data-family=font] {
   display: none;
 }
 

--- a/client/css/fonts.css
+++ b/client/css/fonts.css
@@ -386,6 +386,30 @@
 
 
 
+/* The picker is a dialog, not a document: the title, the search field and the hint stay put and the symbol
+   list is the only part that scrolls. The whole overlay scrolling meant that scrolling down to an icon also
+   scrolled the search field and the close button off the top of the screen. */
+#symbolPickerOverlay {
+  overflow: hidden;
+}
+
+/* the title and the list are separate children, so they need the same width to line up - the close button
+   sits at the right edge of the title */
+#symbolPickerOverlay > .titleWithCloseButton,
+#symbolPickerOverlay > div:not(.titleWithCloseButton) {
+  width: 100%;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+#symbolPickerOverlay > div:not(.titleWithCloseButton),
+#symbolPickerOverlay div[icon] {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
 #symbolPickerOverlay > button {
   position: absolute;
   right: 10px;
@@ -415,6 +439,8 @@
   overflow-x: hidden;
   overflow-y: auto;
   word-wrap: anywhere;
+  flex: 1;
+  min-height: 0;
 }
 #symbolPickerOverlay.bigPreviews.fewResults #symbolList {
   --symbolSize: 64px;

--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -418,7 +418,12 @@ i.error   { color: var(--textHighlightColor3); font-weight: bold; }
   white-space: normal;
 }
 
-#editor:hover #jeWidgetLayers, .editorModule:hover #jeWidgetLayers, body.usedTouch #jeWidgetLayers {
+/* This panel covers the command buttons underneath it and only lists what the cursor is hovering in the room,
+   so it hides while the cursor is over the editor. An open overlay (the symbol picker, a dialog) takes the
+   cursor away from the room in the same way, but does not necessarily put it over the editor - without
+   body.overlayActive the panel stayed up over the commands for as long as the overlay was open. */
+#editor:hover #jeWidgetLayers, .editorModule:hover #jeWidgetLayers, body.usedTouch #jeWidgetLayers,
+body.overlayActive #jeWidgetLayers {
   display: none;
 }
 

--- a/client/js/editor/propertyInputs.js
+++ b/client/js/editor/propertyInputs.js
@@ -233,8 +233,8 @@ async function pickSymbolKeepingOverlay(element, type='all') {
   const picker = $('#symbolPickerOverlay');
   const pickerParent = picker.parentNode;
   hostOverlay.parentNode.appendChild(picker);
-  // Where it lands has no stacking rule of its own, so it would end up behind the deck editor: the class
-  // floats it over the whole editor (see deckeditor.css) for as long as it is parked here.
+  // Where it lands has no box or stacking rule of its own, so it would end up behind the deck editor: the
+  // class gives it the editor's box and floats it above (see deckeditor.css) while it is parked here.
   picker.classList.add('symbolPickerAboveEditor');
 
   // Whatever happens, the user must get their dialog back: the picker's symbol list is fetched, so it can also

--- a/client/js/symbols.js
+++ b/client/js/symbols.js
@@ -129,7 +129,7 @@ export async function pickSymbol(type='all', bigPreviews=true, closeOverlay=true
     $('#symbolPickerOverlay').classList.toggle('bigPreviews', bigPreviews);
     $('#symbolPickerOverlay').classList.toggle('hideFonts',   type=='images');
     $('#symbolPickerOverlay').classList.toggle('hideImages',  type=='fonts');
-    $('#symbolPickerOverlay').scrollTop = 0;
+    $('#symbolList').scrollTop = 0; // the list is built once and is the picker's scroller, so open it at the top
     $('#symbolPickerOverlay input').value = '';
     $('#symbolPickerOverlay input').focus();
     $('#symbolPickerOverlay input').onkeyup();
@@ -226,7 +226,7 @@ export function addRichtextControls(dom) {
     const range = window.getSelection().getRangeAt(0);
 
     showStatesOverlay('symbolPickerOverlay');
-    $('#symbolPickerOverlay').scrollTop = 0;
+    $('#symbolList').scrollTop = 0;
     for(const c of [ 'bigPreviews', 'hideFonts', 'hideImages' ])
       $('#symbolPickerOverlay').classList.remove(c);
     $('#symbolPickerOverlay input').value = '';

--- a/client/js/symbols.js
+++ b/client/js/symbols.js
@@ -114,7 +114,10 @@ export async function loadSymbolPicker() {
         toggleClass(icon, 'hidden', !icon.dataset.keywords.match(text));
       for(const title of $a('#symbolList h2'))
         toggleClass(title, 'hidden', text);
-      toggleClass($('#symbolPickerOverlay'), 'fewResults', $a('#symbolList i:not(.hidden)').length < 100);
+      const matches = $a('#symbolList i:not(.hidden)').length;
+      toggleClass($('#symbolPickerOverlay'), 'fewResults', matches < 100);
+      toggleClass($('#symbolPickerOverlay'), 'noResults', !matches);
+      $('#symbolNoResults').textContent = `No icons match "${$('#symbolPickerOverlay input').value}".`;
     };
   }
 }

--- a/client/js/symbols.js
+++ b/client/js/symbols.js
@@ -72,12 +72,12 @@ export async function loadSymbolPicker() {
     for(const [ category, symbols ] of Object.entries(symbolData)) {
       if(category == 'Emoji - Flags')
         continue;
-      list += `<h2 class="${category.match(/Material|VTT|Emoji/)?'fontCategory':'imageCategory'}">${category}</h2>`;
+      list += `<h2 data-family="${category.match(/Material|VTT|Emoji/)?'font':'image'}">${category}</h2>`;
       for(let [ symbol, keywords ] of Object.entries(symbols)) {
         if(symbol.includes('/')) {
           const gameIconsIndex = keywords.shift();
           // increase resource limits in /etc/ImageMagick-6/policy.xml to 8GiB and then: montage -background none assets/game-icons.net/*/*.svg -geometry 48x48+0+0 -tile 60x assets/game-icons.net/overview.png
-          list += `<i class="gameicons" title="game-icons.net: ${symbol}" data-type="game-icons" data-symbol="${symbol}" data-keywords="${symbol.split('/')[1]},${keywords.join().toLowerCase()}" style="--x:${gameIconsIndex%60};--y:${Math.floor(gameIconsIndex/60)};--url:url('i/game-icons.net/${symbol}.svg')"></i>`;
+          list += `<i class="gameicons" data-family="image" title="game-icons.net: ${symbol}" data-type="game-icons" data-symbol="${symbol}" data-keywords="${symbol.split('/')[1]},${keywords.join().toLowerCase()}" style="--x:${gameIconsIndex%60};--y:${Math.floor(gameIconsIndex/60)};--url:url('i/game-icons.net/${symbol}.svg')"></i>`;
         } else {
           const hasNoFillVariant = symbol.match(/ \(FILL\+NOFILL\)$/);
           symbol = symbol.replace(/ \(FILL\+NOFILL\)$/, '');
@@ -88,21 +88,21 @@ export async function loadSymbolPicker() {
             className = 'material-symbols';
           if(className != 'emoji-monochrome' || !skipForNotoMonochrome(symbol)) {
             const symbolToReturn = className == 'emoji-monochrome' ? `(${symbol})` : symbol;
-            list += `<i class="${className}" title="${className}: ${symbol}" data-type="${className}" data-symbol="${symbolToReturn}" data-keywords="${symbol},${keywords.join().toLowerCase()}" style="--url:url('i/noto-emoji/emoji_u${emojiToFilename(symbol)}.svg')">${toNotoMonochrome(symbol)}</i>`;
+            list += `<i class="${className}" data-family="font" title="${className}: ${symbol}" data-type="${className}" data-symbol="${symbolToReturn}" data-keywords="${symbol},${keywords.join().toLowerCase()}" style="--url:url('i/noto-emoji/emoji_u${emojiToFilename(symbol)}.svg')">${toNotoMonochrome(symbol)}</i>`;
           }
           if(className == 'material-symbols' && hasNoFillVariant)
-            list += `<i class="material-symbols-nofill" title="material-symbols-nofill: ${symbol}" data-type="material-symbols-nofill" data-symbol="${symbol}_NOFILL" data-keywords="${symbol},${keywords.join().toLowerCase()}">${symbol}</i>`;
+            list += `<i class="material-symbols-nofill" data-family="font" title="material-symbols-nofill: ${symbol}" data-type="material-symbols-nofill" data-symbol="${symbol}_NOFILL" data-keywords="${symbol},${keywords.join().toLowerCase()}">${symbol}</i>`;
         }
       }
     }
     for(const [ category, symbols ] of Object.entries(symbolData)) {
       if(category.match(/Emoji/)) {
-        list += `<h2 class="imageCategory">${category}</h2>`;
+        list += `<h2 data-family="image">${category}</h2>`;
         for(const [ symbol, keywords ] of Object.entries(symbols)) {
           let className = 'emoji-color';
           if(category == 'Emoji - Flags')
             className += ' emojiFlag';
-          list += `<i class="${className}" title="${className}: ${symbol}" data-type="${className}" data-symbol="${symbol}" data-keywords="${symbol},${keywords.join().toLowerCase()}" style="--url:url('i/noto-emoji/emoji_u${emojiToFilename(symbol)}.svg')">${symbol}</i>`;
+          list += `<i class="${className}" data-family="image" title="${className}: ${symbol}" data-type="${className}" data-symbol="${symbol}" data-keywords="${symbol},${keywords.join().toLowerCase()}" style="--url:url('i/noto-emoji/emoji_u${emojiToFilename(symbol)}.svg')">${symbol}</i>`;
         }
       }
     }
@@ -114,7 +114,11 @@ export async function loadSymbolPicker() {
         toggleClass(icon, 'hidden', !icon.dataset.keywords.match(text));
       for(const title of $a('#symbolList h2'))
         toggleClass(title, 'hidden', text);
-      const matches = $a('#symbolList i:not(.hidden)').length;
+      // the picker can be restricted to one family of icons, which hides the other one in CSS instead of
+      // adding .hidden - so only counting the search matches would call a blank card "few" or "some results"
+      const hiddenFamily = $('#symbolPickerOverlay').classList.contains('hideImages') ? 'image'
+                         : $('#symbolPickerOverlay').classList.contains('hideFonts')  ? 'font' : null;
+      const matches = $a(`#symbolList i:not(.hidden)${hiddenFamily ? `:not([data-family=${hiddenFamily}])` : ''}`).length;
       toggleClass($('#symbolPickerOverlay'), 'fewResults', matches < 100);
       toggleClass($('#symbolPickerOverlay'), 'noResults', !matches);
       $('#symbolNoResults').textContent = `No icons match "${$('#symbolPickerOverlay input').value}".`;

--- a/client/room.html
+++ b/client/room.html
@@ -535,11 +535,12 @@
       </div>
       <div>
         <div icon="add_reaction">
-          <input placeholder="Search" />
-          <p icon="blur_on">For performance reasons, <span>game-icons are displayed in low resolution and </span>emoji are displayed in your browser font. Filter to less than 100 images or hover over an icon to show the actual image that will be used.</p>
+          <input placeholder="Search icons (sword, heart, dice, …)" />
+          <p icon="blur_on">Click an icon to pick it. Emoji use your browser font<span> and game-icons are previewed in low resolution</span>: hover one, or narrow the search below 100 results, to see the real image.</p>
           <div id="symbolList">
             Loading...
           </div>
+          <div id="symbolNoResults"></div>
         </div>
       </div>
     </div>

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -793,10 +793,24 @@ test('Deck editor: symbol pickers and JSON fallback', async t => {
     .click('#deckEditorTreeAdd')
     .click('#deckEditorAddImage')
     .expect(Selector('#symbolPickerOverlay').visible).ok()
+    // this picker shows images only, so a search that only a font icon answers has to say so instead of
+    // showing the empty list ("10k" is a material symbol and matches nothing among the images)
+    .typeText('#symbolPickerOverlay input', '10k')
+    .expect(Selector('#symbolNoResults').visible).ok()
+    .expect(Selector('#symbolList').visible).notOk()
+    .selectText('#symbolPickerOverlay input')
+    .pressKey('delete')
+    .expect(Selector('#symbolNoResults').visible).notOk()
     .click(Selector('#symbolList .gameicons').nth(0))
     .expect(getObjectTypeCounts(deckID)).eql({ image: 3, icon: 0 })
     .click('#deckEditorAddIcon')
     .expect(Selector('#symbolPickerOverlay').visible).ok()
+    // the same search in the unrestricted picker does find its one match
+    .typeText('#symbolPickerOverlay input', '10k')
+    .expect(Selector('#symbolNoResults').visible).notOk()
+    .expect(Selector('#symbolList i:not(.hidden)').count).eql(1)
+    .selectText('#symbolPickerOverlay input')
+    .pressKey('delete')
     .click(Selector('#symbolList .material-symbols').nth(0))
     .expect(getObjectTypeCounts(deckID)).eql({ image: 3, icon: 1 });
 
@@ -807,6 +821,33 @@ test('Deck editor: symbol pickers and JSON fallback', async t => {
     .pressKey('esc')
     .pressKey('esc');
   await compareState(t, '5019957515d8552f09fed2340a4e1d3d');
+});
+
+test('The symbol picker says an image-only search found nothing', async t => {
+  await setRoomState({
+    // the "Pick a symbol" button only shows up while the text is in symbol mode, which the class decides
+    w: { id: 'w', type: 'basic', x: 200, y: 200, text: 'home', classes: 'material-symbols' }
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  // that picker offers the font icons only, so a search that only an image answers ("abbot" is a
+  // game-icon) leaves the list empty and has to explain that rather than show a blank card
+  await t
+    .click('#editButton')
+    .click('#editorSidebar [icon=tune]')
+    .click('#w_w')
+    .click(Selector('#editorModuleTopLeft button[icon=emoji_symbols]'))
+    .expect(Selector('#symbolPickerOverlay').visible).ok()
+    .typeText('#symbolPickerOverlay input', 'abbot')
+    .expect(Selector('#symbolNoResults').visible).ok()
+    .expect(Selector('#symbolNoResults').innerText).contains('abbot')
+    .expect(Selector('#symbolList').visible).notOk()
+    .typeText('#symbolPickerOverlay input', '10k', { replace: true })
+    .expect(Selector('#symbolNoResults').visible).notOk()
+    .expect(Selector('#symbolList .material-symbols').filterVisible().count).eql(1)
+    .click('#symbolPickerOverlay [icon=close]')
+    .expect(Selector('#symbolPickerOverlay').visible).notOk();
 });
 
 test('Deck editor: breadcrumb undo and redo', async t => {


### PR DESCRIPTION
The edit-mode **"Pick icon"** picker rendered across the whole window with the game board painted on top of it, so the icon list was half covered and the picker looked like it was sitting *behind* the room. This makes it render as a proper modal above the room, scoped to the editor's content area, with only the symbol list scrolling — and makes that layout hold up in the small and narrow boxes the picker is also opened in.

### What was wrong

The shared symbol picker normally lives in the room overlays (`#roomArea`). Opening the deck editor moves it into `#editor` (`DeckEditor.initializeDOM`) and closing it deliberately leaves it there, so that a picker opened from the JSON editor or the properties panel covers the editor instead of being squeezed into the small room box. From that point on, every "Pick icon" in edit mode opens from `#editor`.

But nothing in `#editor` gave it a box or a stacking order of its own, so `.overlay`'s own `height/width: 100%` stretched it across the whole window, and `#roomArea` (`position: fixed; z-index: 1`) painted the board over the open picker. The sound picker next to it already had a rule for exactly this (`#editor > #audioPickerOverlay`); the symbol picker never got one.

### What changed

- `client/css/editor/deckeditor.css` — the `#editor > #audioPickerOverlay` rule now covers `#symbolPickerOverlay` as well, and both are scoped to the deck editor's own box (below the toolbar, beside the sidebar) instead of the whole window, so they are sized like the other editor overlays and float above the sidebar/toolbar/dialogs.
- `client/css/fonts.css` — the picker behaves like a dialog: the title, the search field and the hint stay put in a 1000px-wide centered column and `#symbolList` is the only part that scrolls. Previously the whole overlay scrolled, so scrolling down to an icon took the search field and the close button off the top of the screen. This applies in every host (room overlays, deck editor card column, editor), so the picker in the small room box got noticeably more usable too.
  - The list keeps a floor of about four rows so it can never be squeezed to nothing, and the card around it is never squeezed below what it holds — a box that cannot afford even that overflows the overlay, which scrolls, rather than clipping the bottom of the list away with no way to reach it.
  - In a **short or narrow** box the hint paragraph is dropped and the title shrinks so the close button stops sitting on top of it. That breakpoint is a container query on the picker's own box, because the picker is opened in three hosts of very different sizes and the window size says nothing about which one it is in.
  - The picker gets its own `padding: 20px 10px` instead of inheriting `.overlay`'s `padding: 5% 10%`. That percentage resolves against the box **width** in both directions, so the wider the host the more vertical padding the picker got — ~90px of dead band above the title in `#editor` at 1920px, while the small boxes that need the height got almost none.
- `client/room.html` + `client/js/symbols.js` — the hint now leads with what the dialog is for ("Click an icon to pick it.") instead of with the low-resolution caveat, the search placeholder gives examples, and a search that matches nothing shows `No icons match "…"` instead of a large blank card. That count follows the picker's image-only / font-only restriction, so a search whose only hits belong to the hidden family counts as empty too — every icon and category heading carries `data-family=image|font`, which is also what the restriction itself is now written against.
- `client/js/symbols.js` — the picker opens at the top of the icon list again: the reset used to be on the overlay, which is no longer the scroller.
- `client/css/jsonedit.css` — the JSON editor's widget-layers panel ("This will show you the widgets under your cursor…") is now hidden while an overlay is open. It lists what the cursor hovers in the room and already hides while the cursor is over the editor, but an open overlay takes the cursor away from the room without necessarily putting it over the editor, so it stayed up and covered the command buttons underneath it (visible on the right of the report screenshot).

No state, no widget/routine properties — CSS plus a few lines of client JS for the empty-search message and to keep the existing "open at the top" behaviour working now that the list is the scroller.

### Before / after

Same steps in both: open a room with a deck, enter edit mode, open the deck editor once and close it again, open the JSON editor and the widget properties panel, select a widget, open its Icon property and click "Show all".

| | |
|---|---|
| before | https://agent.virtualtabletop.io/reports/pr/1535013339619655913/pick-icon-before.png |
| after | https://agent.virtualtabletop.io/reports/pr/1535013339619655913/pick-icon-after.png |
| after, list scrolled (search + close stay put) | https://agent.virtualtabletop.io/reports/pr/1535013339619655913/pick-icon-after-scrolled.png |
| after, picker inside the deck editor (unchanged host, still constrained to the card column) | https://agent.virtualtabletop.io/reports/pr/1535013339619655913/pick-icon-after-deckeditor.png |

The narrow host at tablet portrait (the deck editor's card column, a 204×931 box), before and after — the icon list goes from a 77px strip under a 703px hint to the whole column:

| | |
|---|---|
| before | https://agent.virtualtabletop.io/reports/pr/1535013339619655913/ui-review-2/before-deckcol-820x1180.png |
| after | https://agent.virtualtabletop.io/reports/pr/1535013339619655913/ui-review-2/after-deckcol-820x1180.png |

`#symbolList` clientHeight measured in Chromium, all three hosts, before this PR → after:

| host | viewport | picker box | before | after |
|---|---|---|---|---|
| deck editor card column | 820×1180 | 204×931 | 120 (43px clipped) | 776 |
| deck editor card column | 1280×800 | 664×539 | 236 | 282 |
| deck editor card column | 1920×1080 | 1212×819 | 499 | 581 |
| room overlays | 390×844 | 354×221 | 120 (26px clipped) | 169 (+ overlay scrolls) |
| room overlays | 1280×800 | 640×400 | 196 | 245 |
| room overlays | 1920×1080 | 960×600 | 287 | 362 |
| `#editor` | 820×1180 | 784×1156 | 838 | 918 |
| `#editor` | 1280×800 | 1244×764 | 438 | 526 |
| `#editor` | 1920×1080 | 1792×1044 | 654 | 806 |

### Testing

- `npm test` — 590 passed.
- `npx testcafe chromium:headless tests/testcafe/editor.js` — 33 passed, including the empty-state checks added to "Deck editor: symbol pickers and JSON fallback" and the new "The symbol picker says an image-only search found nothing".
- Driven manually in a browser: picker opened from the properties panel in all three hosts (room overlays, `#editor`, deck editor card column) at four viewports, scrolled, searched (no matches / few matches / many matches), and an icon picked — the value lands on the widget.
- After merging `main` (which turned on clean-css level 2 and terser top-level mangling, #3089): re-checked that the minified client still ships the picker's `@container symbolPicker` block, its `min-height` floors and the `padding` override in the right order, then re-ran `npx testcafe chromium:headless tests/testcafe/editor.js` **against a minified client** (the combination `production-environment.yml` now runs) — 33 passed — and re-measured `#symbolList` in all three hosts (918 / 526 / 776 px, unchanged).

Reported by a maintainer with this screenshot: https://agent.virtualtabletop.io/reports/screens/pick-icon-overlay-2026-08-06.png


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3105/pr-test (or any other room on that server)


