### PR TITLE
Add a record button to the routine editor that turns room gestures into operations

### DIFF
--- a/client/css/editor/controls/events.css
+++ b/client/css/editor/controls/events.css
@@ -199,12 +199,6 @@ body.edit.darkMode .events-editor-property-key {
   font-size: 12px;
 }
 
-.events-editor-property-add-button:hover:not(:disabled) {
-  border-color: var(--VTTblue);
-  color: var(--VTTblue);
-  opacity: 1;
-}
-
 /* nothing to add without a name: saying so beats a button that does nothing */
 .events-editor-property-add-button:disabled {
   opacity: 0.4;
@@ -235,12 +229,6 @@ body.edit.darkMode .events-editor-property-key {
   font-size: 14px;
 }
 
-.events-editor-property-buttons button:hover {
-  border-color: var(--VTTblue);
-  color: var(--VTTblue);
-  opacity: 1;
-}
-
 /* one shape for every "add something" in the panel: lowercase, dashed outline.
    "record" is one of them: it is the other way to get an operation into a
    routine, so it is the same button as "add operation" next to it and says
@@ -259,19 +247,42 @@ body.edit.darkMode .events-editor-property-key {
   font-size: 12px;
 }
 
+/* The hover of all of them, the property panel's two included: the outline and
+   the label turn blue and the fill stays off. Saying the fill stays off is what
+   keeps it off - a plain button hovers into a solid var(--VTTblueDark) (see
+   layout.css), which is all but the blue this writes the label in. */
 .events-editor-add:hover,
 .routine-editor-add-operation:hover,
-.routine-editor-record-operation:hover {
+.routine-editor-record-operation:not(.recording):hover,
+.events-editor-property-add-button:hover:not(:disabled),
+.events-editor-property-buttons button:hover {
+  background: none;
   border-color: var(--VTTblue);
   color: var(--VTTblue);
   opacity: 1;
 }
 
+/* that blue is a dark one, drawn on a page that is nearly black on the dark
+   theme - so there it is the teal the popup buttons hover in instead */
+body.edit.darkMode .events-editor-add:hover,
+body.edit.darkMode .routine-editor-add-operation:hover,
+body.edit.darkMode .routine-editor-record-operation:not(.recording):hover,
+body.edit.darkMode .events-editor-property-add-button:hover:not(:disabled),
+body.edit.darkMode .events-editor-property-buttons button:hover {
+  border-color: var(--textHighlightColor7);
+  color: var(--textHighlightColor7);
+}
+
 /* the only add button that sits on an operation card instead of on the page:
    the dashed outline of the others is the color of that card, so it takes the
-   page background the same way a nested routine is a hole carved into the card */
-.routine-editor-add-else {
+   page background the same way a nested routine is a hole carved into the card
+   - on hover as well, where the rule above turns every other one's fill off */
+.routine-editor-add-else,
+.routine-editor-add-else:hover {
   background: var(--backgroundColor);
+}
+
+.routine-editor-add-else {
   border-color: var(--backgroundColor);
   margin-left: 12px;
 }

--- a/client/css/editor/controls/events.css
+++ b/client/css/editor/controls/events.css
@@ -241,9 +241,13 @@ body.edit.darkMode .events-editor-property-key {
   opacity: 1;
 }
 
-/* one shape for every "add something" in the panel: lowercase, dashed outline */
+/* one shape for every "add something" in the panel: lowercase, dashed outline.
+   "record" is one of them: it is the other way to get an operation into a
+   routine, so it is the same button as "add operation" next to it and says
+   what it does with its dot rather than with a shape of its own */
 .events-editor-add,
-.routine-editor-add-operation {
+.routine-editor-add-operation,
+.routine-editor-record-operation {
   align-self: flex-start;
   border: 1px dashed var(--backgroundHighlightColor1);
   border-radius: 4px;
@@ -256,7 +260,8 @@ body.edit.darkMode .events-editor-property-key {
 }
 
 .events-editor-add:hover,
-.routine-editor-add-operation:hover {
+.routine-editor-add-operation:hover,
+.routine-editor-record-operation:hover {
   border-color: var(--VTTblue);
   color: var(--VTTblue);
   opacity: 1;

--- a/client/css/editor/controls/routine.css
+++ b/client/css/editor/controls/routine.css
@@ -495,3 +495,180 @@ body.edit.darkMode .routine-editor-parameter-missing {
 .routine-editor-fields .routine-editor-func-name {
   color: var(--routineVariableColor);
 }
+
+/* The two ways to get an operation into a routine, side by side at the end of
+   it: naming the one wanted ("add operation") and doing the thing in the room
+   and picking from what it could mean ("record"). */
+.routine-editor-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+
+.routine-editor-record-operation .material-symbols {
+  font-size: 15px;
+  vertical-align: -3px;
+  margin-right: 3px;
+  /* the recorder's red lightened until it carries on the blue of a button - the
+     dark one this red is elsewhere disappears into it */
+  color: #ff8a80;
+}
+
+/* armed, the whole button is the red of what it is doing rather than one more
+   blue button among the others: the room is being watched, and that has to be
+   visible from wherever in the sidebar the eye happens to be */
+.routine-editor-record-operation.recording {
+  background-color: var(--routineRecordColor);
+  font-weight: bold;
+}
+
+.routine-editor-record-operation.recording:hover {
+  background-color: #8e1e1e;
+}
+
+.routine-editor-record-operation.recording .material-symbols {
+  color: white;
+  animation: routineRecordBlink 1.4s ease-in-out infinite;
+}
+
+@keyframes routineRecordBlink {
+  50% { opacity: 0.15; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .routine-editor-record-operation.recording .material-symbols {
+    animation: none;
+  }
+}
+
+/* What the room has been doing since the button was pressed, framed in the same
+   red so it reads as one thing with the button below it rather than as another
+   part of the routine. It sits between the operations and the buttons because
+   that is where the operations it offers would land. */
+.routine-editor-recording {
+  border: 1px solid var(--routineRecordColor);
+  border-radius: 6px;
+  padding: 4px 6px;
+  background: var(--backgroundHighlightColor2);
+  font-size: 12px;
+}
+
+.routine-editor-recording-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--routineRecordColor);
+  font-weight: bold;
+}
+
+.routine-editor-recording-header .material-symbols {
+  font-size: 16px;
+  animation: routineRecordBlink 1.4s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .routine-editor-recording-header .material-symbols {
+    animation: none;
+  }
+}
+
+.routine-editor-recording-title {
+  flex: 1;
+}
+
+.routine-editor-recording-hint {
+  color: var(--textColor);
+  opacity: 0.8;
+  margin: 2px 0 4px 0;
+}
+
+/* one card per press-drag-release: what was done, and under it the readings of
+   it the routine could mean */
+.routine-editor-gesture {
+  border-left: 3px solid var(--routineRecordColor);
+  border-radius: 4px 4px 4px 0;
+  background: var(--backgroundHighlightColor1);
+  padding: 3px 6px;
+  margin-top: 4px;
+}
+
+.routine-editor-gesture-what {
+  font-size: 11px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  color: var(--routineRecordColor);
+}
+
+.routine-editor-suggestion {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 2px 4px;
+  padding: 2px 3px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.routine-editor-suggestion:hover {
+  background: var(--routineActiveCardColor);
+}
+
+.routine-editor-suggestion .material-symbols {
+  font-size: 15px;
+  align-self: center;
+  color: var(--routineOperationColor);
+}
+
+.routine-editor-suggestion-sentence {
+  flex: 1;
+  min-width: 0;
+  color: var(--routineOperationColor);
+}
+
+/* why the room thinks this is one of the readings, in the tone of an aside:
+   the sentence is what would be added, this is only what it is for */
+.routine-editor-suggestion-why {
+  width: 100%;
+  padding-left: 19px;
+  font-size: 11px;
+  font-style: italic;
+  color: var(--textColor);
+  opacity: 0.7;
+}
+
+/* a suggestion that was already added: it stays clickable (doing a thing twice
+   is a real thing to want), it just says it was used */
+.routine-editor-suggestion-added .routine-editor-suggestion-sentence {
+  opacity: 0.6;
+}
+
+.routine-editor-suggestion-added .material-symbols {
+  color: var(--routineCollectionColor);
+}
+
+/* While the room is being watched, the pointer says so - the same crosshair the
+   widget picker puts over the room - and the board carries a frame in the
+   recorder's red, so a drag in there is visibly being written down rather than
+   just moving a card around. */
+body.editorRoutineRecording, body.editorRoutineRecording .widget {
+  cursor: crosshair !important;
+}
+
+/* the board rather than #room: #room is only the untransformed box the widgets
+   are scaled out of, so a frame on it would sit somewhere inside the board */
+body.editorRoutineRecording #roomArea::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border: 3px solid var(--routineRecordColor);
+  pointer-events: none;
+  z-index: 100;
+}
+
+/* the drag toolbar of the selected widget is edit-mode's way of moving things,
+   and it needs the selection band's event handling that the recording takes
+   over - so it steps aside while the room is the player's */
+body.editorRoutineRecording #editorDragToolbar {
+  display: none;
+}

--- a/client/css/editor/controls/routine.css
+++ b/client/css/editor/controls/routine.css
@@ -533,6 +533,7 @@ body.edit.darkMode .routine-editor-parameter-missing {
 
 .routine-editor-record-operation.recording:hover {
   filter: brightness(0.85);
+  background: var(--routineRecordColor);
   border-color: var(--routineRecordColor);
   color: var(--backgroundColor);
 }
@@ -690,13 +691,6 @@ body.edit.darkMode .routine-editor-parameter-missing {
   font-style: italic;
   color: var(--textColor);
   opacity: 0.7;
-}
-
-/* a suggestion that was already added stays clickable (doing a thing twice is a
-   real thing to want), so it does not go grey the way a disabled control does -
-   the tick is what says it was used */
-.routine-editor-suggestion-added .material-symbols {
-  color: var(--routineCollectionColor);
 }
 
 /* While the room is being watched, the pointer says so - the same crosshair the

--- a/client/css/editor/controls/routine.css
+++ b/client/css/editor/controls/routine.css
@@ -537,30 +537,28 @@ body.edit.darkMode .routine-editor-parameter-missing {
   color: var(--backgroundColor);
 }
 
+/* the dot does not blink here as well: the panel above the button has one that
+   does, a few pixels away, and two of them blinking at each other is noise */
 .routine-editor-record-operation.recording .material-symbols {
   color: var(--backgroundColor);
-  animation: routineRecordBlink 1.4s ease-in-out infinite;
 }
 
 @keyframes routineRecordBlink {
   50% { opacity: 0.15; }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .routine-editor-record-operation.recording .material-symbols {
-    animation: none;
-  }
-}
-
 /* What the room has been doing since the button was pressed, framed in the same
    red so it reads as one thing with the button below it rather than as another
    part of the routine. It sits between the operations and the buttons because
-   that is where the operations it offers would land. */
+   that is where the operations it offers would land.
+   It is drawn on the page background rather than on a highlight so that the red
+   of the header and the blue of the readings keep the 4.5:1 the rest of the
+   editor is tuned for - the frame around it is what sets it apart. */
 .routine-editor-recording {
   border: 1px solid var(--routineRecordColor);
   border-radius: 6px;
   padding: 4px 6px;
-  background: var(--backgroundHighlightColor2);
+  background: var(--backgroundColor);
   font-size: 12px;
 }
 
@@ -587,6 +585,24 @@ body.edit.darkMode .routine-editor-parameter-missing {
   flex: 1;
 }
 
+/* stopping is not the thing to do here, so it does not look like it: a quiet
+   outline in the recorder's red rather than the sidebar's default filled blue,
+   which made the way out the loudest thing in the panel */
+.routine-editor-recording-done {
+  background: none;
+  border: 1px solid var(--routineRecordColor);
+  border-radius: 4px;
+  color: var(--routineRecordColor);
+  font-size: 11px;
+  padding: 0 5px;
+  cursor: pointer;
+}
+
+.routine-editor-recording-done:hover {
+  background: var(--routineRecordColor);
+  color: var(--backgroundColor);
+}
+
 .routine-editor-recording-hint {
   color: var(--textColor);
   opacity: 0.8;
@@ -594,11 +610,12 @@ body.edit.darkMode .routine-editor-parameter-missing {
 }
 
 /* one card per press-drag-release: what was done, and under it the readings of
-   it the routine could mean */
+   it the routine could mean. The red edge is what makes it a card - a fill of
+   its own would take every line on it a step closer to its background. */
 .routine-editor-gesture {
+  position: relative;
   border-left: 3px solid var(--routineRecordColor);
-  border-radius: 4px 4px 4px 0;
-  background: var(--backgroundHighlightColor1);
+  border-top: 1px solid var(--backgroundHighlightColor1);
   padding: 3px 6px;
   margin-top: 4px;
 }
@@ -607,7 +624,29 @@ body.edit.darkMode .routine-editor-parameter-missing {
   font-size: 11px;
   font-weight: bold;
   letter-spacing: 0.5px;
+  padding-right: 16px; /* the × sits in this corner */
+  color: var(--textColor);
+}
+
+/* taking a gesture back off the card: quiet until the card is looked at, in the
+   red of the thing it belongs to */
+.routine-editor-gesture-forget {
+  position: absolute;
+  top: 0;
+  right: 2px;
+  background: none;
+  border: none;
+  padding: 0 2px;
+  font-size: 14px;
+  line-height: 1;
   color: var(--routineRecordColor);
+  opacity: 0.85;
+  cursor: pointer;
+}
+
+.routine-editor-gesture:hover .routine-editor-gesture-forget,
+.routine-editor-gesture-forget:focus-visible {
+  opacity: 1;
 }
 
 .routine-editor-suggestion {
@@ -620,8 +659,12 @@ body.edit.darkMode .routine-editor-parameter-missing {
   cursor: pointer;
 }
 
+/* an outline rather than a fill: a row is two lines of coloured text, and every
+   fill light enough to read black on is dark enough to lose the blue on it in
+   one of the two themes */
 .routine-editor-suggestion:hover {
-  background: var(--routineActiveCardColor);
+  outline: 1px solid var(--routineOperationColor);
+  outline-offset: -1px;
 }
 
 .routine-editor-suggestion .material-symbols {
@@ -630,15 +673,17 @@ body.edit.darkMode .routine-editor-parameter-missing {
   color: var(--routineOperationColor);
 }
 
-.routine-editor-suggestion-sentence {
+/* what this reading is FOR leads the row: the readings of one gesture nearly
+   all begin with the same words, so this is the line the eye picks one by */
+.routine-editor-suggestion-why {
   flex: 1;
   min-width: 0;
   color: var(--routineOperationColor);
 }
 
-/* why the room thinks this is one of the readings, in the tone of an aside:
-   the sentence is what would be added, this is only what it is for */
-.routine-editor-suggestion-why {
+/* and the operation it would add follows it, in the tone of an aside: it is
+   what the reading is checked against, not what it is chosen by */
+.routine-editor-suggestion-sentence {
   width: 100%;
   padding-left: 19px;
   font-size: 11px;
@@ -647,12 +692,9 @@ body.edit.darkMode .routine-editor-parameter-missing {
   opacity: 0.7;
 }
 
-/* a suggestion that was already added: it stays clickable (doing a thing twice
-   is a real thing to want), it just says it was used */
-.routine-editor-suggestion-added .routine-editor-suggestion-sentence {
-  opacity: 0.6;
-}
-
+/* a suggestion that was already added stays clickable (doing a thing twice is a
+   real thing to want), so it does not go grey the way a disabled control does -
+   the tick is what says it was used */
 .routine-editor-suggestion-added .material-symbols {
   color: var(--routineCollectionColor);
 }
@@ -676,9 +718,32 @@ body.editorRoutineRecording #roomArea::after {
   z-index: 100;
 }
 
+/* which routine the room is being recorded into, in the room: the panel that
+   says so is in a sidebar that is scrolled somewhere else by the time a few
+   gestures have been made */
+body.editorRoutineRecording #routineRecordingLabel {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  z-index: 101; /* above the frame, which is drawn at 100 */
+  max-width: calc(100% - 12px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 1px 6px;
+  border-radius: 0 0 4px 0;
+  background: var(--routineRecordColor);
+  color: var(--backgroundColor);
+  font-size: 12px;
+  font-weight: bold;
+  pointer-events: none;
+}
+
 /* the drag toolbar of the selected widget is edit-mode's way of moving things,
    and it needs the selection band's event handling that the recording takes
-   over - so it steps aside while the room is the player's */
-body.editorRoutineRecording #editorDragToolbar {
+   over - so it steps aside while the room is the player's. The .active is what
+   dragtoolbar.css shows it with, so hiding it takes at least as much. */
+body.editorRoutineRecording #editorDragToolbar,
+body.editorRoutineRecording #editorDragToolbar.active {
   display: none;
 }

--- a/client/css/editor/controls/routine.css
+++ b/client/css/editor/controls/routine.css
@@ -506,29 +506,39 @@ body.edit.darkMode .routine-editor-parameter-missing {
   gap: 4px;
 }
 
+/* the button is the shape of "add operation" next to it (see events.css), so
+   the dot is the only thing that makes it the record button - it carries the
+   recorder's red the panel and the room frame are drawn in */
 .routine-editor-record-operation .material-symbols {
   font-size: 15px;
   vertical-align: -3px;
   margin-right: 3px;
-  /* the recorder's red lightened until it carries on the blue of a button - the
-     dark one this red is elsewhere disappears into it */
-  color: #ff8a80;
+  color: var(--routineRecordColor);
 }
 
-/* armed, the whole button is the red of what it is doing rather than one more
-   blue button among the others: the room is being watched, and that has to be
-   visible from wherever in the sidebar the eye happens to be */
+/* armed, the whole button is filled with the red of what it is doing rather
+   than staying one more outline among the others: the room is being watched,
+   and that has to be visible from wherever in the sidebar the eye happens to
+   be. Only the fill changes - the box stays the size it was, so pressing it
+   does not shift the row it is in. */
 .routine-editor-record-operation.recording {
-  background-color: var(--routineRecordColor);
+  background: var(--routineRecordColor);
+  border-color: var(--routineRecordColor);
+  /* the record red is a dark one on the light theme and a light one on the
+     dark theme, so what reads on it is the page it is drawn on either way */
+  color: var(--backgroundColor);
+  opacity: 1;
   font-weight: bold;
 }
 
 .routine-editor-record-operation.recording:hover {
-  background-color: #8e1e1e;
+  filter: brightness(0.85);
+  border-color: var(--routineRecordColor);
+  color: var(--backgroundColor);
 }
 
 .routine-editor-record-operation.recording .material-symbols {
-  color: white;
+  color: var(--backgroundColor);
   animation: routineRecordBlink 1.4s ease-in-out infinite;
 }
 

--- a/client/css/editor/layout.css
+++ b/client/css/editor/layout.css
@@ -39,6 +39,10 @@ body {
      the 4.5:1 the rest of this file budgets for. Dark mode is fine as it is. */
   --routineBlankColor: #d32f2f;
 
+  /* Watching the room to record a routine: the red every recorder anywhere is,
+     darkened to the same 4.5:1 the blank above is tuned for. */
+  --routineRecordColor: #c62828;
+
   /* The card of the routine editor that was worked on last: a clear step lighter
      than the other cards (--backgroundHighlightColor1) so it is spotted without
      reading, while the chrome on it (see --routineChromeOpacity) still clears
@@ -89,6 +93,7 @@ body.edit.darkMode {
   --routinePropertyColor: #ff8fb1;
   --routineNumberColor: #40e0d0;
   --routineBlankColor: red;
+  --routineRecordColor: #ff6b6b;
   --routineActiveCardColor: #626262;
 
   color-scheme: dark;

--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -2205,9 +2205,15 @@ class RoutineEditor {
   }
 
   addOperation(values) {
+    this.addOperations([ values ]);
+  }
+
+  // several operations added as one: they go in together, in the order given,
+  // and the last of them is where the next one follows
+  addOperations(list) {
     const at = this.insertionIndex();
-    this.routine.splice(at, 0, typeof values == 'string' ? values : JSON.parse(JSON.stringify(values)));
-    this.setActiveOperation(at); // the new operation is where the next one follows
+    this.routine.splice(at, 0, ...list.map(values=>typeof values == 'string' ? values : JSON.parse(JSON.stringify(values))));
+    this.setActiveOperation(at + list.length - 1);
     this.routineChanged();
   }
 
@@ -2268,28 +2274,34 @@ class RoutineEditor {
     forget.title = 'Forget this gesture';
 
     for(const suggestion of gesture.suggestions) {
-      const editor = editorForOperation(suggestion.operation);
-      editor.setOperationDetails(this.widget, suggestion.operation, this.variables, this.collections);
-
       const suggestionDOM = div(gestureDOM, 'routine-editor-suggestion');
       const icon = document.createElement('span');
       icon.className = 'material-symbols';
       icon.textContent = 'add';
       suggestionDOM.append(icon);
-      // what the reading is FOR leads, the operation it would add follows: the
+      // what the reading is FOR leads, the operations it would add follow: the
       // readings of one gesture nearly all start with the same words ("Move 1
       // widget from deckHolder to ..."), so a card of them is only scannable
       // by the thing that tells them apart
       div(suggestionDOM, 'routine-editor-suggestion-why').textContent = suggestion.why;
-      div(suggestionDOM, 'routine-editor-suggestion-sentence').textContent = editor.getSentenceText();
-      suggestionDOM.title = `Add this operation to the routine (${suggestion.operation.func})`;
+      // a reading that takes more than one operation to carry out is still one
+      // line to pick: every operation it would add is spelled out under it
+      for(const operation of suggestion.operations) {
+        const editor = editorForOperation(operation);
+        editor.setOperationDetails(this.widget, operation, this.variables, this.collections);
+        div(suggestionDOM, 'routine-editor-suggestion-sentence').textContent = editor.getSentenceText();
+      }
+      const funcs = suggestion.operations.map(operation=>operation.func).join(', ');
+      suggestionDOM.title = suggestion.operations.length > 1
+        ? `Add these operations to the routine (${funcs})`
+        : `Add this operation to the routine (${funcs})`;
       focusable(suggestionDOM, _=>{
-        // one gesture is one operation: the card is answered and closes, and a
+        // one gesture is one reading: the card is answered and closes, and a
         // second reading of the same gesture is had by doing it again in the
         // room. A card that stays open after a pick invites reading the whole
         // list a second time to see whether anything else applies too.
         closeRoutineGesture(gesture);
-        this.addOperation(suggestion.operation);
+        this.addOperations(suggestion.operations);
       });
     }
   }

--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -2175,23 +2175,110 @@ class RoutineEditor {
       this.domElement.append(emptyHint);
     }
 
-    const addButton = button(this.domElement, 'add operation', async _=>{
+    this.renderRoutineRecording(this.domElement);
+
+    // the two ways to get an operation into the routine, side by side: naming
+    // the one wanted, and doing the thing in the room and picking from what that
+    // could mean
+    const buttonsDOM = div(this.domElement, 'routine-editor-buttons');
+
+    const addButton = button(buttonsDOM, 'add operation', async _=>{
       const popup = new RoutineOperationPopup();
       popup.setSource(addButton);
       popup.setOperationDetails({}, [ 'func' ], this.widget, this.variables, this.collections);
       const values = await newRoutineValues(popup);
-      if(values !== undefined) {
-        // right after the card that was worked on last, so a routine is built in
-        // the order it runs; at the end when that card is the last one anyway
-        const at = activeRoutineOperation && activeRoutineOperation.routine === this.routine ? Math.min(activeRoutineOperation.index+1, this.routine.length) : this.routine.length;
-        this.routine.splice(at, 0, typeof values == 'string' ? values : JSON.parse(JSON.stringify(values)));
-        this.setActiveOperation(at); // the new operation is where the next one follows
-        this.routineChanged();
-      }
+      if(values !== undefined)
+        this.addOperation(values);
     });
     addButton.className = 'routine-editor-add-operation';
 
+    this.renderRecordButton(buttonsDOM);
+
     return this.domElement;
+  }
+
+  // where an added operation goes: right after the card that was worked on last,
+  // so a routine is built in the order it runs; at the end when that card is the
+  // last one anyway
+  addOperation(values) {
+    const at = activeRoutineOperation && activeRoutineOperation.routine === this.routine ? Math.min(activeRoutineOperation.index+1, this.routine.length) : this.routine.length;
+    this.routine.splice(at, 0, typeof values == 'string' ? values : JSON.parse(JSON.stringify(values)));
+    this.setActiveOperation(at); // the new operation is where the next one follows
+    this.routineChanged();
+  }
+
+  // The record button, next to "add operation": armed, it says what it is doing
+  // rather than what it does, in the same words as unarmed - the way the widget
+  // picker's button does. Pressing it in another routine moves the recording
+  // there rather than refusing: one room can only be watched for one routine.
+  renderRecordButton(buttonsDOM) {
+    const recordingHere = isRoutineRecordingIn(this);
+    const recordButton = button(buttonsDOM, recordingHere ? 'recording…' : 'record', _=>{
+      if(recordingHere)
+        stopRoutineRecording();
+      else
+        startRoutineRecording(this);
+    });
+    recordButton.className = 'routine-editor-record-operation';
+    recordButton.classList.toggle('recording', recordingHere);
+    recordButton.title = recordingHere
+      ? 'Stop watching the room'
+      : 'Do something in the room and get the operations that would do the same thing';
+    recordButton.insertAdjacentHTML('afterbegin', '<span class="material-symbols">fiber_manual_record</span>');
+  }
+
+  // What the room has been doing since the record button was pressed: one card
+  // per press-drag-release, each offering the operations that would do the same
+  // thing. Nothing is added until one of them is clicked - a gesture nobody
+  // meant costs a card in the list and no operation in the routine.
+  renderRoutineRecording(dom) {
+    const recording = routineRecordingIn(this);
+    if(!recording)
+      return;
+
+    const panel = div(dom, 'routine-editor-recording');
+    const header = div(panel, 'routine-editor-recording-header');
+    header.insertAdjacentHTML('beforeend', '<span class="material-symbols">fiber_manual_record</span>');
+    div(header, 'routine-editor-recording-title').textContent = 'Watching the room';
+    const doneButton = button(header, 'done', _=>stopRoutineRecording());
+    doneButton.className = 'routine-editor-recording-done';
+    doneButton.title = 'Stop watching the room';
+
+    div(panel, 'routine-editor-recording-hint').textContent = recording.gestures.length
+      ? 'Click a suggestion to add it to this routine. Carry on in the room for the next step.'
+      : 'Drag and click widgets in the room the way the routine should. Each move becomes a list of operations to pick from - the room does not know which reading you meant, so it offers the likely ones.';
+
+    for(const gesture of recording.gestures)
+      this.renderRecordedGesture(panel, recording, gesture);
+  }
+
+  renderRecordedGesture(panel, recording, gesture) {
+    const gestureDOM = div(panel, 'routine-editor-gesture');
+    div(gestureDOM, 'routine-editor-gesture-what').textContent = gesture.label;
+    for(const [ index, suggestion ] of gesture.suggestions.entries()) {
+      const editor = editorForOperation(suggestion.operation);
+      editor.setOperationDetails(this.widget, suggestion.operation, this.variables, this.collections);
+      const key = `${gesture.key}/${index}`;
+      const added = recording.added.indexOf(key) != -1;
+
+      const suggestionDOM = div(gestureDOM, 'routine-editor-suggestion');
+      suggestionDOM.classList.toggle('routine-editor-suggestion-added', added);
+      const icon = document.createElement('span');
+      icon.className = 'material-symbols';
+      icon.textContent = added ? 'check' : 'add';
+      suggestionDOM.append(icon);
+      div(suggestionDOM, 'routine-editor-suggestion-sentence').textContent = editor.getSentenceText();
+      div(suggestionDOM, 'routine-editor-suggestion-why').textContent = suggestion.why;
+      suggestionDOM.title = `Add this operation to the routine (${suggestion.operation.func})`;
+      focusable(suggestionDOM, _=>{
+        // the same suggestion twice is a routine that does the thing twice,
+        // which is a real thing to want - the tick only says it was used once
+        if(recording.added.indexOf(key) == -1)
+          recording.added.push(key);
+        this.addOperation(suggestion.operation);
+        scrollRoutineRecordingIntoView(this);
+      });
+    }
   }
 
   // the operation cards that belong to THIS routine level (nested editors keep
@@ -2653,6 +2740,26 @@ class RoutineOperationEditor {
       })
       .replace(templatePlaceholder, (_, p)=>this.getDisplayedValue(p))
       .trim();
+  }
+
+  // the sentence the card would read, in plain words: the same parts
+  // renderSentenceView lays out as chips, with the options that are switched on
+  // included. What an operation nobody has added yet says (the recorder's
+  // suggestions) has to say what it does with the values it comes with, and
+  // those live in its options as often as in its variant.
+  getSentenceText() {
+    let text = '';
+    for(const part of this.sentenceParts()) {
+      if(part.clause) {
+        if(this.clauseIsActive(part.clause))
+          text += this.resolveTemplate(part.template);
+        else if(part.clause.whenOff)
+          text += this.resolveTemplate(part.clause.whenOff);
+        continue;
+      }
+      text += this.resolveTemplate(part.template);
+    }
+    return text.replace(templatePlaceholder, (_, p)=>this.getDisplayedValue(p)).replace(/\s+([,.])/g, '$1').replace(/\s+/g, ' ').trim();
   }
 
   // the whole sentence as one template string, optional parts in [brackets] -

--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -2200,8 +2200,24 @@ class RoutineEditor {
   // where an added operation goes: right after the card that was worked on last,
   // so a routine is built in the order it runs; at the end when that card is the
   // last one anyway
+  insertionIndex() {
+    return activeRoutineOperation && activeRoutineOperation.routine === this.routine ? Math.min(activeRoutineOperation.index+1, this.routine.length) : this.routine.length;
+  }
+
+  // The collections an operation added there could read: the ones the routine
+  // starts with plus the ones the operations before that point define. The
+  // recorder asks before offering an operation that works on "whatever an
+  // earlier operation picked" - one that reads a collection nothing filled is an
+  // error the moment it lands in the routine.
+  collectionsInScope() {
+    const collections = [ ...this.collections ];
+    for(const operation of this.operations.slice(0, this.insertionIndex()))
+      collections.push(...operation.getDefinedCollections());
+    return [ ...new Set(collections.filter(c=>typeof c == 'string')) ];
+  }
+
   addOperation(values) {
-    const at = activeRoutineOperation && activeRoutineOperation.routine === this.routine ? Math.min(activeRoutineOperation.index+1, this.routine.length) : this.routine.length;
+    const at = this.insertionIndex();
     this.routine.splice(at, 0, typeof values == 'string' ? values : JSON.parse(JSON.stringify(values)));
     this.setActiveOperation(at); // the new operation is where the next one follows
     this.routineChanged();

--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -2223,13 +2223,14 @@ class RoutineEditor {
     this.routineChanged();
   }
 
-  // The record button, next to "add operation": armed, it says what it is doing
-  // rather than what it does, in the same words as unarmed - the way the widget
-  // picker's button does. Pressing it in another routine moves the recording
-  // there rather than refusing: one room can only be watched for one routine.
+  // The record button, next to "add operation". Armed, only its fill changes:
+  // the label stays the word it was, so the button keeps the width it had and
+  // does not shove "add operation" onto a line of its own in a narrow sidebar.
+  // Pressing it in another routine moves the recording there rather than
+  // refusing: one room can only be recorded into one routine.
   renderRecordButton(buttonsDOM) {
     const recordingHere = isRoutineRecordingIn(this);
-    const recordButton = button(buttonsDOM, recordingHere ? 'recording…' : 'record', _=>{
+    const recordButton = button(buttonsDOM, 'record', _=>{
       if(recordingHere)
         stopRoutineRecording();
       else
@@ -2238,7 +2239,7 @@ class RoutineEditor {
     recordButton.className = 'routine-editor-record-operation';
     recordButton.classList.toggle('recording', recordingHere);
     recordButton.title = recordingHere
-      ? 'Stop watching the room'
+      ? 'Stop recording'
       : 'Do something in the room and get the operations that would do the same thing';
     recordButton.insertAdjacentHTML('afterbegin', '<span class="material-symbols">fiber_manual_record</span>');
   }
@@ -2255,14 +2256,14 @@ class RoutineEditor {
     const panel = div(dom, 'routine-editor-recording');
     const header = div(panel, 'routine-editor-recording-header');
     header.insertAdjacentHTML('beforeend', '<span class="material-symbols">fiber_manual_record</span>');
-    div(header, 'routine-editor-recording-title').textContent = 'Watching the room';
+    div(header, 'routine-editor-recording-title').textContent = 'Recording';
     const doneButton = button(header, 'done', _=>stopRoutineRecording());
     doneButton.className = 'routine-editor-recording-done';
-    doneButton.title = 'Stop watching the room';
+    doneButton.title = 'Stop recording';
 
     div(panel, 'routine-editor-recording-hint').textContent = recording.gestures.length
-      ? 'Click a suggestion to add it to this routine. Carry on in the room for the next step.'
-      : 'Drag and click widgets in the room the way the routine should. Each move becomes a list of operations to pick from - the room does not know which reading you meant, so it offers the likely ones.';
+      ? 'Click a suggestion to add it to this routine. Carry on in the room for the next step, or press done when the routine says what you meant.'
+      : 'Drag and click widgets in the room the way the routine should - clicking one records the click instead of selecting it. Each move becomes a list of operations to pick from, because the room does not know which reading you meant. Press done when the routine says what you meant.';
 
     for(const gesture of recording.gestures)
       this.renderRecordedGesture(panel, recording, gesture);
@@ -2271,6 +2272,13 @@ class RoutineEditor {
   renderRecordedGesture(panel, recording, gesture) {
     const gestureDOM = div(panel, 'routine-editor-gesture');
     div(gestureDOM, 'routine-editor-gesture-what').textContent = gesture.label;
+    // a gesture nobody meant is taken off the card rather than lived with: a
+    // slip on the wrong holder otherwise stays in the list until the whole
+    // recording is thrown away, good readings and all
+    const forget = button(gestureDOM, '×', _=>forgetRoutineGesture(gesture));
+    forget.className = 'routine-editor-gesture-forget';
+    forget.title = 'Forget this gesture';
+
     for(const [ index, suggestion ] of gesture.suggestions.entries()) {
       const editor = editorForOperation(suggestion.operation);
       editor.setOperationDetails(this.widget, suggestion.operation, this.variables, this.collections);
@@ -2283,8 +2291,12 @@ class RoutineEditor {
       icon.className = 'material-symbols';
       icon.textContent = added ? 'check' : 'add';
       suggestionDOM.append(icon);
-      div(suggestionDOM, 'routine-editor-suggestion-sentence').textContent = editor.getSentenceText();
+      // what the reading is FOR leads, the operation it would add follows: the
+      // readings of one gesture nearly all start with the same words ("Move 1
+      // widget from deckHolder to ..."), so a card of them is only scannable
+      // by the thing that tells them apart
       div(suggestionDOM, 'routine-editor-suggestion-why').textContent = suggestion.why;
+      div(suggestionDOM, 'routine-editor-suggestion-sentence').textContent = editor.getSentenceText();
       suggestionDOM.title = `Add this operation to the routine (${suggestion.operation.func})`;
       focusable(suggestionDOM, _=>{
         // the same suggestion twice is a routine that does the thing twice,

--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -2204,18 +2204,6 @@ class RoutineEditor {
     return activeRoutineOperation && activeRoutineOperation.routine === this.routine ? Math.min(activeRoutineOperation.index+1, this.routine.length) : this.routine.length;
   }
 
-  // The collections an operation added there could read: the ones the routine
-  // starts with plus the ones the operations before that point define. The
-  // recorder asks before offering an operation that works on "whatever an
-  // earlier operation picked" - one that reads a collection nothing filled is an
-  // error the moment it lands in the routine.
-  collectionsInScope() {
-    const collections = [ ...this.collections ];
-    for(const operation of this.operations.slice(0, this.insertionIndex()))
-      collections.push(...operation.getDefinedCollections());
-    return [ ...new Set(collections.filter(c=>typeof c == 'string')) ];
-  }
-
   addOperation(values) {
     const at = this.insertionIndex();
     this.routine.splice(at, 0, typeof values == 'string' ? values : JSON.parse(JSON.stringify(values)));
@@ -2262,34 +2250,31 @@ class RoutineEditor {
     doneButton.title = 'Stop recording';
 
     div(panel, 'routine-editor-recording-hint').textContent = recording.gestures.length
-      ? 'Click a suggestion to add it to this routine. Carry on in the room for the next step, or press done when the routine says what you meant.'
-      : 'Drag and click widgets in the room the way the routine should - clicking one records the click instead of selecting it. Each move becomes a list of operations to pick from, because the room does not know which reading you meant. Press done when the routine says what you meant.';
+      ? 'Click one of these to add it to the routine - that closes the card. Do the same thing again in the room to add another operation, or press done when the routine says what you meant.'
+      : 'Drag and click widgets in the room the way the routine should - clicking one records the click instead of selecting it. Each move becomes a short list of operations to pick from, because the room does not know which reading you meant. Press done when the routine says what you meant.';
 
     for(const gesture of recording.gestures)
-      this.renderRecordedGesture(panel, recording, gesture);
+      this.renderRecordedGesture(panel, gesture);
   }
 
-  renderRecordedGesture(panel, recording, gesture) {
+  renderRecordedGesture(panel, gesture) {
     const gestureDOM = div(panel, 'routine-editor-gesture');
     div(gestureDOM, 'routine-editor-gesture-what').textContent = gesture.label;
     // a gesture nobody meant is taken off the card rather than lived with: a
     // slip on the wrong holder otherwise stays in the list until the whole
     // recording is thrown away, good readings and all
-    const forget = button(gestureDOM, '×', _=>forgetRoutineGesture(gesture));
+    const forget = button(gestureDOM, '×', _=>closeRoutineGesture(gesture));
     forget.className = 'routine-editor-gesture-forget';
     forget.title = 'Forget this gesture';
 
-    for(const [ index, suggestion ] of gesture.suggestions.entries()) {
+    for(const suggestion of gesture.suggestions) {
       const editor = editorForOperation(suggestion.operation);
       editor.setOperationDetails(this.widget, suggestion.operation, this.variables, this.collections);
-      const key = `${gesture.key}/${index}`;
-      const added = recording.added.indexOf(key) != -1;
 
       const suggestionDOM = div(gestureDOM, 'routine-editor-suggestion');
-      suggestionDOM.classList.toggle('routine-editor-suggestion-added', added);
       const icon = document.createElement('span');
       icon.className = 'material-symbols';
-      icon.textContent = added ? 'check' : 'add';
+      icon.textContent = 'add';
       suggestionDOM.append(icon);
       // what the reading is FOR leads, the operation it would add follows: the
       // readings of one gesture nearly all start with the same words ("Move 1
@@ -2299,12 +2284,12 @@ class RoutineEditor {
       div(suggestionDOM, 'routine-editor-suggestion-sentence').textContent = editor.getSentenceText();
       suggestionDOM.title = `Add this operation to the routine (${suggestion.operation.func})`;
       focusable(suggestionDOM, _=>{
-        // the same suggestion twice is a routine that does the thing twice,
-        // which is a real thing to want - the tick only says it was used once
-        if(recording.added.indexOf(key) == -1)
-          recording.added.push(key);
+        // one gesture is one operation: the card is answered and closes, and a
+        // second reading of the same gesture is had by doing it again in the
+        // room. A card that stays open after a pick invites reading the whole
+        // list a second time to see whether anything else applies too.
+        closeRoutineGesture(gesture);
         this.addOperation(suggestion.operation);
-        scrollRoutineRecordingIntoView(this);
       });
     }
   }

--- a/client/js/editor/controls/routinerecorder.js
+++ b/client/js/editor/controls/routinerecorder.js
@@ -88,6 +88,7 @@ function startRoutineRecording(editor) {
   stopRoutineRecording();
   activeRoutineRecording = { editor, widgetID: editor.widgetID, routineKey: editor.routineKey, gestures: [], added: [] };
   $('body').classList.add('editorRoutineRecording');
+  drawRoutineRecordingLabel(editor);
   editor.render();
 }
 
@@ -98,8 +99,45 @@ export function stopRoutineRecording() {
   activeRoutineRecording = null;
   openRoutineGesture = null;
   $('body').classList.remove('editorRoutineRecording');
+  removeRoutineRecordingLabel();
   if(editor.domElement.isConnected)
     editor.render();
+}
+
+// Which routine the room is being recorded into, said in the room. The frame on
+// its own only says "something here is being written down"; the routine it goes
+// into is named in the sidebar, which is scrollable and usually scrolled
+// somewhere else by the time three gestures have been done.
+function drawRoutineRecordingLabel(editor) {
+  removeRoutineRecordingLabel();
+  const area = $('#roomArea');
+  if(!area)
+    return;
+  const label = document.createElement('div');
+  label.id = 'routineRecordingLabel';
+  label.textContent = `recording → ${[ editor.widgetID, editor.routineKey ].filter(Boolean).join(' · ')}`;
+  area.appendChild(label);
+}
+
+function removeRoutineRecordingLabel() {
+  const label = $('#routineRecordingLabel');
+  if(label)
+    label.remove();
+}
+
+// A gesture nobody meant - a slip onto the wrong holder, a drag done only to put
+// the room back the way it was - can be taken off the card. Only the reading of
+// it goes: an operation already added from it stays in the routine, the way
+// anything else added to a routine stays until it is deleted there.
+export function forgetRoutineGesture(gesture) {
+  const recording = routineRecordingState();
+  if(!recording)
+    return;
+  const at = recording.gestures.indexOf(gesture);
+  if(at == -1)
+    return;
+  recording.gestures.splice(at, 1);
+  recording.editor.render();
 }
 
 // A click in the room while a recording runs belongs to the recording, never to
@@ -128,7 +166,7 @@ function routineRecorderWidget(id) {
 export function routineRecorderPointerDown(widget) {
   if(!routineRecordingState() || !widget)
     return;
-  openRoutineGesture = { before: routineRecorderChain(widget), changes: {} };
+  openRoutineGesture = { before: routineRecorderChain(widget), changes: {}, existed: [ ...widgets.keys() ] };
 }
 
 // A delta is part of the gesture unless somebody else made it. Every delta says
@@ -199,6 +237,16 @@ function describeRoutineGesture(raw, collections=[]) {
   if(!before.length)
     return null;
 
+  // A widget the gesture brought into existence has no properties worth
+  // offering: dropping a card on a card makes a pile, and every property that
+  // pile reports (its size, its type) is the room building it rather than
+  // something a routine would ever set. The author never made it and cannot
+  // find it in the room either, so naming it in a suggestion says nothing.
+  const changes = {};
+  for(const id in raw.changes)
+    if(!raw.existed || raw.existed.indexOf(id) != -1)
+      changes[id] = raw.changes[id];
+
   const placeChanged = entry=>entry.parent !== (entry.widget.get('parent') || null)
     || Math.round(entry.x) != Math.round(entry.widget.get('x')) || Math.round(entry.y) != Math.round(entry.widget.get('y'));
   const moved = before.find(placeChanged);
@@ -215,7 +263,7 @@ function describeRoutineGesture(raw, collections=[]) {
     x: Math.round(widget.get('x')),
     y: Math.round(widget.get('y')),
     dragged: Boolean(moved),
-    changes: raw.changes
+    changes
   };
   gesture.reparented = gesture.dragged && gesture.from !== gesture.to;
   gesture.label = routineGestureWords(gesture);
@@ -223,16 +271,28 @@ function describeRoutineGesture(raw, collections=[]) {
   return gesture;
 }
 
+// What to call a widget in the headline. The ids a game is built out of are
+// generated as often as they are chosen - a card is "pyn6" and the pile a
+// holder made around it is "o0ur", neither of which the author ever typed or
+// can find in the room - so the headline says what kind of thing it was as
+// well. A widget with no type of its own (a plain button, a label) is named by
+// its id alone, which is the one an author did choose.
+function routineRecorderName(id) {
+  const widget = routineRecorderWidget(id);
+  const type = widget && widget.get('type');
+  return type && type != 'basic' ? `the ${type} ${id}` : String(id);
+}
+
 function routineRecorderPlace(id) {
-  return id === null ? 'the table' : id;
+  return id === null ? 'the table' : routineRecorderName(id);
 }
 
 function routineGestureWords(gesture) {
   if(gesture.reparented)
-    return `dragged ${gesture.widgetID} from ${routineRecorderPlace(gesture.from)} to ${routineRecorderPlace(gesture.to)}`;
+    return `dragged ${routineRecorderName(gesture.widgetID)} from ${routineRecorderPlace(gesture.from)} to ${routineRecorderPlace(gesture.to)}`;
   if(gesture.dragged)
-    return `dragged ${gesture.widgetID} to ${gesture.x}, ${gesture.y}`;
-  return `clicked ${gesture.widgetID}`;
+    return `dragged ${routineRecorderName(gesture.widgetID)} to ${gesture.x}, ${gesture.y}`;
+  return `clicked ${routineRecorderName(gesture.widgetID)}`;
 }
 
 // the seats whose hand this holder is: dropping a card into a hand is dealing to
@@ -451,8 +511,6 @@ function clickSuggestions(gesture, add) {
     add('give the turn to it', { func: 'TURN', turnCycle: 'seat', turn: widgetID });
   if(type == 'timer')
     add('start it', { func: 'TIMER', timer: widgetID, mode: 'start' });
-
-  add('change a property of it', { func: 'SET', property: '', value: '', collection });
 }
 
 // What the room did by itself while the gesture ran - the properties a holder,

--- a/client/js/editor/controls/routinerecorder.js
+++ b/client/js/editor/controls/routinerecorder.js
@@ -427,6 +427,11 @@ const routineSuggestionLimit = 5;
 // usually means by it - dealing to everybody rather than to the one seat that
 // was dropped on, putting the deck back together.
 //
+// A reading is one line to pick, however many operations it takes to carry out:
+// putting a widget at a spot is a SET of x and a SET of y, and offering those
+// apart asks the author to notice that half a reading is half a gesture. So a
+// reading carries a list of operations, and picking it adds all of them.
+//
 // The two kinds are collected apart so that the limit can prefer what the room
 // did on its own over the readings of the gesture: the reading that would fall
 // off the end is the one watching the pointer could never produce - "the hand
@@ -435,7 +440,7 @@ const routineSuggestionLimit = 5;
 function routineGestureSuggestions(gesture) {
   const fromGesture = [];
   const fromRoom = [];
-  const into = list=>((why, operation)=>list.push({ why, operation }));
+  const into = list=>((why, ...operations)=>list.push({ why, operations }));
 
   if(gesture.reparented)
     reparentSuggestions(gesture, into(fromGesture));
@@ -451,7 +456,7 @@ function routineGestureSuggestions(gesture) {
     for(const suggestion of list) {
       if(suggestions.length >= limit)
         return;
-      const key = JSON.stringify(suggestion.operation);
+      const key = JSON.stringify(suggestion.operations);
       if(seen.indexOf(key) != -1)
         continue;
       seen.push(key);
@@ -479,11 +484,12 @@ function reparentSuggestions(gesture, add) {
     }
     // x and y are counted from whatever the widget is in, so taking it out on
     // its own drops it wherever its old coordinates land in the room. The two
-    // that follow are what makes it stay where it was let go of - which is why
-    // they say "and", the way the clauses of one gesture do.
-    add('do exactly this', { func: 'SET', property: 'parent', value: null, collection: [ widgetID ] });
-    add('and put it exactly there', { func: 'SET', property: 'x', value: gesture.x, collection: [ widgetID ] });
-    add('and at that height', { func: 'SET', property: 'y', value: gesture.y, collection: [ widgetID ] });
+    // SETs that follow it are what keeps it where it was let go of, so the three
+    // of them are the one reading.
+    add('do exactly this',
+      { func: 'SET', property: 'parent', value: null, collection: [ widgetID ] },
+      { func: 'SET', property: 'x', value: gesture.x, collection: [ widgetID ] },
+      { func: 'SET', property: 'y', value: gesture.y, collection: [ widgetID ] });
     return;
   }
 
@@ -515,8 +521,9 @@ function repositionSuggestions(gesture, add) {
   // what a SET writes as well. MOVEXY is not the same thing: it takes widgets
   // OUT of a holder and puts them at a spot in the room, which is not what a
   // drag that left the widget where it was did.
-  add('put it exactly there', { func: 'SET', property: 'x', value: gesture.x, collection });
-  add('and at that height', { func: 'SET', property: 'y', value: gesture.y, collection });
+  add('put it exactly there',
+    { func: 'SET', property: 'x', value: gesture.x, collection },
+    { func: 'SET', property: 'y', value: gesture.y, collection });
 }
 
 // Rolling a die is the one thing a routine does by clicking rather than by an

--- a/client/js/editor/controls/routinerecorder.js
+++ b/client/js/editor/controls/routinerecorder.js
@@ -38,13 +38,15 @@ let openRoutineGesture = null;
 
 let routineGestureCounter = 0;
 
-// properties that change on their own during any drag, or that the suggestions
-// already say in words of their own: a card that ends up in another holder is a
-// MOVE, not a "Set parent of card1 to discard"
+// properties that change on their own during any drag, that the suggestions
+// already say in words of their own - a card that ends up in another holder is a
+// MOVE, not a "Set parent of card1 to discard" - or that only exist to drive the
+// engine: rollCount is what makes a die that lands on the face it already showed
+// still roll on screen, and a routine that sets it says nothing about the game.
 const routineRecorderIgnoredProperties = [
   'id', 'type', 'deck', 'cardType', 'parent', 'x', 'y', 'z', 'owner',
   'dragging', 'hoverTarget', 'hoverParent', 'dropShadowWidget', 'dropShadowOwner',
-  'movedByButton', 'onlyVisibleForSeat', 'linkedToSeat'
+  'movedByButton', 'onlyVisibleForSeat', 'linkedToSeat', 'rollCount'
 ];
 
 export function isRoutineRecording() {
@@ -145,8 +147,20 @@ export function forgetRoutineGesture(gesture) {
 // the suggestions are in, and running its click routine would play the game
 // instead of describing it. The gesture itself is taken by the pointer hooks
 // below, which see the release whether this swallowed the click or not.
+//
+// This is also where the recording learns that the release was a click at all.
+// Whether a press-release is one is the engine's call, not the recorder's: a
+// release under 10px and 250ms is a click even though every mousemove on the way
+// really did move the widget (see mousehandling.js), so a hand that shakes by
+// two pixels must still record "clicked the die", not "dragged it to 402, 301".
+// This runs from exactly the branch that decided so, and before the release
+// reaches routineRecorderPointerUp().
 function handleRoutineRecorderClick() {
-  return Boolean(routineRecordingState());
+  if(!routineRecordingState())
+    return false;
+  if(openRoutineGesture)
+    openRoutineGesture.clicked = true;
+  return true;
 }
 
 // the widget the press landed on plus its ancestors: a press on a widget that is
@@ -249,9 +263,13 @@ function describeRoutineGesture(raw, collections=[]) {
 
   const placeChanged = entry=>entry.parent !== (entry.widget.get('parent') || null)
     || Math.round(entry.x) != Math.round(entry.widget.get('x')) || Math.round(entry.y) != Math.round(entry.widget.get('y'));
-  const moved = before.find(placeChanged);
+  // whether this was a click is the engine's answer (see handleRoutineRecorderClick);
+  // the coordinates are only asked when the release never reached it, because it
+  // happened over the sidebar or an overlay rather than over the room
+  const moved = raw.clicked ? null : before.find(placeChanged);
   const subject = moved || before[0];
   const widget = subject.widget;
+  const destination = routineRecorderDestination(widget);
 
   const gesture = {
     key: ++routineGestureCounter,
@@ -259,9 +277,9 @@ function describeRoutineGesture(raw, collections=[]) {
     widgetID: subject.id,
     type: widget.get('type') || 'basic',
     from: subject.parent,
-    to: widget.get('parent') || null,
-    x: Math.round(widget.get('x')),
-    y: Math.round(widget.get('y')),
+    to: destination.to,
+    x: destination.x,
+    y: destination.y,
     dragged: Boolean(moved),
     changes
   };
@@ -269,6 +287,29 @@ function describeRoutineGesture(raw, collections=[]) {
   gesture.label = routineGestureWords(gesture);
   gesture.suggestions = routineGestureSuggestions(gesture, collections);
   return gesture;
+}
+
+// Where the drag put the widget, in terms an operation can name. Dropping a card
+// onto a card puts it into a pile the drop invents (see updatePiles): that pile
+// is gone again as soon as it holds one card, and no operation takes one as a
+// destination anyway - MOVE moves widgets into holders and seats. So a
+// destination that is not one of those is read as the place it stands in, at the
+// coordinates it stands at: stacking two cards on the table means "put it there",
+// not "put it into o0ur", and stacking them inside a holder means the card never
+// left that holder.
+function routineRecorderDestination(widget) {
+  let place = widget.get('parent') || null;
+  let x = widget.get('x') || 0;
+  let y = widget.get('y') || 0;
+  // x and y are counted from whatever the widget is in, so a place further up
+  // the chain is only reached by adding what stands between them
+  for(let steps = 0; steps < 10 && place !== null && !isHolderLike(place); steps++) {
+    const container = routineRecorderWidget(place);
+    x += container ? container.get('x') || 0 : 0;
+    y += container ? container.get('y') || 0 : 0;
+    place = container ? container.get('parent') || null : null;
+  }
+  return { to: isHolderLike(place) ? place : null, x: Math.round(x), y: Math.round(y) };
 }
 
 // What to call a widget in the headline. The ids a game is built out of are
@@ -474,8 +515,11 @@ function diceFaceValue(widget, face) {
   return value === undefined || value === null || typeof value == 'object' ? null : String(value);
 }
 
+// a die that has no faces yet - one just added to the room, one whose faces are
+// still being typed - counts them modulo zero, which is not a face to put it on
 function diceActiveFace(widget) {
-  return typeof widget.activeFace == 'function' ? widget.activeFace() : Math.round(widget.get('activeFace')) || 0;
+  const face = typeof widget.activeFace == 'function' ? widget.activeFace() : Math.round(widget.get('activeFace'));
+  return Number.isFinite(face) ? face : 0;
 }
 
 function clickSuggestions(gesture, add) {
@@ -527,12 +571,13 @@ function propertySuggestions(gesture, add) {
         continue;
       const value = changes[property];
       const collection = [ id ];
-      // a die has no flip() of its own, so FLIP passes over it - what puts one
-      // on a face is setting the face
-      if(property == 'activeFace' && typeof value == 'number' && widget.get('type') == 'dice')
-        add(`${id} ended up on that face`, { func: 'SET', property, value, collection });
-      else if(property == 'activeFace' && typeof value == 'number')
-        add(`${id} ended up on that face`, { func: 'FLIP', collection, face: value });
+      // FLIP only turns over what has a flip() of its own (a card, a basic
+      // widget); it passes silently over a die or a spinner, whose faces are
+      // reached by setting the face instead
+      if(property == 'activeFace' && typeof value == 'number')
+        add(`${id} ended up on that face`, typeof widget.flip == 'function'
+          ? { func: 'FLIP', collection, face: value }
+          : { func: 'SET', property, value, collection });
       else if(property == 'rotation' && typeof value == 'number')
         add(`${id} ended up turned that way`, { func: 'ROTATE', collection, mode: 'set', angle: value });
       else if(value === null || [ 'string', 'number', 'boolean' ].indexOf(typeof value) != -1)

--- a/client/js/editor/controls/routinerecorder.js
+++ b/client/js/editor/controls/routinerecorder.js
@@ -393,9 +393,44 @@ function repositionSuggestions(gesture, add) {
   }
 }
 
+// Rolling a die is the one thing a routine does by clicking rather than by an
+// operation of its own: a die that is clicked and has nothing else to do rolls
+// (see Dice.click). So the roll IS the click, told to leave out whatever would
+// stop it - a click routine the author gave the die instead, or a die players
+// are not allowed to click at all.
+function diceRollOperation(widget, collection) {
+  const routine = Array.isArray(widget.get('clickRoutine'));
+  const clickable = Boolean(widget.get('clickable'));
+  const mode = routine && !clickable ? 'ignoreAll' : routine ? 'ignoreClickRoutine' : !clickable ? 'ignoreClickable' : null;
+  return mode ? { func: 'CLICK', collection, mode } : { func: 'CLICK', collection };
+}
+
+// what the die shows on that face, for the aside next to the operation:
+// activeFace counts the faces from 0, and a die nearly always has something
+// else printed on them
+function diceFaceValue(widget, face) {
+  const values = typeof widget.getValueMap == 'function' ? widget.getValueMap() : [];
+  const value = values[face];
+  return value === undefined || value === null || typeof value == 'object' ? null : String(value);
+}
+
+function diceActiveFace(widget) {
+  return typeof widget.activeFace == 'function' ? widget.activeFace() : Math.round(widget.get('activeFace')) || 0;
+}
+
 function clickSuggestions(gesture, add) {
   const { widgetID, type, widget } = gesture;
   const collection = [ widgetID ];
+
+  // Clicking a die rolls it and setting its face puts it on one on purpose, so
+  // both are offered in those words - and before the plain click below, which
+  // for a die is the same operation under a name that never says "roll".
+  if(type == 'dice') {
+    add('roll it the way clicking it does', diceRollOperation(widget, collection));
+    const face = diceActiveFace(widget);
+    const shows = diceFaceValue(widget, face);
+    add(`put it on a face instead of rolling it${shows === null ? '' : ` - it is showing ${shows}`}`, { func: 'SET', property: 'activeFace', value: face, collection });
+  }
 
   add('click it the way a player would', { func: 'CLICK', collection });
   if(Array.isArray(widget.get('clickRoutine')))
@@ -426,14 +461,19 @@ function clickSuggestions(gesture, add) {
 function propertySuggestions(gesture, add) {
   for(const id in gesture.changes) {
     const changes = gesture.changes[id];
-    if(!changes || typeof changes != 'object' || !routineRecorderWidget(id))
+    const widget = routineRecorderWidget(id);
+    if(!changes || typeof changes != 'object' || !widget)
       continue;
     for(const property in changes) {
       if(routineRecorderIgnoredProperties.indexOf(property) != -1 || property.charAt(0) == '_' || property.match(/Routine$/))
         continue;
       const value = changes[property];
       const collection = [ id ];
-      if(property == 'activeFace' && typeof value == 'number')
+      // a die has no flip() of its own, so FLIP passes over it - what puts one
+      // on a face is setting the face
+      if(property == 'activeFace' && typeof value == 'number' && widget.get('type') == 'dice')
+        add(`${id} ended up on that face`, { func: 'SET', property, value, collection });
+      else if(property == 'activeFace' && typeof value == 'number')
         add(`${id} ended up on that face`, { func: 'FLIP', collection, face: value });
       else if(property == 'rotation' && typeof value == 'number')
         add(`${id} ended up turned that way`, { func: 'ROTATE', collection, mode: 'set', angle: value });

--- a/client/js/editor/controls/routinerecorder.js
+++ b/client/js/editor/controls/routinerecorder.js
@@ -91,7 +91,7 @@ function startRoutineRecording(editor) {
   editor.render();
 }
 
-function stopRoutineRecording() {
+export function stopRoutineRecording() {
   if(!activeRoutineRecording)
     return;
   const editor = activeRoutineRecording.editor;
@@ -131,11 +131,24 @@ export function routineRecorderPointerDown(widget) {
   openRoutineGesture = { before: routineRecorderChain(widget), changes: {} };
 }
 
+// A delta is part of the gesture unless somebody else made it. Every delta says
+// who caused it (setDeltaCause in serverstate.js writes "<player> dragged x"),
+// and another player moving something across the table while the author drags a
+// card is not part of what the author just did. A delta with no cause at all
+// counts: the cause is dropped again after every flush, so the second half of a
+// drop that flushes twice arrives without one.
+function routineRecorderOwnDelta(delta) {
+  if(typeof delta.c != 'string')
+    return true;
+  const player = String((getPlayerDetails() || {}).playerName || '');
+  return Boolean(player) && delta.c.substr(0, player.length+1) == `${player} `;
+}
+
 // What changed while the gesture was running, taken from the deltas rather than
 // from a snapshot of the whole room: a holder that turns a card face up as it
 // enters is the one part of a drag the drag itself does not say.
 function routineRecorderReceiveDelta(delta) {
-  if(!openRoutineGesture || !delta || !delta.s)
+  if(!openRoutineGesture || !delta || !delta.s || !routineRecorderOwnDelta(delta))
     return;
   for(const id in delta.s) {
     const properties = delta.s[id];
@@ -151,7 +164,7 @@ export function routineRecorderPointerUp() {
   openRoutineGesture = null;
   if(!recording || !raw)
     return;
-  const gesture = describeRoutineGesture(raw);
+  const gesture = describeRoutineGesture(raw, collectionsAroundRecording(recording));
   if(!gesture || !gesture.suggestions.length)
     return;
   recording.gestures.push(gesture);
@@ -170,11 +183,18 @@ function scrollRoutineRecordingIntoView(editor) {
     last.scrollIntoView({ block: 'nearest' });
 }
 
+// the collections an operation added by this recording could read - see
+// RoutineEditor.collectionsInScope()
+function collectionsAroundRecording(recording) {
+  const editor = recording.editor;
+  return editor && editor.collectionsInScope ? editor.collectionsInScope() : [];
+}
+
 // What the gesture did, in the terms the suggestions are built from. The widget
 // that moved is the first one up the chain whose place changed - a press on a
 // card pinned to a board drags the board - and a gesture that moved nothing at
 // all is a click on the widget the press landed on.
-function describeRoutineGesture(raw) {
+function describeRoutineGesture(raw, collections=[]) {
   const before = raw.before.filter(entry=>routineRecorderWidget(entry.id) === entry.widget);
   if(!before.length)
     return null;
@@ -199,7 +219,7 @@ function describeRoutineGesture(raw) {
   };
   gesture.reparented = gesture.dragged && gesture.from !== gesture.to;
   gesture.label = routineGestureWords(gesture);
-  gesture.suggestions = routineGestureSuggestions(gesture);
+  gesture.suggestions = routineGestureSuggestions(gesture, collections);
   return gesture;
 }
 
@@ -250,33 +270,56 @@ function changedDuringGesture(gesture, id, property) {
   return changes && typeof changes == 'object' ? changes[property] : undefined;
 }
 
+// how many suggestions one gesture is worth reading through before the card
+// stops being a list and becomes a wall
+const routineSuggestionLimit = 8;
+
 // Every reading of a gesture worth offering, in the order they are worth looking
 // at: what was literally just done first, then the ways a routine generalizes it
 // (all of them instead of one, every player instead of the one dropped on), then
 // what those two widgets are usually asked to do next.
-function routineGestureSuggestions(gesture) {
-  const suggestions = [];
-  const seen = [];
-  const add = (why, operation)=>{
-    const key = JSON.stringify(operation);
-    if(seen.indexOf(key) != -1 || suggestions.length >= 8)
-      return;
-    seen.push(key);
-    suggestions.push({ why, operation });
-  };
+//
+// The two kinds are collected apart so that the limit can prefer what the room
+// did on its own over the readings of the gesture: a room with seats in it makes
+// the ordinary dealing gesture produce more readings than fit, and the reading
+// that would fall off the end is the one watching the pointer could never
+// produce - "the hand turned the card face up as it went in". Half the list is
+// kept for those, and whatever they leave unused goes back to the gesture.
+function routineGestureSuggestions(gesture, collections=[]) {
+  const fromGesture = [];
+  const fromRoom = [];
+  const into = list=>((why, operation)=>list.push({ why, operation }));
 
   if(gesture.reparented)
-    reparentSuggestions(gesture, add);
+    reparentSuggestions(gesture, into(fromGesture), collections);
   else if(gesture.dragged)
-    repositionSuggestions(gesture, add);
+    repositionSuggestions(gesture, into(fromGesture));
   else
-    clickSuggestions(gesture, add);
+    clickSuggestions(gesture, into(fromGesture));
+  propertySuggestions(gesture, into(fromRoom));
 
-  propertySuggestions(gesture, add);
+  const suggestions = [];
+  const seen = [];
+  const take = (list, limit)=>{
+    for(const suggestion of list) {
+      if(suggestions.length >= limit)
+        return;
+      const key = JSON.stringify(suggestion.operation);
+      if(seen.indexOf(key) != -1)
+        continue;
+      seen.push(key);
+      suggestions.push(suggestion);
+    }
+  };
+
+  const roomShare = Math.min(fromRoom.length, Math.floor(routineSuggestionLimit/2));
+  take(fromGesture, routineSuggestionLimit - roomShare);
+  take(fromRoom, routineSuggestionLimit);
+  take(fromGesture, routineSuggestionLimit);
   return suggestions;
 }
 
-function reparentSuggestions(gesture, add) {
+function reparentSuggestions(gesture, add, collections=[]) {
   const { from, to, widgetID } = gesture;
   const face = changedDuringGesture(gesture, widgetID, 'activeFace');
 
@@ -287,7 +330,13 @@ function reparentSuggestions(gesture, add) {
       add('take one out onto the table', { func: 'MOVEXY', from, count: 1, x: gesture.x, y: gesture.y });
       add('take all of them out', { func: 'MOVEXY', from, count: 'all', x: gesture.x, y: gesture.y });
     }
+    // x and y are counted from whatever the widget is in, so taking it out on
+    // its own drops it wherever its old coordinates land in the room. The two
+    // that follow are what makes it stay where it was let go of - which is why
+    // they say "and", the way the clauses of one gesture do.
     add('just take it out of whatever it is in', { func: 'SET', property: 'parent', value: null, collection: [ widgetID ] });
+    add('and put it exactly there', { func: 'SET', property: 'x', value: gesture.x, collection: [ widgetID ] });
+    add('and at that height', { func: 'SET', property: 'y', value: gesture.y, collection: [ widgetID ] });
     return;
   }
 
@@ -321,7 +370,12 @@ function reparentSuggestions(gesture, add) {
     add('gather every card back where it came from', { func: 'RECALL', holder: from });
   if(isHolderLike(to))
     add('shuffle what is in there afterwards', { func: 'SHUFFLE', holder: to });
-  add('move whatever an earlier operation picked', { func: 'MOVE', to });
+  // "whatever an earlier operation picked" is the DEFAULT collection, which only
+  // exists once something in the routine before this point has filled it -
+  // offering it anywhere else writes an operation that is an error as soon as it
+  // is added ("no input given and collection DEFAULT is undefined")
+  if(collections.indexOf('DEFAULT') != -1)
+    add('move whatever an earlier operation picked', { func: 'MOVE', to });
 }
 
 function repositionSuggestions(gesture, add) {

--- a/client/js/editor/controls/routinerecorder.js
+++ b/client/js/editor/controls/routinerecorder.js
@@ -1,0 +1,390 @@
+// Recording a routine from what the game author does in the room.
+//
+// "add operation" asks which operation to write down. The record button next to
+// it asks the other way round: do the thing in the room and let the editor say
+// which operations would do it. While it is armed, every press-drag-release in
+// the room becomes a card of suggestions - the operation that does exactly what
+// was just done, plus the ways a routine usually generalizes it - and picking
+// one adds it to the routine where "add operation" would have added it.
+//
+// One gesture is deliberately not one operation. Dragging a card from a hand
+// onto the discard pile is "move 1 card out of that hand", "move all of them",
+// "take one from every player" or "gather every card back into the deck",
+// depending on what the routine is for. The room cannot know which was meant,
+// but it knows the four - so it offers them and writes nothing until one is
+// picked. A gesture nobody picks anything from costs a card in the list.
+//
+// While recording, the room answers the way it does for a player rather than
+// the way it does in edit mode (see selection.js): the selection band stays out
+// of the drag, and a click neither selects the widget nor runs its click
+// routine - selecting one would take the editor off the routine being recorded,
+// and running it would play the game instead of describing it. A drag does move
+// the widget for real, so the next gesture starts from the state the last one
+// left behind, which is what makes a sequence of them read as one macro.
+
+// The routine that is being recorded into, the gestures collected so far and
+// which of their suggestions were already added. Only one recording runs at a
+// time, the way only one widget picker does.
+//
+// Which routine it is is remembered the way the card worked on last is (see
+// activeOperationByWidget): by the widget and the routine inside it, not by the
+// editor object. A nested block is built anew every time anything in the routine
+// changes - adding the first suggestion would otherwise throw the recording away
+// with the editor that collected it.
+let activeRoutineRecording = null;
+
+// what is known about the gesture between the press and the release
+let openRoutineGesture = null;
+
+let routineGestureCounter = 0;
+
+// properties that change on their own during any drag, or that the suggestions
+// already say in words of their own: a card that ends up in another holder is a
+// MOVE, not a "Set parent of card1 to discard"
+const routineRecorderIgnoredProperties = [
+  'id', 'type', 'deck', 'cardType', 'parent', 'x', 'y', 'z', 'owner',
+  'dragging', 'hoverTarget', 'hoverParent', 'dropShadowWidget', 'dropShadowOwner',
+  'movedByButton', 'onlyVisibleForSeat', 'linkedToSeat'
+];
+
+export function isRoutineRecording() {
+  return Boolean(activeRoutineRecording);
+}
+
+// whether this editor is the one the recording belongs to. The editor object
+// that renders the panel is remembered along the way, so a gesture knows where
+// to draw itself after the routine was rebuilt around it.
+function isRoutineRecordingIn(editor) {
+  if(!activeRoutineRecording || !editor)
+    return false;
+  if(activeRoutineRecording.widgetID !== editor.widgetID || activeRoutineRecording.routineKey !== editor.routineKey)
+    return false;
+  activeRoutineRecording.editor = editor;
+  return true;
+}
+
+// the recording to draw into this editor, whether or not it is on screen yet: a
+// nested block renders itself in its own constructor, before anything appended
+// it anywhere
+function routineRecordingIn(editor) {
+  return isRoutineRecordingIn(editor) ? activeRoutineRecording : null;
+}
+
+// the recording, as long as the routine it belongs to is still on screen: a
+// delta can take the widget out of the selection, which throws the sidebar the
+// panel lives in away, and the crosshair over the room must not stay behind
+function routineRecordingState() {
+  if(!activeRoutineRecording)
+    return null;
+  if(!activeRoutineRecording.editor.domElement.isConnected) {
+    stopRoutineRecording();
+    editorNote('recording ended: the routine is no longer open');
+    return null;
+  }
+  return activeRoutineRecording;
+}
+
+function startRoutineRecording(editor) {
+  stopRoutineRecording();
+  activeRoutineRecording = { editor, widgetID: editor.widgetID, routineKey: editor.routineKey, gestures: [], added: [] };
+  $('body').classList.add('editorRoutineRecording');
+  editor.render();
+}
+
+function stopRoutineRecording() {
+  if(!activeRoutineRecording)
+    return;
+  const editor = activeRoutineRecording.editor;
+  activeRoutineRecording = null;
+  openRoutineGesture = null;
+  $('body').classList.remove('editorRoutineRecording');
+  if(editor.domElement.isConnected)
+    editor.render();
+}
+
+// A click in the room while a recording runs belongs to the recording, never to
+// the widget: selecting it would re-render the sidebar out from under the panel
+// the suggestions are in, and running its click routine would play the game
+// instead of describing it. The gesture itself is taken by the pointer hooks
+// below, which see the release whether this swallowed the click or not.
+function handleRoutineRecorderClick() {
+  return Boolean(routineRecordingState());
+}
+
+// the widget the press landed on plus its ancestors: a press on a widget that is
+// pinned to a holder drags the holder, so which of them actually moved is only
+// known once the button comes up
+function routineRecorderChain(widget) {
+  const chain = [];
+  for(let w = widget; w && chain.indexOf(w) == -1 && chain.length < 10; w = routineRecorderWidget(w.get('parent')))
+    chain.push(w);
+  return chain.map(w=>({ widget: w, id: w.get('id'), parent: w.get('parent') || null, x: w.get('x'), y: w.get('y') }));
+}
+
+function routineRecorderWidget(id) {
+  return id && widgets.has(id) ? widgets.get(id) : null;
+}
+
+export function routineRecorderPointerDown(widget) {
+  if(!routineRecordingState() || !widget)
+    return;
+  openRoutineGesture = { before: routineRecorderChain(widget), changes: {} };
+}
+
+// What changed while the gesture was running, taken from the deltas rather than
+// from a snapshot of the whole room: a holder that turns a card face up as it
+// enters is the one part of a drag the drag itself does not say.
+function routineRecorderReceiveDelta(delta) {
+  if(!openRoutineGesture || !delta || !delta.s)
+    return;
+  for(const id in delta.s) {
+    const properties = delta.s[id];
+    if(!properties || typeof properties != 'object')
+      continue;
+    openRoutineGesture.changes[id] = Object.assign(openRoutineGesture.changes[id] || {}, properties);
+  }
+}
+
+export function routineRecorderPointerUp() {
+  const recording = routineRecordingState();
+  const raw = openRoutineGesture;
+  openRoutineGesture = null;
+  if(!recording || !raw)
+    return;
+  const gesture = describeRoutineGesture(raw);
+  if(!gesture || !gesture.suggestions.length)
+    return;
+  recording.gestures.push(gesture);
+  recording.editor.render();
+  scrollRoutineRecordingIntoView(recording.editor);
+}
+
+// The panel sits at the end of a routine that is often taller than the sidebar,
+// and re-rendering it collapses and re-grows the module, which leaves the scroll
+// position wherever the shorter page allowed. So whatever just happened puts
+// itself back where it can be read - the room is where the eye was, not here.
+function scrollRoutineRecordingIntoView(editor) {
+  const gestures = $a('.routine-editor-gesture', editor.domElement);
+  const last = gestures[gestures.length-1];
+  if(last && last.scrollIntoView)
+    last.scrollIntoView({ block: 'nearest' });
+}
+
+// What the gesture did, in the terms the suggestions are built from. The widget
+// that moved is the first one up the chain whose place changed - a press on a
+// card pinned to a board drags the board - and a gesture that moved nothing at
+// all is a click on the widget the press landed on.
+function describeRoutineGesture(raw) {
+  const before = raw.before.filter(entry=>routineRecorderWidget(entry.id) === entry.widget);
+  if(!before.length)
+    return null;
+
+  const placeChanged = entry=>entry.parent !== (entry.widget.get('parent') || null)
+    || Math.round(entry.x) != Math.round(entry.widget.get('x')) || Math.round(entry.y) != Math.round(entry.widget.get('y'));
+  const moved = before.find(placeChanged);
+  const subject = moved || before[0];
+  const widget = subject.widget;
+
+  const gesture = {
+    key: ++routineGestureCounter,
+    widget,
+    widgetID: subject.id,
+    type: widget.get('type') || 'basic',
+    from: subject.parent,
+    to: widget.get('parent') || null,
+    x: Math.round(widget.get('x')),
+    y: Math.round(widget.get('y')),
+    dragged: Boolean(moved),
+    changes: raw.changes
+  };
+  gesture.reparented = gesture.dragged && gesture.from !== gesture.to;
+  gesture.label = routineGestureWords(gesture);
+  gesture.suggestions = routineGestureSuggestions(gesture);
+  return gesture;
+}
+
+function routineRecorderPlace(id) {
+  return id === null ? 'the table' : id;
+}
+
+function routineGestureWords(gesture) {
+  if(gesture.reparented)
+    return `dragged ${gesture.widgetID} from ${routineRecorderPlace(gesture.from)} to ${routineRecorderPlace(gesture.to)}`;
+  if(gesture.dragged)
+    return `dragged ${gesture.widgetID} to ${gesture.x}, ${gesture.y}`;
+  return `clicked ${gesture.widgetID}`;
+}
+
+// the seats whose hand this holder is: dropping a card into a hand is dealing to
+// the player sitting there, and MOVE deals to the seat rather than to its holder
+// (it sets the owner along the way, which a move into the holder does not)
+function seatsWithHand(holderID) {
+  if(!holderID)
+    return [];
+  return widgetFilter(w=>w.get('type') == 'seat' && w.get('hand') == holderID).map(w=>w.get('id')).sort();
+}
+
+function everySeatWithAHand() {
+  return widgetFilter(w=>w.get('type') == 'seat' && w.get('hand') && widgets.has(w.get('hand'))).map(w=>w.get('id')).sort();
+}
+
+function everyHand() {
+  return [ ...new Set(widgetFilter(w=>w.get('type') == 'seat' && w.get('hand') && widgets.has(w.get('hand'))).map(w=>w.get('hand'))) ].sort();
+}
+
+// RECALL gathers the cards of the decks lying IN a holder, so it is only worth
+// offering for a holder that has one
+function holderWithDeck(holderID) {
+  return Boolean(holderID) && widgetFilter(w=>w.get('type') == 'deck' && w.get('parent') == holderID).length > 0;
+}
+
+function isHolderLike(id) {
+  const widget = routineRecorderWidget(id);
+  return Boolean(widget) && [ 'holder', 'seat' ].indexOf(widget.get('type')) != -1;
+}
+
+// the value a property ended up with during this gesture, or undefined when the
+// gesture did not touch it
+function changedDuringGesture(gesture, id, property) {
+  const changes = gesture.changes[id];
+  return changes && typeof changes == 'object' ? changes[property] : undefined;
+}
+
+// Every reading of a gesture worth offering, in the order they are worth looking
+// at: what was literally just done first, then the ways a routine generalizes it
+// (all of them instead of one, every player instead of the one dropped on), then
+// what those two widgets are usually asked to do next.
+function routineGestureSuggestions(gesture) {
+  const suggestions = [];
+  const seen = [];
+  const add = (why, operation)=>{
+    const key = JSON.stringify(operation);
+    if(seen.indexOf(key) != -1 || suggestions.length >= 8)
+      return;
+    seen.push(key);
+    suggestions.push({ why, operation });
+  };
+
+  if(gesture.reparented)
+    reparentSuggestions(gesture, add);
+  else if(gesture.dragged)
+    repositionSuggestions(gesture, add);
+  else
+    clickSuggestions(gesture, add);
+
+  propertySuggestions(gesture, add);
+  return suggestions;
+}
+
+function reparentSuggestions(gesture, add) {
+  const { from, to, widgetID } = gesture;
+  const face = changedDuringGesture(gesture, widgetID, 'activeFace');
+
+  if(to === null) {
+    // out of a holder onto the table: the only operation that puts a widget at a
+    // spot of its own is MOVEXY, and it takes them out of a holder
+    if(isHolderLike(from)) {
+      add('take one out onto the table', { func: 'MOVEXY', from, count: 1, x: gesture.x, y: gesture.y });
+      add('take all of them out', { func: 'MOVEXY', from, count: 'all', x: gesture.x, y: gesture.y });
+    }
+    add('just take it out of whatever it is in', { func: 'SET', property: 'parent', value: null, collection: [ widgetID ] });
+    return;
+  }
+
+  if(from !== null && isHolderLike(from)) {
+    add('do exactly this', { func: 'MOVE', from, to, count: 1 });
+    add('move everything that is in there', { func: 'MOVE', from, to, count: 'all' });
+    if(typeof face == 'number')
+      add('and turn them over on the way', { func: 'MOVE', from, to, count: 1, face });
+  } else {
+    add('do exactly this', { func: 'MOVE', collection: [ widgetID ], to });
+  }
+
+  // dealing: dropping into a hand is dealing to the seat it belongs to, and a
+  // routine nearly always deals to every seat rather than to one
+  const seats = seatsWithHand(to);
+  if(seats.length && from !== null && isHolderLike(from)) {
+    const everySeat = everySeatWithAHand();
+    add(`deal one to ${seats.length > 1 ? 'those seats' : seats[0]}`, { func: 'MOVE', from, to: seats.length > 1 ? seats : seats[0], count: 1 });
+    if(everySeat.length > seats.length)
+      add('deal one to every player', { func: 'MOVE', from, to: everySeat, count: 1 });
+  }
+
+  // collecting: taking a card out of a hand is nearly always done for all of them
+  const hands = everyHand();
+  if(from !== null && hands.indexOf(from) != -1 && hands.length > 1)
+    add('take one from every player', { func: 'MOVE', from: hands, to, count: 1 });
+
+  if(holderWithDeck(to))
+    add('gather every card of its deck back in', { func: 'RECALL', holder: to });
+  if(holderWithDeck(from))
+    add('gather every card back where it came from', { func: 'RECALL', holder: from });
+  if(isHolderLike(to))
+    add('shuffle what is in there afterwards', { func: 'SHUFFLE', holder: to });
+  add('move whatever an earlier operation picked', { func: 'MOVE', to });
+}
+
+function repositionSuggestions(gesture, add) {
+  const { from, widgetID } = gesture;
+  const collection = [ widgetID ];
+  // x and y are measured against whatever the widget is in, which is exactly
+  // what a SET writes as well. MOVEXY is not the same thing: it takes widgets
+  // OUT of a holder and puts them at a spot in the room, which is not what a
+  // drag that left the widget where it was did.
+  add('put it exactly there', { func: 'SET', property: 'x', value: gesture.x, collection });
+  add('and at that height', { func: 'SET', property: 'y', value: gesture.y, collection });
+  if(from !== null && isHolderLike(from)) {
+    add('re-order what is in there instead', { func: 'SORT', holder: from });
+    add('shuffle it instead', { func: 'SHUFFLE', holder: from });
+  }
+}
+
+function clickSuggestions(gesture, add) {
+  const { widgetID, type, widget } = gesture;
+  const collection = [ widgetID ];
+
+  add('click it the way a player would', { func: 'CLICK', collection });
+  if(Array.isArray(widget.get('clickRoutine')))
+    add('run its click routine and wait for it', { func: 'CALL', routine: 'clickRoutine', widget: widgetID });
+
+  if(type == 'card') {
+    add('turn it face up', { func: 'FLIP', collection, face: 1 });
+    add('turn it face down', { func: 'FLIP', collection, face: 0 });
+  }
+  if(type == 'holder' || type == 'pile') {
+    add('shuffle it', { func: 'SHUFFLE', holder: widgetID });
+    add('sort it', { func: 'SORT', holder: widgetID });
+    if(holderWithDeck(widgetID))
+      add('gather every card of its deck back in', { func: 'RECALL', holder: widgetID });
+    add('move something out of it', { func: 'MOVE', from: widgetID, count: 1 });
+  }
+  if(type == 'seat')
+    add('give the turn to it', { func: 'TURN', turnCycle: 'seat', turn: widgetID });
+  if(type == 'timer')
+    add('start it', { func: 'TIMER', timer: widgetID, mode: 'start' });
+
+  add('change a property of it', { func: 'SET', property: '', value: '', collection });
+}
+
+// What the room did by itself while the gesture ran - the properties a holder,
+// a routine or a legacy mode set on the way. They are what a recording adds over
+// watching the pointer: a drop that turns the card face up says so.
+function propertySuggestions(gesture, add) {
+  for(const id in gesture.changes) {
+    const changes = gesture.changes[id];
+    if(!changes || typeof changes != 'object' || !routineRecorderWidget(id))
+      continue;
+    for(const property in changes) {
+      if(routineRecorderIgnoredProperties.indexOf(property) != -1 || property.charAt(0) == '_' || property.match(/Routine$/))
+        continue;
+      const value = changes[property];
+      const collection = [ id ];
+      if(property == 'activeFace' && typeof value == 'number')
+        add(`${id} ended up on that face`, { func: 'FLIP', collection, face: value });
+      else if(property == 'rotation' && typeof value == 'number')
+        add(`${id} ended up turned that way`, { func: 'ROTATE', collection, mode: 'set', angle: value });
+      else if(value === null || [ 'string', 'number', 'boolean' ].indexOf(typeof value) != -1)
+        add(`${id} got ${property} while you did that`, { func: 'SET', property, value, collection });
+    }
+  }
+}

--- a/client/js/editor/controls/routinerecorder.js
+++ b/client/js/editor/controls/routinerecorder.js
@@ -7,12 +7,19 @@
 // was just done, plus the ways a routine usually generalizes it - and picking
 // one adds it to the routine where "add operation" would have added it.
 //
-// One gesture is deliberately not one operation. Dragging a card from a hand
-// onto the discard pile is "move 1 card out of that hand", "move all of them",
-// "take one from every player" or "gather every card back into the deck",
-// depending on what the routine is for. The room cannot know which was meant,
-// but it knows the four - so it offers them and writes nothing until one is
-// picked. A gesture nobody picks anything from costs a card in the list.
+// One gesture is deliberately not one operation. Dragging a card out of the
+// deck into a hand is "move that card there", "deal one to that player", "deal
+// one to everybody" or "put the deck back together afterwards", depending on
+// what the routine is for. The room cannot know which was meant, but it knows
+// the handful worth offering - so it offers those and writes nothing until one
+// is picked. A gesture nobody picks anything from costs a card in the list.
+//
+// The card closes as soon as one of its readings is picked: one gesture is one
+// operation, and a second operation out of the same gesture is had by doing the
+// gesture again. Repeating a gesture does not repeat the card either - dealing
+// five cards out of the same holder into the same hand raises the count on the
+// card already standing there, so it stays one reading that says "move 5"
+// rather than five readings that say "move 1".
 //
 // While recording, the room answers the way it does for a player rather than
 // the way it does in edit mode (see selection.js): the selection band stays out
@@ -88,7 +95,7 @@ function routineRecordingState() {
 
 function startRoutineRecording(editor) {
   stopRoutineRecording();
-  activeRoutineRecording = { editor, widgetID: editor.widgetID, routineKey: editor.routineKey, gestures: [], added: [] };
+  activeRoutineRecording = { editor, widgetID: editor.widgetID, routineKey: editor.routineKey, gestures: [] };
   $('body').classList.add('editorRoutineRecording');
   drawRoutineRecordingLabel(editor);
   editor.render();
@@ -127,11 +134,12 @@ function removeRoutineRecordingLabel() {
     label.remove();
 }
 
-// A gesture nobody meant - a slip onto the wrong holder, a drag done only to put
-// the room back the way it was - can be taken off the card. Only the reading of
-// it goes: an operation already added from it stays in the routine, the way
-// anything else added to a routine stays until it is deleted there.
-export function forgetRoutineGesture(gesture) {
+// Taking a gesture off the list - because a reading of it was picked, or
+// because nobody meant it: a slip onto the wrong holder, a drag done only to
+// put the room back the way it was. Only the reading of it goes; an operation
+// already added from it stays in the routine, the way anything else added to a
+// routine stays until it is deleted there.
+export function closeRoutineGesture(gesture) {
   const recording = routineRecordingState();
   if(!recording)
     return;
@@ -216,10 +224,24 @@ export function routineRecorderPointerUp() {
   openRoutineGesture = null;
   if(!recording || !raw)
     return;
-  const gesture = describeRoutineGesture(raw, collectionsAroundRecording(recording));
+  const gesture = describeRoutineGesture(raw);
   if(!gesture || !gesture.suggestions.length)
     return;
-  recording.gestures.push(gesture);
+  // Doing the same thing again raises the count on the card that says it rather
+  // than writing a second card that says it once more: dealing five cards out of
+  // a holder into a hand is one operation that moves five, and five cards each
+  // offering the same four readings is a list nobody reads to the end of.
+  const repeated = gesture.repeatKey && recording.gestures.find(g=>g.repeatKey === gesture.repeatKey);
+  if(repeated) {
+    repeated.count += gesture.count;
+    // what the room did during the later gestures counts too - a holder that
+    // turns the first card face up turns the fifth one face up as well
+    for(const id in gesture.changes)
+      repeated.changes[id] = Object.assign(repeated.changes[id] || {}, gesture.changes[id]);
+    readRoutineGesture(repeated);
+  } else {
+    recording.gestures.push(gesture);
+  }
   recording.editor.render();
   scrollRoutineRecordingIntoView(recording.editor);
 }
@@ -235,18 +257,11 @@ function scrollRoutineRecordingIntoView(editor) {
     last.scrollIntoView({ block: 'nearest' });
 }
 
-// the collections an operation added by this recording could read - see
-// RoutineEditor.collectionsInScope()
-function collectionsAroundRecording(recording) {
-  const editor = recording.editor;
-  return editor && editor.collectionsInScope ? editor.collectionsInScope() : [];
-}
-
 // What the gesture did, in the terms the suggestions are built from. The widget
 // that moved is the first one up the chain whose place changed - a press on a
 // card pinned to a board drags the board - and a gesture that moved nothing at
 // all is a click on the widget the press landed on.
-function describeRoutineGesture(raw, collections=[]) {
+function describeRoutineGesture(raw) {
   const before = raw.before.filter(entry=>routineRecorderWidget(entry.id) === entry.widget);
   if(!before.length)
     return null;
@@ -270,23 +285,36 @@ function describeRoutineGesture(raw, collections=[]) {
   const subject = moved || before[0];
   const widget = subject.widget;
   const destination = routineRecorderDestination(widget);
+  const from = routineRecorderSource(raw.before, subject);
 
   const gesture = {
     key: ++routineGestureCounter,
     widget,
     widgetID: subject.id,
     type: widget.get('type') || 'basic',
-    from: subject.parent,
+    from,
     to: destination.to,
     x: destination.x,
     y: destination.y,
     dragged: Boolean(moved),
+    count: 1,
     changes
   };
   gesture.reparented = gesture.dragged && gesture.from !== gesture.to;
-  gesture.label = routineGestureWords(gesture);
-  gesture.suggestions = routineGestureSuggestions(gesture, collections);
+  // which gestures are the same gesture done again. Only a move from one holder
+  // into another is one: that is the operation with a count to raise, and it is
+  // the gesture that is really done over and over (dealing, discarding a hand).
+  gesture.repeatKey = gesture.reparented && isHolderLike(gesture.from) && isHolderLike(gesture.to)
+    ? `${gesture.from} > ${gesture.to}` : null;
+  readRoutineGesture(gesture);
   return gesture;
+}
+
+// how the gesture reads, from what it did and how often it was done - said again
+// whenever the count changes
+function readRoutineGesture(gesture) {
+  gesture.label = routineGestureWords(gesture);
+  gesture.suggestions = routineGestureSuggestions(gesture);
 }
 
 // Where the drag put the widget, in terms an operation can name. Dropping a card
@@ -312,6 +340,22 @@ function routineRecorderDestination(widget) {
   return { to: isHolderLike(place) ? place : null, x: Math.round(x), y: Math.round(y) };
 }
 
+// Where the drag started, read the same way. A card taken off a stack inside a
+// holder has that stack as its parent, and a pile is neither something MOVE
+// takes widgets out of nor something that is still there once it holds one
+// card - so what such a card came out of is the holder the pile stands in.
+// That is also what makes the fifth card dealt out of a holder the same gesture
+// as the first, rather than a gesture out of the stack the rest of them formed.
+//
+// The chain is the one taken at the press (see routineRecorderChain), because
+// by the release the pile can be gone.
+function routineRecorderSource(chain, subject) {
+  for(let i = chain.indexOf(subject)+1; i > 0 && i < chain.length; i++)
+    if(isHolderLike(chain[i].id))
+      return chain[i].id;
+  return isHolderLike(subject.parent) ? subject.parent : null;
+}
+
 // What to call a widget in the headline. The ids a game is built out of are
 // generated as often as they are chosen - a card is "pyn6" and the pile a
 // holder made around it is "o0ur", neither of which the author ever typed or
@@ -328,12 +372,24 @@ function routineRecorderPlace(id) {
   return id === null ? 'the table' : routineRecorderName(id);
 }
 
+// the same gesture done more than once is named by how many widgets went that
+// way rather than by the last of them: after five drags the id in the headline
+// is the one card that happened to be dragged last, which says nothing
+function routineGestureSubject(gesture) {
+  return gesture.count > 1 ? `${gesture.count} widgets` : routineRecorderName(gesture.widgetID);
+}
+
 function routineGestureWords(gesture) {
   if(gesture.reparented)
-    return `dragged ${routineRecorderName(gesture.widgetID)} from ${routineRecorderPlace(gesture.from)} to ${routineRecorderPlace(gesture.to)}`;
+    return `dragged ${routineGestureSubject(gesture)} from ${routineRecorderPlace(gesture.from)} to ${routineRecorderPlace(gesture.to)}`;
   if(gesture.dragged)
     return `dragged ${routineRecorderName(gesture.widgetID)} to ${gesture.x}, ${gesture.y}`;
   return `clicked ${routineRecorderName(gesture.widgetID)}`;
+}
+
+// how many, in a reading meant to be read out loud
+function routineGestureCount(gesture) {
+  return gesture.count > 1 ? String(gesture.count) : 'one';
 }
 
 // the seats whose hand this holder is: dropping a card into a hand is dealing to
@@ -349,10 +405,6 @@ function everySeatWithAHand() {
   return widgetFilter(w=>w.get('type') == 'seat' && w.get('hand') && widgets.has(w.get('hand'))).map(w=>w.get('id')).sort();
 }
 
-function everyHand() {
-  return [ ...new Set(widgetFilter(w=>w.get('type') == 'seat' && w.get('hand') && widgets.has(w.get('hand'))).map(w=>w.get('hand'))) ].sort();
-}
-
 // RECALL gathers the cards of the decks lying IN a holder, so it is only worth
 // offering for a holder that has one
 function holderWithDeck(holderID) {
@@ -364,35 +416,29 @@ function isHolderLike(id) {
   return Boolean(widget) && [ 'holder', 'seat' ].indexOf(widget.get('type')) != -1;
 }
 
-// the value a property ended up with during this gesture, or undefined when the
-// gesture did not touch it
-function changedDuringGesture(gesture, id, property) {
-  const changes = gesture.changes[id];
-  return changes && typeof changes == 'object' ? changes[property] : undefined;
-}
-
-// how many suggestions one gesture is worth reading through before the card
-// stops being a list and becomes a wall
-const routineSuggestionLimit = 8;
+// how many suggestions one gesture is worth reading through. A list of readings
+// is only useful while it can be read at a glance - past that the card asks the
+// author to compare a page of ways of saying nearly the same thing, which is
+// more work than writing the operation by hand would have been.
+const routineSuggestionLimit = 5;
 
 // Every reading of a gesture worth offering, in the order they are worth looking
-// at: what was literally just done first, then the ways a routine generalizes it
-// (all of them instead of one, every player instead of the one dropped on), then
-// what those two widgets are usually asked to do next.
+// at: what was literally just done first, then the two or three things a game
+// usually means by it - dealing to everybody rather than to the one seat that
+// was dropped on, putting the deck back together.
 //
 // The two kinds are collected apart so that the limit can prefer what the room
-// did on its own over the readings of the gesture: a room with seats in it makes
-// the ordinary dealing gesture produce more readings than fit, and the reading
-// that would fall off the end is the one watching the pointer could never
-// produce - "the hand turned the card face up as it went in". Half the list is
-// kept for those, and whatever they leave unused goes back to the gesture.
-function routineGestureSuggestions(gesture, collections=[]) {
+// did on its own over the readings of the gesture: the reading that would fall
+// off the end is the one watching the pointer could never produce - "the hand
+// turned the card face up as it went in". Two places are kept for those, and
+// whatever they leave unused goes back to the gesture.
+function routineGestureSuggestions(gesture) {
   const fromGesture = [];
   const fromRoom = [];
   const into = list=>((why, operation)=>list.push({ why, operation }));
 
   if(gesture.reparented)
-    reparentSuggestions(gesture, into(fromGesture), collections);
+    reparentSuggestions(gesture, into(fromGesture));
   else if(gesture.dragged)
     repositionSuggestions(gesture, into(fromGesture));
   else
@@ -413,85 +459,64 @@ function routineGestureSuggestions(gesture, collections=[]) {
     }
   };
 
-  const roomShare = Math.min(fromRoom.length, Math.floor(routineSuggestionLimit/2));
+  const roomShare = Math.min(fromRoom.length, 2);
   take(fromGesture, routineSuggestionLimit - roomShare);
   take(fromRoom, routineSuggestionLimit);
   take(fromGesture, routineSuggestionLimit);
   return suggestions;
 }
 
-function reparentSuggestions(gesture, add, collections=[]) {
-  const { from, to, widgetID } = gesture;
-  const face = changedDuringGesture(gesture, widgetID, 'activeFace');
+function reparentSuggestions(gesture, add) {
+  const { from, to, widgetID, count } = gesture;
+  const many = routineGestureCount(gesture);
 
   if(to === null) {
     // out of a holder onto the table: the only operation that puts a widget at a
     // spot of its own is MOVEXY, and it takes them out of a holder
     if(isHolderLike(from)) {
-      add('take one out onto the table', { func: 'MOVEXY', from, count: 1, x: gesture.x, y: gesture.y });
-      add('take all of them out', { func: 'MOVEXY', from, count: 'all', x: gesture.x, y: gesture.y });
+      add('do exactly this', { func: 'MOVEXY', from, count, x: gesture.x, y: gesture.y });
+      return;
     }
     // x and y are counted from whatever the widget is in, so taking it out on
     // its own drops it wherever its old coordinates land in the room. The two
     // that follow are what makes it stay where it was let go of - which is why
     // they say "and", the way the clauses of one gesture do.
-    add('just take it out of whatever it is in', { func: 'SET', property: 'parent', value: null, collection: [ widgetID ] });
+    add('do exactly this', { func: 'SET', property: 'parent', value: null, collection: [ widgetID ] });
     add('and put it exactly there', { func: 'SET', property: 'x', value: gesture.x, collection: [ widgetID ] });
     add('and at that height', { func: 'SET', property: 'y', value: gesture.y, collection: [ widgetID ] });
     return;
   }
 
-  if(from !== null && isHolderLike(from)) {
-    add('do exactly this', { func: 'MOVE', from, to, count: 1 });
-    add('move everything that is in there', { func: 'MOVE', from, to, count: 'all' });
-    if(typeof face == 'number')
-      add('and turn them over on the way', { func: 'MOVE', from, to, count: 1, face });
-  } else {
+  if(from !== null && isHolderLike(from))
+    add('do exactly this', { func: 'MOVE', from, to, count });
+  else
     add('do exactly this', { func: 'MOVE', collection: [ widgetID ], to });
-  }
 
   // dealing: dropping into a hand is dealing to the seat it belongs to, and a
   // routine nearly always deals to every seat rather than to one
   const seats = seatsWithHand(to);
   if(seats.length && from !== null && isHolderLike(from)) {
     const everySeat = everySeatWithAHand();
-    add(`deal one to ${seats.length > 1 ? 'those seats' : seats[0]}`, { func: 'MOVE', from, to: seats.length > 1 ? seats : seats[0], count: 1 });
+    add(`deal ${many} to ${seats.length > 1 ? 'those seats' : seats[0]}`, { func: 'MOVE', from, to: seats.length > 1 ? seats : seats[0], count });
     if(everySeat.length > seats.length)
-      add('deal one to every player', { func: 'MOVE', from, to: everySeat, count: 1 });
+      add(`deal ${many} to every player`, { func: 'MOVE', from, to: everySeat, count });
   }
 
-  // collecting: taking a card out of a hand is nearly always done for all of them
-  const hands = everyHand();
-  if(from !== null && hands.indexOf(from) != -1 && hands.length > 1)
-    add('take one from every player', { func: 'MOVE', from: hands, to, count: 1 });
-
-  if(holderWithDeck(to))
-    add('gather every card of its deck back in', { func: 'RECALL', holder: to });
-  if(holderWithDeck(from))
-    add('gather every card back where it came from', { func: 'RECALL', holder: from });
-  if(isHolderLike(to))
-    add('shuffle what is in there afterwards', { func: 'SHUFFLE', holder: to });
-  // "whatever an earlier operation picked" is the DEFAULT collection, which only
-  // exists once something in the routine before this point has filled it -
-  // offering it anywhere else writes an operation that is an error as soon as it
-  // is added ("no input given and collection DEFAULT is undefined")
-  if(collections.indexOf('DEFAULT') != -1)
-    add('move whatever an earlier operation picked', { func: 'MOVE', to });
+  // putting a deck back together: the one holder worth offering that for is the
+  // one the deck lies in, at whichever end of the drag it is
+  const deckHolder = [ to, from ].find(holderWithDeck);
+  if(deckHolder)
+    add(`put every card back into ${deckHolder}`, { func: 'RECALL', holder: deckHolder });
 }
 
 function repositionSuggestions(gesture, add) {
-  const { from, widgetID } = gesture;
-  const collection = [ widgetID ];
+  const collection = [ gesture.widgetID ];
   // x and y are measured against whatever the widget is in, which is exactly
   // what a SET writes as well. MOVEXY is not the same thing: it takes widgets
   // OUT of a holder and puts them at a spot in the room, which is not what a
   // drag that left the widget where it was did.
   add('put it exactly there', { func: 'SET', property: 'x', value: gesture.x, collection });
   add('and at that height', { func: 'SET', property: 'y', value: gesture.y, collection });
-  if(from !== null && isHolderLike(from)) {
-    add('re-order what is in there instead', { func: 'SORT', holder: from });
-    add('shuffle it instead', { func: 'SHUFFLE', holder: from });
-  }
 }
 
 // Rolling a die is the one thing a routine does by clicking rather than by an
@@ -515,6 +540,19 @@ function diceFaceValue(widget, face) {
   return value === undefined || value === null || typeof value == 'object' ? null : String(value);
 }
 
+// the same for a canvas: activeColor is a place in its color map, not a color,
+// so the reading says which color that place holds
+function canvasColorValue(widget, index) {
+  const colors = typeof widget.getColorMap == 'function' ? widget.getColorMap() : [];
+  const color = colors[index];
+  return typeof color == 'string' ? color : null;
+}
+
+function canvasNumber(widget, property, fallback) {
+  const value = Math.round(widget.get(property));
+  return Number.isFinite(value) ? value : fallback;
+}
+
 // a die that has no faces yet - one just added to the room, one whose faces are
 // still being typed - counts them modulo zero, which is not a face to put it on
 function diceActiveFace(widget) {
@@ -526,19 +564,31 @@ function clickSuggestions(gesture, add) {
   const { widgetID, type, widget } = gesture;
   const collection = [ widgetID ];
 
-  // Clicking a die rolls it and setting its face puts it on one on purpose, so
-  // both are offered in those words - and before the plain click below, which
-  // for a die is the same operation under a name that never says "roll".
+  // Clicking a die is rolling it, and the other thing a routine does to a die is
+  // put it on a face on purpose. Neither of them is a plain "click it": that is
+  // the same operation as the roll under a name that never says roll.
   if(type == 'dice') {
     add('roll it the way clicking it does', diceRollOperation(widget, collection));
     const face = diceActiveFace(widget);
     const shows = diceFaceValue(widget, face);
     add(`put it on a face instead of rolling it${shows === null ? '' : ` - it is showing ${shows}`}`, { func: 'SET', property: 'activeFace', value: face, collection });
+    return;
+  }
+
+  // A canvas is drawn on rather than clicked, so what a routine does to one is
+  // wipe it and set what the next stroke looks like. activeColor and lineWidth
+  // are offered at the values the canvas has now, to be changed to the wanted
+  // ones the way the die's face is.
+  if(type == 'canvas') {
+    add('wipe everything drawn on it', { func: 'CANVAS', collection, mode: 'reset' });
+    const activeColor = canvasNumber(widget, 'activeColor', 1);
+    const color = canvasColorValue(widget, activeColor);
+    add(`draw in another color${color === null ? '' : ` - it is drawing in ${color}`}`, { func: 'SET', property: 'activeColor', value: activeColor, collection });
+    add('draw with a thicker or thinner brush', { func: 'SET', property: 'lineWidth', value: canvasNumber(widget, 'lineWidth', 1), collection });
+    return;
   }
 
   add('click it the way a player would', { func: 'CLICK', collection });
-  if(Array.isArray(widget.get('clickRoutine')))
-    add('run its click routine and wait for it', { func: 'CALL', routine: 'clickRoutine', widget: widgetID });
 
   if(type == 'card') {
     add('turn it face up', { func: 'FLIP', collection, face: 1 });
@@ -546,10 +596,8 @@ function clickSuggestions(gesture, add) {
   }
   if(type == 'holder' || type == 'pile') {
     add('shuffle it', { func: 'SHUFFLE', holder: widgetID });
-    add('sort it', { func: 'SORT', holder: widgetID });
     if(holderWithDeck(widgetID))
-      add('gather every card of its deck back in', { func: 'RECALL', holder: widgetID });
-    add('move something out of it', { func: 'MOVE', from: widgetID, count: 1 });
+      add('put every card back into it', { func: 'RECALL', holder: widgetID });
   }
   if(type == 'seat')
     add('give the turn to it', { func: 'TURN', turnCycle: 'seat', turn: widgetID });

--- a/client/js/editor/selection.js
+++ b/client/js/editor/selection.js
@@ -10,6 +10,11 @@ let draggingDragButton = null;
 let widgetRectangles = null;
 
 export function editInputHandler(name, e) {
+  // While a routine is being recorded the room belongs to the recording: a
+  // selection band drawn over it would swallow every drag before it reaches the
+  // widget, and a drag is what is being recorded
+  if(isRoutineRecording())
+    return;
   // While Space is held (edit-space-pan), never show selection rectangles
   if(document.body.classList.contains('spacePanActive')) {
     if(selectionRectangleActive)
@@ -230,6 +235,11 @@ export async function editClick(widget) {
   // because that one is selected the whole time the picker runs
   if(handleWidgetPickerClick(widget))
     return true;
+  // and so does a running recording: selecting the clicked widget would take the
+  // editor off the routine the click is being recorded into, and running its
+  // click routine would play the game instead of describing it
+  if(handleRoutineRecorderClick())
+    return true;
   if(selectedWidgets.indexOf(widget) == -1) {
     setSelection([ widget ]);
     return true;
@@ -237,6 +247,10 @@ export async function editClick(widget) {
 }
 
 export function editorReceiveDelta(delta) {
+  // what the room did on its own while a gesture was being recorded (a holder
+  // turning a card face up as it enters) only shows up here
+  routineRecorderReceiveDelta(delta);
+
   // a widget can disappear while it is selected - a pile removes itself as soon
   // as it holds a single card. Its sidebar inputs would keep writing to the
   // dead id, and the server re-creates an unknown id as a typeless widget that

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1873,6 +1873,10 @@ class PropertiesModule extends SidebarModule {
     // controls they are anchored to just like moving on to another widget does -
     // so they go the same way, and the picks they run in the room with them.
     stopWidgetPicker();
+    // and so does a routine recording, for the same reason: it lives in a
+    // routine editor of this module, and an armed one keeps the crosshair and
+    // the frame around the room over a game that is being played again
+    stopRoutineRecording();
     closeEditorPopups();
   }
 

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -756,9 +756,15 @@ window.addEventListener('keydown', async function(e) {
 
 async function toggleEditMode() {
   await loadEditMode();
-  if(edit)
+  if(edit) {
     $('body').classList.remove('edit');
-  else
+    // A routine recording watches the room on the editor's behalf and puts a
+    // crosshair over the whole page while it does. Leaving edit mode from the
+    // Active Game tab does not go through the editor's own close (which stops
+    // it along with the widget picker, see properties.js), so it is stopped
+    // here as well - a game being played must not be left under the crosshair.
+    stopRoutineRecording();
+  } else
     $('body').classList.add('edit');
   edit = !edit;
   resetZoomAndPan();

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -66,6 +66,12 @@ async function inputHandler(name, e) {
   } finally {
     if(name == 'mouseup')
       await endDrag(dragTarget);
+    // A recorded gesture ends wherever the button comes up, which is not always
+    // in the room: a release over the sidebar or an overlay never reaches the
+    // widget handling above, and the recording must not stay open for it and
+    // then report the next gesture as this one.
+    if(edit && (name == 'mouseup' || name == 'touchend' || name == 'touchcancel'))
+      routineRecorderPointerUp();
   }
 }
 
@@ -117,6 +123,12 @@ async function handleInput(name, e, dragTarget) {
     // The drag still has to end - endDrag() only discards its state in that case.
     if(!widget)
       return;
+
+    // where a recorded gesture starts: which widget was pressed and where
+    // everything around it was, so the release can say what the drag did
+    if(edit && (name == 'mousedown' || name == 'touchstart'))
+      routineRecorderPointerDown(widget);
+
     batchStart();
     // batchEnd() has to run even if a routine triggered by the drop or click below
     // throws: batchStart() increments batchDepth and sendDelta() only sends anything

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -218,6 +218,7 @@ export default async function minifyHTML() {
     'client/js/editor/deckeditor.js',
 
     'client/js/editor/controls/routine.js',
+    'client/js/editor/controls/routinerecorder.js',
     'client/js/editor/controls/popup.js',
     'client/js/editor/controls/events.js',
 

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -3953,6 +3953,10 @@ describe('recording a routine from the room', () => {
       get: property => state[property] === undefined ? null : state[property],
       set: (property, value) => { state[property] = value; }
     };
+    // only Card and BasicWidget have a flip() - FLIP passes over everything else,
+    // and the recorder asks the widget rather than its type name
+    if([ 'card', 'basic' ].indexOf(state.type) != -1)
+      widget.flip = () => {};
     widgets.set(state.id, widget);
     return widget;
   };
@@ -4181,11 +4185,13 @@ describe('recording a routine from the room', () => {
     roomWidget({ id: 'card1', type: 'card' });
     const suggested = operations(routineGestureSuggestions(gesture({
       widgetID: 'card1', from: 'hand', to: 'table', reparented: true,
-      changes: { die1: { activeFace: 4 } }
+      changes: { die1: { activeFace: 4, rollCount: 7 } }
     })));
     // FLIP has no effect on a die: Dice has no flip() for it to call
     expect(suggested).toContainEqual({ func: 'SET', property: 'activeFace', value: 4, collection: [ 'die1' ] });
     expect(suggested).not.toContainEqual({ func: 'FLIP', collection: [ 'die1' ], face: 4 });
+    // and the counter the roll animation runs off is not a second reading of it
+    expect(suggested.filter(o => o.func == 'SET').map(o => o.property)).not.toContain('rollCount');
   });
 
   test('every suggestion reads as a finished sentence, with nothing of the template left in it', () => {
@@ -4289,6 +4295,50 @@ describe('recording a routine from the room', () => {
     const sentences = [ ...editor.domElement.querySelectorAll('.routine-editor-suggestion-sentence') ].map(s => s.textContent);
     expect(sentences).toContain('Turn card1 face up');
     expect(sentences).not.toContain('Set width of pile1 to 103');
+    // and no operation is offered that would have to name it either: the card
+    // went into a pile that stands in the hand, which is where the card already was
+    expect(sentences.join(' ')).not.toContain('pile1');
+  });
+
+  test('stacking two cards on the table puts one where the other is, not into the pile the drop invented', () => {
+    const card = roomWidget({ id: 'card1', type: 'card', x: 100, y: 100 });
+    roomWidget({ id: 'card2', type: 'card', x: 300, y: 200 });
+    startRoutineRecording(editor);
+    routineRecorderPointerDown(card);
+    // what the engine does when a card lands on a card: a pile appears where the
+    // other card was, with an id nobody typed and that is gone again as soon as
+    // the pile holds one card, and both cards go into it at its own coordinates
+    roomWidget({ id: 'o0ur', type: 'pile', x: 300, y: 200 });
+    card.set('parent', 'o0ur');
+    card.set('x', 0);
+    card.set('y', 0);
+    routineRecorderPointerUp();
+
+    // no operation moves anything into a pile - MOVE takes holders and seats -
+    // so what the gesture did is read as the place that pile stands in
+    expect(editor.domElement.querySelector('.routine-editor-gesture-what').textContent).toBe('dragged the card card1 to 300, 200');
+    const sentences = [ ...editor.domElement.querySelectorAll('.routine-editor-suggestion-sentence') ].map(s => s.textContent);
+    expect(sentences.join(' ')).not.toContain('o0ur');
+    editor.domElement.querySelector('.routine-editor-suggestion').click();
+    expect(editor.routine).toEqual([ { func: 'SET', property: 'x', value: 300, collection: [ 'card1' ] } ]);
+  });
+
+  test('a release the engine calls a click is recorded as one, however far the widget slid', () => {
+    const die = roomWidget({ id: 'die1', type: 'dice', clickable: true, x: 400, y: 300 });
+    startRoutineRecording(editor);
+    routineRecorderPointerDown(die);
+    // every mousemove moves the widget for real, so a hand that shakes by three
+    // pixels does leave it three pixels away - but a release under 10px and 250ms
+    // is a click to the engine, which is what runs the hook below
+    die.set('x', 403);
+    expect(handleRoutineRecorderClick()).toBe(true);
+    routineRecorderPointerUp();
+
+    expect(editor.domElement.querySelector('.routine-editor-gesture-what').textContent).toBe('clicked the dice die1');
+    const sentences = [ ...editor.domElement.querySelectorAll('.routine-editor-suggestion-sentence') ].map(s => s.textContent);
+    expect(sentences.join(' ')).not.toContain('403');
+    editor.domElement.querySelector('.routine-editor-suggestion').click();
+    expect(editor.routine).toEqual([ { func: 'CLICK', collection: [ 'die1' ] } ]);
   });
 
   test('a recording does not outlive the editor it was started in', () => {

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -3976,13 +3976,16 @@ describe('recording a routine from the room', () => {
     editor.domElement.remove();
   });
 
-  test('the button sits next to "add operation" and says what it is doing while it does it', () => {
+  test('the button sits next to "add operation" and shows what it is doing without changing width', () => {
     const record = () => editor.domElement.querySelector('.routine-editor-record-operation');
     expect(record().textContent).toBe('fiber_manual_recordrecord');
     expect(isRoutineRecording()).toBe(false);
     record().click();
     expect(isRoutineRecording()).toBe(true);
-    expect(record().textContent).toBe('fiber_manual_recordrecording…');
+    // the label is the same word armed - only the fill changes, so the button
+    // keeps its width and does not push "add operation" onto a line of its own
+    expect(record().textContent).toBe('fiber_manual_recordrecord');
+    expect(record().classList.contains('recording')).toBe(true);
     expect(document.body.classList.contains('editorRoutineRecording')).toBe(true);
     expect(editor.domElement.querySelector('.routine-editor-recording')).not.toBeNull();
     editor.domElement.querySelector('.routine-editor-recording-done').click();
@@ -4007,11 +4010,30 @@ describe('recording a routine from the room', () => {
     routineRecorderPointerUp();
 
     const sentences = [ ...editor.domElement.querySelectorAll('.routine-editor-suggestion-sentence') ].map(s => s.textContent);
-    expect(editor.domElement.querySelector('.routine-editor-gesture-what').textContent).toBe('dragged card1 from hand to discard');
+    // the ids of a real game are generated as often as they are chosen, so the
+    // headline says what kind of thing each of them is as well
+    expect(editor.domElement.querySelector('.routine-editor-gesture-what').textContent).toBe('dragged the card card1 from the holder hand to the holder discard');
     expect(sentences[0]).toBe('Move 1 widget from hand to discard');
     expect(sentences).toContain('Move all widgets from hand to discard');
     // nothing before it picked anything, so there is no collection to move
     expect(sentences).not.toContain('Move the picked widgets to discard');
+  });
+
+  test('a gesture nobody meant is taken off the card, and what it already added stays', () => {
+    roomWidget({ id: 'hand', type: 'holder' });
+    roomWidget({ id: 'discard', type: 'holder' });
+    const card = roomWidget({ id: 'card1', type: 'card', parent: 'hand' });
+    startRoutineRecording(editor);
+    routineRecorderPointerDown(card);
+    card.set('parent', 'discard');
+    routineRecorderPointerUp();
+    expect(editor.domElement.querySelectorAll('.routine-editor-gesture').length).toBe(1);
+
+    editor.domElement.querySelector('.routine-editor-suggestion').click();
+    editor.domElement.querySelector('.routine-editor-gesture-forget').click();
+    expect(editor.domElement.querySelectorAll('.routine-editor-gesture').length).toBe(0);
+    expect(isRoutineRecording()).toBe(true); // only that reading goes, not the recording
+    expect(editor.routine).toEqual([ { func: 'MOVE', from: 'hand', to: 'discard', count: 1 } ]);
   });
 
   test('moving "whatever an earlier operation picked" is only offered where something picked', () => {
@@ -4251,6 +4273,22 @@ describe('recording a routine from the room', () => {
     const sentences = [ ...editor.domElement.querySelectorAll('.routine-editor-suggestion-sentence') ].map(s => s.textContent);
     expect(sentences).toContain('Turn card1 face up');
     expect(sentences).not.toContain('Turn card2 face up');
+  });
+
+  test('a widget the gesture created is not offered as something to set properties on', () => {
+    roomWidget({ id: 'hand', type: 'holder' });
+    const card = roomWidget({ id: 'card1', type: 'card', parent: 'hand' });
+    startRoutineRecording(editor);
+    routineRecorderPointerDown(card);
+    // dropping a card onto a card makes a pile around them, and the pile reports
+    // everything it is as it appears - none of which a routine would ever set
+    roomWidget({ id: 'pile1', type: 'pile', parent: 'hand' });
+    routineRecorderReceiveDelta({ s: { pile1: { width: 103, height: 160 }, card1: { activeFace: 1 } } });
+    card.set('parent', 'pile1');
+    routineRecorderPointerUp();
+    const sentences = [ ...editor.domElement.querySelectorAll('.routine-editor-suggestion-sentence') ].map(s => s.textContent);
+    expect(sentences).toContain('Turn card1 face up');
+    expect(sentences).not.toContain('Set width of pile1 to 103');
   });
 
   test('a recording does not outlive the editor it was started in', () => {

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -3966,7 +3966,7 @@ describe('recording a routine from the room', () => {
     dragged: true, reparented: false, count: 1, changes: {}
   }, properties, { widget: widgets.get(properties.widgetID || 'card1') });
 
-  const operations = suggestions => suggestions.map(s => s.operation);
+  const operations = suggestions => suggestions.flatMap(s => s.operations);
 
   let editor;
   beforeEach(() => {
@@ -4159,12 +4159,16 @@ describe('recording a routine from the room', () => {
     roomWidget({ id: 'card1', type: 'card', parent: 'pile1' });
     // x and y are counted from the parent, so dropping the parent alone would put
     // the widget wherever those coordinates land in the room instead
-    const suggested = operations(routineGestureSuggestions(gesture({
+    const suggestions = routineGestureSuggestions(gesture({
       widgetID: 'card1', from: 'pile1', to: null, reparented: true, x: 300, y: 200
-    })));
-    expect(suggested).toContainEqual({ func: 'SET', property: 'parent', value: null, collection: [ 'card1' ] });
-    expect(suggested).toContainEqual({ func: 'SET', property: 'x', value: 300, collection: [ 'card1' ] });
-    expect(suggested).toContainEqual({ func: 'SET', property: 'y', value: 200, collection: [ 'card1' ] });
+    }));
+    // and all three are one reading rather than three: half of them done is a
+    // widget somewhere nobody dropped it
+    expect(suggestions[0].operations).toEqual([
+      { func: 'SET', property: 'parent', value: null, collection: [ 'card1' ] },
+      { func: 'SET', property: 'x', value: 300, collection: [ 'card1' ] },
+      { func: 'SET', property: 'y', value: 200, collection: [ 'card1' ] }
+    ]);
   });
 
   test('a click offers the ways a routine does what a click does', () => {
@@ -4251,12 +4255,15 @@ describe('recording a routine from the room', () => {
     for(const g of gestures) {
       const suggestions = routineGestureSuggestions(g);
       expect(suggestions.length).toBeGreaterThan(0);
-      for(const { operation, why } of suggestions) {
-        const operationEditor = editorForOperation(operation);
-        operationEditor.setOperationDetails(null, operation, [], []);
-        const sentence = operationEditor.getSentenceText();
-        expect(sentence).not.toMatch(/\{[a-zA-Z,]+\}/);
-        expect(sentence).not.toContain('undefined');
+      for(const { operations, why } of suggestions) {
+        expect(operations.length).toBeGreaterThan(0);
+        for(const operation of operations) {
+          const operationEditor = editorForOperation(operation);
+          operationEditor.setOperationDetails(null, operation, [], []);
+          const sentence = operationEditor.getSentenceText();
+          expect(sentence).not.toMatch(/\{[a-zA-Z,]+\}/);
+          expect(sentence).not.toContain('undefined');
+        }
         expect(why.length).toBeGreaterThan(3);
       }
     }
@@ -4358,8 +4365,15 @@ describe('recording a routine from the room', () => {
     expect(editor.domElement.querySelector('.routine-editor-gesture-what').textContent).toBe('dragged the card card1 to 300, 200');
     const sentences = [ ...editor.domElement.querySelectorAll('.routine-editor-suggestion-sentence') ].map(s => s.textContent);
     expect(sentences.join(' ')).not.toContain('o0ur');
+    // where it was put is one row to pick, spelling out both operations it adds
+    expect(editor.domElement.querySelectorAll('.routine-editor-suggestion').length).toBe(1);
+    expect(sentences).toEqual([ 'Set x of card1 to 300', 'Set y of card1 to 200' ]);
+    // and picking it writes both
     editor.domElement.querySelector('.routine-editor-suggestion').click();
-    expect(editor.routine).toEqual([ { func: 'SET', property: 'x', value: 300, collection: [ 'card1' ] } ]);
+    expect(editor.routine).toEqual([
+      { func: 'SET', property: 'x', value: 300, collection: [ 'card1' ] },
+      { func: 'SET', property: 'y', value: 200, collection: [ 'card1' ] }
+    ]);
   });
 
   test('a release the engine calls a click is recorded as one, however far the widget slid', () => {

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -21,6 +21,7 @@ beforeAll(() => {
   window.widgetFilter = filter => [ ...window.widgets.values() ].filter(filter);
   window.roomID = 'testroom'; // the tutorial links of info popups use it
   window.setSelection = () => {};
+  window.getPlayerDetails = () => ({ playerName: 'Alice' }); // the recorder tells its own deltas from other players'
   window.closePropertyInfoPopup = () => {}; // the sidebar's own info tips (propertyInputs.js)
   window.editorTypeNames = { basic: 'Widget', button: 'Button', canvas: 'Canvas', card: 'Card', holder: 'Holder', label: 'Label', seat: 'Seat', timer: 'Timer' };
   // the validator tables are part of the editor bundle; the property proposals read them
@@ -4009,7 +4010,27 @@ describe('recording a routine from the room', () => {
     expect(editor.domElement.querySelector('.routine-editor-gesture-what').textContent).toBe('dragged card1 from hand to discard');
     expect(sentences[0]).toBe('Move 1 widget from hand to discard');
     expect(sentences).toContain('Move all widgets from hand to discard');
+    // nothing before it picked anything, so there is no collection to move
+    expect(sentences).not.toContain('Move the picked widgets to discard');
+  });
+
+  test('moving "whatever an earlier operation picked" is only offered where something picked', () => {
+    roomWidget({ id: 'hand', type: 'holder' });
+    roomWidget({ id: 'discard', type: 'holder' });
+    const card = roomWidget({ id: 'card1', type: 'card', parent: 'hand' });
+    const widget = { state: { id: 'button3' }, get: p => ({ id: 'button3' })[p] || null };
+    const withSelect = new RoutineEditor(widget, [ { func: 'SELECT', type: 'card' } ]);
+    document.getElementById('editor').append(withSelect.domElement);
+    expect(withSelect.collectionsInScope()).toContain('DEFAULT');
+
+    startRoutineRecording(withSelect);
+    routineRecorderPointerDown(card);
+    card.set('parent', 'discard');
+    routineRecorderPointerUp();
+
+    const sentences = [ ...withSelect.domElement.querySelectorAll('.routine-editor-suggestion-sentence') ].map(s => s.textContent);
     expect(sentences).toContain('Move the picked widgets to discard');
+    withSelect.domElement.remove();
   });
 
   test('dropping into a hand offers dealing to that seat and to every player', () => {
@@ -4065,6 +4086,41 @@ describe('recording a routine from the room', () => {
     // the drag itself is what the move says - it is not also a "Set parent of"
     expect(suggested.filter(o => o.func == 'SET').map(o => o.property)).not.toContain('parent');
     expect(suggested.filter(o => o.func == 'SET').map(o => o.property)).not.toContain('x');
+  });
+
+  test('what the room did survives a gesture that has more readings than fit', () => {
+    // the ordinary dealing gesture in a room with seats: it alone reads more ways
+    // than the list is long, and what the hand did to the card as it went in must
+    // not be what falls off the end
+    roomWidget({ id: 'deckHolder', type: 'holder' });
+    roomWidget({ id: 'deck1', type: 'deck', parent: 'deckHolder' });
+    for(const seat of [ 1, 2, 3 ]) {
+      roomWidget({ id: `hand-p${seat}`, type: 'holder' });
+      roomWidget({ id: `seat-p${seat}`, type: 'seat', hand: `hand-p${seat}` });
+    }
+    roomWidget({ id: 'card1', type: 'card' });
+    const suggestions = routineGestureSuggestions(gesture({
+      widgetID: 'card1', from: 'deckHolder', to: 'hand-p1', reparented: true,
+      changes: { card1: { activeFace: 1, rotation: 90, parent: 'hand-p1' } }
+    }));
+    const suggested = operations(suggestions);
+    expect(suggestions.length).toBeLessThanOrEqual(8);
+    expect(suggested).toContainEqual({ func: 'MOVE', from: 'deckHolder', to: 'hand-p1', count: 1 });
+    expect(suggested).toContainEqual({ func: 'FLIP', collection: [ 'card1' ], face: 1 });
+    expect(suggested).toContainEqual({ func: 'ROTATE', collection: [ 'card1' ], mode: 'set', angle: 90 });
+  });
+
+  test('taking a widget out onto the table offers the position that keeps it there', () => {
+    roomWidget({ id: 'pile1', type: 'pile' });
+    roomWidget({ id: 'card1', type: 'card', parent: 'pile1' });
+    // x and y are counted from the parent, so dropping the parent alone would put
+    // the widget wherever those coordinates land in the room instead
+    const suggested = operations(routineGestureSuggestions(gesture({
+      widgetID: 'card1', from: 'pile1', to: null, reparented: true, x: 300, y: 200
+    })));
+    expect(suggested).toContainEqual({ func: 'SET', property: 'parent', value: null, collection: [ 'card1' ] });
+    expect(suggested).toContainEqual({ func: 'SET', property: 'x', value: 300, collection: [ 'card1' ] });
+    expect(suggested).toContainEqual({ func: 'SET', property: 'y', value: 200, collection: [ 'card1' ] });
   });
 
   test('a click offers the ways a routine does what a click does', () => {
@@ -4144,6 +4200,34 @@ describe('recording a routine from the room', () => {
     routineRecorderPointerUp();
     const sentences = [ ...editor.domElement.querySelectorAll('.routine-editor-suggestion-sentence') ].map(s => s.textContent);
     expect(sentences).toContain('Turn card1 face down');
+  });
+
+  test('what another player does at the same time is not part of the gesture', () => {
+    roomWidget({ id: 'hand', type: 'holder' });
+    roomWidget({ id: 'table', type: 'holder' });
+    roomWidget({ id: 'card2', type: 'card' });
+    const card = roomWidget({ id: 'card1', type: 'card', parent: 'hand' });
+    startRoutineRecording(editor);
+    routineRecorderPointerDown(card);
+    routineRecorderReceiveDelta({ s: { card2: { activeFace: 1 } }, c: 'Bob dragged card2' });
+    routineRecorderReceiveDelta({ s: { card1: { activeFace: 1 } }, c: 'Alice dragged card1' });
+    card.set('parent', 'table');
+    routineRecorderPointerUp();
+    const sentences = [ ...editor.domElement.querySelectorAll('.routine-editor-suggestion-sentence') ].map(s => s.textContent);
+    expect(sentences).toContain('Turn card1 face up');
+    expect(sentences).not.toContain('Turn card2 face up');
+  });
+
+  test('a recording does not outlive the editor it was started in', () => {
+    startRoutineRecording(editor);
+    expect(document.body.classList.contains('editorRoutineRecording')).toBe(true);
+    // what the properties module does when it closes: the routine editor goes
+    // with the sidebar, and leaving edit mode only display:none's the editor, so
+    // nothing else would take the crosshair and the frame off the room again
+    editor.domElement.remove();
+    stopRoutineRecording();
+    expect(isRoutineRecording()).toBe(false);
+    expect(document.body.classList.contains('editorRoutineRecording')).toBe(false);
   });
 
   test('only one routine is recorded at a time - starting another one moves it there', () => {

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -3963,7 +3963,7 @@ describe('recording a routine from the room', () => {
 
   const gesture = properties => Object.assign({
     key: 1, widgetID: 'card1', type: 'card', from: null, to: null, x: 0, y: 0,
-    dragged: true, reparented: false, changes: {}
+    dragged: true, reparented: false, count: 1, changes: {}
   }, properties, { widget: widgets.get(properties.widgetID || 'card1') });
 
   const operations = suggestions => suggestions.map(s => s.operation);
@@ -4004,7 +4004,7 @@ describe('recording a routine from the room', () => {
     expect(handleRoutineRecorderClick()).toBe(true);
   });
 
-  test('a drag from one holder into another offers the move it was, and the same move for all of them', () => {
+  test('a drag from one holder into another offers the move it was, and nothing much beside it', () => {
     roomWidget({ id: 'hand', type: 'holder' });
     roomWidget({ id: 'discard', type: 'holder' });
     const card = roomWidget({ id: 'card1', type: 'card', parent: 'hand' });
@@ -4017,13 +4017,54 @@ describe('recording a routine from the room', () => {
     // the ids of a real game are generated as often as they are chosen, so the
     // headline says what kind of thing each of them is as well
     expect(editor.domElement.querySelector('.routine-editor-gesture-what').textContent).toBe('dragged the card card1 from the holder hand to the holder discard');
-    expect(sentences[0]).toBe('Move 1 widget from hand to discard');
-    expect(sentences).toContain('Move all widgets from hand to discard');
-    // nothing before it picked anything, so there is no collection to move
-    expect(sentences).not.toContain('Move the picked widgets to discard');
+    // no seats, no deck: nothing about this drag reads any other way, so the one
+    // reading of it stands alone rather than among ways of rewording it
+    expect(sentences).toEqual([ 'Move 1 widget from hand to discard' ]);
   });
 
-  test('a gesture nobody meant is taken off the card, and what it already added stays', () => {
+  test('the same drag done again raises the count instead of writing another card', () => {
+    roomWidget({ id: 'deckHolder', type: 'holder' });
+    roomWidget({ id: 'hand', type: 'holder' });
+    const cards = [ 1, 2, 3 ].map(n => roomWidget({ id: `card${n}`, type: 'card', parent: 'deckHolder' }));
+    startRoutineRecording(editor);
+    for(const card of cards) {
+      routineRecorderPointerDown(card);
+      card.set('parent', 'hand');
+      routineRecorderPointerUp();
+    }
+
+    expect(editor.domElement.querySelectorAll('.routine-editor-gesture').length).toBe(1);
+    // the id of the card that happened to be dragged last says nothing about
+    // three drags, so the headline counts them instead
+    expect(editor.domElement.querySelector('.routine-editor-gesture-what').textContent).toBe('dragged 3 widgets from the holder deckHolder to the holder hand');
+    const sentences = [ ...editor.domElement.querySelectorAll('.routine-editor-suggestion-sentence') ].map(s => s.textContent);
+    expect(sentences).toEqual([ 'Move 3 widgets from deckHolder to hand' ]);
+
+    // the way back is not the same gesture done again
+    routineRecorderPointerDown(cards[0]);
+    cards[0].set('parent', 'deckHolder');
+    routineRecorderPointerUp();
+    expect(editor.domElement.querySelectorAll('.routine-editor-gesture').length).toBe(2);
+  });
+
+  test('a card taken off a stack in a holder comes out of the holder, not out of the stack', () => {
+    roomWidget({ id: 'deckHolder', type: 'holder' });
+    roomWidget({ id: 'hand', type: 'holder' });
+    roomWidget({ id: 'pile1', type: 'pile', parent: 'deckHolder' });
+    const card = roomWidget({ id: 'card1', type: 'card', parent: 'pile1' });
+    startRoutineRecording(editor);
+    routineRecorderPointerDown(card);
+    card.set('parent', 'hand');
+    routineRecorderPointerUp();
+
+    // no operation takes widgets out of a pile, and the pile is gone again as
+    // soon as it holds one card - what the card came out of is the holder
+    expect(editor.domElement.querySelector('.routine-editor-gesture-what').textContent).toBe('dragged the card card1 from the holder deckHolder to the holder hand');
+    const sentences = [ ...editor.domElement.querySelectorAll('.routine-editor-suggestion-sentence') ].map(s => s.textContent);
+    expect(sentences).toEqual([ 'Move 1 widget from deckHolder to hand' ]);
+  });
+
+  test('a gesture nobody meant is taken off the card, and what was already added stays', () => {
     roomWidget({ id: 'hand', type: 'holder' });
     roomWidget({ id: 'discard', type: 'holder' });
     const card = roomWidget({ id: 'card1', type: 'card', parent: 'hand' });
@@ -4031,32 +4072,18 @@ describe('recording a routine from the room', () => {
     routineRecorderPointerDown(card);
     card.set('parent', 'discard');
     routineRecorderPointerUp();
-    expect(editor.domElement.querySelectorAll('.routine-editor-gesture').length).toBe(1);
-
     editor.domElement.querySelector('.routine-editor-suggestion').click();
+
+    // and now a drag nobody meant: the way back, done only to put the room right
+    routineRecorderPointerDown(card);
+    card.set('parent', 'hand');
+    routineRecorderPointerUp();
+    expect(editor.domElement.querySelectorAll('.routine-editor-gesture').length).toBe(1);
     editor.domElement.querySelector('.routine-editor-gesture-forget').click();
+
     expect(editor.domElement.querySelectorAll('.routine-editor-gesture').length).toBe(0);
     expect(isRoutineRecording()).toBe(true); // only that reading goes, not the recording
     expect(editor.routine).toEqual([ { func: 'MOVE', from: 'hand', to: 'discard', count: 1 } ]);
-  });
-
-  test('moving "whatever an earlier operation picked" is only offered where something picked', () => {
-    roomWidget({ id: 'hand', type: 'holder' });
-    roomWidget({ id: 'discard', type: 'holder' });
-    const card = roomWidget({ id: 'card1', type: 'card', parent: 'hand' });
-    const widget = { state: { id: 'button3' }, get: p => ({ id: 'button3' })[p] || null };
-    const withSelect = new RoutineEditor(widget, [ { func: 'SELECT', type: 'card' } ]);
-    document.getElementById('editor').append(withSelect.domElement);
-    expect(withSelect.collectionsInScope()).toContain('DEFAULT');
-
-    startRoutineRecording(withSelect);
-    routineRecorderPointerDown(card);
-    card.set('parent', 'discard');
-    routineRecorderPointerUp();
-
-    const sentences = [ ...withSelect.domElement.querySelectorAll('.routine-editor-suggestion-sentence') ].map(s => s.textContent);
-    expect(sentences).toContain('Move the picked widgets to discard');
-    withSelect.domElement.remove();
   });
 
   test('dropping into a hand offers dealing to that seat and to every player', () => {
@@ -4072,31 +4099,22 @@ describe('recording a routine from the room', () => {
     expect(suggested).toContainEqual({ func: 'MOVE', from: 'deckHolder', to: [ 'seat-p1', 'seat-p2' ], count: 1 });
   });
 
-  test('taking a card out of a hand offers taking one from every player', () => {
-    roomWidget({ id: 'table', type: 'holder' });
-    roomWidget({ id: 'hand-p1', type: 'holder' });
-    roomWidget({ id: 'hand-p2', type: 'holder' });
-    roomWidget({ id: 'seat-p1', type: 'seat', hand: 'hand-p1' });
-    roomWidget({ id: 'seat-p2', type: 'seat', hand: 'hand-p2' });
-    const suggested = operations(routineGestureSuggestions(gesture({
-      widgetID: 'card1', from: 'hand-p1', to: 'table', reparented: true
-    })));
-    expect(suggested).toContainEqual({ func: 'MOVE', from: [ 'hand-p1', 'hand-p2' ], to: 'table', count: 1 });
-  });
-
-  test('a holder that has a deck in it is offered as somewhere to recall to', () => {
+  test('the holder a deck lies in is offered as somewhere to put every card back into', () => {
     roomWidget({ id: 'deckHolder', type: 'holder' });
     roomWidget({ id: 'deck1', type: 'deck', parent: 'deckHolder' });
     roomWidget({ id: 'discard', type: 'holder' });
+    // whichever end of the drag it is: dealing out of the deck is the gesture a
+    // "recall and shuffle" button is written after just as often as tidying up
     const intoDeck = operations(routineGestureSuggestions(gesture({
       widgetID: 'card1', from: 'discard', to: 'deckHolder', reparented: true
     })));
     expect(intoDeck).toContainEqual({ func: 'RECALL', holder: 'deckHolder' });
-    // a holder without a deck has nothing to gather - RECALL would do nothing
-    const intoDiscard = operations(routineGestureSuggestions(gesture({
+    const outOfDeck = operations(routineGestureSuggestions(gesture({
       widgetID: 'card1', from: 'deckHolder', to: 'discard', reparented: true
     })));
-    expect(intoDiscard).not.toContainEqual({ func: 'RECALL', holder: 'discard' });
+    expect(outOfDeck).toContainEqual({ func: 'RECALL', holder: 'deckHolder' });
+    // a holder without a deck has nothing to gather - RECALL would do nothing
+    expect(outOfDeck).not.toContainEqual({ func: 'RECALL', holder: 'discard' });
   });
 
   test('what the room did on its own during the gesture becomes a suggestion of its own', () => {
@@ -4130,7 +4148,7 @@ describe('recording a routine from the room', () => {
       changes: { card1: { activeFace: 1, rotation: 90, parent: 'hand-p1' } }
     }));
     const suggested = operations(suggestions);
-    expect(suggestions.length).toBeLessThanOrEqual(8);
+    expect(suggestions.length).toBeLessThanOrEqual(5);
     expect(suggested).toContainEqual({ func: 'MOVE', from: 'deckHolder', to: 'hand-p1', count: 1 });
     expect(suggested).toContainEqual({ func: 'FLIP', collection: [ 'card1' ], face: 1 });
     expect(suggested).toContainEqual({ func: 'ROTATE', collection: [ 'card1' ], mode: 'set', angle: 90 });
@@ -4159,13 +4177,30 @@ describe('recording a routine from the room', () => {
     expect(holder).toContainEqual({ func: 'SHUFFLE', holder: 'h1' });
   });
 
-  test('clicking a die offers rolling it and putting it on a face', () => {
+  test('clicking a die offers rolling it and putting it on a face, and nothing else', () => {
     roomWidget({ id: 'die1', type: 'dice', clickable: true, activeFace: 2 });
     const suggested = routineGestureSuggestions(gesture({ widgetID: 'die1', type: 'dice', dragged: false }));
-    // rolling a die is what clicking one does - there is no operation for it
-    expect(operations(suggested)).toContainEqual({ func: 'CLICK', collection: [ 'die1' ] });
-    expect(operations(suggested)).toContainEqual({ func: 'SET', property: 'activeFace', value: 2, collection: [ 'die1' ] });
+    // rolling a die is what clicking one does - there is no operation for it,
+    // and "click it" as a second reading of the same click says nothing
+    expect(operations(suggested)).toEqual([
+      { func: 'CLICK', collection: [ 'die1' ] },
+      { func: 'SET', property: 'activeFace', value: 2, collection: [ 'die1' ] }
+    ]);
     expect(suggested[0].why).toContain('roll');
+  });
+
+  test('clicking a canvas offers wiping it and what the next stroke looks like', () => {
+    const canvas = roomWidget({ id: 'canvas1', type: 'canvas', activeColor: 2, lineWidth: 3 });
+    canvas.getColorMap = () => [ '#000000', '#ff0000', '#00ff00' ];
+    const suggested = routineGestureSuggestions(gesture({ widgetID: 'canvas1', type: 'canvas', dragged: false }));
+    expect(operations(suggested)).toEqual([
+      { func: 'CANVAS', collection: [ 'canvas1' ], mode: 'reset' },
+      { func: 'SET', property: 'activeColor', value: 2, collection: [ 'canvas1' ] },
+      { func: 'SET', property: 'lineWidth', value: 3, collection: [ 'canvas1' ] }
+    ]);
+    // activeColor is a place in the color map rather than a color, so the
+    // reading says which color that place holds
+    expect(suggested[1].why).toContain('#00ff00');
   });
 
   test('a die that has something else to do when clicked still rolls by leaving that out', () => {
@@ -4202,13 +4237,16 @@ describe('recording a routine from the room', () => {
     roomWidget({ id: 'card1', type: 'card', parent: 'deckHolder' });
     roomWidget({ id: 'timer1', type: 'timer' });
     roomWidget({ id: 'die1', type: 'dice', clickable: true });
+    roomWidget({ id: 'canvas1', type: 'canvas', activeColor: 1, lineWidth: 1 });
     const gestures = [
       gesture({ widgetID: 'card1', from: 'deckHolder', to: 'hand', reparented: true }),
+      gesture({ widgetID: 'card1', from: 'deckHolder', to: 'hand', reparented: true, count: 4 }),
       gesture({ widgetID: 'card1', from: 'hand', to: null, reparented: true, x: 300, y: 200 }),
       gesture({ widgetID: 'card1', from: null, to: null, x: 300, y: 200 }),
       gesture({ widgetID: 'card1', dragged: false }),
       gesture({ widgetID: 'timer1', type: 'timer', dragged: false }),
-      gesture({ widgetID: 'die1', type: 'dice', dragged: false })
+      gesture({ widgetID: 'die1', type: 'dice', dragged: false }),
+      gesture({ widgetID: 'canvas1', type: 'canvas', dragged: false })
     ];
     for(const g of gestures) {
       const suggestions = routineGestureSuggestions(g);
@@ -4236,9 +4274,10 @@ describe('recording a routine from the room', () => {
 
     editor.domElement.querySelector('.routine-editor-suggestion').click();
     expect(editor.routine).toEqual([ { func: 'MOVE', from: 'hand', to: 'discard', count: 1 } ]);
-    // the card that was worked on last is the one it was added as, so the next
-    // one follows it - and the suggestion says it was used
-    expect(editor.domElement.querySelector('.routine-editor-suggestion').className).toContain('routine-editor-suggestion-added');
+    // the card is answered and closes: a second operation out of the same
+    // gesture is had by doing the gesture again
+    expect(editor.domElement.querySelectorAll('.routine-editor-gesture').length).toBe(0);
+    expect(isRoutineRecording()).toBe(true);
   });
 
   test('a gesture the pointer never finished in the room does not become the next one', () => {

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -18,6 +18,7 @@ beforeAll(() => {
   };
   window.html = string => String(string).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
   window.widgets = new Map();
+  window.widgetFilter = filter => [ ...window.widgets.values() ].filter(filter);
   window.roomID = 'testroom'; // the tutorial links of info popups use it
   window.setSelection = () => {};
   window.closePropertyInfoPopup = () => {}; // the sidebar's own info tips (propertyInputs.js)
@@ -36,9 +37,12 @@ beforeAll(() => {
     'client/js/editor/controls/widgetselection.js',
     'client/js/editor/controls/popup.js',
     'client/js/editor/controls/routine.js',
+    'client/js/editor/controls/routinerecorder.js',
     'client/js/editor/controls/events.js'
   ];
-  const code = files.map(f => fs.readFileSync(f, 'utf8')).join('\n');
+  // the recorder exports the hooks mousehandling.js calls; the bundle keeps them
+  // (main.js imports it), but eval has no module scope to export from
+  const code = files.map(f => fs.readFileSync(f, 'utf8')).join('\n').replace(/^export /gm, '');
   const exposed = [
     'RoutineEditor', 'RoutineOperationEditor', 'IfRoutineOperationEditor', 'ForeachRoutineOperationEditor',
     'VarStringRoutineOperationEditor', 'CommentRoutineOperationEditor', 'UnknownRoutineOperationEditor',
@@ -51,6 +55,8 @@ beforeAll(() => {
     'parseVarStatement', 'writeVarStatement', 'encodeVarOperand', 'decodeVarOperand',
     'EventsEditor', 'propertyAutomations', 'AddEventPopup', 'cardDefaultRoutines', 'InfoPopup', 'RoutineStringPopup', 'RoutineNumberPopup', 'RoutinePropertyNamePopup',
     'RoutineColorPopup', 'RoutineIconPopup', 'RoutineSoundPopup', 'RoutineJSONPopup', 'RoutineFullOperationJSONPopup', 'RoutineKeyValuePopup', 'RoutineWidgetIDPopup', 'RoutineEnumMenu',
+    'isRoutineRecording', 'startRoutineRecording', 'stopRoutineRecording', 'routineRecorderPointerDown',
+    'routineRecorderPointerUp', 'routineRecorderReceiveDelta', 'handleRoutineRecorderClick', 'routineGestureSuggestions',
     'renderWidgetSelectPopout', 'startWidgetPicker', 'stopWidgetPicker', 'isWidgetPickerActive',
     'handleWidgetPickerSelection', 'handleWidgetPickerClick', 'selectWidgetsInRoom', 'widgetPickerTarget', 'endWidgetPickerWithoutTarget',
     'isWidgetPickerChangingSelection', 'closeEditorPopups', 'commonInfoTopic', 'parameterInfoLine', 'templateLead', 'leadLabel', 'infoButton',
@@ -1241,7 +1247,7 @@ describe('picking how an operation works and which options it uses', () => {
     const ifEditor = editorForOperation({ func: 'IF', operand1: 1 });
     ifEditor.setOperationDetails({ state: {} }, { func: 'IF', operand1: 1 }, [], []);
     const rendered = ifEditor.render();
-    expect([...rendered.querySelectorAll('button')].map(b => b.textContent)).toEqual([ 'add operation', 'add else' ]);
+    expect([...rendered.querySelectorAll('button')].map(b => b.textContent)).toEqual([ 'add operation', 'fiber_manual_recordrecord', 'add else' ]);
   });
 
   test('parameters no variant and no option words become an option of their own', () => {
@@ -3932,5 +3938,222 @@ describe('working out a value with var', () => {
     expect(plain.querySelector('.popup-operation-func')).toBeNull();
     expect(plain.querySelector('.popup-operation-example').textContent).toBe('the value');
     popup.hide();
+  });
+});
+
+// The record button next to "add operation": what a press-drag-release in the
+// room turns into, and that nothing of it reaches the routine until it is picked.
+describe('recording a routine from the room', () => {
+  // a stand-in for a widget in the room: the recorder only ever reads properties
+  // through get(), the way every other part of the editor does
+  const roomWidget = state => {
+    const widget = {
+      state,
+      get: property => state[property] === undefined ? null : state[property],
+      set: (property, value) => { state[property] = value; }
+    };
+    widgets.set(state.id, widget);
+    return widget;
+  };
+
+  const gesture = properties => Object.assign({
+    key: 1, widgetID: 'card1', type: 'card', from: null, to: null, x: 0, y: 0,
+    dragged: true, reparented: false, changes: {}
+  }, properties, { widget: widgets.get(properties.widgetID || 'card1') });
+
+  const operations = suggestions => suggestions.map(s => s.operation);
+
+  let editor;
+  beforeEach(() => {
+    widgets.clear();
+    stopRoutineRecording();
+    editor = new RoutineEditor({ state: { id: 'button1' }, get: p => ({ id: 'button1' })[p] || null }, []);
+    document.getElementById('editor').append(editor.domElement);
+  });
+  afterEach(() => {
+    stopRoutineRecording();
+    editor.domElement.remove();
+  });
+
+  test('the button sits next to "add operation" and says what it is doing while it does it', () => {
+    const record = () => editor.domElement.querySelector('.routine-editor-record-operation');
+    expect(record().textContent).toBe('fiber_manual_recordrecord');
+    expect(isRoutineRecording()).toBe(false);
+    record().click();
+    expect(isRoutineRecording()).toBe(true);
+    expect(record().textContent).toBe('fiber_manual_recordrecording…');
+    expect(document.body.classList.contains('editorRoutineRecording')).toBe(true);
+    expect(editor.domElement.querySelector('.routine-editor-recording')).not.toBeNull();
+    editor.domElement.querySelector('.routine-editor-recording-done').click();
+    expect(isRoutineRecording()).toBe(false);
+    expect(document.body.classList.contains('editorRoutineRecording')).toBe(false);
+    expect(editor.domElement.querySelector('.routine-editor-recording')).toBeNull();
+  });
+
+  test('a click in the room while recording is the recording\'s, not the widget\'s', () => {
+    expect(handleRoutineRecorderClick()).toBe(false);
+    startRoutineRecording(editor);
+    expect(handleRoutineRecorderClick()).toBe(true);
+  });
+
+  test('a drag from one holder into another offers the move it was, and the same move for all of them', () => {
+    roomWidget({ id: 'hand', type: 'holder' });
+    roomWidget({ id: 'discard', type: 'holder' });
+    const card = roomWidget({ id: 'card1', type: 'card', parent: 'hand' });
+    startRoutineRecording(editor);
+    routineRecorderPointerDown(card);
+    card.set('parent', 'discard');
+    routineRecorderPointerUp();
+
+    const sentences = [ ...editor.domElement.querySelectorAll('.routine-editor-suggestion-sentence') ].map(s => s.textContent);
+    expect(editor.domElement.querySelector('.routine-editor-gesture-what').textContent).toBe('dragged card1 from hand to discard');
+    expect(sentences[0]).toBe('Move 1 widget from hand to discard');
+    expect(sentences).toContain('Move all widgets from hand to discard');
+    expect(sentences).toContain('Move the picked widgets to discard');
+  });
+
+  test('dropping into a hand offers dealing to that seat and to every player', () => {
+    roomWidget({ id: 'deckHolder', type: 'holder' });
+    roomWidget({ id: 'hand-p1', type: 'holder' });
+    roomWidget({ id: 'hand-p2', type: 'holder' });
+    roomWidget({ id: 'seat-p1', type: 'seat', hand: 'hand-p1' });
+    roomWidget({ id: 'seat-p2', type: 'seat', hand: 'hand-p2' });
+    const suggested = operations(routineGestureSuggestions(gesture({
+      widgetID: 'card1', from: 'deckHolder', to: 'hand-p1', reparented: true
+    })));
+    expect(suggested).toContainEqual({ func: 'MOVE', from: 'deckHolder', to: 'seat-p1', count: 1 });
+    expect(suggested).toContainEqual({ func: 'MOVE', from: 'deckHolder', to: [ 'seat-p1', 'seat-p2' ], count: 1 });
+  });
+
+  test('taking a card out of a hand offers taking one from every player', () => {
+    roomWidget({ id: 'table', type: 'holder' });
+    roomWidget({ id: 'hand-p1', type: 'holder' });
+    roomWidget({ id: 'hand-p2', type: 'holder' });
+    roomWidget({ id: 'seat-p1', type: 'seat', hand: 'hand-p1' });
+    roomWidget({ id: 'seat-p2', type: 'seat', hand: 'hand-p2' });
+    const suggested = operations(routineGestureSuggestions(gesture({
+      widgetID: 'card1', from: 'hand-p1', to: 'table', reparented: true
+    })));
+    expect(suggested).toContainEqual({ func: 'MOVE', from: [ 'hand-p1', 'hand-p2' ], to: 'table', count: 1 });
+  });
+
+  test('a holder that has a deck in it is offered as somewhere to recall to', () => {
+    roomWidget({ id: 'deckHolder', type: 'holder' });
+    roomWidget({ id: 'deck1', type: 'deck', parent: 'deckHolder' });
+    roomWidget({ id: 'discard', type: 'holder' });
+    const intoDeck = operations(routineGestureSuggestions(gesture({
+      widgetID: 'card1', from: 'discard', to: 'deckHolder', reparented: true
+    })));
+    expect(intoDeck).toContainEqual({ func: 'RECALL', holder: 'deckHolder' });
+    // a holder without a deck has nothing to gather - RECALL would do nothing
+    const intoDiscard = operations(routineGestureSuggestions(gesture({
+      widgetID: 'card1', from: 'deckHolder', to: 'discard', reparented: true
+    })));
+    expect(intoDiscard).not.toContainEqual({ func: 'RECALL', holder: 'discard' });
+  });
+
+  test('what the room did on its own during the gesture becomes a suggestion of its own', () => {
+    roomWidget({ id: 'hand', type: 'holder' });
+    roomWidget({ id: 'table', type: 'holder' });
+    roomWidget({ id: 'card1', type: 'card' });
+    const suggested = operations(routineGestureSuggestions(gesture({
+      widgetID: 'card1', from: 'hand', to: 'table', reparented: true,
+      changes: { card1: { activeFace: 1, x: 10, parent: 'table', someFlag: true } }
+    })));
+    expect(suggested).toContainEqual({ func: 'FLIP', collection: [ 'card1' ], face: 1 });
+    expect(suggested).toContainEqual({ func: 'SET', property: 'someFlag', value: true, collection: [ 'card1' ] });
+    // the drag itself is what the move says - it is not also a "Set parent of"
+    expect(suggested.filter(o => o.func == 'SET').map(o => o.property)).not.toContain('parent');
+    expect(suggested.filter(o => o.func == 'SET').map(o => o.property)).not.toContain('x');
+  });
+
+  test('a click offers the ways a routine does what a click does', () => {
+    roomWidget({ id: 'card1', type: 'card' });
+    const suggested = operations(routineGestureSuggestions(gesture({ widgetID: 'card1', dragged: false })));
+    expect(suggested).toContainEqual({ func: 'CLICK', collection: [ 'card1' ] });
+    expect(suggested).toContainEqual({ func: 'FLIP', collection: [ 'card1' ], face: 1 });
+    roomWidget({ id: 'h1', type: 'holder' });
+    const holder = operations(routineGestureSuggestions(gesture({ widgetID: 'h1', type: 'holder', dragged: false })));
+    expect(holder).toContainEqual({ func: 'SHUFFLE', holder: 'h1' });
+  });
+
+  test('every suggestion reads as a finished sentence, with nothing of the template left in it', () => {
+    roomWidget({ id: 'hand', type: 'holder' });
+    roomWidget({ id: 'deckHolder', type: 'holder' });
+    roomWidget({ id: 'deck1', type: 'deck', parent: 'deckHolder' });
+    roomWidget({ id: 'seat-p1', type: 'seat', hand: 'hand' });
+    roomWidget({ id: 'card1', type: 'card', parent: 'deckHolder' });
+    roomWidget({ id: 'timer1', type: 'timer' });
+    const gestures = [
+      gesture({ widgetID: 'card1', from: 'deckHolder', to: 'hand', reparented: true }),
+      gesture({ widgetID: 'card1', from: 'hand', to: null, reparented: true, x: 300, y: 200 }),
+      gesture({ widgetID: 'card1', from: null, to: null, x: 300, y: 200 }),
+      gesture({ widgetID: 'card1', dragged: false }),
+      gesture({ widgetID: 'timer1', type: 'timer', dragged: false })
+    ];
+    for(const g of gestures) {
+      const suggestions = routineGestureSuggestions(g);
+      expect(suggestions.length).toBeGreaterThan(0);
+      for(const { operation, why } of suggestions) {
+        const operationEditor = editorForOperation(operation);
+        operationEditor.setOperationDetails(null, operation, [], []);
+        const sentence = operationEditor.getSentenceText();
+        expect(sentence).not.toMatch(/\{[a-zA-Z,]+\}/);
+        expect(sentence).not.toContain('undefined');
+        expect(why.length).toBeGreaterThan(3);
+      }
+    }
+  });
+
+  test('nothing reaches the routine until a suggestion is picked, and then exactly that operation does', () => {
+    roomWidget({ id: 'hand', type: 'holder' });
+    roomWidget({ id: 'discard', type: 'holder' });
+    const card = roomWidget({ id: 'card1', type: 'card', parent: 'hand' });
+    startRoutineRecording(editor);
+    routineRecorderPointerDown(card);
+    card.set('parent', 'discard');
+    routineRecorderPointerUp();
+    expect(editor.routine).toEqual([]);
+
+    editor.domElement.querySelector('.routine-editor-suggestion').click();
+    expect(editor.routine).toEqual([ { func: 'MOVE', from: 'hand', to: 'discard', count: 1 } ]);
+    // the card that was worked on last is the one it was added as, so the next
+    // one follows it - and the suggestion says it was used
+    expect(editor.domElement.querySelector('.routine-editor-suggestion').className).toContain('routine-editor-suggestion-added');
+  });
+
+  test('a gesture the pointer never finished in the room does not become the next one', () => {
+    roomWidget({ id: 'hand', type: 'holder' });
+    const card = roomWidget({ id: 'card1', type: 'card', parent: 'hand' });
+    startRoutineRecording(editor);
+    routineRecorderPointerDown(card);
+    routineRecorderPointerUp(); // a click, which is a gesture of its own
+    routineRecorderPointerUp(); // the release that never had a press
+    expect(editor.domElement.querySelectorAll('.routine-editor-gesture').length).toBe(1);
+  });
+
+  test('the deltas of a gesture only count while one is running', () => {
+    roomWidget({ id: 'hand', type: 'holder' });
+    roomWidget({ id: 'table', type: 'holder' });
+    const card = roomWidget({ id: 'card1', type: 'card', parent: 'hand' });
+    startRoutineRecording(editor);
+    routineRecorderReceiveDelta({ s: { card1: { activeFace: 1 } } }); // before the press
+    routineRecorderPointerDown(card);
+    routineRecorderReceiveDelta({ s: { card1: { activeFace: 0 } } });
+    card.set('parent', 'table');
+    routineRecorderPointerUp();
+    const sentences = [ ...editor.domElement.querySelectorAll('.routine-editor-suggestion-sentence') ].map(s => s.textContent);
+    expect(sentences).toContain('Turn card1 face down');
+  });
+
+  test('only one routine is recorded at a time - starting another one moves it there', () => {
+    const other = new RoutineEditor({ state: { id: 'button2' }, get: p => ({ id: 'button2' })[p] || null }, []);
+    document.getElementById('editor').append(other.domElement);
+    startRoutineRecording(editor);
+    expect(editor.domElement.querySelector('.routine-editor-recording')).not.toBeNull();
+    other.domElement.querySelector('.routine-editor-record-operation').click();
+    expect(editor.domElement.querySelector('.routine-editor-recording')).toBeNull();
+    expect(other.domElement.querySelector('.routine-editor-recording')).not.toBeNull();
+    other.domElement.remove();
   });
 });

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -4133,6 +4133,39 @@ describe('recording a routine from the room', () => {
     expect(holder).toContainEqual({ func: 'SHUFFLE', holder: 'h1' });
   });
 
+  test('clicking a die offers rolling it and putting it on a face', () => {
+    roomWidget({ id: 'die1', type: 'dice', clickable: true, activeFace: 2 });
+    const suggested = routineGestureSuggestions(gesture({ widgetID: 'die1', type: 'dice', dragged: false }));
+    // rolling a die is what clicking one does - there is no operation for it
+    expect(operations(suggested)).toContainEqual({ func: 'CLICK', collection: [ 'die1' ] });
+    expect(operations(suggested)).toContainEqual({ func: 'SET', property: 'activeFace', value: 2, collection: [ 'die1' ] });
+    expect(suggested[0].why).toContain('roll');
+  });
+
+  test('a die that has something else to do when clicked still rolls by leaving that out', () => {
+    roomWidget({ id: 'die1', type: 'dice', clickable: true, clickRoutine: [ { func: 'FLIP' } ] });
+    const withRoutine = operations(routineGestureSuggestions(gesture({ widgetID: 'die1', type: 'dice', dragged: false })));
+    expect(withRoutine).toContainEqual({ func: 'CLICK', collection: [ 'die1' ], mode: 'ignoreClickRoutine' });
+    // and the same for a die players are not allowed to click at all
+    roomWidget({ id: 'die2', type: 'dice', clickable: false });
+    const unclickable = operations(routineGestureSuggestions(gesture({ widgetID: 'die2', type: 'dice', dragged: false })));
+    expect(unclickable).toContainEqual({ func: 'CLICK', collection: [ 'die2' ], mode: 'ignoreClickable' });
+  });
+
+  test('a die the room rolled during the gesture is set to that face, not flipped to it', () => {
+    roomWidget({ id: 'table', type: 'holder' });
+    roomWidget({ id: 'hand', type: 'holder' });
+    roomWidget({ id: 'die1', type: 'dice' });
+    roomWidget({ id: 'card1', type: 'card' });
+    const suggested = operations(routineGestureSuggestions(gesture({
+      widgetID: 'card1', from: 'hand', to: 'table', reparented: true,
+      changes: { die1: { activeFace: 4 } }
+    })));
+    // FLIP has no effect on a die: Dice has no flip() for it to call
+    expect(suggested).toContainEqual({ func: 'SET', property: 'activeFace', value: 4, collection: [ 'die1' ] });
+    expect(suggested).not.toContainEqual({ func: 'FLIP', collection: [ 'die1' ], face: 4 });
+  });
+
   test('every suggestion reads as a finished sentence, with nothing of the template left in it', () => {
     roomWidget({ id: 'hand', type: 'holder' });
     roomWidget({ id: 'deckHolder', type: 'holder' });
@@ -4140,12 +4173,14 @@ describe('recording a routine from the room', () => {
     roomWidget({ id: 'seat-p1', type: 'seat', hand: 'hand' });
     roomWidget({ id: 'card1', type: 'card', parent: 'deckHolder' });
     roomWidget({ id: 'timer1', type: 'timer' });
+    roomWidget({ id: 'die1', type: 'dice', clickable: true });
     const gestures = [
       gesture({ widgetID: 'card1', from: 'deckHolder', to: 'hand', reparented: true }),
       gesture({ widgetID: 'card1', from: 'hand', to: null, reparented: true, x: 300, y: 200 }),
       gesture({ widgetID: 'card1', from: null, to: null, x: 300, y: 200 }),
       gesture({ widgetID: 'card1', dragged: false }),
-      gesture({ widgetID: 'timer1', type: 'timer', dragged: false })
+      gesture({ widgetID: 'timer1', type: 'timer', dragged: false }),
+      gesture({ widgetID: 'die1', type: 'dice', dragged: false })
     ];
     for(const g of gestures) {
       const suggestions = routineGestureSuggestions(g);

--- a/tests/validator/turn.test.js
+++ b/tests/validator/turn.test.js
@@ -1,0 +1,54 @@
+import { validateGameFile } from '../../validator/validate_gamefile.js';
+
+// TURN reads 'turn' in two completely different ways: with turnCycle 'seat' it is the id
+// of the seat that gets the turn, everywhere else it counts seats. Naming a seat where a
+// number is expected - or a number/'first'/'last' where a seat id is expected - is not a
+// value the engine works with: seat mode looks the id up among the seats and falls back to
+// the first one after reporting a problem (see TURN in client/js/widgets/widget.js).
+function turnProblems(operation, extraWidgets = {}) {
+  const game = Object.assign({
+    button1: { id: 'button1', type: 'button', clickRoutine: [ operation ] },
+    seat1: { id: 'seat1', type: 'seat', index: 1 },
+    seat2: { id: 'seat2', type: 'seat', index: 2 }
+  }, extraWidgets);
+  return validateGameFile(game, false).filter(p=>p.property.join('.') == 'clickRoutine.0.turn').map(p=>p.message);
+}
+
+describe("TURN's turn value", () => {
+  test('takes a whole number, first or last while counting seats', () => {
+    for(const turnCycle of [ undefined, 'forward', 'backward', 'position', 'random' ])
+      for(const turn of [ 1, 3, -1, 'first', 'last' ])
+        expect(turnProblems({ func: 'TURN', turnCycle, turn })).toEqual([]);
+  });
+
+  test('rejects a seat id where seats are counted', () => {
+    expect(turnProblems({ func: 'TURN', turnCycle: 'position', turn: 'seat2' })).toEqual([
+      "'seat2' is neither a whole number, 'first' nor 'last' - turn names a seat by its id only with turnCycle 'seat'"
+    ]);
+  });
+
+  test('takes the id of a seat with turnCycle seat', () => {
+    expect(turnProblems({ func: 'TURN', turnCycle: 'seat', turn: 'seat2' })).toEqual([]);
+  });
+
+  test('rejects a widget that is not a seat with turnCycle seat', () => {
+    expect(turnProblems({ func: 'TURN', turnCycle: 'seat', turn: 'button1' })).toEqual([
+      "'button1' is not a valid widget type (found button - valid types: seat) - with turnCycle 'seat', turn gives the turn to the seat with that id"
+    ]);
+    expect(turnProblems({ func: 'TURN', turnCycle: 'seat', turn: 'seat3' })).toEqual([
+      "'seat3' is not a widget - with turnCycle 'seat', turn gives the turn to the seat with that id"
+    ]);
+  });
+
+  test('rejects first, last and a number with turnCycle seat', () => {
+    for(const turn of [ 'first', 'last', 2 ])
+      expect(turnProblems({ func: 'TURN', turnCycle: 'seat', turn })).toEqual([
+        `'${turn}' is not a widget - with turnCycle 'seat', turn gives the turn to the seat with that id`
+      ]);
+  });
+
+  test('is left alone when the turn cycle is only known at runtime', () => {
+    expect(turnProblems({ func: 'TURN', turnCycle: '${PROPERTY cycle}', turn: 'seat2' })).toEqual([]);
+    expect(turnProblems({ func: 'TURN', turnCycle: '${PROPERTY cycle}', turn: 3 })).toEqual([]);
+  });
+});

--- a/validator/validate_gamefile.js
+++ b/validator/validate_gamefile.js
@@ -888,7 +888,11 @@ const operationProps = {
         'seconds': v=>typeof v === 'number' || typeof v === 'string' && /^-?\d+:\d+(\.\d+)?$/.test(v)
     },
     'TURN': {
-        'turn': v=>typeof v === 'number' && Number.isInteger(v) || v === 'first' || v === 'last',
+        // with turnCycle 'seat', turn names the seat to give the turn to by its
+        // widget id instead of counting seats (see TURN in client/js/widgets/widget.js)
+        'turn': (v, context)=>typeof v === 'number' && Number.isInteger(v) || v === 'first' || v === 'last'
+            || typeof v === 'string' && Boolean((context.widgets || {})[v])
+            || `'${v}' is neither a whole number, 'first', 'last' nor the id of a seat`,
         'turnCycle': getEnumValidator(['forward','backward','random','position','seat']),
         'source': 'inCollection',
         'collection': 'string'
@@ -908,6 +912,14 @@ function customRoutineChecks(operation, problems, context, operationPath) {
             widget: context.widgetId,
             property: operationPath,
             message: 'IF uses both operand1 and condition - did you mean to use relation instead?'
+        });
+    }
+    if(operation.func === 'TURN' && typeof operation.turn === 'string' && !['first', 'last'].includes(operation.turn)
+            && !operation.turn.includes('${') && operation.turnCycle !== 'seat') {
+        problems.push({
+            widget: context.widgetId,
+            property: operationPath,
+            message: `TURN reads 'turn' as the id of a seat only with turnCycle 'seat' - otherwise it takes a whole number, 'first' or 'last'`
         });
     }
 }

--- a/validator/validate_gamefile.js
+++ b/validator/validate_gamefile.js
@@ -888,11 +888,21 @@ const operationProps = {
         'seconds': v=>typeof v === 'number' || typeof v === 'string' && /^-?\d+:\d+(\.\d+)?$/.test(v)
     },
     'TURN': {
-        // with turnCycle 'seat', turn names the seat to give the turn to by its
-        // widget id instead of counting seats (see TURN in client/js/widgets/widget.js)
-        'turn': (v, context)=>typeof v === 'number' && Number.isInteger(v) || v === 'first' || v === 'last'
-            || typeof v === 'string' && Boolean((context.widgets || {})[v])
-            || `'${v}' is neither a whole number, 'first', 'last' nor the id of a seat`,
+        // with turnCycle 'seat', turn names the seat to give the turn to by its widget
+        // id instead of counting seats, and nothing else works there - the engine looks
+        // the id up among the seats and falls back to the first one when it finds none
+        // (see TURN in client/js/widgets/widget.js)
+        'turn': (v, context)=>{
+            const turnCycle = context.operation.turnCycle;
+            if(typeof turnCycle === 'string' && turnCycle.includes('${'))
+                return true;
+            if(turnCycle === 'seat') {
+                const result = getWidgetTypeValidator([ 'seat' ])(v, context);
+                return result === true || `${result} - with turnCycle 'seat', turn gives the turn to the seat with that id`;
+            }
+            return typeof v === 'number' && Number.isInteger(v) || v === 'first' || v === 'last'
+                || `'${v}' is neither a whole number, 'first' nor 'last' - turn names a seat by its id only with turnCycle 'seat'`;
+        },
         'turnCycle': getEnumValidator(['forward','backward','random','position','seat']),
         'source': 'inCollection',
         'collection': 'string'
@@ -912,14 +922,6 @@ function customRoutineChecks(operation, problems, context, operationPath) {
             widget: context.widgetId,
             property: operationPath,
             message: 'IF uses both operand1 and condition - did you mean to use relation instead?'
-        });
-    }
-    if(operation.func === 'TURN' && typeof operation.turn === 'string' && !['first', 'last'].includes(operation.turn)
-            && !operation.turn.includes('${') && operation.turnCycle !== 'seat') {
-        problems.push({
-            widget: context.widgetId,
-            property: operationPath,
-            message: `TURN reads 'turn' as the id of a seat only with turnCycle 'seat' - otherwise it takes a whole number, 'first' or 'last'`
         });
     }
 }


### PR DESCRIPTION
## What this does

The visual routine editor gets a second way to add an operation. Next to **add operation** there is now a **⏺ record** button: press it, do the thing in the room, and every press-drag-release you make is offered as the handful of operations that would do the same thing when the routine runs. Click one and it is added to the routine exactly where "add operation" would have added it.

Dragging a card out of the deck holder into a player's hand, for example, offers:

```
dragged the card card1 from the holder deckHolder to the holder hand-p1     ×
  + do exactly this                     Move 1 widget from deckHolder to hand-p1
  + deal one to seat-p1                 Move 1 widget from deckHolder to seat-p1
  + deal one to every player            Move 1 widget from deckHolder to seat-p1 and seat-p2
  + put every card back into deckHolder Gather all the cards back into deckHolder
  + card1 ended up on that face         Turn card1 face up
```

The last one is not something the pointer did: the hand flips what enters it face up, and the recorder read that out of the delta the drop produced.

Clicking a die offers rolling it and putting it on a face; clicking a canvas offers wiping it, the color it draws in and how thick the brush is; clicking a holder offers shuffling it and putting every card of its deck back into it.

## Why it is a short list and not one operation

One gesture is deliberately not one operation. The same drag is "move that card there", "deal one to that player", "deal one to everybody" or "put the deck back together" depending on what the routine is for — the room cannot know which was meant, but it knows the handful worth offering, so it offers those and writes nothing until one is picked. A gesture nobody picks anything from costs a card in the list and no operation in the routine; a `×` in its corner takes it off.

A card is answered once: picking a reading adds the operation and closes the card. A second operation out of the same gesture is had by doing the gesture again — which is also why doing the same drag five times does not write five cards. The fifth deal out of the same holder into the same hand raises the count on the card that is already there, so it reads `Move 5 widgets from deckHolder to hand-p1` rather than filling the panel with five readings of `Move 1`.

The readings come from two places:

- **what the gesture did** — which widget moved out of what into what (`MOVE`, and `MOVEXY` when it ends up on the table), where it was put (`SET x` / `SET y`), or that it was only clicked (`CLICK` for the roll of a die, `CANVAS reset` and the two `SET`s for a canvas, `FLIP` for a card, `SHUFFLE`/`RECALL` on a holder, `TURN` on a seat, `TIMER` on a timer);
- **what the room did on its own while it ran** — taken from the deltas, so a holder that turns a card face up as it enters becomes a "Turn card1 face up" of its own, and any other property the drop set becomes a `SET` for it. Positions, parents and the transient drag properties are left out: the move already says those.

Dealing is recognised: a holder that is a seat's `hand` is offered as the seat (`MOVE to: seat-p1`, because MOVE to a seat also sets the owner) and as every seat at once. `RECALL` is only offered for a holder that actually has a deck in it. A card taken off a stack inside a holder reads as coming out of that holder, not out of the pile the stack formed — no operation takes widgets out of a pile, and the pile is gone again as soon as it holds one card.

## While it is recording

The room answers the way it does for a player rather than the way it does in edit mode:

- the selection band and the drag toolbar step aside, so a left-drag reaches the widget instead of drawing a rubber band;
- a click neither selects the widget — that would take the editor off the routine being recorded — nor runs its click routine; it is only written down;
- a drag *does* move the widget for real, so the next gesture starts from the state the last one left behind, which is what makes a sequence of them read as one macro (undo works as usual).

The board carries a red frame and the pointer is the crosshair the widget picker already uses, so it is visible that a drag in there is being written down. Recording runs in one routine at a time; pressing record in another routine moves it there.

## Notes

- No widget property, routine function or parameter is added or changed, so there is nothing for the JSON editor's insert buttons to learn — this is purely the visual routine editor, which is where the standing "usable from the editing UI" rule points anyway.
- One validator fix rides along (see the review follow-ups below): `validate_gamefile.js` now reads `TURN`'s `turn` the way the engine does — the id of a seat with `turnCycle: 'seat'`, a whole number/`first`/`last` with every other cycle.
- New file `client/js/editor/controls/routinerecorder.js` (added to the editor bundle in `server/minify.mjs`); `mousehandling.js` gains two `edit`-gated hook calls, `selection.js` three.
- New jest tests in `tests/client/routineeditor.test.js` cover the suggestions per gesture kind, the repeat count, that nothing is written until a suggestion is picked and that picking closes the card, and that every suggested operation renders as a finished sentence. `npm test` passes (1297 tests); the TestCafe `editor.js`, `routines.js`, `interactions.js` and `domsnapshot.js` suites were run locally against a Chromium build and pass.
- Creator-facing behaviour is new, so the wiki (Edit-Mode) could use a paragraph about the record button.
- **Draft tutorial on the test server, not in the diff.** The feature is user-visible and no tutorial covers it, so I authored one to tutorial quality and published it as a draft rather than committing it: **`Xtras - Recording Routines`** (single variant, `variant: ""`), in this PR's `pr-test-ai` room — <https://test.virtualtabletop.io/PR-3122/pr-test-ai>. It is a deck holder with the conventional "Recall & Shuffle" button, a discard holder that flips what enters it face up (so the recorder's "the room did this too" suggestions show up), two seats with hands (so dealing suggestions show up), and a **Deal a card** button whose click routine is empty on purpose — the one to record into. Metadata template: `Properties - dragLimit` (the newest tutorial), mirrored field for field; the library image is a 530×530 square SVG in the style of its `Xtras - …` neighbours, reusing the shared graduate glyph and the "Xtras" category lettering. `node validator/validate_gamefile_node.js` exits 0 and I walked it end to end (sit down, record two gestures, pick a suggestion, leave edit mode, click the button and watch the card get dealt). `library/tutorials/` itself is untouched — move it in only if you want it.

## Review follow-up (automated review 1/4)

- **The recording no longer outlives the editor.** It is stopped when the properties module closes (next to the `stopWidgetPicker()` the review pointed at) *and* in `toggleEditMode()`, because the two ways out of edit mode are not the same: the editor's close button and Ctrl-J run `closeEditor()` → `onEditorClose()`, but clicking the **Active Game** tab leaves edit mode without ever calling it. Both were reproduced in a browser (crosshair + red frame left over play mode) and both are clean now.
- **The 8-suggestion cap no longer eats the delta-derived readings.** Gesture readings and "the room did this too" readings are collected in separate lists; half the card is reserved for the latter and anything they leave unused goes back to the gesture. The example above is the real output of the reviewer's own two-seat dealing gesture.
- **`TURN turn: <seat id>` validates.** Widened in `operationProps.TURN` — as a side effect this removes four false-positive errors in existing public-library games (Code Numbers ×2, Shell Game, Temple Trek) and turns `Property is invalid false` into a message that says what is allowed. (Review 3/4 then tied this to `turnCycle`; see below for the final rule.)
- **`MOVE to:` without a source is only offered when a `DEFAULT` collection is in scope** (`RoutineEditor.collectionsInScope()` walks the operations before the insertion point), so the recorder cannot write an operation that is an error the moment it is added.
- **`SET parent: null` keeps its place.** Dragging a widget out onto the table now also offers the `x` and the `y` it was dropped at, since those are counted from the parent and would otherwise land the widget somewhere else.
- **Foreign deltas stay out of a gesture.** `routineRecorderReceiveDelta()` drops deltas whose `delta.c` names another player.
- **Tests:** five new jest tests cover the cap, the collection gate, the position pair, the foreign-delta filter and the recording ending with its editor. `npm test` is green (1283) and the TestCafe `editor.js` suite passes locally.

## Feedback follow-up (Discord, 2/2)

> Clicking dice should show options to roll the die and set to a specific face.
>
> Style mismatch between add Operation and record.

(<https://discord.com/channels/770758631146782780/1538058046285160518/1538097648350007317>)

- **Clicking a die now offers the roll and the face.** A dice widget used to fall through to the generic readings — `Click die1` and a blank `SET`. Rolling a die is the one thing a routine does by clicking rather than with an operation of its own (`Dice.click()` rolls when nothing else claims the click), so the roll is now the first reading of the gesture: a `CLICK` told to leave out whatever would stop it rolling — `mode: ignoreClickRoutine` for a die whose click was given a routine, `ignoreClickable` for one players may not click, `ignoreAll` for both. Under it comes `SET activeFace`, filled in with the face the die is showing, for putting it on a face on purpose; the aside says which face that is, since `activeFace` counts from 0 and a die usually has something else printed on it. This is what the two library idioms for dice already look like (`CLICK … mode: ignoreClickRoutine` in *Bustin' at the Blue Diamond*, `SET activeFace` in *Types - Dice*).
- **A die the room rolled during a gesture is read as `SET activeFace` too.** The delta-derived readings turned every `activeFace` change into a `FLIP`, which does nothing on a die — `Dice` has no `flip()` for `FLIP` to call. Cards and basic widgets are unchanged.
- **`record` is the same button as `add operation` now.** It was a filled blue button standing next to the dashed lowercase outline it belongs with; it now shares that shape (the `.events-editor-add` rule in `events.css`), with the red dot as the only thing that sets it apart. Armed, only the fill changes — the box keeps its size, so pressing it no longer resizes the row — and the text on the fill is the page colour, which reads on the dark red of the light theme and the light red of the dark theme alike.

Before/after and the new suggestions:

| | |
|---|---|
| the two buttons | [light](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/record-button-light.png) · [dark](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/record-button-dark.png) |
| armed | [light](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/record-button-armed-light.png) · [dark](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/record-button-armed-dark.png) |
| clicking two dice | [suggestions](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/dice-suggestions.png) |
| in the draft tutorial | [screenshot](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/tutorial-dice-recording.png) |

Three new jest tests cover the roll, the modes that keep it rolling and the die-rolled-by-the-room reading; the dice gesture also joined the "every suggestion reads as a finished sentence" test. `npm test` is green (1286) and the TestCafe `editor.js` suite passes locally. Walked in a browser end to end as well: record a click on a die into an empty click routine, pick the roll, leave edit mode, press the button — the die rolls; pick `Set activeFace` instead and the button pulls the die back onto that face after every roll.

The **draft tutorial** on the test server was amended to match and re-published: it now has a die with a paragraph of its own next to it, so the new readings can be tried where the rest of the recorder is tried. Still a draft, still not in `library/tutorials/`.


## UI/UX review follow-up

The record button and its suggestion panel were reviewed for layout and readability. Everything that was actionable is fixed:

- **The drag toolbar really steps aside now.** `body.editorRoutineRecording #editorDragToolbar { display: none }` was outranked by `body:not(.overlayActive) #editorDragToolbar.active` in `dragtoolbar.css`, so a 299×36 edit toolbar sat inside the red "being recorded" frame. The rule now matches `.active` as well. Verified in a browser: `display: none`, `0×0`, in both themes.
- **Every line of the panel clears 4.5:1 in both themes**, measured in the running app against the actually painted background: header 5.62 / 7.18, hint 12.63 / 11.89, gesture headline 21.0 / 18.69, the reading 6.69 / 9.53, the sentence 8.52 / 9.18. Three changes get there: the panel is drawn on the page background instead of `--backgroundHighlightColor2`, the gesture headline is text-coloured instead of red (the left border already carries the colour), and a row now hovers with an outline instead of a fill — every fill light enough to read black on is dark enough to lose the blue on it in the other theme. `--routineRecordColor` itself is unchanged, so the frame and the armed button keep their identity.
- **Each suggestion leads with what the reading is FOR** and follows with the operation it would add, in the aside style the intent used to have. Six of eight rows used to start with the same eleven characters; the line that tells them apart is now the line you read first.
- **The headline names what kind of thing each widget is** — `dragged the card card_S_4K from the holder deckHolder to the holder hand-p1`, and `... to the pile o0ur` for the auto-created pile the reviewer hit. Ids in a real game are generated as often as chosen.
- **A widget the gesture created contributes no readings.** Dropping a card onto a card makes a pile, and that pile reported `it got width while you did that` / `... height` as two of its eight suggestions. Only widgets that existed when the gesture started can produce "the room did this too" readings now.
- **A gesture nobody meant can be taken off the card** with a quiet `×` in its corner. What it already added stays in the routine, like anything else added to a routine.
- **One name for one state.** The button keeps the label `record` and only its fill changes (so it no longer grows 70→96px and can no longer wrap the row), its tooltip says *Stop recording*, and the panel header says *Recording*. `done` is a quiet outlined button in the recorder's red instead of falling through to the sidebar's default filled blue, which made the way out the loudest thing in the panel. Only the header's dot blinks now.
- **The room says which routine it is being recorded into** — a small caption in the top-left of the frame, e.g. `recording → dealButton · clickRoutine`, because the panel that knows is in a sidebar that is usually scrolled elsewhere by the third gesture.
- **The empty-state hint says how to stop and what a click does**: "clicking one records the click instead of selecting it … Press done when the routine says what you meant."
- **The unfilled `Set property of X to number or text` reading is gone.** A card of three readings where one is a blank form undermines the other two.

Not changed: the record button is still offered at every width (a phone shows a 354×221 room strip where the gesture is barely performable) — worth a separate look, but hiding a feature by viewport is a bigger decision than this PR should make on its own.

Screenshots: [panel, light](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/panel-light.png) · [panel, dark](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/panel-dark.png) · [recording inside the tutorial](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/recording-in-the-tutorial.png)

Two new jest tests cover forgetting a gesture (and that what it added stays) and the created-widget filter; the button test now asserts the label does not change. `npm test` is green (1288).

### Draft tutorial, re-published

`Xtras - Recording Routines` was reworked along the review's notes and re-published to this PR's `pr-test-ai` room ([board screenshot](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/tutorial-board.png), [library tile next to its neighbour](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/tutorial-tile.png)):

- the prerequisites are a numbered **To try it** strip directly under the intro (1. sit down · 2. `ctrl-j` · 3. click **Deal a card** · 4. unfold *click* · 5. press **record** · 6. drag a card), instead of a clause buried in a paragraph below the objects;
- the finish line ("press **done** … then click **Deal a card** and watch the room do it again") is the last block on the board;
- the intro is two sentences and the full-width paragraph at the bottom is folded into a note beside the seats, where the "a seat only takes cards while somebody is in it" rule applies;
- the **discard holder** carries a `Discard` label, in the place the deck holder's "Recall & Shuffle" button occupies;
- the die is 120×120 showing five pips instead of 70×70 showing one, so it reads as a die;
- the four objects and their captions share left edges (120 / 480 / 840 / 1180) on one pitch, and the dead band between the die row and the bottom is gone;
- the library tile leads with a big red record dot on a small board frame, instead of a large frame with a play-shaped glyph.

Still a draft, still not in `library/tutorials/`. Validator exits 0 and I walked it end to end again in the running app: open from the shelf (with its preview image), sit, `ctrl-j`, **Deal a card** → *click* → **record**, drag a card into the hand, pick *deal one to every player*, **done**, leave edit mode, press the button — both seats get a card.

## Review follow-up (automated review 3/4)

- **`TURN`'s `turn` is validated against the turn cycle it is used with.** The widened predicate above accepted any existing widget id in every mode, so `{ "turnCycle": "seat", "turn": "button1" }` and `{ "turnCycle": "seat", "turn": "first" }` both validated clean although seat mode only ever looks the value up among the seats and falls back to the first one after reporting a problem. It now asks for a widget of type `seat` in seat mode and for a whole number/`first`/`last` everywhere else, with messages that name the other mode; a `turnCycle` that is only known at runtime (`${...}`) leaves `turn` alone. The `customRoutineChecks` special case for the reverse direction is gone — one predicate covers both now.
- Six regression tests in the new `tests/validator/turn.test.js`. `npm test` is green (1294).
- Running the validator over all 575 public-library game and tutorial variants before and after gives an identical problem set except for one reworded message (`Irrigation/0.json` points `turnCycle: 'seat'` at `0_seat` while its seats are `1_seat`…`5_seat` — already reported before this commit).

Not changed, and pre-existing on `main`: the visual editor declares `turn` once for all five variants (`special: [ 'first', 'last' ], widgetType: 'seat'`), so its popup offers `first`/`last` and a seat picker whichever cycle is selected. Making that variant-aware means teaching `parameterSpec()` per-variant overrides — a change to the routine editor's parameter machinery rather than to the recorder, and it looks like its own PR.


## Feedback follow-up (maintainer, open-PR overview)

> less options, less technical. options should be what an inexperienced user would want. clicking dice: roll dice or set active face. clicking canvas: reset, set color, set brush size. move card: deal cards to hands, recall if moved to deck's parent. stuff like that; nothing too fancy.
>
> also: if the user moves 5 cards between the same holders, update the suggestions to MOVE 5 instead of listing 5 new suggestion blocks
>
> when a user picks one of the options, close the box. if the user wants multiple options, they have to do the action again.
>
> hover state of the "record" button has bad font color - barely readable. the same applies to the "add X" buttons with the same style

All four, and the top of this description was rewritten to match.

**Fewer readings, and the ones an inexperienced author would want.** The cap is 5 instead of 8, and most cards now come in well under it. A drag between holders reads as the move it was, as dealing to the seat the hand belongs to and to every player, and as putting every card back into the holder the deck lies in — `MOVE count: all`, `MOVE ... face`, "take one from every player", the shuffle-afterwards and the `DEFAULT`-collection reading are gone, and with the last of them `RoutineEditor.collectionsInScope()`, which nothing else used. A drag inside a holder no longer offers sorting and shuffling it, only the position it was dropped at. Clicking a die offers exactly the roll and the face, with no "click it" underneath saying the same thing in words that never mention rolling; clicking a canvas is new and offers wiping it (`CANVAS mode: reset`), the color it draws in (`SET activeColor`, with the color that place in its map holds named in the reading) and how thick the brush is (`SET lineWidth`) — the three things the canvas's own buttons do; clicking a holder offers shuffling and recalling, not sorting and moving something out of it; and `CALL clickRoutine` is gone everywhere.

**Doing the same thing again raises the count.** A drag from one holder into another carries a key of the two holders, and a later drag with the same key adds to the card that is already there instead of writing another one: the headline becomes `dragged 5 widgets from the holder deckHolder to the holder hand-p1` and every reading of it counts 5. What the room did during the later drags is folded in as well. Only holder-to-holder moves coalesce — that is the operation with a count to raise, and the gesture that is really done over and over.

Making that work in a real room needed one more fix: the second card dealt out of a holder comes off a stack, and its parent is the pile that stack formed, which is neither something `MOVE` takes widgets out of nor something that is still there afterwards. The source of a drag is now resolved up to the nearest holder or seat, the way the destination already was — so the second deal is the same gesture as the first, and reads `Move 2 widgets from deckHolder to hand-p1` rather than `Move card2 to hand-p1`.

**Picking closes the card.** The tick that marked a used reading and the `added` bookkeeping behind it are gone; the card is answered once and disappears, and the panel's hint says so. The recording itself carries on, so the next gesture opens the next card.

**The hover was a fill nobody asked for.** `.routine-editor-record-operation:hover` and the `add …` buttons it shares its shape with set only `border-color` and `color`, so the `button:hover { background-color: var(--VTTblueDark) }` in `layout.css` filled them with a solid dark blue under text written in `--VTTblue` — 1.95:1 in the light theme, 2.21:1 in the dark one, measured in the running app. They keep no fill on hover now, and on the dark theme they are written in the teal the popup buttons already hover in, because `--VTTblue` on the near-black page is only 3:1. Measured after: **7.22:1** light, **12.32:1** dark. The armed record button and `done`, which are meant to be filled, are unchanged at 5.6/7.2 and 5.0/7.0. The same fix reaches `add routine`, the property panel's `add` and its two buttons — every button with that shape.

| | light | dark |
|---|---|---|
| hover, before | [screenshot](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/hover-before-light.png) | [screenshot](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/hover-before-dark.png) |
| hover, after | [screenshot](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/hover-after-light.png) | [screenshot](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/hover-after-dark.png) |
| the new cards | [screenshot](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/light-suggestions.png) | [screenshot](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/dark-suggestions.png) |

`npm test` is green (1297) and the TestCafe `editor.js` suite passes locally (45/45). Walked in a browser in both themes: three deals out of a deck holder into a hand collapse into one card counting 2 (one of the three drags never left the holder and became its own card, correctly), the die and the canvas read as above, and picking *deal 2 to every player* writes `{"func":"MOVE","from":"deckHolder","to":["seat-p1","seat-p2"],"count":2}` and closes the card.

The draft tutorial on the test server still walks correctly — its steps are "press record, drag a card, pick a reading, press done" — so it was not re-published.

## Feedback follow-up (open-PR overview)

> set x+y must be offered in _one_ suggestion but added as two operations

**A reading is one row, however many operations it takes to carry out.** A suggestion now carries a list of operations, and picking it adds all of them in order, where "add operation" would have added them. The drag that puts a widget at a spot is one row again — `put it exactly there`, spelling out `Set x of free1 to 715` and `Set y of free1 to 870` under it — and taking a widget out onto the table is one row of `SET parent: null`, `SET x` and `SET y` instead of three. The `and put it exactly there` / `and at that height` labels are gone with them: they only existed because the clauses of one reading had to be separate rows, and half a reading picked is a widget somewhere nobody dropped it. [Screenshot](https://agent.virtualtabletop.io/reports/pr/1538058046285160518/one-reading-two-operations.png)

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3122/pr-test (or any other room on that server)







