### PR TITLE
Offer each routine the values and collections its trigger hands it, in the routine editor

### DIFF
--- a/client/css/editor/controls/popup.css
+++ b/client/css/editor/controls/popup.css
@@ -490,17 +490,51 @@ body.edit.darkMode .inline-popup button.primary:hover {
   color: var(--VTTblue);
 }
 
+/* a name is a name: one that came from somewhere else (an argument a CALL in
+   another widget hands over) can be longer than the popup is wide, and wrapping
+   it is the only way it does not run out of the popup on a phone */
 .inline-popup .popup-entry {
   display: inline-block;
+  max-width: 100%;
+}
+
+.inline-popup .popup-entry button {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  text-align: left;
+}
+
+/* one the routine only has when a particular operation is what ran it */
+.inline-popup .popup-entry button.popup-entry-partial {
+  opacity: 0.65;
+  border-style: dashed;
 }
 
 /* where the values of a section come from: a quiet line rather than a heading
    in a color of its own - the section around it already says what kind of value
-   its entries are, and they carry that color the way the sentence does */
+   its entries are, and they carry that color the way the sentence does. Which
+   group a name is in is what the section is about once there are three or four
+   of them, so each one is separated from the run of chips above it by a rule */
 .inline-popup .popup-value-group {
   font-size: 11px;
-  opacity: 0.7;
+  opacity: 0.85;
   margin: 8px 2px 2px 2px;
+}
+
+.inline-popup .popup-entry + .popup-value-group {
+  border-top: 1px solid var(--backgroundHighlightColor1);
+  padding-top: 6px;
+}
+
+/* what the name the pointer or the keyboard is on holds - see
+   renderRoutineValueKindSection. Two lines are kept free whether one is shown or
+   not, so the list above it does not move while the pointer travels along it */
+.inline-popup .popup-entry-description {
+  margin: 8px 2px 0 2px;
+  font-size: 12px;
+  opacity: 0.8;
+  min-height: 2.8em;
+  overflow-wrap: anywhere;
 }
 
 .inline-popup button[data-kind=variable] {

--- a/client/css/editor/controls/popup.css
+++ b/client/css/editor/controls/popup.css
@@ -528,11 +528,22 @@ body.edit.darkMode .inline-popup button.primary:hover {
 
 /* what the name the pointer or the keyboard is on holds - see
    renderRoutineValueKindSection. Two lines are kept free whether one is shown or
-   not, so the list above it does not move while the pointer travels along it */
+   not, so the list above it does not move while the pointer travels along it.
+   It sticks to the foot of the popup while its section is on screen: a section
+   with four or five groups in it is taller than a short window, so the line
+   would sit below the fold exactly while the pointer is on a name near the top -
+   and the keyboard scrolls the focused button into view, pushing it further out
+   still. The background is the popup's own so the chips do not show through. */
 .inline-popup .popup-entry-description {
+  position: sticky;
+  bottom: 0;
+  background: var(--backgroundColor);
   margin: 8px 2px 0 2px;
+  padding-bottom: 2px;
   font-size: 12px;
-  opacity: 0.8;
+  /* quiet through the text color rather than the opacity of the whole line: a
+     line at 0.8 lets the chips scrolling under it show through its background */
+  color: color-mix(in srgb, var(--textColor) 80%, transparent);
   min-height: 2.8em;
   overflow-wrap: anywhere;
 }

--- a/client/js/editor/controls/events.js
+++ b/client/js/editor/controls/events.js
@@ -116,15 +116,17 @@ const routinePresets = {
 };
 
 // The arguments every CALL in the room that runs this routine by name hands it,
-// as { arguments: { name: which CALLs pass it }, sources: every CALL that runs
+// as { arguments: Map(name -> which CALLs pass it), calls: every CALL that runs
 // it }. CALL copies the calling routine's values and collections into the
 // routine it runs and merges its arguments on top (widget.js), so those names
 // are values the routine has before its first operation - the same kind of thing
 // an event hands its routine, except that what they are is written in the game
 // rather than in the engine.
 function callArgumentsFor(routineName) {
-  const args = {};
-  const sources = new Set();
+  // the names are written in the game, so they are kept in a Map: a plain object
+  // answers "constructor" with what it inherits from Object instead of nothing
+  const args = new Map();
+  const calls = [];
   const scan = (routine, source)=>{
     for(const operation of Array.isArray(routine) ? routine : []) {
       if(!operation || typeof operation != 'object')
@@ -132,30 +134,46 @@ function callArgumentsFor(routineName) {
       // a CALL given a list of names runs the first of them (widget.js)
       const called = Array.isArray(operation.routine) ? operation.routine[0] : operation.routine;
       if(operation.func == 'CALL' && called === routineName) {
-        sources.add(source);
+        // one entry per CALL rather than per routine one is in: two CALLs in the
+        // same routine can hand over different arguments, and an argument only
+        // one of them passes is one the routine only sometimes has
+        const call = { source };
+        calls.push(call);
         if(operation.arguments && typeof operation.arguments == 'object')
-          for(const name of Object.keys(operation.arguments))
-            (args[name] = args[name] || new Set()).add(source);
+          for(const name of Object.keys(operation.arguments)) {
+            if(!args.has(name))
+              args.set(name, new Set());
+            args.get(name).add(call);
+          }
       }
       for(const block of [ 'thenRoutine', 'elseRoutine', 'loopRoutine' ])
         scan(operation[block], source);
     }
   };
-  for(const widget of widgets.values())
-    for(const [ key, value ] of Object.entries(widget.state))
+  const scanRoutinesIn = (source, describe)=>{
+    for(const [ key, value ] of Object.entries(source))
       if(key.match(/Routine$/) && Array.isArray(value))
-        scan(value, `${key} of ${widget.state.id}`);
-  return { arguments: args, sources };
+        scan(value, describe(key));
+  };
+  for(const widget of widgets.values()) {
+    scanRoutinesIn(widget.state, key=>`${key} of ${widget.state.id}`);
+    // the cards of a deck run the routines in its cardDefaults, so a CALL in one
+    // of them runs this routine just like one written on a widget itself
+    if(widgetTypeOf(widget) == 'deck')
+      scanRoutinesIn(cardDefaultsOf(widget), key=>`${key} of the cards of ${widget.state.id}`);
+  }
+  return { arguments: args, calls };
 }
 
 // Which operations hand an argument over, named rather than counted: a count
 // ("3 of the operations that run this routine") is nothing the reader can go and
 // look at. More than two of them would fill the line, so the rest is a count.
-function describeCallers(sources, total) {
-  const names = [ ...sources ];
+// Two CALLs in the same routine are one name in the list but two operations.
+function describeCallers(calls, total) {
+  const names = [ ...new Set([ ...calls ].map(call=>call.source)) ];
   const listed = names.length > 2 ? `${names.slice(0, 2).join(', ')} and ${names.length-2} more` : names.join(' and ');
-  const missing = total - names.length;
-  return `handed over by the ${names.length == 1 ? 'CALL' : 'CALLs'} in ${listed}`
+  const missing = total - calls.size;
+  return `handed over by the ${calls.size == 1 ? 'CALL' : 'CALLs'} in ${listed}`
        + (missing ? ` - not by the ${missing == 1 ? 'other operation that runs' : `other ${missing} operations that run`} this routine` : '');
 }
 
@@ -188,23 +206,25 @@ function routinePresetsOf(property) {
     // it is one the routine only has when that call is what ran it - so they are
     // a group of their own rather than part of "In every fooRoutine", and the
     // ones not every call hands over are shown as the exception they are
-    const { arguments: args, sources } = callArgumentsFor(property);
-    const variables = {};
-    for(const name of Object.keys(args).sort())
+    const { arguments: args, calls } = callArgumentsFor(property);
+    // a name written in the game, so the map it goes into inherits nothing (see
+    // presetEntryOf in popup.js)
+    const variables = Object.create(null);
+    for(const name of [ ...args.keys() ].sort())
       variables[name] = {
-        description: describeCallers(args[name], sources.size),
-        partial: args[name].size < sources.size
+        description: describeCallers(args.get(name), calls.length),
+        partial: args.get(name).size < calls.length
       };
     if(Object.keys(variables).length)
       groups.push({
-        title: `From the ${sources.size == 1 ? 'operation that runs' : 'operations that run'} it`,
+        title: `From the ${calls.length == 1 ? 'operation that runs' : 'operations that run'} it`,
         source: 'the CALL that runs this routine',
-        shadowedByOperations: true, variables, collections: {}
+        variables, collections: {}
       });
   }
   // handed over before the first operation runs, so an operation of the routine
   // that stores the same name wins over them (see presetSections in popup.js)
-  const group = Object.assign({ title: `In every ${property}`, source: `the ${property}`, shadowedByOperations: true, variables: {}, collections: {} }, preset);
+  const group = Object.assign({ title: `In every ${property}`, source: `the ${property}`, variables: {}, collections: {} }, preset);
   if(Object.keys(group.variables).length + Object.keys(group.collections).length)
     groups.push(group);
   return groups;

--- a/client/js/editor/controls/events.js
+++ b/client/js/editor/controls/events.js
@@ -115,29 +115,62 @@ const routinePresets = {
   editorAddToRoomRoutine: {}
 };
 
-// The arguments every CALL in the room that runs this routine by name hands it,
-// as { arguments: Map(name -> which CALLs pass it), calls: every CALL that runs
-// it }. CALL copies the calling routine's values and collections into the
-// routine it runs and merges its arguments on top (widget.js), so those names
+// Where a widget runs a routine of this name from, as the place the editor
+// shows routines in - the widget's own properties, or the cardDefaults of the
+// deck a card takes what it does not have itself from (Card.getDefaultValue).
+// null for an id that is in no widget of the room, which rules nothing out.
+function routineHomeOf(widgetID, routineName) {
+  const widget = widgets.get(widgetID);
+  if(!widget)
+    return null;
+  if(Array.isArray(widget.state[routineName]))
+    return { widgetID, cardDefaults: false };
+  if(widgetTypeOf(widget) == 'card') {
+    const deck = widgets.get(widget.state.deck);
+    if(deck && Array.isArray(cardDefaultsOf(deck)[routineName]))
+      return { widgetID: deck.state.id, cardDefaults: true };
+  }
+  return { widgetID, cardDefaults: false };
+}
+
+// Whether a CALL can reach the routine that is open in the editor. It names the
+// widget it runs the routine on, and with no widget of its own it runs it on the
+// widget it is written on (widget.js) - which, in the cardDefaults of a deck, is
+// the card running it rather than the deck. An id the game computes (${...}) or
+// hands over as anything but a string can be any widget, so it stays in.
+function callReaches(operation, where, routineName, target) {
+  if(!target)
+    return true;
+  const named = Array.isArray(operation.widget) ? operation.widget[0] : operation.widget;
+  const home = named === undefined ? where : (typeof named == 'string' && named.indexOf('${') == -1 ? routineHomeOf(named, routineName) : null);
+  return !home || (home.widgetID == target.widgetID && !home.cardDefaults == !target.cardDefaults);
+}
+
+// The arguments every CALL in the room that runs the routine open in the editor
+// hands it, as { arguments: Map(name -> which CALLs pass it), calls: every CALL
+// that runs it }. CALL copies the calling routine's values and collections into
+// the routine it runs and merges its arguments on top (widget.js), so those names
 // are values the routine has before its first operation - the same kind of thing
 // an event hands its routine, except that what they are is written in the game
-// rather than in the engine.
-function callArgumentsFor(routineName) {
+// rather than in the engine. target is the routine being edited as { widgetID,
+// cardDefaults }: another widget's routine of the same name is a different
+// routine, and its arguments are none of this one's business.
+function callArgumentsFor(routineName, target) {
   // the names are written in the game, so they are kept in a Map: a plain object
   // answers "constructor" with what it inherits from Object instead of nothing
   const args = new Map();
   const calls = [];
-  const scan = (routine, source)=>{
+  const scan = (routine, where)=>{
     for(const operation of Array.isArray(routine) ? routine : []) {
       if(!operation || typeof operation != 'object')
         continue;
       // a CALL given a list of names runs the first of them (widget.js)
       const called = Array.isArray(operation.routine) ? operation.routine[0] : operation.routine;
-      if(operation.func == 'CALL' && called === routineName) {
+      if(operation.func == 'CALL' && called === routineName && callReaches(operation, where, routineName, target)) {
         // one entry per CALL rather than per routine one is in: two CALLs in the
         // same routine can hand over different arguments, and an argument only
         // one of them passes is one the routine only sometimes has
-        const call = { source };
+        const call = { source: where.source };
         calls.push(call);
         if(operation.arguments && typeof operation.arguments == 'object')
           for(const name of Object.keys(operation.arguments)) {
@@ -147,20 +180,20 @@ function callArgumentsFor(routineName) {
           }
       }
       for(const block of [ 'thenRoutine', 'elseRoutine', 'loopRoutine' ])
-        scan(operation[block], source);
+        scan(operation[block], where);
     }
   };
-  const scanRoutinesIn = (source, describe)=>{
+  const scanRoutinesIn = (source, where)=>{
     for(const [ key, value ] of Object.entries(source))
       if(key.match(/Routine$/) && Array.isArray(value))
-        scan(value, describe(key));
+        scan(value, where(key));
   };
   for(const widget of widgets.values()) {
-    scanRoutinesIn(widget.state, key=>`${key} of ${widget.state.id}`);
+    scanRoutinesIn(widget.state, key=>({ source: `${key} of ${widget.state.id}`, widgetID: widget.state.id, cardDefaults: false }));
     // the cards of a deck run the routines in its cardDefaults, so a CALL in one
     // of them runs this routine just like one written on a widget itself
     if(widgetTypeOf(widget) == 'deck')
-      scanRoutinesIn(cardDefaultsOf(widget), key=>`${key} of the cards of ${widget.state.id}`);
+      scanRoutinesIn(cardDefaultsOf(widget), key=>({ source: `${key} of the cards of ${widget.state.id}`, widgetID: widget.state.id, cardDefaults: true }));
   }
   return { arguments: args, calls };
 }
@@ -181,8 +214,10 @@ function describeCallers(calls, total) {
 // the most specific group first (see presetSections in popup.js). The routines
 // named after a property hear about that one property only, so theirs are worded
 // with its name and have no property variable. Everything else is a custom
-// routine, which only ever runs through CALL.
-function routinePresetsOf(property) {
+// routine, which only ever runs through CALL. target says which routine of which
+// widget is open ({ widgetID, cardDefaults }), so the CALLs that run a routine of
+// the same name somewhere else are left out of it.
+function routinePresetsOf(property, target) {
   let match;
   const groups = [];
   let preset = routinePresets[property];
@@ -200,28 +235,35 @@ function routinePresetsOf(property) {
       },
       collections: { widget: `the widget whose ${match[1]} changed` }
     };
-  if(!preset && !predefinedEvents.some(event=>event.property == property)) {
+  // a routine nothing in the engine triggers is a custom one: it only ever runs
+  // through CALL, so what a CALL hands over is what it always has
+  const custom = !preset && !predefinedEvents.some(event=>event.property == property);
+  if(custom)
     preset = { collections: { caller: 'the widget whose routine used CALL to run this one' } };
-    // an argument only some of the calls hand over is still worth offering, but
-    // it is one the routine only has when that call is what ran it - so they are
-    // a group of their own rather than part of "In every fooRoutine", and the
-    // ones not every call hands over are shown as the exception they are
-    const { arguments: args, calls } = callArgumentsFor(property);
-    // a name written in the game, so the map it goes into inherits nothing (see
-    // presetEntryOf in popup.js)
-    const variables = Object.create(null);
-    for(const name of [ ...args.keys() ].sort())
-      variables[name] = {
-        description: describeCallers(args.get(name), calls.length),
-        partial: args.get(name).size < calls.length
-      };
-    if(Object.keys(variables).length)
-      groups.push({
-        title: `From the ${calls.length == 1 ? 'operation that runs' : 'operations that run'} it`,
-        source: 'the CALL that runs this routine',
-        variables, collections: {}
-      });
-  }
+  // CALL runs any routine by name, a clickRoutine as readily as a custom one, and
+  // hands it its arguments and its caller either way - so they are offered
+  // wherever a CALL in the room runs this routine. They are a group of their own
+  // rather than part of "In every fooRoutine" because the routine only has them
+  // when that CALL is what ran it: an argument not every call hands over is shown
+  // as the exception it is, and in a routine a player can trigger as well, all of
+  // them are.
+  const { arguments: args, calls } = callArgumentsFor(property, target);
+  // a name written in the game, so the map it goes into inherits nothing (see
+  // presetEntryOf in popup.js)
+  const variables = Object.create(null);
+  for(const name of [ ...args.keys() ].sort())
+    variables[name] = {
+      description: describeCallers(args.get(name), calls.length),
+      partial: !custom || args.get(name).size < calls.length
+    };
+  const collections = !custom && calls.length
+    ? { caller: { description: 'the widget whose routine used CALL to run this one', partial: true } } : {};
+  if(Object.keys(variables).length + Object.keys(collections).length)
+    groups.push({
+      title: custom ? `From the ${calls.length == 1 ? 'operation that runs' : 'operations that run'} it` : 'Only when a CALL runs it',
+      source: 'the CALL that runs this routine',
+      variables, collections
+    });
   // handed over before the first operation runs, so an operation of the routine
   // that stores the same name wins over them (see presetSections in popup.js)
   const group = Object.assign({ title: `In every ${property}`, source: `the ${property}`, variables: {}, collections: {} }, preset);
@@ -249,6 +291,10 @@ const routineTargets = {
     describe: property=>property
   }
 };
+
+function widgetIDOf(widget) {
+  return typeof widget.get == 'function' ? widget.get('id') : widget.state.id;
+}
 
 function widgetTypeOf(widget) {
   return typeof widget.get == 'function' ? widget.get('type') : widget.state.type;
@@ -649,7 +695,7 @@ class EventsEditor {
           // clone in both directions: the editor mutates its own copy, and the widget must
           // never share references with it (deltas would alias widget state to the editor's
           // arrays and make later set() calls no-op because the state already "changed")
-          this.routineEditors[key] = new RoutineEditor(this.widget, JSON.parse(JSON.stringify(this.routineSource(target)[property])), [], [], { routineKey: key, presets: routinePresetsOf(property) });
+          this.routineEditors[key] = new RoutineEditor(this.widget, JSON.parse(JSON.stringify(this.routineSource(target)[property])), [], [], { routineKey: key, presets: routinePresetsOf(property, { widgetID: widgetIDOf(this.widget), cardDefaults: target == 'cardDefaults' }) });
           this.routineEditors[key].registerChangeListener(v=>this.setRoutine(entry, JSON.parse(JSON.stringify(v))));
         }
         contentDOM.append(this.routineEditors[key].domElement);

--- a/client/js/editor/controls/events.js
+++ b/client/js/editor/controls/events.js
@@ -17,22 +17,22 @@ const predefinedEvents = [
   {
     property: 'enterRoutine',
     label: 'widget enters',
-    description: 'Runs when another widget is dropped into this widget. The routine starts with the widget that entered picked, and can use oldParentID - the widget it came from.'
+    description: 'Runs when another widget is dropped into this widget. The routine is handed the widget that entered as the collection child, and oldParentID - the id of the widget it came from.'
   },
   {
     property: 'leaveRoutine',
     label: 'widget leaves',
-    description: 'Runs when a widget is taken out of this widget. The routine starts with the widget that left picked. It can run more than once for a single move.'
+    description: 'Runs when a widget is taken out of this widget. The routine is handed the widget that left as the collection child. It can run more than once for a single move.'
   },
   {
     property: 'gameStartRoutine',
     label: 'game starts',
-    description: 'Runs once when a player loads the game fresh from the game shelf or public library, but not when loading a saved game in progress.'
+    description: 'Runs once when a player loads the game fresh from the game shelf or public library, but not when loading a saved game in progress. The routine is handed the widget it is on as the collection widget and its id as widgetID.'
   },
   {
     property: 'globalUpdateRoutine',
     label: 'any widget changed',
-    description: 'Runs when any property of any widget in the room changes. The routine starts with the changed widget picked and can use value - what the property is now - as well as oldValue, property and widgetID. To react to one property only, name the routine after it, like fooGlobalUpdateRoutine for the property foo.'
+    description: 'Runs when any property of any widget in the room changes. The routine is handed the changed widget as the collection widget and can use value - what the property is now - as well as oldValue, property and widgetID. To react to one property only, name the routine after it, like fooGlobalUpdateRoutine for the property foo.'
   }
 ];
 
@@ -53,14 +53,93 @@ function describeEventProperty(property) {
     return {
       property,
       label: `${match[1]} changed anywhere`,
-      description: `Runs whenever the ${match[1]} property of any widget in the room changes. The routine starts with that widget picked and can use value - what ${match[1]} is now - as well as oldValue and widgetID.`
+      description: `Runs whenever the ${match[1]} property of any widget in the room changes. The routine is handed that widget as the collection widget and can use value - what ${match[1]} is now - as well as oldValue and widgetID.`
     };
   }
   return {
     property,
     label: property.replace(/Routine$/, ''),
-    description: 'Runs only when another routine runs it by this name - the "Run the routine" operation. Nothing else triggers it.'
+    description: 'Runs only when another routine runs it by this name - the "Run the routine" operation. Nothing else triggers it. It is handed the widget whose routine ran it as the collection caller.'
   };
+}
+
+// What a routine is handed the moment it starts, because of what triggered it:
+// an enterRoutine knows the widget that entered as the collection "child" and
+// where it came from as ${oldParentID}. No operation creates them, so nothing in
+// the routine editor would offer them - they are what the engine passes to
+// evaluateRoutine (widget.js, statemanaged.js, serverstate.js) before the first
+// operation runs. A routine that gets nothing of its own (a clickRoutine) has no
+// entry here and only has what every routine has.
+const routinePresets = {
+  changeRoutine: {
+    variables: {
+      property: 'the name of the property that changed',
+      value: 'what the property is now',
+      oldValue: 'what the property was before'
+    }
+  },
+  enterRoutine: {
+    variables: {
+      oldParentID: 'id of the widget the entering widget came from (null when a player dragged it - picking it up already took it out of its parent)'
+    },
+    collections: {
+      child: 'the widget that entered'
+    }
+  },
+  leaveRoutine: {
+    collections: {
+      child: 'the widget that left'
+    }
+  },
+  gameStartRoutine: {
+    variables: {
+      widgetID: 'id of the widget this routine is on (the same as thisID)'
+    },
+    collections: {
+      widget: 'the widget this routine is on (the same as thisButton)'
+    }
+  },
+  globalUpdateRoutine: {
+    variables: {
+      widgetID: 'id of the widget whose property changed',
+      property: 'the name of the property that changed',
+      value: 'what the property is now',
+      oldValue: 'what the property was before'
+    },
+    collections: {
+      widget: 'the widget whose property changed'
+    }
+  },
+  // the editor runs it on the widget it just added, the way a click runs a
+  // clickRoutine - there is nothing else to tell it about
+  editorAddToRoomRoutine: {}
+};
+
+// The presets of one routine, as the group the routine editor lists them under.
+// The routines named after a property hear about that one property only, so
+// theirs are worded with its name and have no property variable. Everything else
+// is a custom routine, which only ever runs through CALL.
+function routinePresetsOf(property) {
+  let match;
+  let preset = routinePresets[property];
+  if(!preset && (match = property.match(/^(.+)ChangeRoutine$/)))
+    preset = { variables: {
+      value: `what ${match[1]} is now`,
+      oldValue: `what ${match[1]} was before`
+    } };
+  if(!preset && (match = property.match(/^(.+)GlobalUpdateRoutine$/)))
+    preset = {
+      variables: {
+        widgetID: `id of the widget whose ${match[1]} changed`,
+        value: `what ${match[1]} is now`,
+        oldValue: `what ${match[1]} was before`
+      },
+      collections: { widget: `the widget whose ${match[1]} changed` }
+    };
+  if(!preset && !predefinedEvents.some(event=>event.property == property))
+    preset = { collections: { caller: 'the widget whose routine used CALL to run this one' } };
+  const group = Object.assign({ title: `In every ${property}`, variables: {}, collections: {} }, preset);
+  return Object.keys(group.variables).length + Object.keys(group.collections).length ? [ group ] : [];
 }
 
 // A deck is two things in one place: the widget on the table, which nobody
@@ -482,7 +561,7 @@ class EventsEditor {
           // clone in both directions: the editor mutates its own copy, and the widget must
           // never share references with it (deltas would alias widget state to the editor's
           // arrays and make later set() calls no-op because the state already "changed")
-          this.routineEditors[key] = new RoutineEditor(this.widget, JSON.parse(JSON.stringify(this.routineSource(target)[property])), [], [], { routineKey: key });
+          this.routineEditors[key] = new RoutineEditor(this.widget, JSON.parse(JSON.stringify(this.routineSource(target)[property])), [], [], { routineKey: key, presets: routinePresetsOf(property) });
           this.routineEditors[key].registerChangeListener(v=>this.setRoutine(entry, JSON.parse(JSON.stringify(v))));
         }
         contentDOM.append(this.routineEditors[key].domElement);

--- a/client/js/editor/controls/events.js
+++ b/client/js/editor/controls/events.js
@@ -59,7 +59,7 @@ function describeEventProperty(property) {
   return {
     property,
     label: property.replace(/Routine$/, ''),
-    description: 'Runs only when another routine runs it by this name - the "Run the routine" operation. Nothing else triggers it. It is handed the widget whose routine ran it as the collection caller.'
+    description: 'Runs only when another routine runs it by this name - the "Run the routine" operation. Nothing else triggers it. It starts with everything the routine that ran it had at that point - all of its values and collections - plus the arguments that operation hands over and the widget it ran on as the collection caller.'
   };
 }
 
@@ -115,12 +115,41 @@ const routinePresets = {
   editorAddToRoomRoutine: {}
 };
 
-// The presets of one routine, as the group the routine editor lists them under.
+// The arguments every CALL in the room that runs this routine by name hands it,
+// as { name: which CALLs pass it }. CALL copies the calling routine's values and
+// collections into the routine it runs and merges its arguments on top
+// (widget.js), so those names are values the routine has before its first
+// operation - the same kind of thing an event hands its routine, except that
+// what they are is written in the game rather than in the engine.
+function callArgumentsFor(routineName) {
+  const callers = {};
+  const scan = (routine, source)=>{
+    for(const operation of Array.isArray(routine) ? routine : []) {
+      if(!operation || typeof operation != 'object')
+        continue;
+      // a CALL given a list of names runs the first of them (widget.js)
+      const called = Array.isArray(operation.routine) ? operation.routine[0] : operation.routine;
+      if(operation.func == 'CALL' && called === routineName && operation.arguments && typeof operation.arguments == 'object')
+        for(const name of Object.keys(operation.arguments))
+          (callers[name] = callers[name] || new Set()).add(source);
+      for(const block of [ 'thenRoutine', 'elseRoutine', 'loopRoutine' ])
+        scan(operation[block], source);
+    }
+  };
+  for(const widget of widgets.values())
+    for(const [ key, value ] of Object.entries(widget.state))
+      if(key.match(/Routine$/) && Array.isArray(value))
+        scan(value, `${key} of ${widget.state.id}`);
+  return callers;
+}
+
+// The presets of one routine, as the groups the routine editor lists them under.
 // The routines named after a property hear about that one property only, so
 // theirs are worded with its name and have no property variable. Everything else
 // is a custom routine, which only ever runs through CALL.
 function routinePresetsOf(property) {
   let match;
+  const groups = [];
   let preset = routinePresets[property];
   if(!preset && (match = property.match(/^(.+)ChangeRoutine$/)))
     preset = { variables: {
@@ -136,10 +165,26 @@ function routinePresetsOf(property) {
       },
       collections: { widget: `the widget whose ${match[1]} changed` }
     };
-  if(!preset && !predefinedEvents.some(event=>event.property == property))
+  if(!preset && !predefinedEvents.some(event=>event.property == property)) {
     preset = { collections: { caller: 'the widget whose routine used CALL to run this one' } };
-  const group = Object.assign({ title: `In every ${property}`, variables: {}, collections: {} }, preset);
-  return Object.keys(group.variables).length + Object.keys(group.collections).length ? [ group ] : [];
+    // an argument only some of the calls hand over is still worth offering, but
+    // it is one the routine only has when that call is what ran it - so they are
+    // a group of their own rather than part of "In every fooRoutine"
+    const args = callArgumentsFor(property);
+    const variables = {};
+    for(const name of Object.keys(args).sort())
+      variables[name] = args[name].size == 1
+        ? `handed over by the CALL in ${[ ...args[name] ][0]}`
+        : `handed over by ${args[name].size} of the operations that run this routine`;
+    if(Object.keys(variables).length)
+      groups.push({ title: 'From the operation that runs it', shadowedByOperations: true, variables, collections: {} });
+  }
+  // handed over before the first operation runs, so an operation of the routine
+  // that stores the same name wins over them (see presetSections in popup.js)
+  const group = Object.assign({ title: `In every ${property}`, shadowedByOperations: true, variables: {}, collections: {} }, preset);
+  if(Object.keys(group.variables).length + Object.keys(group.collections).length)
+    groups.unshift(group);
+  return groups;
 }
 
 // A deck is two things in one place: the widget on the table, which nobody

--- a/client/js/editor/controls/events.js
+++ b/client/js/editor/controls/events.js
@@ -12,27 +12,27 @@ const predefinedEvents = [
   {
     property: 'changeRoutine',
     label: 'property changed',
-    description: 'Runs whenever any property of this widget changes. The routine can use value - what the property is now - as well as oldValue and property. To react to one property only, name the routine after it, like fooChangeRoutine for the property foo.'
+    description: 'Runs whenever any property of this widget changes. The routine can use "value" - what the property is now - as well as "oldValue" and "property". To react to one property only, name the routine after it, like fooChangeRoutine for the property foo.'
   },
   {
     property: 'enterRoutine',
     label: 'widget enters',
-    description: 'Runs when another widget is dropped into this widget. The routine is handed the widget that entered as the collection child, and oldParentID - the id of the widget it came from.'
+    description: 'Runs when another widget is dropped into this widget. The routine is handed the widget that entered as the collection "child", and "oldParentID" - the id of the widget it came from.'
   },
   {
     property: 'leaveRoutine',
     label: 'widget leaves',
-    description: 'Runs when a widget is taken out of this widget. The routine is handed the widget that left as the collection child. It can run more than once for a single move.'
+    description: 'Runs when a widget is taken out of this widget. The routine is handed the widget that left as the collection "child". It can run more than once for a single move.'
   },
   {
     property: 'gameStartRoutine',
     label: 'game starts',
-    description: 'Runs once when a player loads the game fresh from the game shelf or public library, but not when loading a saved game in progress. The routine is handed the widget it is on as the collection widget and its id as widgetID.'
+    description: 'Runs once when a player loads the game fresh from the game shelf or public library, but not when loading a saved game in progress. The routine is handed the widget it is on as the collection "widget" and its id as "widgetID".'
   },
   {
     property: 'globalUpdateRoutine',
     label: 'any widget changed',
-    description: 'Runs when any property of any widget in the room changes. The routine is handed the changed widget as the collection widget and can use value - what the property is now - as well as oldValue, property and widgetID. To react to one property only, name the routine after it, like fooGlobalUpdateRoutine for the property foo.'
+    description: 'Runs when any property of any widget in the room changes. The routine is handed the changed widget as the collection "widget" and can use "value" - what the property is now - as well as "oldValue", "property" and "widgetID". To react to one property only, name the routine after it, like fooGlobalUpdateRoutine for the property foo.'
   }
 ];
 
@@ -46,20 +46,20 @@ function describeEventProperty(property) {
     return {
       property,
       label: `${match[1]} changed`,
-      description: `Runs whenever the ${match[1]} property of this widget changes. The routine can use value - what ${match[1]} is now - and oldValue, what it was before.`
+      description: `Runs whenever the ${match[1]} property of this widget changes. The routine can use "value" - what ${match[1]} is now - and "oldValue", what it was before.`
     };
   }
   if(match = property.match(/^(.+)GlobalUpdateRoutine$/)) {
     return {
       property,
       label: `${match[1]} changed anywhere`,
-      description: `Runs whenever the ${match[1]} property of any widget in the room changes. The routine is handed that widget as the collection widget and can use value - what ${match[1]} is now - as well as oldValue and widgetID.`
+      description: `Runs whenever the ${match[1]} property of any widget in the room changes. The routine is handed that widget as the collection "widget" and can use "value" - what ${match[1]} is now - as well as "oldValue" and "widgetID".`
     };
   }
   return {
     property,
     label: property.replace(/Routine$/, ''),
-    description: 'Runs only when another routine runs it by this name - the "Run the routine" operation. Nothing else triggers it. It starts with everything the routine that ran it had at that point - all of its values and collections - plus the arguments that operation hands over and the widget it ran on as the collection caller.'
+    description: 'Runs only when another routine runs it by this name - the "Run the routine" operation. Nothing else triggers it. It starts with everything the routine that ran it had at that point - all of its values and collections - plus the arguments that operation hands over and the widget it ran on as the collection "caller".'
   };
 }
 
@@ -93,10 +93,10 @@ const routinePresets = {
   },
   gameStartRoutine: {
     variables: {
-      widgetID: 'id of the widget this routine is on (the same as thisID)'
+      widgetID: 'another name for thisID - the id of the widget this routine is on, either works'
     },
     collections: {
-      widget: 'the widget this routine is on (the same as thisButton)'
+      widget: 'another name for thisButton - the widget this routine is on, either works'
     }
   },
   globalUpdateRoutine: {
@@ -116,22 +116,27 @@ const routinePresets = {
 };
 
 // The arguments every CALL in the room that runs this routine by name hands it,
-// as { name: which CALLs pass it }. CALL copies the calling routine's values and
-// collections into the routine it runs and merges its arguments on top
-// (widget.js), so those names are values the routine has before its first
-// operation - the same kind of thing an event hands its routine, except that
-// what they are is written in the game rather than in the engine.
+// as { arguments: { name: which CALLs pass it }, sources: every CALL that runs
+// it }. CALL copies the calling routine's values and collections into the
+// routine it runs and merges its arguments on top (widget.js), so those names
+// are values the routine has before its first operation - the same kind of thing
+// an event hands its routine, except that what they are is written in the game
+// rather than in the engine.
 function callArgumentsFor(routineName) {
-  const callers = {};
+  const args = {};
+  const sources = new Set();
   const scan = (routine, source)=>{
     for(const operation of Array.isArray(routine) ? routine : []) {
       if(!operation || typeof operation != 'object')
         continue;
       // a CALL given a list of names runs the first of them (widget.js)
       const called = Array.isArray(operation.routine) ? operation.routine[0] : operation.routine;
-      if(operation.func == 'CALL' && called === routineName && operation.arguments && typeof operation.arguments == 'object')
-        for(const name of Object.keys(operation.arguments))
-          (callers[name] = callers[name] || new Set()).add(source);
+      if(operation.func == 'CALL' && called === routineName) {
+        sources.add(source);
+        if(operation.arguments && typeof operation.arguments == 'object')
+          for(const name of Object.keys(operation.arguments))
+            (args[name] = args[name] || new Set()).add(source);
+      }
       for(const block of [ 'thenRoutine', 'elseRoutine', 'loopRoutine' ])
         scan(operation[block], source);
     }
@@ -140,13 +145,25 @@ function callArgumentsFor(routineName) {
     for(const [ key, value ] of Object.entries(widget.state))
       if(key.match(/Routine$/) && Array.isArray(value))
         scan(value, `${key} of ${widget.state.id}`);
-  return callers;
+  return { arguments: args, sources };
 }
 
-// The presets of one routine, as the groups the routine editor lists them under.
-// The routines named after a property hear about that one property only, so
-// theirs are worded with its name and have no property variable. Everything else
-// is a custom routine, which only ever runs through CALL.
+// Which operations hand an argument over, named rather than counted: a count
+// ("3 of the operations that run this routine") is nothing the reader can go and
+// look at. More than two of them would fill the line, so the rest is a count.
+function describeCallers(sources, total) {
+  const names = [ ...sources ];
+  const listed = names.length > 2 ? `${names.slice(0, 2).join(', ')} and ${names.length-2} more` : names.join(' and ');
+  const missing = total - names.length;
+  return `handed over by the ${names.length == 1 ? 'CALL' : 'CALLs'} in ${listed}`
+       + (missing ? ` - not by the ${missing == 1 ? 'other operation that runs' : `other ${missing} operations that run`} this routine` : '');
+}
+
+// The presets of one routine, as the groups the routine editor lists them under,
+// the most specific group first (see presetSections in popup.js). The routines
+// named after a property hear about that one property only, so theirs are worded
+// with its name and have no property variable. Everything else is a custom
+// routine, which only ever runs through CALL.
 function routinePresetsOf(property) {
   let match;
   const groups = [];
@@ -169,21 +186,27 @@ function routinePresetsOf(property) {
     preset = { collections: { caller: 'the widget whose routine used CALL to run this one' } };
     // an argument only some of the calls hand over is still worth offering, but
     // it is one the routine only has when that call is what ran it - so they are
-    // a group of their own rather than part of "In every fooRoutine"
-    const args = callArgumentsFor(property);
+    // a group of their own rather than part of "In every fooRoutine", and the
+    // ones not every call hands over are shown as the exception they are
+    const { arguments: args, sources } = callArgumentsFor(property);
     const variables = {};
     for(const name of Object.keys(args).sort())
-      variables[name] = args[name].size == 1
-        ? `handed over by the CALL in ${[ ...args[name] ][0]}`
-        : `handed over by ${args[name].size} of the operations that run this routine`;
+      variables[name] = {
+        description: describeCallers(args[name], sources.size),
+        partial: args[name].size < sources.size
+      };
     if(Object.keys(variables).length)
-      groups.push({ title: 'From the operation that runs it', shadowedByOperations: true, variables, collections: {} });
+      groups.push({
+        title: `From the ${sources.size == 1 ? 'operation that runs' : 'operations that run'} it`,
+        source: 'the CALL that runs this routine',
+        shadowedByOperations: true, variables, collections: {}
+      });
   }
   // handed over before the first operation runs, so an operation of the routine
   // that stores the same name wins over them (see presetSections in popup.js)
-  const group = Object.assign({ title: `In every ${property}`, shadowedByOperations: true, variables: {}, collections: {} }, preset);
+  const group = Object.assign({ title: `In every ${property}`, source: `the ${property}`, shadowedByOperations: true, variables: {}, collections: {} }, preset);
   if(Object.keys(group.variables).length + Object.keys(group.collections).length)
-    groups.unshift(group);
+    groups.push(group);
   return groups;
 }
 

--- a/client/js/editor/controls/popup.js
+++ b/client/js/editor/controls/popup.js
@@ -540,6 +540,24 @@ const predefinedCollectionDescriptions = {
   thisButton: 'the widget that contains the routine (not necessarily a button)'
 };
 
+// The presets of a routine (routinePresetsOf in events.js) as sections of the
+// popup: one group per source, each { name: description }. A name a later group
+// hands over again is only listed there - the innermost FOREACH decides what
+// ${value} is for the operations inside it, so listing the outer one as well
+// would offer the same name twice for two different things.
+function presetSections(presets, kind, toEntry) {
+  return (presets || []).map((group, index, groups)=>({
+    title: group.title,
+    list: Object.keys(group[kind] || {})
+      .filter(name=>!groups.slice(index+1).some(later=>(later[kind] || {})[name]))
+      .map(name=>toEntry(name, group[kind][name]))
+  }));
+}
+
+function presetNames(presets, kind) {
+  return (presets || []).flatMap(group=>Object.keys(group[kind] || {}));
+}
+
 const routineWidgetPickerKey = 'routineWidgets';
 
 let propertySuggestionListCounter = 0;
@@ -855,12 +873,13 @@ class RoutinePopup extends Popup {
     button(host, 'use property', apply);
   }
 
-  setOperationDetails(operation, parameterNames, widget, variables, collections) {
+  setOperationDetails(operation, parameterNames, widget, variables, collections, presets=[]) {
     this.operation = operation;
     this.parameterNames = parameterNames;
     this.widget = widget;
     this.variables = variables;
     this.collections = collections;
+    this.presets = presets;
   }
 
   // One section per kind of thing the routine offers instead of four groups in
@@ -869,6 +888,12 @@ class RoutinePopup extends Popup {
   // for it - and only one of them is open at a time. Where an entry comes from
   // is a plain line inside the section rather than a heading of its own color.
   renderRoutineValueSection(showVariables, showCollections) {
+    // what a routine is handed the moment it starts is listed under its own name
+    // ("In every enterRoutine"), between what its operations made and what every
+    // routine has - a name it brings is not one an earlier operation stored
+    const presetVariables = presetNames(this.presets, 'variables');
+    const presetCollections = presetNames(this.presets, 'collections');
+
     if(showVariables)
       this.renderRoutineValueKindSection('Values the routine has', 'variable', `
         <pre>
@@ -876,13 +901,17 @@ class RoutinePopup extends Popup {
 
         Earlier operations remember values under a name: [COUNT] and [GET] store what they counted or read, [VAR] and [var] store what you calculate, and [CALL] stores what another routine returned. Picking one here uses whatever it holds when the routine runs.
 
-        The ones below "In every routine" are there without any operation creating them.
+        The ones below the "In every ..." lines are there without any operation creating them: some in every routine, the others because of what started this one - a changeRoutine is told what changed.
         </pre>
       `, [
-        { title: 'From earlier operations', list: [ ...this.variables ].sort().map(variable=>({
+        { title: 'From earlier operations', list: [ ...this.variables ].filter(variable=>presetVariables.indexOf(variable) == -1).sort().map(variable=>({
           label: variable,
           onClick: _=>this.setNewValue(`\$\{${variable}\}`)
         })) },
+        ...presetSections(this.presets, 'variables', (variable, description)=>({
+          label: variable, description,
+          onClick: _=>this.setNewValue(`\$\{${variable}\}`)
+        })),
         { title: 'In every routine', list: Object.keys(predefinedVariableDescriptions).map(variable=>({
           label: variable, description: predefinedVariableDescriptions[variable],
           onClick: _=>this.setNewValue(`\$\{${variable}\}`)
@@ -894,14 +923,18 @@ class RoutinePopup extends Popup {
         <pre>
         A collection is a group of widgets an earlier [SELECT] picked out, by the name it is stored under. Operations that act on widgets take one instead of a single widget.
 
-        The ones below "In every routine" are there without any operation creating them.
+        The ones below the "In every ..." lines are there without any operation creating them: some in every routine, the others because of what started this one - an enterRoutine is handed the widget that entered.
         </pre>
       `, [
-        { title: 'From earlier operations', list: [ ...this.collections ].sort((a, b)=>JSON.stringify(a) < JSON.stringify(b) ? -1 : 1).map(collection=>({
+        { title: 'From earlier operations', list: [ ...this.collections ].filter(collection=>typeof collection != 'string' || presetCollections.indexOf(collection) == -1).sort((a, b)=>JSON.stringify(a) < JSON.stringify(b) ? -1 : 1).map(collection=>({
           label: typeof collection == 'string' ? collection : `[ ${collection.join(', ')} ]`,
           description: typeof collection == 'string' ? null : 'these widgets, listed in the routine itself',
           onClick: _=>this.setNewCollectionValue(typeof collection == 'string' ? collection : [ ...collection ])
         })) },
+        ...presetSections(this.presets, 'collections', (collection, description)=>({
+          label: collection, description,
+          onClick: _=>this.setNewCollectionValue(collection)
+        })),
         { title: 'In every routine', list: Object.keys(predefinedCollectionDescriptions).map(collection=>({
           label: collection, description: predefinedCollectionDescriptions[collection],
           onClick: _=>this.setNewCollectionValue(collection)

--- a/client/js/editor/controls/popup.js
+++ b/client/js/editor/controls/popup.js
@@ -541,21 +541,30 @@ const predefinedCollectionDescriptions = {
 };
 
 // The presets of a routine (routinePresetsOf in events.js) as sections of the
-// popup: one group per source, each { name: description }. A name a later group
-// hands over again is only listed there - the innermost FOREACH decides what
-// ${value} is for the operations inside it, so listing the outer one as well
-// would offer the same name twice for two different things.
-function presetSections(presets, kind, toEntry) {
+// popup: one group per source, each { name: description }. Whoever hands a name
+// over last wins, so a name two groups have is only listed in the later one -
+// the innermost FOREACH decides what ${value} is for the operations inside it.
+//
+// Against what an operation stored it depends on when the group is handed over.
+// A FOREACH establishes its values when the block is entered, i.e. after every
+// operation outside it, so it wins. What starts a routine (shadowedByOperations)
+// is there before the first operation instead, so an operation of the routine
+// storing the same name wins over it - a changeRoutine whose first operation is
+// a GET into value has the GET result from there on, not what changed.
+function presetSections(presets, kind, existing, toEntry) {
   return (presets || []).map((group, index, groups)=>({
     title: group.title,
     list: Object.keys(group[kind] || {})
       .filter(name=>!groups.slice(index+1).some(later=>(later[kind] || {})[name]))
+      .filter(name=>!group.shadowedByOperations || existing.indexOf(name) == -1)
       .map(name=>toEntry(name, group[kind][name]))
   }));
 }
 
+// the preset names that win over an operation of the same name, i.e. the ones to
+// leave out of "From earlier operations"
 function presetNames(presets, kind) {
-  return (presets || []).flatMap(group=>Object.keys(group[kind] || {}));
+  return (presets || []).filter(group=>!group.shadowedByOperations).flatMap(group=>Object.keys(group[kind] || {}));
 }
 
 const routineWidgetPickerKey = 'routineWidgets';
@@ -890,7 +899,9 @@ class RoutinePopup extends Popup {
   renderRoutineValueSection(showVariables, showCollections) {
     // what a routine is handed the moment it starts is listed under its own name
     // ("In every enterRoutine"), between what its operations made and what every
-    // routine has - a name it brings is not one an earlier operation stored
+    // routine has; a FOREACH block additionally gets what the round it runs is
+    // for. Only the latter also takes the name out of "From earlier operations"
+    // (see presetSections)
     const presetVariables = presetNames(this.presets, 'variables');
     const presetCollections = presetNames(this.presets, 'collections');
 
@@ -901,14 +912,14 @@ class RoutinePopup extends Popup {
 
         Earlier operations remember values under a name: [COUNT] and [GET] store what they counted or read, [VAR] and [var] store what you calculate, and [CALL] stores what another routine returned. Picking one here uses whatever it holds when the routine runs.
 
-        The ones below the "In every ..." lines are there without any operation creating them: some in every routine, the others because of what started this one - a changeRoutine is told what changed.
+        The ones below the other lines are there without any operation creating them: some in every routine, the others because of what started this one - a changeRoutine is told what changed, and a routine another one runs gets the arguments it was called with.
         </pre>
       `, [
         { title: 'From earlier operations', list: [ ...this.variables ].filter(variable=>presetVariables.indexOf(variable) == -1).sort().map(variable=>({
           label: variable,
           onClick: _=>this.setNewValue(`\$\{${variable}\}`)
         })) },
-        ...presetSections(this.presets, 'variables', (variable, description)=>({
+        ...presetSections(this.presets, 'variables', [ ...this.variables ], (variable, description)=>({
           label: variable, description,
           onClick: _=>this.setNewValue(`\$\{${variable}\}`)
         })),
@@ -923,7 +934,7 @@ class RoutinePopup extends Popup {
         <pre>
         A collection is a group of widgets an earlier [SELECT] picked out, by the name it is stored under. Operations that act on widgets take one instead of a single widget.
 
-        The ones below the "In every ..." lines are there without any operation creating them: some in every routine, the others because of what started this one - an enterRoutine is handed the widget that entered.
+        The ones below the other lines are there without any operation creating them: some in every routine, the others because of what started this one - an enterRoutine is handed the widget that entered.
         </pre>
       `, [
         { title: 'From earlier operations', list: [ ...this.collections ].filter(collection=>typeof collection != 'string' || presetCollections.indexOf(collection) == -1).sort((a, b)=>JSON.stringify(a) < JSON.stringify(b) ? -1 : 1).map(collection=>({
@@ -931,7 +942,7 @@ class RoutinePopup extends Popup {
           description: typeof collection == 'string' ? null : 'these widgets, listed in the routine itself',
           onClick: _=>this.setNewCollectionValue(typeof collection == 'string' ? collection : [ ...collection ])
         })) },
-        ...presetSections(this.presets, 'collections', (collection, description)=>({
+        ...presetSections(this.presets, 'collections', [ ...this.collections ], (collection, description)=>({
           label: collection, description,
           onClick: _=>this.setNewCollectionValue(collection)
         })),

--- a/client/js/editor/controls/popup.js
+++ b/client/js/editor/controls/popup.js
@@ -541,9 +541,12 @@ const predefinedCollectionDescriptions = {
 };
 
 // The presets of a routine (routinePresetsOf in events.js) as sections of the
-// popup: one group per source, each { name: description }. Whoever hands a name
-// over last wins, so a name two groups have is only listed in the later one -
-// the innermost FOREACH decides what ${value} is for the operations inside it.
+// popup: one group per source, each { name: description } or { name: {
+// description, partial } }. The groups come the nearest one first and are listed
+// in that order, so the section reads from what is closest to the operation out
+// to what every routine has - and a name two groups have is only listed in the
+// nearer one, the innermost FOREACH being what decides what ${value} is for the
+// operations inside it.
 //
 // Against what an operation stored it depends on when the group is handed over.
 // A FOREACH establishes its values when the block is entered, i.e. after every
@@ -555,10 +558,25 @@ function presetSections(presets, kind, existing, toEntry) {
   return (presets || []).map((group, index, groups)=>({
     title: group.title,
     list: Object.keys(group[kind] || {})
-      .filter(name=>!groups.slice(index+1).some(later=>(later[kind] || {})[name]))
+      .filter(name=>!groups.slice(0, index).some(nearer=>(nearer[kind] || {})[name]))
       .filter(name=>!group.shadowedByOperations || existing.indexOf(name) == -1)
-      .map(name=>toEntry(name, group[kind][name]))
+      .map(name=>{
+        const preset = group[kind][name];
+        const entry = toEntry(name, typeof preset == 'string' ? preset : preset.description);
+        if(preset && preset.partial)
+          entry.partial = true;
+        return entry;
+      })
   }));
+}
+
+// What an operation stored under a name the routine was also handed: which of
+// the two the name means changes halfway through the routine, which is exactly
+// what makes it confusing - so the entry says so rather than standing there as
+// the only one in the list without an explanation.
+function presetShadowNote(presets, kind, name) {
+  const group = (presets || []).find(group=>group.shadowedByOperations && (group[kind] || {})[name]);
+  return group ? `stored by an earlier operation - it replaced the ${name} ${group.source} hands over` : null;
 }
 
 // the preset names that win over an operation of the same name, i.e. the ones to
@@ -912,11 +930,12 @@ class RoutinePopup extends Popup {
 
         Earlier operations remember values under a name: [COUNT] and [GET] store what they counted or read, [VAR] and [var] store what you calculate, and [CALL] stores what another routine returned. Picking one here uses whatever it holds when the routine runs.
 
-        The ones below the other lines are there without any operation creating them: some in every routine, the others because of what started this one - a changeRoutine is told what changed, and a routine another one runs gets the arguments it was called with.
+        Everything below "From earlier operations" is there without any operation creating it: some of it in every routine, the rest because of what started this one - a changeRoutine is told what changed, and a routine another one runs gets the arguments it was called with.
         </pre>
       `, [
         { title: 'From earlier operations', list: [ ...this.variables ].filter(variable=>presetVariables.indexOf(variable) == -1).sort().map(variable=>({
           label: variable,
+          description: presetShadowNote(this.presets, 'variables', variable) || 'stored by an earlier operation of this routine',
           onClick: _=>this.setNewValue(`\$\{${variable}\}`)
         })) },
         ...presetSections(this.presets, 'variables', [ ...this.variables ], (variable, description)=>({
@@ -934,12 +953,13 @@ class RoutinePopup extends Popup {
         <pre>
         A collection is a group of widgets an earlier [SELECT] picked out, by the name it is stored under. Operations that act on widgets take one instead of a single widget.
 
-        The ones below the other lines are there without any operation creating them: some in every routine, the others because of what started this one - an enterRoutine is handed the widget that entered.
+        Everything below "From earlier operations" is there without any operation creating it: some of it in every routine, the rest because of what started this one - an enterRoutine is handed the widget that entered.
         </pre>
       `, [
         { title: 'From earlier operations', list: [ ...this.collections ].filter(collection=>typeof collection != 'string' || presetCollections.indexOf(collection) == -1).sort((a, b)=>JSON.stringify(a) < JSON.stringify(b) ? -1 : 1).map(collection=>({
           label: typeof collection == 'string' ? collection : `[ ${collection.join(', ')} ]`,
-          description: typeof collection == 'string' ? null : 'these widgets, listed in the routine itself',
+          description: typeof collection != 'string' ? 'these widgets, listed in the routine itself'
+            : presetShadowNote(this.presets, 'collections', collection) || 'picked out by an earlier operation of this routine',
           onClick: _=>this.setNewCollectionValue(typeof collection == 'string' ? collection : [ ...collection ])
         })) },
         ...presetSections(this.presets, 'collections', [ ...this.collections ], (collection, description)=>({
@@ -953,11 +973,20 @@ class RoutinePopup extends Popup {
       ]);
   }
 
-  // what each entry is stays a hover tip: written out below every button the
-  // list turns into a wall of text nobody reads through
+  // What each entry is, on one line at the foot of the section, filled by the
+  // entry the pointer or the keyboard is on. It stays a hover tip on the button
+  // as well, but a hover tip is never shown on a touch screen, never to the
+  // keyboard and a second late on the desktop - and what the names hold is what
+  // this list is for. One line rather than a line under every button: written
+  // out below every one of them the list turns into a wall of text nobody reads
+  // through.
   renderRoutineValueKindSection(title, kind, infoHTML, groups) {
     const [ heading, content ] = this.addAccordionSection(title, '', kind);
     infoButton(heading, infoHTML);
+    const descriptionDOM = document.createElement('div');
+    descriptionDOM.className = 'popup-entry-description';
+    const describe = text=>descriptionDOM.textContent = text || 'Point at one of the names above to see what it holds.';
+    describe(null);
     for(const group of groups) {
       if(!group.list.length)
         continue;
@@ -966,9 +995,19 @@ class RoutinePopup extends Popup {
         const dom = div(content, 'popup-entry');
         const entryButton = button(dom, entry.label, entry.onClick);
         entryButton.dataset.kind = kind;
-        entryButton.title = entry.description || group.title;
+        if(entry.description)
+          entryButton.title = entry.description;
+        // one the routine only sometimes has, so it does not read as one of the
+        // names that are always there
+        if(entry.partial)
+          entryButton.classList.add('popup-entry-partial');
+        for(const event of [ 'mouseenter', 'focus' ])
+          entryButton.addEventListener(event, _=>describe(entry.description));
+        for(const event of [ 'mouseleave', 'blur' ])
+          entryButton.addEventListener(event, _=>describe(null));
       }
     }
+    content.append(descriptionDOM);
   }
 
   renderWidgetPropertySection() {

--- a/client/js/editor/controls/popup.js
+++ b/client/js/editor/controls/popup.js
@@ -548,18 +548,20 @@ const predefinedCollectionDescriptions = {
 // nearer one, the innermost FOREACH being what decides what ${value} is for the
 // operations inside it.
 //
-// Against what an operation stored it depends on when the group is handed over.
-// A FOREACH establishes its values when the block is entered, i.e. after every
-// operation outside it, so it wins. What starts a routine (shadowedByOperations)
-// is there before the first operation instead, so an operation of the routine
-// storing the same name wins over it - a changeRoutine whose first operation is
-// a GET into value has the GET result from there on, not what changed.
+// Every group is handed over before the operations that can see it run: what
+// starts a routine is there before its first operation, and a FOREACH block
+// gets what its round is for before the first operation inside it (the ones
+// before the block are no longer in "From earlier operations" by then, see
+// subroutineScope in routine.js). So an operation that stored the same name is
+// always the later one and wins - a changeRoutine whose first operation is a GET
+// into value has the GET result from there on, not what changed, and so does a
+// loopRoutine whose first operation writes over what the round is for.
 function presetSections(presets, kind, existing, toEntry) {
   return (presets || []).map((group, index, groups)=>({
     title: group.title,
     list: Object.keys(group[kind] || {})
-      .filter(name=>!groups.slice(0, index).some(nearer=>(nearer[kind] || {})[name]))
-      .filter(name=>!group.shadowedByOperations || existing.indexOf(name) == -1)
+      .filter(name=>!groups.slice(0, index).some(nearer=>presetEntryOf(nearer, kind, name) !== undefined))
+      .filter(name=>existing.indexOf(name) == -1)
       .map(name=>{
         const preset = group[kind][name];
         const entry = toEntry(name, typeof preset == 'string' ? preset : preset.description);
@@ -570,19 +572,21 @@ function presetSections(presets, kind, existing, toEntry) {
   }));
 }
 
+// what a group hands over under a name - asked for with hasOwnProperty because
+// the names come out of the game: an argument named "constructor" is one a CALL
+// may well hand over, and every plain object claims to have that one
+function presetEntryOf(group, kind, name) {
+  const entries = group[kind];
+  return entries && Object.prototype.hasOwnProperty.call(entries, name) ? entries[name] : undefined;
+}
+
 // What an operation stored under a name the routine was also handed: which of
 // the two the name means changes halfway through the routine, which is exactly
 // what makes it confusing - so the entry says so rather than standing there as
 // the only one in the list without an explanation.
 function presetShadowNote(presets, kind, name) {
-  const group = (presets || []).find(group=>group.shadowedByOperations && (group[kind] || {})[name]);
+  const group = (presets || []).find(group=>presetEntryOf(group, kind, name) !== undefined);
   return group ? `stored by an earlier operation - it replaced the ${name} ${group.source} hands over` : null;
-}
-
-// the preset names that win over an operation of the same name, i.e. the ones to
-// leave out of "From earlier operations"
-function presetNames(presets, kind) {
-  return (presets || []).filter(group=>!group.shadowedByOperations).flatMap(group=>Object.keys(group[kind] || {}));
 }
 
 const routineWidgetPickerKey = 'routineWidgets';
@@ -918,11 +922,8 @@ class RoutinePopup extends Popup {
     // what a routine is handed the moment it starts is listed under its own name
     // ("In every enterRoutine"), between what its operations made and what every
     // routine has; a FOREACH block additionally gets what the round it runs is
-    // for. Only the latter also takes the name out of "From earlier operations"
-    // (see presetSections)
-    const presetVariables = presetNames(this.presets, 'variables');
-    const presetCollections = presetNames(this.presets, 'collections');
-
+    // for. A name an operation has stored since then is in "From earlier
+    // operations" and only there (see presetSections)
     if(showVariables)
       this.renderRoutineValueKindSection('Values the routine has', 'variable', `
         <pre>
@@ -933,7 +934,7 @@ class RoutinePopup extends Popup {
         Everything below "From earlier operations" is there without any operation creating it: some of it in every routine, the rest because of what started this one - a changeRoutine is told what changed, and a routine another one runs gets the arguments it was called with.
         </pre>
       `, [
-        { title: 'From earlier operations', list: [ ...this.variables ].filter(variable=>presetVariables.indexOf(variable) == -1).sort().map(variable=>({
+        { title: 'From earlier operations', list: [ ...this.variables ].sort().map(variable=>({
           label: variable,
           description: presetShadowNote(this.presets, 'variables', variable) || 'stored by an earlier operation of this routine',
           onClick: _=>this.setNewValue(`\$\{${variable}\}`)
@@ -956,7 +957,7 @@ class RoutinePopup extends Popup {
         Everything below "From earlier operations" is there without any operation creating it: some of it in every routine, the rest because of what started this one - an enterRoutine is handed the widget that entered.
         </pre>
       `, [
-        { title: 'From earlier operations', list: [ ...this.collections ].filter(collection=>typeof collection != 'string' || presetCollections.indexOf(collection) == -1).sort((a, b)=>JSON.stringify(a) < JSON.stringify(b) ? -1 : 1).map(collection=>({
+        { title: 'From earlier operations', list: [ ...this.collections ].sort((a, b)=>JSON.stringify(a) < JSON.stringify(b) ? -1 : 1).map(collection=>({
           label: typeof collection == 'string' ? collection : `[ ${collection.join(', ')} ]`,
           description: typeof collection != 'string' ? 'these widgets, listed in the routine itself'
             : presetShadowNote(this.presets, 'collections', collection) || 'picked out by an earlier operation of this routine',

--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -3359,11 +3359,11 @@ class IfRoutineOperationEditor extends RoutineOperationEditor {
 }
 
 // A FOREACH inside a FOREACH hands its block the values of both loops, so the
-// groups they are listed in say which loop each one is: "In every loopRoutine"
-// is the one the block is directly in, the ones around it are counted outwards.
+// groups they are listed in say which loop each one is: "In this loopRoutine" is
+// the one the block is directly in, the ones around it are counted outwards.
 function loopPresetTitle(levelsOut) {
   if(!levelsOut)
-    return 'In every loopRoutine';
+    return 'In this loopRoutine';
   return levelsOut == 1 ? 'In the loopRoutine around it' : `In the loopRoutine ${levelsOut} levels out`;
 }
 
@@ -3391,7 +3391,7 @@ class ForeachRoutineOperationEditor extends RoutineOperationEditor {
   // over - which is the picked widget of the block, so operations inside it work
   // on one widget at a time without naming it
   subroutinePresets(property) {
-    const group = { title: 'In every loopRoutine', loop: true, variables: {}, collections: {} };
+    const group = { title: loopPresetTitle(0), loop: true, variables: {}, collections: {} };
     const variant = this.currentVariant().id;
     if(variant == 'list')
       Object.assign(group.variables, { key: 'the name/index of the entry this round is for', value: 'the entry this round is for' });
@@ -3399,11 +3399,13 @@ class ForeachRoutineOperationEditor extends RoutineOperationEditor {
       group.variables.value = 'the number this round is for';
     else if(variant == 'collection')
       Object.assign(group, { variables: { widgetID: 'id of the widget this round is for' }, collections: { DEFAULT: 'the widget this round is for' } });
-    // the loops of the routine around this one are re-titled rather than left as
-    // another "In every loopRoutine" - copied, because they belong to that editor
-    const groups = [ ...(this.presets || []), group ];
-    const loops = groups.filter(preset=>preset.loop);
-    return groups.map(preset=>preset.loop ? Object.assign({}, preset, { title: loopPresetTitle(loops.length - 1 - loops.indexOf(preset)) }) : preset);
+    // the loop the block is in comes first, the ones around it behind it: the
+    // groups are listed nearest first (see presetSections in popup.js), and they
+    // are re-titled rather than left as another "In this loopRoutine" - copied,
+    // because they belong to the editor around this one
+    const groups = [ group, ...(this.presets || []) ];
+    let levelsOut = 0;
+    return groups.map(preset=>preset.loop ? Object.assign({}, preset, { title: loopPresetTitle(levelsOut++) }) : preset);
   }
 
   render() {

--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -2538,11 +2538,15 @@ class RoutineOperationEditor {
 
   // the names a list of pairs proposes: the variables the operations before this
   // one define, so a VAR that overwrites one of them picks the name instead of
-  // spelling it out again
+  // spelling it out again - plus the ones the routine was handed without any
+  // operation storing them, which are just as overwritable. Inside a FOREACH
+  // block that is the only place ${value} is left: the block no longer counts it
+  // as stored by an earlier operation (see subroutineScope).
   parameterKeySuggestions(name) {
     const value = this.parameterValue(name);
     const taken = value && typeof value == 'object' ? Object.keys(value) : [];
-    return (this.variables || []).filter(variable=>typeof variable == 'string' && taken.indexOf(variable) == -1);
+    const handedOver = (this.presets || []).flatMap(group=>Object.keys(group.variables || {}));
+    return [ ...new Set([ ...(this.variables || []), ...handedOver ]) ].filter(variable=>typeof variable == 'string' && taken.indexOf(variable) == -1);
   }
 
   getDefaults() {

--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -3358,6 +3358,15 @@ class IfRoutineOperationEditor extends RoutineOperationEditor {
   }
 }
 
+// A FOREACH inside a FOREACH hands its block the values of both loops, so the
+// groups they are listed in say which loop each one is: "In every loopRoutine"
+// is the one the block is directly in, the ones around it are counted outwards.
+function loopPresetTitle(levelsOut) {
+  if(!levelsOut)
+    return 'In every loopRoutine';
+  return levelsOut == 1 ? 'In the loopRoutine around it' : `In the loopRoutine ${levelsOut} levels out`;
+}
+
 class ForeachRoutineOperationEditor extends RoutineOperationEditor {
   constructor() {
     super('FOREACH');
@@ -3382,7 +3391,7 @@ class ForeachRoutineOperationEditor extends RoutineOperationEditor {
   // over - which is the picked widget of the block, so operations inside it work
   // on one widget at a time without naming it
   subroutinePresets(property) {
-    const group = { title: 'In every loopRoutine', variables: {}, collections: {} };
+    const group = { title: 'In every loopRoutine', loop: true, variables: {}, collections: {} };
     const variant = this.currentVariant().id;
     if(variant == 'list')
       Object.assign(group.variables, { key: 'the name/index of the entry this round is for', value: 'the entry this round is for' });
@@ -3390,7 +3399,11 @@ class ForeachRoutineOperationEditor extends RoutineOperationEditor {
       group.variables.value = 'the number this round is for';
     else if(variant == 'collection')
       Object.assign(group, { variables: { widgetID: 'id of the widget this round is for' }, collections: { DEFAULT: 'the widget this round is for' } });
-    return [ ...(this.presets || []), group ];
+    // the loops of the routine around this one are re-titled rather than left as
+    // another "In every loopRoutine" - copied, because they belong to that editor
+    const groups = [ ...(this.presets || []), group ];
+    const loops = groups.filter(preset=>preset.loop);
+    return groups.map(preset=>preset.loop ? Object.assign({}, preset, { title: loopPresetTitle(loops.length - 1 - loops.indexOf(preset)) }) : preset);
   }
 
   render() {

--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -3268,6 +3268,13 @@ class RoutineOperationEditor {
     return this.presets || [];
   }
 
+  // the values and collections an operation of a block below this one can pick
+  // from "From earlier operations": everything the operations before it stored,
+  // minus what the block itself is handed under the same name (see FOREACH)
+  subroutineScope(property) {
+    return { variables: this.variables, collections: this.collections };
+  }
+
   renderSubroutine(dom, property, options={}) {
     // only assign the array to the operation when something actually changes
     const routine = Array.isArray(this.operation[property]) ? this.operation[property] : [];
@@ -3283,7 +3290,8 @@ class RoutineOperationEditor {
       attachRoutine: _=>{ this.operation[property] = routine; },
       presets: this.subroutinePresets(property)
     };
-    const routineEditor = new RoutineEditor(this.widget, routine, this.variables, this.collections, options);
+    const scope = this.subroutineScope(property);
+    const routineEditor = new RoutineEditor(this.widget, routine, scope.variables, scope.collections, options);
     routineEditor.registerChangeListener(v=>{
       this.operation[property] = v;
       this.notifyChangeListeners(this.operation);
@@ -3367,6 +3375,13 @@ function loopPresetTitle(levelsOut) {
   return levelsOut == 1 ? 'In the loopRoutine around it' : `In the loopRoutine ${levelsOut} levels out`;
 }
 
+// the same loop named inside a sentence (see presetShadowNote in popup.js)
+function loopPresetSource(levelsOut) {
+  if(!levelsOut)
+    return 'this loopRoutine';
+  return levelsOut == 1 ? 'the loopRoutine around it' : `the loopRoutine ${levelsOut} levels out`;
+}
+
 class ForeachRoutineOperationEditor extends RoutineOperationEditor {
   constructor() {
     super('FOREACH');
@@ -3390,8 +3405,8 @@ class ForeachRoutineOperationEditor extends RoutineOperationEditor {
   // and value of a list entry, the number of a range, or the widget being looped
   // over - which is the picked widget of the block, so operations inside it work
   // on one widget at a time without naming it
-  subroutinePresets(property) {
-    const group = { title: loopPresetTitle(0), loop: true, variables: {}, collections: {} };
+  loopPresetGroup() {
+    const group = { title: loopPresetTitle(0), source: loopPresetSource(0), loop: true, variables: {}, collections: {} };
     const variant = this.currentVariant().id;
     if(variant == 'list')
       Object.assign(group.variables, { key: 'the name/index of the entry this round is for', value: 'the entry this round is for' });
@@ -3399,13 +3414,36 @@ class ForeachRoutineOperationEditor extends RoutineOperationEditor {
       group.variables.value = 'the number this round is for';
     else if(variant == 'collection')
       Object.assign(group, { variables: { widgetID: 'id of the widget this round is for' }, collections: { DEFAULT: 'the widget this round is for' } });
+    return group;
+  }
+
+  subroutinePresets(property) {
     // the loop the block is in comes first, the ones around it behind it: the
     // groups are listed nearest first (see presetSections in popup.js), and they
     // are re-titled rather than left as another "In this loopRoutine" - copied,
     // because they belong to the editor around this one
-    const groups = [ group, ...(this.presets || []) ];
+    const groups = [ this.loopPresetGroup(), ...(this.presets || []) ];
     let levelsOut = 0;
-    return groups.map(preset=>preset.loop ? Object.assign({}, preset, { title: loopPresetTitle(levelsOut++) }) : preset);
+    return groups.map(preset=>{
+      if(!preset.loop)
+        return preset;
+      const out = levelsOut++;
+      return Object.assign({}, preset, { title: loopPresetTitle(out), source: loopPresetSource(out) });
+    });
+  }
+
+  // the round hands its names over when the block is entered, i.e. after every
+  // operation outside it - so inside the block they are what the loop is for and
+  // no longer what an operation before it stored under that name. An operation
+  // inside the block is later still and wins again, which it does by putting the
+  // name back into this list (see setRoutine).
+  subroutineScope(property) {
+    const group = this.loopPresetGroup();
+    const handedOver = (kind, name)=>Object.prototype.hasOwnProperty.call(group[kind], name);
+    return {
+      variables: this.variables.filter(variable=>!handedOver('variables', variable)),
+      collections: this.collections.filter(collection=>typeof collection != 'string' || !handedOver('collections', collection))
+    };
   }
 
   render() {

--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -2002,6 +2002,11 @@ class RoutineEditor {
     // the path into a nested block), so the card worked on last can be found
     // again after the widget was selected anew
     this.routineKey = options.routineKey || '';
+    // the values and groups of widgets this routine has before its first
+    // operation because of what starts it, as groups of { name: description }
+    // (see routinePresetsOf in events.js) - the popups list them next to the
+    // ones every routine has
+    this.presets = options.presets || [];
     this.widgetID = widget ? (typeof widget.get == 'function' ? widget.get('id') : widget.state.id) : null;
     this.changeListeners = [];
     // indices (into this level's routine) of the operations selected for a
@@ -2057,7 +2062,7 @@ class RoutineEditor {
     let collections = [ ...this.collections ];
     for(const [ index, operation ] of this.routine.entries()) {
       const editor = editorForOperation(operation);
-      editor.setOperationDetails(this.widget, operation, variables, collections);
+      editor.setOperationDetails(this.widget, operation, variables, collections, this.presets);
       this.operations.push(editor);
       editor.registerChangeListener(v=>{
         this.routine[index] = v;
@@ -2178,7 +2183,7 @@ class RoutineEditor {
     const addButton = button(this.domElement, 'add operation', async _=>{
       const popup = new RoutineOperationPopup();
       popup.setSource(addButton);
-      popup.setOperationDetails({}, [ 'func' ], this.widget, this.variables, this.collections);
+      popup.setOperationDetails({}, [ 'func' ], this.widget, this.variables, this.collections, this.presets);
       const values = await newRoutineValues(popup);
       if(values !== undefined) {
         // right after the card that was worked on last, so a routine is built in
@@ -2991,7 +2996,7 @@ class RoutineOperationEditor {
       focusable(jsonButton, async _=>{
         const popup = new RoutineFullOperationJSONPopup();
         popup.setSource(jsonButton);
-        popup.setOperationDetails(this.operation, [ 'json' ], this.widget, this.variables, this.collections);
+        popup.setOperationDetails(this.operation, [ 'json' ], this.widget, this.variables, this.collections, this.presets);
         const values = await newRoutineValues(popup);
         if(values !== undefined)
           this.onNewValue(values);
@@ -3014,7 +3019,7 @@ class RoutineOperationEditor {
   // when the drop-down of a setting is asked for something it cannot offer
   async editParameter(span, parameterNames, popup) {
     popup.setSource(span);
-    popup.setOperationDetails(this.operation, parameterNames, this.widget, this.variables, this.collections);
+    popup.setOperationDetails(this.operation, parameterNames, this.widget, this.variables, this.collections, this.presets);
     const values = await newRoutineValues(popup);
     if(values === routineFullPopupRequest)
       return this.editParameter(span, parameterNames, this.createFullPopup(parameterNames));
@@ -3183,7 +3188,7 @@ class RoutineOperationEditor {
           values: this.clauseAddValues(clause)
         })), null, null, `Add an option to ${this.func || 'this operation'}`);
         popup.setSource(addClause);
-        popup.setOperationDetails(this.operation, [ 'func' ], this.widget, this.variables, this.collections);
+        popup.setOperationDetails(this.operation, [ 'func' ], this.widget, this.variables, this.collections, this.presets);
         const values = await newRoutineValues(popup);
         if(values !== undefined)
           this.onNewValue(values);
@@ -3256,6 +3261,13 @@ class RoutineOperationEditor {
     return Object.keys(this.operation).filter(name=>known.indexOf(name) == -1);
   }
 
+  // what a block below this operation starts with: whatever the routine around
+  // it has, plus what the operation itself hands its block (see FOREACH). An
+  // IF branch is the same routine going on, so it adds nothing.
+  subroutinePresets(property) {
+    return this.presets || [];
+  }
+
   renderSubroutine(dom, property, options={}) {
     // only assign the array to the operation when something actually changes
     const routine = Array.isArray(this.operation[property]) ? this.operation[property] : [];
@@ -3268,7 +3280,8 @@ class RoutineOperationEditor {
       // the place of this block in the widget: the routine it is in, the card it
       // belongs to and which of that card's blocks (see restoreActiveOperation)
       routineKey: this.routineEditor ? `${this.routineEditor.routineKey}/${this.routineEditor.routine.indexOf(this.operation)}/${property}` : '',
-      attachRoutine: _=>{ this.operation[property] = routine; }
+      attachRoutine: _=>{ this.operation[property] = routine; },
+      presets: this.subroutinePresets(property)
     };
     const routineEditor = new RoutineEditor(this.widget, routine, this.variables, this.collections, options);
     routineEditor.registerChangeListener(v=>{
@@ -3293,11 +3306,12 @@ class RoutineOperationEditor {
     return property;
   }
 
-  setOperationDetails(widget, operation, variables, collections) {
+  setOperationDetails(widget, operation, variables, collections, presets=[]) {
     this.widget = widget;
     this.operation = operation;
     this.variables = variables;
     this.collections = collections;
+    this.presets = presets;
   }
 }
 
@@ -3360,6 +3374,23 @@ class ForeachRoutineOperationEditor extends RoutineOperationEditor {
 
   subroutineProperties() {
     return [ 'loopRoutine' ];
+  }
+
+  // one round of the loop hands its block whatever that round is for, and what
+  // that is depends on what is repeated over (see FOREACH in widget.js): the key
+  // and value of a list entry, the number of a range, or the widget being looped
+  // over - which is the picked widget of the block, so operations inside it work
+  // on one widget at a time without naming it
+  subroutinePresets(property) {
+    const group = { title: 'In every loopRoutine', variables: {}, collections: {} };
+    const variant = this.currentVariant().id;
+    if(variant == 'list')
+      Object.assign(group.variables, { key: 'the name/index of the entry this round is for', value: 'the entry this round is for' });
+    else if(variant == 'range')
+      group.variables.value = 'the number this round is for';
+    else if(variant == 'collection')
+      Object.assign(group, { variables: { widgetID: 'id of the widget this round is for' }, collections: { DEFAULT: 'the widget this round is for' } });
+    return [ ...(this.presets || []), group ];
   }
 
   render() {
@@ -3462,13 +3493,14 @@ function routineInputFieldChoices() {
 // routine editor's list one level down rather than the routine editor itself -
 // a line is not an operation, so it neither drags between routines nor nests.
 class RoutineInputFieldsEditor {
-  constructor(widget, fields, variables=[], collections=[]) {
+  constructor(widget, fields, variables=[], collections=[], presets=[]) {
     this.domElement = document.createElement('div');
     this.domElement.className = 'routine-editor routine-editor-fields';
     this.widget = widget;
     this.fields = fields;
     this.variables = variables;
     this.collections = collections;
+    this.presets = presets;
     this.changeListeners = [];
     this.render();
   }
@@ -3491,7 +3523,7 @@ class RoutineInputFieldsEditor {
     this.domElement.innerHTML = '';
     for(const [ index, field ] of this.fields.entries()) {
       const editor = new RoutineInputFieldEditor(field && typeof field == 'object' ? field.type : null);
-      editor.setOperationDetails(this.widget, field, this.variables, this.collections);
+      editor.setOperationDetails(this.widget, field, this.variables, this.collections, this.presets);
       editor.registerChangeListener(v=>{
         this.fields[index] = v;
         this.fieldsChanged();
@@ -3537,7 +3569,7 @@ class RoutineInputFieldsEditor {
         The kinds of line a dialog can hold. Three of them only show something - a heading, a subheading, a paragraph - and every other one asks a question and remembers the answer under a name.
       `, 'the lines of a dialog', 'Add a line to this dialog');
       popup.setSource(addButton);
-      popup.setOperationDetails({}, [ 'func' ], this.widget, this.variables, this.collections);
+      popup.setOperationDetails({}, [ 'func' ], this.widget, this.variables, this.collections, this.presets);
       const values = await newRoutineValues(popup);
       if(values !== undefined) {
         this.fields.push(newInputField(values.func));
@@ -3568,7 +3600,7 @@ class InputRoutineOperationEditor extends RoutineOperationEditor {
     if(this.operation.fields !== undefined && !Array.isArray(this.operation.fields))
       return this.domElement;
     const fields = Array.isArray(this.operation.fields) ? this.operation.fields : [];
-    this.fieldsEditor = new RoutineInputFieldsEditor(this.widget, fields, this.variables, this.collections);
+    this.fieldsEditor = new RoutineInputFieldsEditor(this.widget, fields, this.variables, this.collections, this.presets);
     this.fieldsEditor.registerChangeListener(fields=>{
       this.operation.fields = fields;
       this.notifyChangeListeners(this.operation);
@@ -3745,7 +3777,7 @@ class VarStringRoutineOperationEditor extends RoutineOperationEditor {
     else if(!this.parameterIsBlank(name))
       current[name] = this.getDisplayedValue(name);
     popup.setSource(span);
-    popup.setOperationDetails(current, parameterNames, this.widget, this.variables, this.collections);
+    popup.setOperationDetails(current, parameterNames, this.widget, this.variables, this.collections, this.presets);
     const values = await newRoutineValues(popup);
     if(values === routineFullPopupRequest)
       return this.editParameter(span, parameterNames, this.createFullPopup(parameterNames));
@@ -3894,7 +3926,7 @@ class VarSetRoutineOperationEditor extends RoutineOperationEditor {
     const pair = this.pairs()[0];
     const current = pair ? { [name]: name == 'variableName' ? pair[0] : pair[1] } : {};
     popup.setSource(span);
-    popup.setOperationDetails(current, parameterNames, this.widget, this.variables, this.collections);
+    popup.setOperationDetails(current, parameterNames, this.widget, this.variables, this.collections, this.presets);
     const values = await newRoutineValues(popup);
     if(values === routineFullPopupRequest)
       return this.editParameter(span, parameterNames, this.createFullPopup(parameterNames));

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -1959,11 +1959,21 @@ describe('the values a parameter popup offers', () => {
     popup.hide();
   });
 
-  test('what an entry is stays a hover tip instead of a line of its own', () => {
+  test('what an entry is fills one line at the foot of the section, not a line under every entry', () => {
     const popup = showPopup(RoutineStringPopup, { func: 'LABEL' }, [ 'value' ], [ 'cards' ]);
-    expect(popup.domElement.querySelector('.popup-entry-description')).toBeNull();
-    const playerName = [...popup.domElement.querySelectorAll('.popup-entry button')].find(b => b.textContent == 'playerName');
+    const section = popup.domElement.querySelector('.accordion-section[data-kind=variable]');
+    expect(section.querySelectorAll('.popup-entry-description')).toHaveLength(1);
+    const description = section.querySelector('.popup-entry-description');
+    expect(description.textContent).toBe('Point at one of the names above to see what it holds.');
+    const playerName = [...section.querySelectorAll('.popup-entry button')].find(b => b.textContent == 'playerName');
+    // a hover tip as well, but a tip is never shown to a touch screen or the keyboard
     expect(playerName.title).toBe('name of the player who started the routine');
+    playerName.dispatchEvent(new Event('mouseenter'));
+    expect(description.textContent).toBe('name of the player who started the routine');
+    playerName.dispatchEvent(new Event('mouseleave'));
+    expect(description.textContent).toBe('Point at one of the names above to see what it holds.');
+    playerName.dispatchEvent(new Event('focus'));
+    expect(description.textContent).toBe('name of the player who started the routine');
     popup.hide();
   });
 

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -2680,12 +2680,20 @@ test('A routine offers the values and widgets that what started it hands over', 
   await t.resizeWindow(1280, 800);
   const operation = { func: 'SET', collection: 'someWidgets', property: 'x', value: 0 };
   await setRoomState({
-    holder: { id: 'holder', type: 'holder', x: 100, y: 100, enterRoutine: [ { ...operation } ] },
+    holder: { id: 'holder', type: 'holder', x: 100, y: 100,
+      enterRoutine: [ { ...operation } ],
+      clickRoutine: [ { func: 'CALL', widget: 'label', routine: 'dealCardsRoutine', arguments: { amount: 3 } } ]
+    },
     label: { id: 'label', type: 'label', x: 300, y: 100,
-      textChangeRoutine: [ { ...operation } ],
+      // the GET stores value, which the routine is handed as well - from the
+      // second operation on it is the GET result, not what changed
+      textChangeRoutine: [ { func: 'GET', variable: 'value', property: 'foo' }, { ...operation } ],
       globalUpdateRoutine: [ { ...operation } ],
       dealCardsRoutine: [ { ...operation } ],
-      clickRoutine: [ { func: 'FOREACH', collection: 'someWidgets', loopRoutine: [ { ...operation } ] } ]
+      clickRoutine: [ { func: 'FOREACH', collection: 'someWidgets', loopRoutine: [ { ...operation } ] } ],
+      doubleClickRoutine: [ { func: 'FOREACH', collection: 'someWidgets', loopRoutine: [
+        { func: 'FOREACH', in: [ 1, 2 ], loopRoutine: [ { ...operation } ] }
+      ] } ]
     }
   });
   await ClientFunction(prepareClient)();
@@ -2710,7 +2718,7 @@ test('A routine offers the values and widgets that what started it hands over', 
   // one card open at a time, so the chip below can only be the one meant
   const openRoutine = async (widget, name)=>{
     await t.click(`#w_${widget}`);
-    for(const header of [ 'enterRoutine', 'textChangeRoutine', 'globalUpdateRoutine', 'dealCardsRoutine', 'clickRoutine' ]) {
+    for(const header of [ 'enterRoutine', 'textChangeRoutine', 'globalUpdateRoutine', 'dealCardsRoutine', 'clickRoutine', 'doubleClickRoutine' ]) {
       const dom = Selector('.events-editor-event-header').withText(header);
       if(await dom.exists && await dom.getAttribute('aria-expanded') == (header == name ? 'false' : 'true'))
         await t.click(dom);
@@ -2731,11 +2739,21 @@ test('A routine offers the values and widgets that what started it hands over', 
   // a routine named after a property hears about that property only, so its
   // value/oldValue are worded with it and there is no property variable
   await openRoutine('label', 'textChangeRoutine');
-  await openChip('value');
+  await openChip('property');
   await t
     .expect(popupEntries('variable')).contains('In every textChangeRoutine: value')
     .expect(popupEntries('variable')).contains('In every textChangeRoutine: oldValue')
     .expect(popupEntries('variable')).notContains('In every textChangeRoutine: property');
+  await t.click(popup.find('.popup-close'));
+
+  // what the routine is handed is there before the first operation, so the GET
+  // above wins over it from the second operation on - the other way round than
+  // for a FOREACH, which starts its round after everything outside the block
+  await t.click(Selector('.routine-editor-operation').nth(1).find('[data-parameter=value]')).expect(popup.exists).ok();
+  await t
+    .expect(popupEntries('variable')).contains('From earlier operations: value')
+    .expect(popupEntries('variable')).notContains('In every textChangeRoutine: value')
+    .expect(popupEntries('variable')).contains('In every textChangeRoutine: oldValue');
   await t.click(popup.find('.popup-close'));
 
   await openRoutine('label', 'globalUpdateRoutine');
@@ -2745,10 +2763,13 @@ test('A routine offers the values and widgets that what started it hands over', 
     .expect(popupEntries('collection')).contains('In every globalUpdateRoutine: widget');
   await t.click(popup.find('.popup-close'));
 
-  // a custom routine only ever runs through CALL, which hands it its caller
+  // a custom routine only ever runs through CALL, which hands it its caller and
+  // the arguments the CALL that runs it lists
   await openRoutine('label', 'dealCardsRoutine');
   await openChip('collection');
-  await t.expect(popupEntries('collection')).contains('In every dealCardsRoutine: caller');
+  await t
+    .expect(popupEntries('collection')).contains('In every dealCardsRoutine: caller')
+    .expect(popupEntries('variable')).contains('From the operation that runs it: amount');
   await t.click(popup.find('.popup-close'));
 
   // the block of a FOREACH gets what the round it runs is for on top of that
@@ -2757,6 +2778,16 @@ test('A routine offers the values and widgets that what started it hands over', 
   await t
     .expect(popupEntries('variable')).contains('In every loopRoutine: widgetID')
     .expect(popupEntries('collection')).contains('In every loopRoutine: DEFAULT');
+  await t.click(popup.find('.popup-close'));
+
+  // a FOREACH inside a FOREACH: which loop hands a value over is in the name of
+  // the group, and the inner one wins where both use the same name
+  await openRoutine('label', 'doubleClickRoutine');
+  await t.click(Selector('.routine-editor .routine-editor .routine-editor .routine-editor-operation [data-parameter=collection]')).expect(popup.exists).ok();
+  await t
+    .expect(popupEntries('variable')).contains('In every loopRoutine: value')
+    .expect(popupEntries('variable')).contains('In the loopRoutine around it: widgetID')
+    .expect(popupEntries('collection')).contains('In the loopRoutine around it: DEFAULT');
   await t.click(popup.find('.popup-close'));
   await setEditorState(null);
 });

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -2681,18 +2681,36 @@ test('A routine offers the values and widgets that what started it hands over', 
   const operation = { func: 'SET', collection: 'someWidgets', property: 'x', value: 0 };
   await setRoomState({
     holder: { id: 'holder', type: 'holder', x: 100, y: 100,
-      // two CALLs of the same routine, one of them handing over an argument the
-      // other does not - which of them hands a name over is what the routine
-      // needs to know about it
-      enterRoutine: [ { ...operation }, { func: 'CALL', widget: 'label', routine: 'dealCardsRoutine', arguments: { amount: 5, faceUp: true } } ],
-      clickRoutine: [ { func: 'CALL', widget: 'label', routine: 'dealCardsRoutine', arguments: { amount: 3 } } ]
+      // two CALLs of the same routine in one routine, one of them handing over an
+      // argument the other does not - which of them hands a name over is what the
+      // routine needs to know about it, so they count as two operations
+      enterRoutine: [ { ...operation },
+        { func: 'CALL', widget: 'label', routine: 'dealCardsRoutine', arguments: { amount: 5, faceUp: true } },
+        { func: 'CALL', widget: 'label', routine: 'dealCardsRoutine', arguments: { amount: 3 } } ],
+      clickRoutine: [
+        { func: 'CALL', widget: 'label', routine: 'shuffleRoutine', arguments: { times: 2, reverse: true } },
+        { func: 'CALL', widget: 'label', routine: 'shuffleRoutine', arguments: { times: 1 } } ]
     },
+    // the cards of a deck run the routines in its cardDefaults, so a CALL in one
+    // of them runs the routine as much as one written on a widget does
+    deck: { id: 'deck', type: 'deck', x: 500, y: 100, cardDefaults: {
+      // an argument may be named anything the game likes, "constructor" included
+      clickRoutine: [ { func: 'CALL', widget: 'label', routine: 'dealCardsRoutine', arguments: { amount: 2, constructor: 'x' } } ]
+    } },
     label: { id: 'label', type: 'label', x: 300, y: 100,
       // the GET stores value, which the routine is handed as well - from the
       // second operation on it is the GET result, not what changed
       textChangeRoutine: [ { func: 'GET', variable: 'value', property: 'foo' }, { ...operation } ],
       globalUpdateRoutine: [ { ...operation } ],
       dealCardsRoutine: [ { ...operation } ],
+      shuffleRoutine: [ { ...operation } ],
+      // the loop hands its block what the round is for, over what the GET before
+      // it stored - but a GET inside the block wins over the loop again
+      enterRoutine: [ { func: 'GET', variable: 'value', property: 'foo' }, { func: 'FOREACH', in: [ 1, 2 ], loopRoutine: [
+        { ...operation },
+        { func: 'GET', variable: 'value', property: 'foo' },
+        { ...operation }
+      ] } ],
       clickRoutine: [ { func: 'FOREACH', collection: 'someWidgets', loopRoutine: [ { ...operation } ] } ],
       doubleClickRoutine: [ { func: 'FOREACH', collection: 'someWidgets', loopRoutine: [
         { func: 'FOREACH', in: [ 1, 2 ], loopRoutine: [ { ...operation } ] }
@@ -2721,7 +2739,7 @@ test('A routine offers the values and widgets that what started it hands over', 
   // one card open at a time, so the chip below can only be the one meant
   const openRoutine = async (widget, name)=>{
     await t.click(`#w_${widget}`);
-    for(const header of [ 'enterRoutine', 'textChangeRoutine', 'globalUpdateRoutine', 'dealCardsRoutine', 'clickRoutine', 'doubleClickRoutine' ]) {
+    for(const header of [ 'enterRoutine', 'textChangeRoutine', 'globalUpdateRoutine', 'dealCardsRoutine', 'shuffleRoutine', 'clickRoutine', 'doubleClickRoutine' ]) {
       const dom = Selector('.events-editor-event-header').withText(header);
       if(await dom.exists && await dom.getAttribute('aria-expanded') == (header == name ? 'false' : 'true'))
         await t.click(dom);
@@ -2787,15 +2805,35 @@ test('A routine offers the values and widgets that what started it hands over', 
 
   // a custom routine only ever runs through CALL, which hands it its caller and
   // the arguments the CALLs that run it list - an argument only one of them
-  // hands over says which one that is
+  // hands over says which one that is. One of the three CALLs is in the
+  // cardDefaults of a deck, i.e. in a routine its cards run, and one of them
+  // hands over an argument named like something every object has
   await openRoutine('label', 'dealCardsRoutine');
   await openChip('collection');
   await t
     .expect(popupEntries('collection')).contains('In every dealCardsRoutine: caller')
     .expect(popupEntries('variable')).contains('From the operations that run it: amount')
-    .expect(popupEntries('variable')).contains('From the operations that run it: faceUp');
+    .expect(popupEntries('variable')).contains('From the operations that run it: faceUp')
+    .expect(popupEntries('variable')).contains('From the operations that run it: constructor');
   await t.expect(await hoverEntry('variable', 'faceUp'))
-    .eql('handed over by the CALL in enterRoutine of holder - not by the other operation that runs this routine');
+    .eql('handed over by the CALL in enterRoutine of holder - not by the other 2 operations that run this routine');
+  await t.expect(await hoverEntry('variable', 'constructor'))
+    .eql('handed over by the CALL in clickRoutine of the cards of deck - not by the other 2 operations that run this routine');
+  await t.expect(await hoverEntry('variable', 'amount'))
+    .eql('handed over by the CALLs in enterRoutine of holder and clickRoutine of the cards of deck');
+  await t.click(popup.find('.popup-close'));
+
+  // two CALLs in one routine are two operations that run it: an argument only
+  // one of them hands over is one the routine does not always have
+  await openRoutine('label', 'shuffleRoutine');
+  await openChip('collection');
+  await t
+    .expect(popupEntries('variable')).contains('From the operations that run it: times')
+    .expect(popupEntries('variable')).contains('From the operations that run it: reverse');
+  await t.expect(await hoverEntry('variable', 'reverse'))
+    .eql('handed over by the CALL in clickRoutine of holder - not by the other operation that runs this routine');
+  await t.expect(await hoverEntry('variable', 'times'))
+    .eql('handed over by the CALLs in clickRoutine of holder');
   await t.click(popup.find('.popup-close'));
 
   // the block of a FOREACH gets what the round it runs is for on top of that
@@ -2804,6 +2842,26 @@ test('A routine offers the values and widgets that what started it hands over', 
   await t
     .expect(popupEntries('variable')).contains('In this loopRoutine: widgetID')
     .expect(popupEntries('collection')).contains('In this loopRoutine: DEFAULT');
+  await t.click(popup.find('.popup-close'));
+
+  // a round of the loop starts after everything outside the block, so what it is
+  // for wins over the GET before the FOREACH...
+  await openRoutine('label', 'enterRoutine');
+  const inLoop = Selector('.routine-editor .routine-editor .routine-editor-operation');
+  await t.click(inLoop.nth(0).find('[data-parameter=value]')).expect(popup.exists).ok();
+  await t
+    .expect(popupEntries('variable')).contains('In this loopRoutine: value')
+    .expect(popupEntries('variable')).notContains('From earlier operations: value');
+  await t.click(popup.find('.popup-close'));
+  // ...while an operation inside the block runs after the round started, so from
+  // there on the name is what that operation stored, not what the round is for
+  await t.click(inLoop.nth(2).find('[data-parameter=value]')).expect(popup.exists).ok();
+  await t
+    .expect(popupEntries('variable')).contains('From earlier operations: value')
+    .expect(popupEntries('variable')).notContains('In this loopRoutine: value')
+    .expect(popupEntries('variable')).contains('In this loopRoutine: key');
+  await t.expect(await hoverEntry('variable', 'value'))
+    .eql('stored by an earlier operation - it replaced the value this loopRoutine hands over');
   await t.click(popup.find('.popup-close'));
 
   // a FOREACH inside a FOREACH: which loop hands a value over is in the name of

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -2676,6 +2676,91 @@ test('A property info tip goes away with the widget it explains', async t => {
   await setEditorState(null);
 });
 
+test('A routine offers the values and widgets that what started it hands over', async t => {
+  await t.resizeWindow(1280, 800);
+  const operation = { func: 'SET', collection: 'someWidgets', property: 'x', value: 0 };
+  await setRoomState({
+    holder: { id: 'holder', type: 'holder', x: 100, y: 100, enterRoutine: [ { ...operation } ] },
+    label: { id: 'label', type: 'label', x: 300, y: 100,
+      textChangeRoutine: [ { ...operation } ],
+      globalUpdateRoutine: [ { ...operation } ],
+      dealCardsRoutine: [ { ...operation } ],
+      clickRoutine: [ { func: 'FOREACH', collection: 'someWidgets', loopRoutine: [ { ...operation } ] } ]
+    }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState(propertiesModuleOpen);
+  await setName(t);
+
+  const popup = Selector('.inline-popup');
+  // what the open popup offers, as "group: name" - which group an entry is in is
+  // the whole point here: a name that comes with the routine is not one an
+  // earlier operation stored
+  const popupEntries = ClientFunction(kind => {
+    const entries = [];
+    let group = null;
+    for(const child of document.querySelectorAll(`.inline-popup .accordion-section[data-kind=${kind}] .popup-value-group, .inline-popup .accordion-section[data-kind=${kind}] .popup-entry button`)) {
+      if(child.classList.contains('popup-value-group'))
+        group = child.textContent;
+      else
+        entries.push(`${group}: ${child.textContent}`);
+    }
+    return entries;
+  });
+  // one card open at a time, so the chip below can only be the one meant
+  const openRoutine = async (widget, name)=>{
+    await t.click(`#w_${widget}`);
+    for(const header of [ 'enterRoutine', 'textChangeRoutine', 'globalUpdateRoutine', 'dealCardsRoutine', 'clickRoutine' ]) {
+      const dom = Selector('.events-editor-event-header').withText(header);
+      if(await dom.exists && await dom.getAttribute('aria-expanded') == (header == name ? 'false' : 'true'))
+        await t.click(dom);
+    }
+  };
+  const openChip = async parameter=>await t.click(Selector(`.routine-editor-operation [data-parameter=${parameter}]`)).expect(popup.exists).ok();
+
+  await t.click('#editButton').expect(propertiesModule.exists).ok();
+
+  await openRoutine('holder', 'enterRoutine');
+  await openChip('value');
+  await t.expect(popupEntries('variable')).contains('In every enterRoutine: oldParentID');
+  await t.click(popup.find('.popup-close'));
+  await openChip('collection');
+  await t.expect(popupEntries('collection')).contains('In every enterRoutine: child');
+  await t.click(popup.find('.popup-close'));
+
+  // a routine named after a property hears about that property only, so its
+  // value/oldValue are worded with it and there is no property variable
+  await openRoutine('label', 'textChangeRoutine');
+  await openChip('value');
+  await t
+    .expect(popupEntries('variable')).contains('In every textChangeRoutine: value')
+    .expect(popupEntries('variable')).contains('In every textChangeRoutine: oldValue')
+    .expect(popupEntries('variable')).notContains('In every textChangeRoutine: property');
+  await t.click(popup.find('.popup-close'));
+
+  await openRoutine('label', 'globalUpdateRoutine');
+  await openChip('collection');
+  await t
+    .expect(popupEntries('variable')).contains('In every globalUpdateRoutine: property')
+    .expect(popupEntries('collection')).contains('In every globalUpdateRoutine: widget');
+  await t.click(popup.find('.popup-close'));
+
+  // a custom routine only ever runs through CALL, which hands it its caller
+  await openRoutine('label', 'dealCardsRoutine');
+  await openChip('collection');
+  await t.expect(popupEntries('collection')).contains('In every dealCardsRoutine: caller');
+  await t.click(popup.find('.popup-close'));
+
+  // the block of a FOREACH gets what the round it runs is for on top of that
+  await openRoutine('label', 'clickRoutine');
+  await t.click(Selector('.routine-editor .routine-editor .routine-editor-operation [data-parameter=collection]')).expect(popup.exists).ok();
+  await t
+    .expect(popupEntries('variable')).contains('In every loopRoutine: widgetID')
+    .expect(popupEntries('collection')).contains('In every loopRoutine: DEFAULT');
+  await t.click(popup.find('.popup-close'));
+  await setEditorState(null);
+});
+
 test('A long list of widget ids shrinks instead of pushing the apply button out of the popup', async t => {
   await t.resizeWindow(1280, 500);
   const roomState = {

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -2681,7 +2681,10 @@ test('A routine offers the values and widgets that what started it hands over', 
   const operation = { func: 'SET', collection: 'someWidgets', property: 'x', value: 0 };
   await setRoomState({
     holder: { id: 'holder', type: 'holder', x: 100, y: 100,
-      enterRoutine: [ { ...operation } ],
+      // two CALLs of the same routine, one of them handing over an argument the
+      // other does not - which of them hands a name over is what the routine
+      // needs to know about it
+      enterRoutine: [ { ...operation }, { func: 'CALL', widget: 'label', routine: 'dealCardsRoutine', arguments: { amount: 5, faceUp: true } } ],
       clickRoutine: [ { func: 'CALL', widget: 'label', routine: 'dealCardsRoutine', arguments: { amount: 3 } } ]
     },
     label: { id: 'label', type: 'label', x: 300, y: 100,
@@ -2753,7 +2756,13 @@ test('A routine offers the values and widgets that what started it hands over', 
   await t
     .expect(popupEntries('variable')).contains('From earlier operations: value')
     .expect(popupEntries('variable')).notContains('In every textChangeRoutine: value')
-    .expect(popupEntries('variable')).contains('In every textChangeRoutine: oldValue');
+    .expect(popupEntries('variable')).contains('In every textChangeRoutine: oldValue')
+    // and says so, instead of being the one entry in the list without an
+    // explanation of what it holds
+    .click(Selector('.inline-popup .accordion-section[data-kind=variable] h3'))
+    .hover(Selector('.inline-popup .accordion-section[data-kind=variable] .popup-entry button').withExactText('value'))
+    .expect(Selector('.inline-popup .accordion-section[data-kind=variable] .popup-entry-description').innerText)
+      .eql('stored by an earlier operation - it replaced the value the textChangeRoutine hands over');
   await t.click(popup.find('.popup-close'));
 
   await openRoutine('label', 'globalUpdateRoutine');
@@ -2764,30 +2773,39 @@ test('A routine offers the values and widgets that what started it hands over', 
   await t.click(popup.find('.popup-close'));
 
   // a custom routine only ever runs through CALL, which hands it its caller and
-  // the arguments the CALL that runs it lists
+  // the arguments the CALLs that run it list - an argument only one of them
+  // hands over says which one that is
   await openRoutine('label', 'dealCardsRoutine');
   await openChip('collection');
   await t
     .expect(popupEntries('collection')).contains('In every dealCardsRoutine: caller')
-    .expect(popupEntries('variable')).contains('From the operation that runs it: amount');
+    .expect(popupEntries('variable')).contains('From the operations that run it: amount')
+    .expect(popupEntries('variable')).contains('From the operations that run it: faceUp')
+    .click(Selector('.inline-popup .accordion-section[data-kind=variable] h3'))
+    .hover(Selector('.inline-popup .accordion-section[data-kind=variable] .popup-entry button').withExactText('faceUp'))
+    .expect(Selector('.inline-popup .accordion-section[data-kind=variable] .popup-entry-description').innerText)
+      .eql('handed over by the CALL in enterRoutine of holder - not by the other operation that runs this routine');
   await t.click(popup.find('.popup-close'));
 
   // the block of a FOREACH gets what the round it runs is for on top of that
   await openRoutine('label', 'clickRoutine');
   await t.click(Selector('.routine-editor .routine-editor .routine-editor-operation [data-parameter=collection]')).expect(popup.exists).ok();
   await t
-    .expect(popupEntries('variable')).contains('In every loopRoutine: widgetID')
-    .expect(popupEntries('collection')).contains('In every loopRoutine: DEFAULT');
+    .expect(popupEntries('variable')).contains('In this loopRoutine: widgetID')
+    .expect(popupEntries('collection')).contains('In this loopRoutine: DEFAULT');
   await t.click(popup.find('.popup-close'));
 
   // a FOREACH inside a FOREACH: which loop hands a value over is in the name of
-  // the group, and the inner one wins where both use the same name
+  // the group, the inner one wins where both use the same name, and the loop the
+  // block is in is listed before the one around it
   await openRoutine('label', 'doubleClickRoutine');
   await t.click(Selector('.routine-editor .routine-editor .routine-editor .routine-editor-operation [data-parameter=collection]')).expect(popup.exists).ok();
   await t
-    .expect(popupEntries('variable')).contains('In every loopRoutine: value')
+    .expect(popupEntries('variable')).contains('In this loopRoutine: value')
     .expect(popupEntries('variable')).contains('In the loopRoutine around it: widgetID')
-    .expect(popupEntries('collection')).contains('In the loopRoutine around it: DEFAULT');
+    .expect(popupEntries('collection')).contains('In the loopRoutine around it: DEFAULT')
+    .expect((await popupEntries('variable')).indexOf('In this loopRoutine: value'))
+      .lt((await popupEntries('variable')).indexOf('In the loopRoutine around it: widgetID'));
   await t.click(popup.find('.popup-close'));
   await setEditorState(null);
 });

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -2728,6 +2728,21 @@ test('A routine offers the values and widgets that what started it hands over', 
     }
   };
   const openChip = async parameter=>await t.click(Selector(`.routine-editor-operation [data-parameter=${parameter}]`)).expect(popup.exists).ok();
+  // the heading of a section carries an info button which swallows a click that
+  // lands on it, so the heading is clicked at its left edge where its title is -
+  // and clicking an open section leaves it open, so trying again costs nothing
+  const openSection = async kind=>{
+    const section = Selector(`.inline-popup .accordion-section[data-kind=${kind}]`);
+    for(let attempt = 0; attempt < 3 && !await section.hasClass('open'); attempt++)
+      await t.click(section.find('h3'), { offsetX: 8, offsetY: 8 });
+    await t.expect(section.hasClass('open')).ok();
+  };
+  // what the entry the pointer is on holds, on the line at the foot of its section
+  const hoverEntry = async (kind, label)=>{
+    await openSection(kind);
+    await t.hover(Selector(`.inline-popup .accordion-section[data-kind=${kind}] .popup-entry button`).withExactText(label));
+    return Selector(`.inline-popup .accordion-section[data-kind=${kind}] .popup-entry-description`).innerText;
+  };
 
   await t.click('#editButton').expect(propertiesModule.exists).ok();
 
@@ -2756,13 +2771,11 @@ test('A routine offers the values and widgets that what started it hands over', 
   await t
     .expect(popupEntries('variable')).contains('From earlier operations: value')
     .expect(popupEntries('variable')).notContains('In every textChangeRoutine: value')
-    .expect(popupEntries('variable')).contains('In every textChangeRoutine: oldValue')
-    // and says so, instead of being the one entry in the list without an
-    // explanation of what it holds
-    .click(Selector('.inline-popup .accordion-section[data-kind=variable] h3'))
-    .hover(Selector('.inline-popup .accordion-section[data-kind=variable] .popup-entry button').withExactText('value'))
-    .expect(Selector('.inline-popup .accordion-section[data-kind=variable] .popup-entry-description').innerText)
-      .eql('stored by an earlier operation - it replaced the value the textChangeRoutine hands over');
+    .expect(popupEntries('variable')).contains('In every textChangeRoutine: oldValue');
+  // and says so, instead of being the one entry in the list without an
+  // explanation of what it holds
+  await t.expect(await hoverEntry('variable', 'value'))
+    .eql('stored by an earlier operation - it replaced the value the textChangeRoutine hands over');
   await t.click(popup.find('.popup-close'));
 
   await openRoutine('label', 'globalUpdateRoutine');
@@ -2780,11 +2793,9 @@ test('A routine offers the values and widgets that what started it hands over', 
   await t
     .expect(popupEntries('collection')).contains('In every dealCardsRoutine: caller')
     .expect(popupEntries('variable')).contains('From the operations that run it: amount')
-    .expect(popupEntries('variable')).contains('From the operations that run it: faceUp')
-    .click(Selector('.inline-popup .accordion-section[data-kind=variable] h3'))
-    .hover(Selector('.inline-popup .accordion-section[data-kind=variable] .popup-entry button').withExactText('faceUp'))
-    .expect(Selector('.inline-popup .accordion-section[data-kind=variable] .popup-entry-description').innerText)
-      .eql('handed over by the CALL in enterRoutine of holder - not by the other operation that runs this routine');
+    .expect(popupEntries('variable')).contains('From the operations that run it: faceUp');
+  await t.expect(await hoverEntry('variable', 'faceUp'))
+    .eql('handed over by the CALL in enterRoutine of holder - not by the other operation that runs this routine');
   await t.click(popup.find('.popup-close'));
 
   // the block of a FOREACH gets what the round it runs is for on top of that

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -2686,7 +2686,11 @@ test('A routine offers the values and widgets that what started it hands over', 
       // routine needs to know about it, so they count as two operations
       enterRoutine: [ { ...operation },
         { func: 'CALL', widget: 'label', routine: 'dealCardsRoutine', arguments: { amount: 5, faceUp: true } },
-        { func: 'CALL', widget: 'label', routine: 'dealCardsRoutine', arguments: { amount: 3 } } ],
+        { func: 'CALL', widget: 'label', routine: 'dealCardsRoutine', arguments: { amount: 3 } },
+        // CALL runs a clickRoutine as readily as a custom routine, and hands it
+        // the same arguments and caller - which that routine only has when a CALL
+        // is what ran it, not when a player clicked the widget
+        { func: 'CALL', widget: 'button', routine: 'clickRoutine', arguments: { from: 'the menu' } } ],
       clickRoutine: [
         { func: 'CALL', widget: 'label', routine: 'shuffleRoutine', arguments: { times: 2, reverse: true } },
         { func: 'CALL', widget: 'label', routine: 'shuffleRoutine', arguments: { times: 1 } } ]
@@ -2702,7 +2706,11 @@ test('A routine offers the values and widgets that what started it hands over', 
       // second operation on it is the GET result, not what changed
       textChangeRoutine: [ { func: 'GET', variable: 'value', property: 'foo' }, { ...operation } ],
       globalUpdateRoutine: [ { ...operation } ],
-      dealCardsRoutine: [ { ...operation } ],
+      // its second operation is two nested FOREACHes, so an operation inside them
+      // has four groups of names to pick from - more than a short window can show
+      dealCardsRoutine: [ { ...operation }, { func: 'FOREACH', in: [ 1, 2 ], loopRoutine: [
+        { func: 'FOREACH', collection: 'someWidgets', loopRoutine: [ { ...operation } ] }
+      ] } ],
       shuffleRoutine: [ { ...operation } ],
       // the loop hands its block what the round is for, over what the GET before
       // it stored - but a GET inside the block wins over the loop again
@@ -2714,8 +2722,21 @@ test('A routine offers the values and widgets that what started it hands over', 
       clickRoutine: [ { func: 'FOREACH', collection: 'someWidgets', loopRoutine: [ { ...operation } ] } ],
       doubleClickRoutine: [ { func: 'FOREACH', collection: 'someWidgets', loopRoutine: [
         { func: 'FOREACH', in: [ 1, 2 ], loopRoutine: [ { ...operation } ] }
-      ] } ]
-    }
+      ] } ],
+      // a VAR inside the block writes over what the round is for, so the loop's
+      // own names are among the ones it proposes
+      leaveRoutine: [ { func: 'FOREACH', in: [ 1, 2 ], loopRoutine: [ { func: 'VAR', variables: { foo: 1, bar: 2 } } ] } ]
+    },
+    // the same routine name on another widget is another routine: the CALLs that
+    // run this one hand their arguments to this one only
+    label2: { id: 'label2', type: 'label', x: 700, y: 100,
+      dealCardsRoutine: [ { ...operation } ],
+      // a CALL without a widget of its own runs the routine on the widget it is
+      // written on, so the first of these reaches label2 and the second label
+      gameStartRoutine: [ { func: 'CALL', routine: 'dealCardsRoutine', arguments: { theme: 'dark' } },
+        { func: 'CALL', widget: 'label', routine: 'dealCardsRoutine', arguments: { amount: 1 } } ]
+    },
+    button: { id: 'button', type: 'button', x: 900, y: 100, clickRoutine: [ { ...operation } ] }
   });
   await ClientFunction(prepareClient)();
   await setEditorState(propertiesModuleOpen);
@@ -2739,7 +2760,7 @@ test('A routine offers the values and widgets that what started it hands over', 
   // one card open at a time, so the chip below can only be the one meant
   const openRoutine = async (widget, name)=>{
     await t.click(`#w_${widget}`);
-    for(const header of [ 'enterRoutine', 'textChangeRoutine', 'globalUpdateRoutine', 'dealCardsRoutine', 'shuffleRoutine', 'clickRoutine', 'doubleClickRoutine' ]) {
+    for(const header of [ 'enterRoutine', 'leaveRoutine', 'textChangeRoutine', 'globalUpdateRoutine', 'gameStartRoutine', 'dealCardsRoutine', 'shuffleRoutine', 'clickRoutine', 'doubleClickRoutine' ]) {
       const dom = Selector('.events-editor-event-header').withText(header);
       if(await dom.exists && await dom.getAttribute('aria-expanded') == (header == name ? 'false' : 'true'))
         await t.click(dom);
@@ -2760,6 +2781,11 @@ test('A routine offers the values and widgets that what started it hands over', 
     await openSection(kind);
     await t.hover(Selector(`.inline-popup .accordion-section[data-kind=${kind}] .popup-entry button`).withExactText(label));
     return Selector(`.inline-popup .accordion-section[data-kind=${kind}] .popup-entry-description`).innerText;
+  };
+  // a name the routine only sometimes has is dimmed rather than only explained
+  const entryIsPartial = async (kind, label)=>{
+    await openSection(kind);
+    return Selector(`.inline-popup .accordion-section[data-kind=${kind}] .popup-entry button`).withExactText(label).hasClass('popup-entry-partial');
   };
 
   await t.click('#editButton').expect(propertiesModule.exists).ok();
@@ -2814,13 +2840,46 @@ test('A routine offers the values and widgets that what started it hands over', 
     .expect(popupEntries('collection')).contains('In every dealCardsRoutine: caller')
     .expect(popupEntries('variable')).contains('From the operations that run it: amount')
     .expect(popupEntries('variable')).contains('From the operations that run it: faceUp')
-    .expect(popupEntries('variable')).contains('From the operations that run it: constructor');
+    .expect(popupEntries('variable')).contains('From the operations that run it: constructor')
+    // the argument of the same-named routine on the other widget is not one of
+    // this routine's, and the CALL handing it over is not one of its callers
+    .expect(popupEntries('variable')).notContains('From the operations that run it: theme');
   await t.expect(await hoverEntry('variable', 'faceUp'))
-    .eql('handed over by the CALL in enterRoutine of holder - not by the other 2 operations that run this routine');
+    .eql('handed over by the CALL in enterRoutine of holder - not by the other 3 operations that run this routine');
   await t.expect(await hoverEntry('variable', 'constructor'))
-    .eql('handed over by the CALL in clickRoutine of the cards of deck - not by the other 2 operations that run this routine');
+    .eql('handed over by the CALL in clickRoutine of the cards of deck - not by the other 3 operations that run this routine');
+  // more callers than a line can name are named as far as it goes and counted
+  // from there on
   await t.expect(await hoverEntry('variable', 'amount'))
-    .eql('handed over by the CALLs in enterRoutine of holder and clickRoutine of the cards of deck');
+    .eql('handed over by the CALLs in enterRoutine of holder, clickRoutine of the cards of deck and 1 more');
+  await t
+    .expect(await entryIsPartial('variable', 'faceUp')).ok()
+    .expect(await entryIsPartial('variable', 'amount')).notOk();
+  await t.click(popup.find('.popup-close'));
+
+  // the same routine name on another widget hears about its own CALLs only - and
+  // a CALL with no widget of its own runs the routine on the widget it is on
+  await openRoutine('label2', 'dealCardsRoutine');
+  await openChip('collection');
+  await t
+    .expect(popupEntries('variable')).contains('From the operation that runs it: theme')
+    .expect(popupEntries('variable')).notContains('From the operation that runs it: amount')
+    .expect(popupEntries('variable')).notContains('From the operation that runs it: faceUp');
+  await t.expect(await hoverEntry('variable', 'theme'))
+    .eql('handed over by the CALL in gameStartRoutine of label2');
+  await t.click(popup.find('.popup-close'));
+
+  // a routine a player triggers can be run by CALL as well, and then it has the
+  // arguments and the caller that CALL hands over - only then, which is what the
+  // group says and why the names are dimmed
+  await openRoutine('button', 'clickRoutine');
+  await openChip('collection');
+  await t
+    .expect(popupEntries('variable')).contains('Only when a CALL runs it: from')
+    .expect(popupEntries('collection')).contains('Only when a CALL runs it: caller')
+    .expect(await entryIsPartial('variable', 'from')).ok();
+  await t.expect(await hoverEntry('collection', 'caller'))
+    .eql('the widget whose routine used CALL to run this one');
   await t.click(popup.find('.popup-close'));
 
   // two CALLs in one routine are two operations that run it: an argument only
@@ -2841,7 +2900,10 @@ test('A routine offers the values and widgets that what started it hands over', 
   await t.click(Selector('.routine-editor .routine-editor .routine-editor-operation [data-parameter=collection]')).expect(popup.exists).ok();
   await t
     .expect(popupEntries('variable')).contains('In this loopRoutine: widgetID')
-    .expect(popupEntries('collection')).contains('In this loopRoutine: DEFAULT');
+    .expect(popupEntries('collection')).contains('In this loopRoutine: DEFAULT')
+    // the CALL of a clickRoutine in the room runs the one on the button, so this
+    // clickRoutine hears nothing of its argument
+    .expect(popupEntries('variable')).notContains('Only when a CALL runs it: from');
   await t.click(popup.find('.popup-close'));
 
   // a round of the loop starts after everything outside the block, so what it is
@@ -2875,6 +2937,46 @@ test('A routine offers the values and widgets that what started it hands over', 
     .expect(popupEntries('collection')).contains('In the loopRoutine around it: DEFAULT')
     .expect((await popupEntries('variable')).indexOf('In this loopRoutine: value'))
       .lt((await popupEntries('variable')).indexOf('In the loopRoutine around it: widgetID'));
+  await t.click(popup.find('.popup-close'));
+
+  // writing over what the round is for is what an operation inside the block may
+  // well want to do, so the names it can be given include the loop's own - they
+  // are not in "From earlier operations" inside the block, which is where the
+  // list of names to write to used to come from in full
+  await openRoutine('label', 'leaveRoutine');
+  await t.click(Selector('.routine-editor .routine-editor .routine-editor-operation [data-parameter=variables]')).expect(popup.exists).ok();
+  // spread over a NodeList does not survive into the browser here, so the list
+  // is copied the way the rest of this file does it
+  const suggestedNames = ClientFunction(_=>[].slice.call(document.querySelectorAll('.inline-popup .popup-key-value-add option')).map(option=>option.value));
+  await t
+    .expect(suggestedNames()).contains('value')
+    .expect(suggestedNames()).contains('key');
+  await t.click(popup.find('.popup-close'));
+
+  // a section with several groups in it is taller than a short window, and the
+  // line that says what a name holds is at its foot - so it sticks to the bottom
+  // of the popup instead of being scrolled out of sight exactly while the
+  // pointer is on a name near the top of the list
+  await t.resizeWindow(1280, 320);
+  await openRoutine('label', 'dealCardsRoutine');
+  await t.click(Selector('.routine-editor .routine-editor .routine-editor .routine-editor-operation [data-parameter=collection]')).expect(popup.exists).ok();
+  await openSection('variable');
+  await t.hover(Selector('.inline-popup .accordion-section[data-kind=variable] .popup-entry button').withExactText('amount'));
+  const descriptionInView = await ClientFunction(_=>{
+    const popup = document.querySelector('.inline-popup');
+    const section = popup.querySelector('.accordion-section[data-kind=variable]');
+    const description = section.querySelector('.popup-entry-description');
+    // the section scrolled to its top, which is where the name the pointer is on
+    // puts it - the foot of the section is a screenful further down from there
+    popup.scrollTop = section.offsetTop;
+    const popupRect = popup.getBoundingClientRect(), descriptionRect = description.getBoundingClientRect();
+    return {
+      sectionTallerThanPopup: section.getBoundingClientRect().height > popupRect.height,
+      descriptionInPopup: descriptionRect.top >= popupRect.top && descriptionRect.bottom <= popupRect.bottom + 1,
+      describes: description.textContent.substr(0, 24)
+    };
+  })();
+  await t.expect(descriptionInView).eql({ sectionTallerThanPopup: true, descriptionInPopup: true, describes: 'handed over by the CALLs' });
   await t.click(popup.find('.popup-close'));
   await setEditorState(null);
 });

--- a/validator/validate_gamefile.js
+++ b/validator/validate_gamefile.js
@@ -177,7 +177,9 @@ const COMMON_PROPERTIES = {
     enterRoutine: getRoutineValidator({'oldParentID': 1}, {'child': 1}),
     leaveRoutine: getRoutineValidator({}, {'child': 1}),
     globalUpdateRoutine: 'routine',
-    gameStartRoutine: 'routine',
+    // the engine starts it with the widget it is on (serverstate.js), so a game
+    // may use widgetID/widget instead of thisID/thisButton
+    gameStartRoutine: getRoutineValidator({'widgetID': 1}, {'widget': 1}),
     editorAddToRoomRoutine: 'routine',
     hotkey: 'string',
     lineOriginalRotation: 'object',

--- a/validator/validate_gamefile.js
+++ b/validator/validate_gamefile.js
@@ -1325,7 +1325,10 @@ function validateGameFile(data, checkMeta) {
         // Routine validation for properties ending with 'Routine'
         for (const [propName, propValue] of Object.entries(widget)) {
             if (propName.endsWith('Routine') && !known[propName] && Array.isArray(propValue) && !calledCustomRoutines.includes(propName) && !propName.match(/^((.+G|g)lobalUpdateRoutine|(.+C|c)hangeRoutine)$/)) {
-                const context = { widgetId: key, widgets: data, validVariables: {...SUPER_GLOBALS.variables}, validCollections: {...SUPER_GLOBALS.collections}, customProperties, calledCustomRoutines };
+                // a custom routine is run by CALL, which hands it the caller
+                // collection - even this one, which no CALL in the file reaches
+                // (that is reported separately, right below)
+                const context = { widgetId: key, widgets: data, validVariables: {...SUPER_GLOBALS.variables}, validCollections: {...SUPER_GLOBALS.collections, caller: 1}, customProperties, calledCustomRoutines };
                 const routineProblems = validateRoutine(propValue, context, [propName]);
                 problems.push({
                     widget: key,


### PR DESCRIPTION
The routine editor in the Edit Widgets **Automations** section only ever offered two kinds of value: what an earlier operation of the routine stored, and the nine values (and three collections) that every routine has. The ones a routine gets *because of what started it* were nowhere in the UI, so the only way to find out that an `enterRoutine` is handed the collection `child` and the variable `oldParentID` was the wiki.

This adds them. Every routine now lists what its trigger hands it, in the value and collection sections of the parameter popups, as its own group named after the routine — for example "In every enterRoutine" between "From earlier operations" and "In every routine" — and what each entry holds is written out on a line at the foot of the open section, filled by the entry the pointer or the keyboard is on.

What is offered where (taken from the `evaluateRoutine` calls in `widget.js`, `statemanaged.js` and `serverstate.js`):

| routine | values | collections |
| --- | --- | --- |
| `changeRoutine` | `property`, `value`, `oldValue` | – |
| `<property>ChangeRoutine` | `value`, `oldValue` (worded with that property) | – |
| `globalUpdateRoutine` | `widgetID`, `property`, `value`, `oldValue` | `widget` |
| `<property>GlobalUpdateRoutine` | `widgetID`, `value`, `oldValue` | `widget` |
| `enterRoutine` | `oldParentID` | `child` |
| `leaveRoutine` | – | `child` |
| `gameStartRoutine` | `widgetID` | `widget` |
| any custom routine | the `arguments` of every CALL in the room that runs it on this widget, in a group of their own | `caller` (from the CALL that runs it) |
| a routine a CALL runs that a player can trigger too | the `arguments` of those CALLs, under "Only when a CALL runs it" | `caller`, same group |
| the `loopRoutine` of a FOREACH | `key`/`value` over a list, `value` over a range, `widgetID` over a collection | `DEFAULT` over a collection |

`clickRoutine` and `doubleClickRoutine` get nothing of their own from the engine, so nothing is added for them - unless a CALL in the room runs one of them by name, which hands it arguments and `caller` like any other routine. Those are listed in a group of their own and dimmed, because the player clicking the widget hands over none of them.

Which CALLs count is decided by the widget they run the routine on: a CALL without a `widget` runs it on the widget it is written on (in a deck's `cardDefaults`, on the card running it), an id written out is looked up, and an id the game computes can be any widget and is included. So two widgets with a routine of the same name are not shown each other's arguments.

Where two of those hand the same name over, the one that is established last wins and the others are not listed, so a name is never offered twice for two different things:

- a trigger hands its values over *before* the first operation, so an operation of the routine storing the same name wins: in a `changeRoutine` that starts with a GET into `value`, `value` stays under "From earlier operations" from the second operation on — and says so ("stored by an earlier operation - it replaced the value the changeRoutine hands over").
- a FOREACH establishes its round *after* everything outside the block, so inside the loop `${value}` is the loop's and neither an operation before the block nor the trigger is offered under that name. An operation *inside* the block runs later still and wins again, the same way as above. The loop groups are listed nearest first: "In this loopRoutine" is the loop the block is in, then "In the loopRoutine around it", "In the loopRoutine 2 levels out".

Three things came out of writing that table down:

- The routine cards of the Automations section claimed an `enterRoutine`/`leaveRoutine`/`globalUpdateRoutine` "starts with the widget picked". It does not — the widget is in a collection named `child` resp. `widget`, while operations default to `DEFAULT`, so following that description gave you a routine that quietly did nothing. The descriptions now name the collection, with the literal names in quotes so they do not read as prose.
- CALL hands over more than `caller`: it copies the whole variable and collection set of the calling routine into the routine it runs and merges the `arguments` on top (`widget.js`). The card of a custom routine says so now, and the argument names are collected from every CALL in the room that names the routine — each saying which CALLs hand it over, dimmed when not all of them do.
- The validator flagged `${widgetID}` and the `widget` collection in a `gameStartRoutine` as undefined, which is the same table being incomplete one file over. `validate_gamefile.js` now knows them (`enterRoutine`/`leaveRoutine`/`changeRoutine`/`globalUpdateRoutine` were already covered there), and it knows `caller` in a custom routine that no CALL reaches, which used to be reported as an undefined collection on top of being uncalled.

### The list itself

The only CSS in the diff, all in the parameter popups, from the UI/UX review:

- **A description line at the foot of the open section.** The descriptions are the point of this PR and they used to exist only as `title=` tooltips — never shown on a touch screen, never to the keyboard, a second late on the desktop. One line, filled on hover *and* on keyboard focus, with two lines kept free so the list does not move while the pointer travels along it. The tooltips stay.
- **A hairline above each group caption**, so which group a name is in is readable at a glance now that a nested FOREACH stacks four of them.
- **A long name wraps** instead of running out of the popup: an argument name comes from another widget's CALL, so the author of the routine cannot shorten it, and at 390px width it overflowed the popup by 25px.
- **The description line sticks to the foot of the popup**, so it stays on screen in a section too tall for the window instead of being scrolled out of sight exactly while the pointer - or the keyboard, which scrolls the focused name into view - is on a name near the top.

One thing outside the popups: inside a `FOREACH` block, a VAR is offered the loop's own names (`value`, `key`, ...) among the names it can write to again, and the trigger's names as well. Writing over what the round is for is exactly what an operation in the block may want to do.

### Verified

- `npm test` — 1265 jest tests pass.
- `npx testcafe chromium:headless tests/testcafe/editor.js` — including a test that walks every case of the table above through the editor UI, plus the shadowing rules, the nested-FOREACH group titles, the description line and the "not by the other operation that runs this routine" wording.
- The editor test also covers the arguments of two CALLs in one routine, a CALL in the `cardDefaults` of a deck (its cards run those routines), an argument named `constructor`, two widgets with a routine of the same name, a `clickRoutine` run by CALL, the VAR suggestions inside a FOREACH and the description line staying in view at 1280x320.
- `node validator/validate_gamefile_node.js` on a game whose only custom routine is never called: no undefined-collection problem for `caller`.
- Clicked through in a browser at 1280×800 and 390×844: [a custom routine's arguments at phone width](https://agent.virtualtabletop.io/reports/pr/1538977191579099247/uiux-390-customRoutine-values.png) (the long name wraps, the arguments not every call passes are dimmed), [a nested FOREACH](https://agent.virtualtabletop.io/reports/pr/1538977191579099247/uiux-1280-nested-foreach.png) (group rules, the description line at the foot), [a shadowed preset](https://agent.virtualtabletop.io/reports/pr/1538977191579099247/uiux-1280-shadowed-value.png).

### Try it

A demo room, **Routine presets demo**, is uploaded into this PR's `pr-test-ai` test-server room (it is not part of the diff and not in the public library; it can be added to `library/tutorials/` on request). It now has one block per row of the table, in two aligned columns: drop the token into the holder (`enterRoutine`/`leaveRoutine`, and the `rotationGlobalUpdateRoutine` that hears the rotation it causes), drag it around (its own `changeRoutine`, which is told which property changed), type in the label (`textChangeRoutine`), click "name the chips" (a FOREACH over a group of widgets), and the two buttons on the right run the same custom routine with different arguments. Its widgets are meant to be opened in edit mode: pick a routine under Automations, click one of its blanks and the group named after the routine is right there. The file is also at [Routine presets demo.vtt](https://agent.virtualtabletop.io/reports/pr/1538977191579099247/Routine%20presets%20demo.vtt).

No new widget property and no new routine function, so there is nothing to add to `jeCommands`; the change is entirely in the visual routine editor.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3124/pr-test (or any other room on that server)


