### PR TITLE
Render each nested routine block once instead of twice per nesting level

### DIFF
--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -3276,7 +3276,10 @@ class RoutineOperationEditor {
       this.notifyChangeListeners(this.operation);
     });
     this.subroutineEditors[property] = routineEditor;
-    dom.append(routineEditor.render());
+    // the constructor already rendered the block into domElement - rendering it a
+    // second time here would do the whole nested subtree twice per level, which
+    // is 2^depth renders for a deeply nested routine
+    dom.append(routineEditor.domElement);
   }
 
   resolveParameter(property) {

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -1526,18 +1526,21 @@ describe('routine editor state handling', () => {
     let routine = [ { func: 'FLIP' } ];
     for(let level = 0; level < 12; level++)
       routine = [ { func: 'IF', operand1: 1, thenRoutine: routine } ];
-    const original = RoutineOperationEditor.prototype.render;
+    // counting on RoutineEditor rather than on the operation editors: it is the
+    // one class that renders a block, so no subclass can render without being
+    // counted here
+    const original = RoutineEditor.prototype.render;
     let renders = 0;
-    RoutineOperationEditor.prototype.render = function(...args) {
+    RoutineEditor.prototype.render = function(...args) {
       renders++;
       return original.apply(this, args);
     };
     try {
       new RoutineEditor({ state: {} }, routine);
     } finally {
-      RoutineOperationEditor.prototype.render = original;
+      RoutineEditor.prototype.render = original;
     }
-    expect(renders).toBe(13); // one per operation
+    expect(renders).toBe(13); // the routine itself plus one per nested block
   });
 
   test('ignores echoes of its own edits but applies remote changes', () => {

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -1520,6 +1520,26 @@ describe('routine editor state handling', () => {
     expect(foreachEditor.domElement.textContent).toContain('Add operations to run for each iteration');
   });
 
+  test('a nested block is rendered once per level, not once per level per level above it', () => {
+    // a block that renders itself again after its editor built it costs 2^depth
+    // renders, which is what made a deeply nested routine take seconds to open
+    let routine = [ { func: 'FLIP' } ];
+    for(let level = 0; level < 12; level++)
+      routine = [ { func: 'IF', operand1: 1, thenRoutine: routine } ];
+    const original = RoutineOperationEditor.prototype.render;
+    let renders = 0;
+    RoutineOperationEditor.prototype.render = function(...args) {
+      renders++;
+      return original.apply(this, args);
+    };
+    try {
+      new RoutineEditor({ state: {} }, routine);
+    } finally {
+      RoutineOperationEditor.prototype.render = original;
+    }
+    expect(renders).toBe(13); // one per operation
+  });
+
   test('ignores echoes of its own edits but applies remote changes', () => {
     const routine = [ { func: 'FLIP' } ];
     const editor = new RoutineEditor({ state: {} }, routine);


### PR DESCRIPTION
The Automations (routine) editor rendered every nested IF/FOREACH block **twice**, so the cost of opening a routine was `2^depth` rather than proportional to the number of operations. A routine nested 13 levels deep produced **8191** operation renders instead of 13. This makes a deeply nested routine open essentially instantly again, with no visual or functional change.

## The cause

`RoutineEditor`'s constructor already renders the block into `this.domElement` (via `setRoutine` → `render`), but `renderSubroutine()` then called `render()` a second time just to get an element to append:

```js
const routineEditor = new RoutineEditor(...);   // renders the whole subtree
...
dom.append(routineEditor.render());             // renders the whole subtree again
```

Every nesting level therefore doubled the work of everything below it. Appending the element the constructor already built removes the second pass; `render()` returns that very same `domElement` after clearing it, so the result is identical.

Profiling (Playwright + CDP sampler) showed no single hot function — the time was spread evenly over `renderSentenceView`, `div`, `createElement`, `addEventListener`, `parseVarStatement` and GC, i.e. ordinary rendering work simply done ~1600× too often. Instrumented render counters confirmed it: **87 cards on screen, 142 729 operation renders**.

## Measured before/after

Headless Chromium, `performance.now()` around the click that expands a routine in the Automations panel (median of 3):

| routine | operations / cards | before | after |
|---|---|---|---|
| the reported example (`sortRoutine`, 8 levels of nesting) | 87 cards | **17 195 ms** | **31 ms** |
| a flat routine of the same length (89 `var` statements) | 89 cards | 9 ms | 12 ms |
| `Rails Before the War` – `modify_values_anchor.onlyVisibleForSeatChangeRoutine` | 80 cards | **600 ms** | **39 ms** |
| `Rails Before the War` – `1_auction_anchor.statusChangeRoutine` | 60 cards | **585 ms** | **25 ms** |
| `Celtic Knots` – `useful.validateHoldersRoutine` | 32 cards | 76 ms | 10 ms |
| all 21 routines of that test room, summed | | **1438 ms** | **124 ms** |

(The reported ~11 s reproduces as ~17 s in headless Chromium in this sandbox — same effect, slower machine.)

## Verification

- The rendered DOM is **byte-identical** before and after: dumped the full `innerHTML` of the expanded Automations panel for the example routine plus **21 real routines** from `Rails Before the War`, `Celtic Knots` and the `Functions - CALL` tutorial, and diffed — no difference.
- Editing still works from deep inside a nested block: parameter chips open their popups, "add operation" opens the operation list, and the outdent button hoists an operation out of the innermost block and writes it back to the widget.
- `npm test` (jest): 1154 passed, including a new regression test that renders a 13-level-deep routine and asserts one block render per nesting level (it reports 8191 without the fix).
- TestCafe `editor.js` (32 tests) and `routines.js` (4 tests) pass locally against Chromium headless.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3106/pr-test (or any other room on that server)
