### PR TITLE
Give deck editor preview cards their own id so html card designs render correctly

### DIFF
--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -241,6 +241,7 @@ class DeckEditor {
     this.applyingHistory = false;
     this.maxHistory = 60;
     this.actionSeq = 0;
+    this.previewCardSeq = 0; // numbers the cards rendered by renderCard() so each one gets its own widget id
 
     this.groupCollapsed = {}; // which sidebar property groups the user folded away, keyed "tab:group"
   }
@@ -1415,8 +1416,17 @@ class DeckEditor {
     return `Face ${face}`;
   }
 
+  // Every card rendered here gets an id of its own. An html face object scopes its css to a class built from
+  // the card's id, and those rules end up in a <style> element in the document - so cards without an id all
+  // shared one scope and whichever was rendered last styled every other one, which is why the card type strip
+  // showed the same design for all card types instead of what the room shows. A running number keeps the
+  // scopes apart without consuming the room's random sequence the way generateUniqueWidgetID() would.
   renderCard(cardType, face, target) {
-    const card = new Card();
+    let id;
+    do {
+      id = `deckEditorPreview${++this.previewCardSeq}`;
+    } while(widgets.has(id));
+    const card = new Card(id);
     return card.renderReadonlyCopyRaw({ deck: this.deckID, cardType, activeFace: face }, target);
   }
 


### PR DESCRIPTION
Fixes html-based card designs looking wrong in the Deck Editor: every card type was drawn with the same design instead of its own, so the editor did not show what the room shows.

## The bug

A face object of type `html` scopes its css to a generated class, `html-object-<card id>-<face>-<object>` (`client/js/widgets/card.js`). Those rules are emitted as a `<style>` element, so they are document-global and only stay apart because the card's widget id is in the class name.

The deck editor renders its preview cards with `new Card()` — without an id. All of them therefore carried the very same class, `html-object-undefined-1-0`, and the `<style>` of whichever card was rendered last won for every other card on screen. Since the design in the deck of PR #3110 is one html object whose css is built from per-card-type properties (`${PROPERTY tint1}`, `${PROPERTY ink}`, `${PROPERTY icon}`, …), all 13 card types came out in the last card type's colours and with the last card type's corner icon.

This affected the card type strip, the main design area, the tree object previews and the PDF/print export — anywhere the deck editor renders a card.

## The change

`DeckEditor.renderCard()` now numbers the cards it renders and hands each one its own widget id (`deckEditorPreview<n>`, checked against the room's ids), so every preview scopes its own css. A running number rather than `generateUniqueWidgetID()`, because that draws from the room's random sequence, which the TestCafe suite pins to a fixed seed.

One-line behaviour change, no property, routine or save-format change — so nothing to add to the validator, the JSON editor's context buttons or the editing UI, and no test room needed.

## Before / after

Same deck (the `cats` deck from #3110), same room, deck editor open on Face 1:

| | before | after |
| --- | --- | --- |
| card type strip | ![before](https://agent.virtualtabletop.io/reports/pr/1536135432717475841/before/deckeditor.png) | ![after](https://agent.virtualtabletop.io/reports/pr/1536135432717475841/after/deckeditor.png) |
| `cat-loaf` selected | ![before](https://agent.virtualtabletop.io/reports/pr/1536135432717475841/before/deckeditor-card.png) | ![after](https://agent.virtualtabletop.io/reports/pr/1536135432717475841/after/deckeditor-card.png) |

Before, all 13 strip cards share one yellow gradient and the boombox corner icon (the `cat-yowl` design); the selected `cat-loaf` card shows the boombox chip too. After, each card type shows its own gradient, ink colour and corner icon — the same as in the room.

## Verification

* Loaded the game from #3110 into a local room, opened the deck editor and compared the computed `background-image`, `color` and `box-shadow` of the rendered html face object against the same card type's widget in the room: **13/13 card types differed before the change, 13/13 are identical after it.**
* `npm test` — 1167 tests pass.
* TestCafe `editor.js`, all 17 `Deck editor:` tests — pass. `domsnapshot.js` — passes (the `html-object-card-0-0` scope of a real room card is unchanged).


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3113/pr-test (or any other room on that server)