### PR TITLE
Give every preview widget its own css scope so the deck editor stops showing one card type's colors on all of them

### DIFF
--- a/client/css/editor/deckeditor.css
+++ b/client/css/editor/deckeditor.css
@@ -1846,7 +1846,7 @@ body.deckEditorPanning #deckEditorMain * {
   bottom: 0;
   text-align: center;
   font-size: 12px;
-  opacity: 0.7;
+  opacity: 0.9; /* it is the only hint that the big card is interactive, so it has to be readable */
   padding: 4px 10px;
   pointer-events: none;
 }
@@ -1866,6 +1866,34 @@ body.deckEditorPanning #deckEditorMain * {
   flex-shrink: 0;
 }
 
+/* A deck of 13 (let alone 52) card types is far wider than the strip, so it scrolls sideways - and since every
+   tile now carries its own card type's colors, the strip is the fastest way to find a type by sight, which it
+   can only be if it doesn't look like it ends where its box does. The platform draws an overlay scrollbar that
+   is invisible while the strip sits still, so fade out whichever edge still has tiles behind it (the classes
+   come from updateStripOverflow). Sticky flex items with a negative margin: pinned to the visible edge without
+   adding to the scrollable width, and above the preview cards' own z-index (1000000). */
+#deckEditorStrip.deckEditorStripMoreLeft::before,
+#deckEditorStrip.deckEditorStripMoreRight::after {
+  content: '';
+  position: sticky;
+  flex: 0 0 48px;
+  align-self: stretch;
+  z-index: 1000002;
+  pointer-events: none;
+}
+
+#deckEditorStrip.deckEditorStripMoreLeft::before {
+  left: -10px; /* cancels the strip's own padding, so the fade reaches its edge */
+  margin-right: -53px; /* fade width plus the flex gap */
+  background: linear-gradient(to right, var(--backgroundColor), transparent);
+}
+
+#deckEditorStrip.deckEditorStripMoreRight::after {
+  right: -10px;
+  margin-left: -53px;
+  background: linear-gradient(to left, var(--backgroundColor), transparent);
+}
+
 .deckEditorStripCard {
   display: flex;
   flex-direction: column;
@@ -1883,8 +1911,15 @@ body.deckEditorPanning #deckEditorMain * {
   border-color: var(--backgroundHighlightColor1);
 }
 
+/* The tiles are as saturated as the card types they show, so an outline alone is easy to lose among them: the
+   selected tile also gets the plate and the bold label. */
 .deckEditorStripCard.selected {
   border-color: var(--textHighlightColor2);
+  background: var(--backgroundHighlightColor1);
+}
+
+.deckEditorStripCard.selected > span {
+  font-weight: bold;
 }
 
 .deckEditorStripCard.selectedInactive {

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -499,10 +499,13 @@ class DeckEditor {
     }, { passive: false });
     $('#deckEditorMain').addEventListener('touchend', e=>{ if(e.touches.length < 2) pinchStartDist = 0; if(!e.touches.length) touchPanning = false; });
 
+    $('#deckEditorStrip').addEventListener('scroll', _=>this.updateStripOverflow());
+
     window.addEventListener('resize', _=>{
       if(this.isOpen()) {
         this.renderMain();
         this.updateDragToolbar();
+        this.updateStripOverflow();
       }
     });
     window.addEventListener('keydown', e=>this.onKeyDown(e));
