### PR TITLE
Fix unreadable deck editor property group headers on hover in light mode

### DIFF
--- a/client/css/editor/deckeditor.css
+++ b/client/css/editor/deckeditor.css
@@ -1419,6 +1419,13 @@ body.deckEditorPanning #deckEditorMain * {
   cursor: pointer;
 }
 
+/* The global button:hover fill (layout.css) is more specific than the rule above, so without this the header
+   turned VTTblueDark on hover while its label stayed --textColor - black on navy, unreadable in light mode.
+   Highlight it with the theme's own lighter shade, which keeps the label readable in both themes. */
+.deckEditorGroupHeader:hover {
+  background: var(--backgroundHighlightColor2);
+}
+
 /* Focus ring like the Edit Widget sidebar's collapsible headers (propertyInputs.css), which this mirrors. */
 .deckEditorGroupHeader:focus-visible {
   outline: 2px solid var(--VTTblue);


### PR DESCRIPTION
## What this changes

In the deck editor's right sidebar, the property blocks (Content / Position / Size / Colors / Appearance / Custom) have collapsible headers. Hovering one of those headers turned it dark navy while the label stayed the theme's text color — in light mode that is **black on `--VTTblueDark` (#0d2f5e), ~1.6:1 contrast**, so the section title became unreadable exactly while you were pointing at it. This gives the header its own hover fill so it stays readable.

## Why it happened

`.deckEditorGroupHeader` (specificity 0,1,0) sets `background: var(--backgroundHighlightColor1)` and `color: var(--textColor)`, but the global `button:hover { background-color: var(--VTTblueDark) }` in `client/css/layout.css` is *more* specific (0,1,1) and won on hover — while the `color` stayed the theme's. Dark mode was unaffected because there `--textColor` is near-white. The Edit Widget sidebar's equivalent headers (`.editorModule .collapsibleHeader`, specificity 0,2,0) already outrank that rule, which is why only the deck editor showed it.

## The fix

One rule in `client/css/editor/deckeditor.css`:

```css
.deckEditorGroupHeader:hover {
  background: var(--backgroundHighlightColor2);
}
```

`--backgroundHighlightColor2` is one step lighter than the header's resting `--backgroundHighlightColor1` in both themes (`#dedede` on `#ccc` in light, `#565656` on `#444` in dark), so the header still visibly reacts to hover — it just does it with a fill the theme's text color is legible on (15:1 light, 7:1 dark).

## Verification

* `npm test` — 1167 passed.
* TestCafe `editor.js` → "Deck editor: add card type, dynamic object, delete face, undo" passes.
* Checked in a real browser (deck editor → face object → hovering the "Content" header), light and dark:

| | |
|---|---|
| before, light mode (bug) | ![before](https://agent.virtualtabletop.io/reports/pr/1536146770936201246/before-hover-crop.png) |
| after, light mode | ![after light](https://agent.virtualtabletop.io/reports/pr/1536146770936201246/after-hover-crop.png) |
| after, dark mode | ![after dark](https://agent.virtualtabletop.io/reports/pr/1536146770936201246/after-dark-hover-crop.png) |

CSS-only, hover-state-only: no widget properties, routine functions or room state are touched, so no editing-UI, validator or `jeCommands` work applies.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3114/pr-test (or any other room on that server)