@@ -1428,7 +1431,7 @@ class DeckEditor {
     if(!this.deck())
       return;
     if(this.deckSymbolSelected)
-      return div(container, 'deckEditorEmpty', '<p>Edit the default properties of every card in this deck to the right, or select a card type below to edit that card.</p>');
+      return div(container, 'deckEditorEmpty', '<p>Edit the default properties of every card in this deck in the properties panel, or select a card type in the "Card types" strip to edit that card.</p>');
     if(this.cardType === null)
       return div(container, 'deckEditorEmpty', '<p>This deck does not have any card types yet. Add one using the button in the bottom strip.</p>');
     if(!this.faceTemplates.length)
@@ -1904,7 +1907,7 @@ class DeckEditor {
     const prevScroll = strip.scrollLeft; // rebuilding the tiles must not snap the strip back to the start
     strip.innerHTML = '';
     if(!this.deck())
-      return;
+      return this.updateStripOverflow(); // an empty strip hides nothing behind either edge
 
     // The card-type toolbar's copy/delete need a selected card type; "± All" needs at least one card type.
     $('#deckEditorStripCopy').disabled = this.cardType === null;
@@ -1963,7 +1966,7 @@ class DeckEditor {
       };
       // Per-card-type "cards in game" count with +/- right under the tile.
       const count = widgetFilter(w=>w.get('deck') == this.deckID && w.get('type') == 'card' && w.get('cardType') == cardType).length;
-      const countRow = div(button, 'deckEditorStripCount', `<button icon=remove title="One fewer card of this type"></button><span class=deckEditorStripCountVal>${count}</span><button icon=add title="One more card of this type"></button>`);
+      const countRow = div(button, 'deckEditorStripCount', `<button icon=remove title="One fewer card of this type"></button><span class=deckEditorStripCountVal title="Cards of this type in the game">${count}</span><button icon=add title="One more card of this type"></button>`);
       countRow.draggable = false;
       countRow.onmousedown = e=>e.stopPropagation();
       countRow.ondragstart = e=>{ e.preventDefault(); e.stopPropagation(); };
@@ -1979,6 +1982,15 @@ class DeckEditor {
     if(selectedTile && selectedTile.scrollIntoView && this.stripScrolledTo !== selectionKey)
       selectedTile.scrollIntoView({ block: 'nearest', inline: 'nearest' });
     this.stripScrolledTo = selectionKey;
+    this.updateStripOverflow();
+  }
+
+  // Which side of the strip still has card types hidden behind its edge, for the fades in deckeditor.css.
+  updateStripOverflow() {
+    const strip = $('#deckEditorStrip');
+    const hidden = strip.scrollWidth - strip.clientWidth;
+    strip.classList.toggle('deckEditorStripMoreLeft',  hidden > 1 && strip.scrollLeft > 1);
+    strip.classList.toggle('deckEditorStripMoreRight', hidden > 1 && strip.scrollLeft < hidden - 1);
   }
 
   renderSidebar() {
@@ -3368,7 +3380,7 @@ class DeckEditor {
     if(!hint)
       return;
     const show = this.deck() && !this.deckSymbolSelected && this.selectedObject === null && this.faceTemplates.length;
-    hint.textContent = show ? 'Click a face object above or on the list to the left to select, edit, or drag it around.' : '';
+    hint.textContent = show ? 'Click a face object on the card, or in the "Face objects" list, to select, edit, or drag it around.' : '';
     hint.classList.toggle('active', !!show);
   }
 

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -1,6 +1,16 @@
+// Counts the cards that were created without an id so each of them still gets a css scope of its own - see
+// the cssScope below.
+let unnamedCardCount = 0;
+
 class Card extends Widget {
   constructor(id) {
     super(id);
+
+    // The css of an html face object is written into a style element and scoped to this class (see
+    // createFaces). A card in a room has a unique id, but the read-only copies the editor renders (deck
+    // editor, card type list, widget picker) are all created without one - they would end up sharing a class,
+    // so the last copy rendered would restyle every other one with its own card type's properties.
+    this.cssScope = id !== undefined ? escapeID(id) : `unnamed${++unnamedCardCount}`;
 
     this.addDefaults({
       width: 103,
@@ -184,7 +194,7 @@ class Card extends Widget {
                     if (typeof object.css === 'object' && object.css !== null && !Array.isArray(object.css)) {
                         const faceIndex = faceTemplates.indexOf(face);
                         const objectIndex = face.objects.indexOf(original);
-                        const uniqueScope = `html-object-${this.id}-${faceIndex}-${objectIndex}`;
+                        const uniqueScope = `html-object-${this.cssScope}-${faceIndex}-${objectIndex}`;
                         objectDiv.classList.add(uniqueScope);
 
                         let styleString = '';

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -1,16 +1,6 @@
-// Counts the cards that were created without an id so each of them still gets a css scope of its own - see
-// the cssScope below.
-let unnamedCardCount = 0;
-
 class Card extends Widget {
   constructor(id) {
     super(id);
-
-    // The css of an html face object is written into a style element and scoped to this class (see
-    // createFaces). A card in a room has a unique id, but the read-only copies the editor renders (deck
-    // editor, card type list, widget picker) are all created without one - they would end up sharing a class,
-    // so the last copy rendered would restyle every other one with its own card type's properties.
-    this.cssScope = id !== undefined ? escapeID(id) : `unnamed${++unnamedCardCount}`;
 
     this.addDefaults({
       width: 103,

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -69,12 +69,42 @@ function hasPlayerSpecificChooseField(overlay) {
 
 let lastExecutedOperation = null;
 
+// Counts the widgets that were created without an id so each of them still gets a css scope of its own - see
+// the cssScope below.
+let unnamedWidgetCount = 0;
+
+// A widget without an id is a read-only preview the editor renders: it is simply dropped from the dom instead
+// of going through applyRemove, so nobody removes the stylesheet its css property created. Every such
+// stylesheet is registered here, keyed by scope and valued by the preview it styles, and the ones whose
+// preview has left the document are collected after the render that replaced them - otherwise they would pile
+// up in head as the editor re-renders its previews.
+const unnamedWidgetStyles = new Map();
+let unnamedWidgetStyleCollection = null;
+
+function collectUnnamedWidgetStyles() {
+  unnamedWidgetStyleCollection = null;
+  for(const [ scope, element ] of unnamedWidgetStyles) {
+    if(element.isConnected)
+      continue;
+    if($(`#STYLES_${scope}`))
+      removeFromDOM($(`#STYLES_${scope}`));
+    unnamedWidgetStyles.delete(scope);
+  }
+}
+
 export class Widget extends StateManaged {
   constructor(id) {
+    // Everything that identifies this widget in css - its dom id, the id of its stylesheet element and the
+    // selectors in it - is built from this scope. A widget in a room has a unique id, but the read-only copies
+    // the editor renders (deck editor, card type list, widget picker) are created without one: they would all
+    // share the scope of an empty id, so the last copy rendered would restyle every other one with its own
+    // card type's properties. Widgets that do have an id keep using it, so nothing changes for a room.
+    const cssScope = id === undefined || id === null ? `unnamed_${++unnamedWidgetCount}` : escapeID(id);
     const div = document.createElement('div');
-    div.id = 'w_' + escapeID(id);
+    div.id = 'w_' + cssScope;
     super();
     this.id = id;
+    this.cssScope = cssScope;
     this.domElement = div;
     this.dropShadowWidget = null;
     this.targetTransform = '';
@@ -383,8 +413,8 @@ export class Widget extends StateManaged {
       widgets.get(this.get('parent')).applyChildRemove(this);
     if(this.get('deck') && widgets.has(this.get('deck')))
       widgets.get(this.get('deck')).removeCard(this);
-    if($(`#STYLES_${escapeID(this.id)}`))
-      removeFromDOM($(`#STYLES_${escapeID(this.id)}`));
+    if($(`#STYLES_${this.cssScope}`))
+      removeFromDOM($(`#STYLES_${this.cssScope}`));
     removeFromDOM(this.domElement);
     this.inheritFromUnregister();
     this.globalUpdateListenersUnregister();
@@ -623,8 +653,8 @@ export class Widget extends StateManaged {
   }
 
   css() {
-    if($(`#STYLES_${escapeID(this.id)}`))
-      removeFromDOM($(`#STYLES_${escapeID(this.id)}`));
+    if($(`#STYLES_${this.cssScope}`))
+      removeFromDOM($(`#STYLES_${this.cssScope}`));
     const usedProperties = new Set();
     let css = this.cssReplaceProperties(this.cssAsText(this.get('css'), usedProperties), usedProperties);
     this.propertiesUsedInProperty['css'] = Array.from(usedProperties);
@@ -691,14 +721,14 @@ export class Widget extends StateManaged {
     let styleString = '';
     for(const key in css) {
       let usesVariables = false;
-      let selector = key.replace(/\$\{THIS\}/g, m => {usesVariables = true; return `#w_${escapeID(this.id)}`});
+      let selector = key.replace(/\$\{THIS\}/g, m => {usesVariables = true; return `#w_${this.cssScope}`});
       if(!nested) {
         if(key == 'inline')
           continue;
         if(key == 'default')
           selector = '';
         if(!usesVariables && selector.charAt(0) != '@')
-          selector = `#w_${escapeID(this.id)}${selector}`;
+          selector = `#w_${this.cssScope}${selector}`;
       }
       styleString += `${selector} { ${mapAssetURLs(this.cssReplaceProperties(this.cssAsText(css[key], usedProperties, true), usedProperties))} }\n`;
     }
@@ -707,9 +737,17 @@ export class Widget extends StateManaged {
       return styleString;
 
     const style = document.createElement('style');
-    style.id = `STYLES_${escapeID(this.id)}`;
+    style.id = `STYLES_${this.cssScope}`;
     style.appendChild(document.createTextNode(styleString));
     $('head').appendChild(style);
+
+    // see unnamedWidgetStyles - the collection is deferred so previews that are built into a container before
+    // that container is put into the document are not collected while they are still being rendered
+    if(this.id === undefined || this.id === null) {
+      unnamedWidgetStyles.set(this.cssScope, this.domElement);
+      if(!unnamedWidgetStyleCollection)
+        unnamedWidgetStyleCollection = setTimeout(collectUnnamedWidgetStyles);
+    }
 
     return this.cssAsText(css.inline || '', usedProperties);
   }
@@ -3045,13 +3083,13 @@ export class Widget extends StateManaged {
       if(cursor.top < window.innerHeight/2)
         e.classList.add('bottom');
 
-      const wStyle = $(`#STYLES_${escapeID(id)}`);
+      const wStyle = $(`#STYLES_${this.cssScope}`);
       if(wStyle) {
         if($('#enlargeStyle'))
           removeFromDOM($('#enlargeStyle'));
         const eStyle = document.createElement('style');
         eStyle.id = "enlargeStyle";
-        eStyle.appendChild(document.createTextNode(wStyle.textContent.replaceAll(`#w_${escapeID(id)}`,'#enlarged')));
+        eStyle.appendChild(document.createTextNode(wStyle.textContent.replaceAll(`#w_${this.cssScope}`,'#enlarged')));
         $('head').appendChild(eStyle);
       }
     }

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -908,34 +908,48 @@ test('Deck editor: add card type, dynamic object, delete face, undo', async t =>
   await compareState(t, '3e20074150f78219095df84abeeb74dc');
 });
 
-// The css of an html face object is put into a style element and scoped to a class built from the card's id.
-// Every preview card the editor renders is created without one, so they used to share that class and the last
-// preview rendered restyled all the others - a strip in which every card type wore the last one's colors.
-test('Deck editor: every card type preview keeps its own html face css', async t => {
+// Both the object form of the css property and the css of an html face object are put into a style element
+// and scoped to the widget's id. Every preview card the editor renders is created without one, so they used
+// to share that scope and the last preview rendered restyled all the others - a strip in which every card
+// type wore the last one's colors. The room card with a space in its id covers the other half: an id that is
+// not a valid class name made classList.add() throw, so that card rendered no html face objects at all.
+test('Deck editor: every card type preview keeps its own css', async t => {
   await t.resizeWindow(1280, 800);
   await setRoomState({
     deck: { id: 'deck', type: 'deck', x: 20, y: 20,
-      cardDefaults: { width: 100, height: 150 },
+      cardDefaults: { width: 100, height: 150, css: { default: { 'border-color': '${PROPERTY tint}' } } },
       cardTypes: { red: { tint: '#ff0000' }, green: { tint: '#008000' }, blue: { tint: '#0000ff' } },
       faceTemplates: [ { objects: [] }, { objects: [ {
         type: 'html', x: 0, y: 0, width: 100, height: 150,
         value: '<div>tinted</div>', css: { body: { 'background-color': '${PROPERTY tint}' } }
       } ] } ]
-    }
+    },
+    'my card': { id: 'my card', type: 'card', deck: 'deck', cardType: 'green', x: 300, y: 20, activeFace: 1 }
   });
   await ClientFunction(prepareClient)();
   await setEditorState(null);
 
+  const roomCardColor = ClientFunction(() => {
+    const object = document.querySelector('#w_my_x0020_card .cardFace.active .cardFaceObject');
+    return object && getComputedStyle(object).backgroundColor;
+  });
   const stripColors = ClientFunction(() => {
     const colors = [];
     document.querySelectorAll('#deckEditorStrip .cardFace.active .cardFaceObject').forEach(o=>colors.push(getComputedStyle(o).backgroundColor));
     return colors;
   });
+  const stripBorderColors = ClientFunction(() => {
+    const colors = [];
+    document.querySelectorAll('#deckEditorStrip .card').forEach(c=>colors.push(getComputedStyle(c).borderTopColor));
+    return colors;
+  });
   await t
+    .expect(roomCardColor()).eql('rgb(0, 128, 0)', 'a card whose id is not a valid class name renders its html face object')
     .click('#editButton')
     .click('#w_deck')
     .click('#propertiesOpenDeckEditor')
-    .expect(stripColors()).eql([ 'rgb(255, 0, 0)', 'rgb(0, 128, 0)', 'rgb(0, 0, 255)' ], 'each card type preview shows its own tint')
+    .expect(stripColors()).eql([ 'rgb(255, 0, 0)', 'rgb(0, 128, 0)', 'rgb(0, 0, 255)' ], 'each card type preview shows its own html face object tint')
+    .expect(stripBorderColors()).eql([ 'rgb(255, 0, 0)', 'rgb(0, 128, 0)', 'rgb(0, 0, 255)' ], 'each card type preview shows its own css property tint')
     .pressKey('esc');
 });
 

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -908,6 +908,37 @@ test('Deck editor: add card type, dynamic object, delete face, undo', async t =>
   await compareState(t, '3e20074150f78219095df84abeeb74dc');
 });
 
+// The css of an html face object is put into a style element and scoped to a class built from the card's id.
+// Every preview card the editor renders is created without one, so they used to share that class and the last
+// preview rendered restyled all the others - a strip in which every card type wore the last one's colors.
+test('Deck editor: every card type preview keeps its own html face css', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    deck: { id: 'deck', type: 'deck', x: 20, y: 20,
+      cardDefaults: { width: 100, height: 150 },
+      cardTypes: { red: { tint: '#ff0000' }, green: { tint: '#008000' }, blue: { tint: '#0000ff' } },
+      faceTemplates: [ { objects: [] }, { objects: [ {
+        type: 'html', x: 0, y: 0, width: 100, height: 150,
+        value: '<div>tinted</div>', css: { body: { 'background-color': '${PROPERTY tint}' } }
+      } ] } ]
+    }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState(null);
+
+  const stripColors = ClientFunction(() => {
+    const colors = [];
+    document.querySelectorAll('#deckEditorStrip .cardFace.active .cardFaceObject').forEach(o=>colors.push(getComputedStyle(o).backgroundColor));
+    return colors;
+  });
+  await t
+    .click('#editButton')
+    .click('#w_deck')
+    .click('#propertiesOpenDeckEditor')
+    .expect(stripColors()).eql([ 'rgb(255, 0, 0)', 'rgb(0, 128, 0)', 'rgb(0, 0, 255)' ], 'each card type preview shows its own tint')
+    .pressKey('esc');
+});
+
 test('Deck editor: symbol pickers and JSON fallback', async t => {
   await t.resizeWindow(1280, 800);
   await setRoomState();


### PR DESCRIPTION
Every widget the editor renders as a read-only preview now gets its own CSS scope, so a deck that tints its card types — through an `html` face object or through the `css` property — shows each card type in its own colors instead of all of them in the last card type's colors.

## The bug

Both ways of styling a card put CSS into a `<style>` element that is scoped to the card's widget id, and preview cards are created without one (`new Card()`), so every preview shared the same scope and whichever preview was rendered last restyled all the others:

* the CSS of an `html` face object is scoped to a generated class, `html-object-<card id>-<face>-<object>` — every preview got `html-object-undefined-<face>-<object>`;
* the object form of the widget-level `css` property is written into `<style id="STYLES_<card id>">` with `#w_<card id>` selectors — every preview got `<style id="STYLES_">` and `#w_`, and since all id-less previews also share the DOM id `w_`, that one surviving stylesheet painted all of them.

That hits every place the editor renders preview cards:

* the deck editor's card type strip and its main card view,
* the card type list in the widget properties (Card type / Card Count),
* the deck previews in the "add widget" picker.

It is very visible on decks that tint their faces from a card type property, e.g. `"background": "linear-gradient(..., ${PROPERTY tint1}, ${PROPERTY tint2})"`. Cards in the room itself were never affected — those have real, unique widget ids.

Reproduced with the deck of [#3110](https://github.com/ArnoldSmith86/virtualtabletop/pull/3110) (https://test.virtualtabletop.io/PR-3110/pr-test), whose 13 card types each carry their own `tint1`/`tint2`/`ink`. All 13 strip previews rendered in the yellow of `cat-yowl`, the last card type:

| before | after |
| --- | --- |
| ![before](https://agent.virtualtabletop.io/reports/pr/1536134762509504622/deckeditor-before.png) | ![after](https://agent.virtualtabletop.io/reports/pr/1536134762509504622/deckeditor-after.png) |

## The change

`Widget` now computes a `cssScope` once, in its constructor: the escaped id when the widget has one, a per-instance `unnamed_<n>` when it does not. Everything that identifies the widget in CSS is built from it — its DOM id, the id of its stylesheet element, the `#w_…` selectors in it, and the `html-object-…` class of `Card.createFaces`. Nothing changes for a widget in a room: `escapeID('card')` is `card`, so both the DOM id and the generated class stay exactly what they were, and `escapeID` never emits a lone `_`, so `unnamed_<n>` cannot collide with a real id.

Preview widgets are simply dropped from the DOM instead of going through `applyRemove`, so nobody removed their stylesheet. With one shared `STYLES_` id that did not matter — the next preview overwrote it — but one stylesheet per preview would pile up in `<head>` as the editor re-renders (measured: +4 per click in the deck editor's card type strip). Their stylesheets are now collected once their preview has left the document, which keeps the count at the number of previews actually on screen.

Running the id through `escapeID` also fixes a second, smaller bug: a card whose id contains a character that is not valid in a class name (a space, for example) made `classList.add()` throw, and its html face objects were not rendered at all. They render now.

## Testing

* `npm test` — 1167 passed.
* New TestCafe regression test in `tests/testcafe/editor.js`: a deck with three card types tinted red/green/blue from a `${PROPERTY}` — once through an `html` face object, once through `cardDefaults.css` — must show three different strip previews, and a room card whose id is `my card` must render its html face object at all. Each assertion fails without the corresponding fix and passes with it.
* Full `tests/testcafe/editor.js` suite: 40 passed. `tests/testcafe/pixelsnapshot.js`: 4 passed. `tests/testcafe/domsnapshot.js`: `html-card` and `holder-image` pass, `widget-gallery` fails on `main` in this sandbox as well (an unrelated opacity/`hidden` timing difference), so it is not caused by this change.
* Walked the deck editor of the #3110 deck end to end in a browser, plus the card type list in the widget properties, and checked that the room itself still renders identically.
* Browser check of the `css` half of the bug — a deck of five card types tinted from `cardDefaults.css`, in the deck editor's card type strip:

| before | after |
| --- | --- |
| ![before](https://agent.virtualtabletop.io/reports/pr/1536134762509504622/deckeditor-css-before.png) | ![after](https://agent.virtualtabletop.io/reports/pr/1536134762509504622/deckeditor-css-after.png) |


## Follow-up from the UI review: the card type strip

The fix makes the `CARD TYPES` strip the fastest way to find a card type by sight, which brought two things about
that strip to the surface (both pre-existing, both raised in the UI/UX review):

* **It scrolls sideways with nothing saying so.** 20 card types at 1280x800 is a 1875px strip in a 1044px box, and
  the platform's overlay scrollbar reserves no space at all (`offsetHeight - clientHeight` is 0), so the repo's
  global `::-webkit-scrollbar` styling never shows. Whichever edge still has tiles behind it now fades out - sticky
  pseudo-elements with a compensating negative margin, so `scrollWidth` is unchanged and the strip's scroll-restore
  and `scrollIntoView` logic is untouched. `updateStripOverflow()` sets the classes from `renderStrip`, the strip's
  `scroll` handler and the window `resize` handler.
* **The selected tile was only a 2px outline**, which is easy to lose between tiles that are now as saturated as the
  card types they show. It also gets the highlight plate and a bold label.

| before | after |
| --- | --- |
| ![before](https://agent.virtualtabletop.io/reports/pr/1536134762509504622/deckeditor-strip-before.png) | ![after](https://agent.virtualtabletop.io/reports/pr/1536134762509504622/deckeditor-strip-after.png) |

![selected](https://agent.virtualtabletop.io/reports/pr/1536134762509504622/deckeditor-strip-selected-after.png)

Three small readability fixes came along with it: a tooltip on the per-card-type count (the `-`/`+` buttons had one,
the number did not), the "Click a face object..." hint under the card view raised from `opacity: 0.7` to `0.9`, and
the deck editor's two layout-relative strings ("to the right" / "below" / "the list to the left") replaced by the
names of the panels they point at.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3112/pr-test (or any other room on that server)

