### PR TITLE
Give the deck editor's standard deck the same sorting properties as the add widget overlay's

### DIFF
--- a/assets/decks/standard.json
+++ b/assets/decks/standard.json
@@ -1,6 +1,6 @@
 {
   "name": "Standard playing cards",
-  "description": "French-suited 52-card deck with 2 jokers.",
+  "description": "French-suited 52-card deck with 2 jokers. The card types carry sorting keys: suit, suitColor and suitAlt group the suits, rank (ace low), rankA (ace high) and rankFixed order the cards.",
   "attribution": "Card images by Adrian Kennard, released under CC0 at https://www.me.uk/cards/. Jokers based on Byron Knoll's public domain playing cards.",
   "deck": {
     "type": "deck",

--- a/assets/decks/standard.json
+++ b/assets/decks/standard.json
@@ -1,6 +1,6 @@
 {
   "name": "Standard playing cards",
-  "description": "French-suited 52-card deck with 2 jokers. The card types carry sorting keys: suit, suitColor and suitAlt group the suits, rank (ace low), rankA (ace high) and rankFixed order the cards.",
+  "description": "French-suited 52-card deck with 2 jokers. The cards carry extra properties so a hand or a pile can be sorted by suit or by rank.",
   "attribution": "Card images by Adrian Kennard, released under CC0 at https://www.me.uk/cards/. Jokers based on Byron Knoll's public domain playing cards.",
   "deck": {
     "type": "deck",

--- a/assets/decks/standard.json
+++ b/assets/decks/standard.json
@@ -7,271 +7,489 @@
     "cardTypes": {
       "2 of spades": {
         "image": "/i/cards-default/2S.svg",
-        "rank": "2",
-        "suit": "spades"
+        "suit": "S",
+        "suitColor": "♠",
+        "suitAlt": "3♠",
+        "rank": "02",
+        "rankA": "02",
+        "rankFixed": "02 S"
       },
       "3 of spades": {
         "image": "/i/cards-default/3S.svg",
-        "rank": "3",
-        "suit": "spades"
+        "suit": "S",
+        "suitColor": "♠",
+        "suitAlt": "3♠",
+        "rank": "03",
+        "rankA": "03",
+        "rankFixed": "03 S"
       },
       "4 of spades": {
         "image": "/i/cards-default/4S.svg",
-        "rank": "4",
-        "suit": "spades"
+        "suit": "S",
+        "suitColor": "♠",
+        "suitAlt": "3♠",
+        "rank": "04",
+        "rankA": "04",
+        "rankFixed": "04 S"
       },
       "5 of spades": {
         "image": "/i/cards-default/5S.svg",
-        "rank": "5",
-        "suit": "spades"
+        "suit": "S",
+        "suitColor": "♠",
+        "suitAlt": "3♠",
+        "rank": "05",
+        "rankA": "05",
+        "rankFixed": "05 S"
       },
       "6 of spades": {
         "image": "/i/cards-default/6S.svg",
-        "rank": "6",
-        "suit": "spades"
+        "suit": "S",
+        "suitColor": "♠",
+        "suitAlt": "3♠",
+        "rank": "06",
+        "rankA": "06",
+        "rankFixed": "06 S"
       },
       "7 of spades": {
         "image": "/i/cards-default/7S.svg",
-        "rank": "7",
-        "suit": "spades"
+        "suit": "S",
+        "suitColor": "♠",
+        "suitAlt": "3♠",
+        "rank": "07",
+        "rankA": "07",
+        "rankFixed": "07 S"
       },
       "8 of spades": {
         "image": "/i/cards-default/8S.svg",
-        "rank": "8",
-        "suit": "spades"
+        "suit": "S",
+        "suitColor": "♠",
+        "suitAlt": "3♠",
+        "rank": "08",
+        "rankA": "08",
+        "rankFixed": "08 S"
       },
       "9 of spades": {
         "image": "/i/cards-default/9S.svg",
-        "rank": "9",
-        "suit": "spades"
+        "suit": "S",
+        "suitColor": "♠",
+        "suitAlt": "3♠",
+        "rank": "09",
+        "rankA": "09",
+        "rankFixed": "09 S"
       },
       "A of spades": {
         "image": "/i/cards-default/AS.svg",
-        "rank": "A",
-        "suit": "spades"
+        "suit": "S",
+        "suitColor": "♠",
+        "suitAlt": "3♠",
+        "rank": "01",
+        "rankA": "5A",
+        "rankFixed": "01 S"
       },
       "10 of spades": {
         "image": "/i/cards-default/TS.svg",
+        "suit": "S",
+        "suitColor": "♠",
+        "suitAlt": "3♠",
         "rank": "10",
-        "suit": "spades"
+        "rankA": "10",
+        "rankFixed": "10 S"
       },
       "J of spades": {
         "image": "/i/cards-default/JS.svg",
-        "rank": "J",
-        "suit": "spades"
+        "suit": "S",
+        "suitColor": "♠",
+        "suitAlt": "3♠",
+        "rank": "2J",
+        "rankA": "2J",
+        "rankFixed": "2J S"
       },
       "Q of spades": {
         "image": "/i/cards-default/QS.svg",
-        "rank": "Q",
-        "suit": "spades"
+        "suit": "S",
+        "suitColor": "♠",
+        "suitAlt": "3♠",
+        "rank": "3Q",
+        "rankA": "3Q",
+        "rankFixed": "3Q S"
       },
       "K of spades": {
         "image": "/i/cards-default/KS.svg",
-        "rank": "K",
-        "suit": "spades"
+        "suit": "S",
+        "suitColor": "♠",
+        "suitAlt": "3♠",
+        "rank": "4K",
+        "rankA": "4K",
+        "rankFixed": "4K S"
       },
       "2 of hearts": {
         "image": "/i/cards-default/2H.svg",
-        "rank": "2",
-        "suit": "hearts"
+        "suit": "H",
+        "suitColor": "♥",
+        "suitAlt": "2♥",
+        "rank": "02",
+        "rankA": "02",
+        "rankFixed": "02 H"
       },
       "3 of hearts": {
         "image": "/i/cards-default/3H.svg",
-        "rank": "3",
-        "suit": "hearts"
+        "suit": "H",
+        "suitColor": "♥",
+        "suitAlt": "2♥",
+        "rank": "03",
+        "rankA": "03",
+        "rankFixed": "03 H"
       },
       "4 of hearts": {
         "image": "/i/cards-default/4H.svg",
-        "rank": "4",
-        "suit": "hearts"
+        "suit": "H",
+        "suitColor": "♥",
+        "suitAlt": "2♥",
+        "rank": "04",
+        "rankA": "04",
+        "rankFixed": "04 H"
       },
       "5 of hearts": {
         "image": "/i/cards-default/5H.svg",
-        "rank": "5",
-        "suit": "hearts"
+        "suit": "H",
+        "suitColor": "♥",
+        "suitAlt": "2♥",
+        "rank": "05",
+        "rankA": "05",
+        "rankFixed": "05 H"
       },
       "6 of hearts": {
         "image": "/i/cards-default/6H.svg",
-        "rank": "6",
-        "suit": "hearts"
+        "suit": "H",
+        "suitColor": "♥",
+        "suitAlt": "2♥",
+        "rank": "06",
+        "rankA": "06",
+        "rankFixed": "06 H"
       },
       "7 of hearts": {
         "image": "/i/cards-default/7H.svg",
-        "rank": "7",
-        "suit": "hearts"
+        "suit": "H",
+        "suitColor": "♥",
+        "suitAlt": "2♥",
+        "rank": "07",
+        "rankA": "07",
+        "rankFixed": "07 H"
       },
       "8 of hearts": {
         "image": "/i/cards-default/8H.svg",
-        "rank": "8",
-        "suit": "hearts"
+        "suit": "H",
+        "suitColor": "♥",
+        "suitAlt": "2♥",
+        "rank": "08",
+        "rankA": "08",
+        "rankFixed": "08 H"
       },
       "9 of hearts": {
         "image": "/i/cards-default/9H.svg",
-        "rank": "9",
-        "suit": "hearts"
+        "suit": "H",
+        "suitColor": "♥",
+        "suitAlt": "2♥",
+        "rank": "09",
+        "rankA": "09",
+        "rankFixed": "09 H"
       },
       "A of hearts": {
         "image": "/i/cards-default/AH.svg",
-        "rank": "A",
-        "suit": "hearts"
+        "suit": "H",
+        "suitColor": "♥",
+        "suitAlt": "2♥",
+        "rank": "01",
+        "rankA": "5A",
+        "rankFixed": "01 H"
       },
       "10 of hearts": {
         "image": "/i/cards-default/TH.svg",
+        "suit": "H",
+        "suitColor": "♥",
+        "suitAlt": "2♥",
         "rank": "10",
-        "suit": "hearts"
+        "rankA": "10",
+        "rankFixed": "10 H"
       },
       "J of hearts": {
         "image": "/i/cards-default/JH.svg",
-        "rank": "J",
-        "suit": "hearts"
+        "suit": "H",
+        "suitColor": "♥",
+        "suitAlt": "2♥",
+        "rank": "2J",
+        "rankA": "2J",
+        "rankFixed": "2J H"
       },
       "Q of hearts": {
         "image": "/i/cards-default/QH.svg",
-        "rank": "Q",
-        "suit": "hearts"
+        "suit": "H",
+        "suitColor": "♥",
+        "suitAlt": "2♥",
+        "rank": "3Q",
+        "rankA": "3Q",
+        "rankFixed": "3Q H"
       },
       "K of hearts": {
         "image": "/i/cards-default/KH.svg",
-        "rank": "K",
-        "suit": "hearts"
+        "suit": "H",
+        "suitColor": "♥",
+        "suitAlt": "2♥",
+        "rank": "4K",
+        "rankA": "4K",
+        "rankFixed": "4K H"
       },
       "2 of diamonds": {
         "image": "/i/cards-default/2D.svg",
-        "rank": "2",
-        "suit": "diamonds"
+        "suit": "D",
+        "suitColor": "♦",
+        "suitAlt": "4♦",
+        "rank": "02",
+        "rankA": "02",
+        "rankFixed": "02 D"
       },
       "3 of diamonds": {
         "image": "/i/cards-default/3D.svg",
-        "rank": "3",
-        "suit": "diamonds"
+        "suit": "D",
+        "suitColor": "♦",
+        "suitAlt": "4♦",
+        "rank": "03",
+        "rankA": "03",
+        "rankFixed": "03 D"
       },
       "4 of diamonds": {
         "image": "/i/cards-default/4D.svg",
-        "rank": "4",
-        "suit": "diamonds"
+        "suit": "D",
+        "suitColor": "♦",
+        "suitAlt": "4♦",
+        "rank": "04",
+        "rankA": "04",
+        "rankFixed": "04 D"
       },
       "5 of diamonds": {
         "image": "/i/cards-default/5D.svg",
-        "rank": "5",
-        "suit": "diamonds"
+        "suit": "D",
+        "suitColor": "♦",
+        "suitAlt": "4♦",
+        "rank": "05",
+        "rankA": "05",
+        "rankFixed": "05 D"
       },
       "6 of diamonds": {
         "image": "/i/cards-default/6D.svg",
-        "rank": "6",
-        "suit": "diamonds"
+        "suit": "D",
+        "suitColor": "♦",
+        "suitAlt": "4♦",
+        "rank": "06",
+        "rankA": "06",
+        "rankFixed": "06 D"
       },
       "7 of diamonds": {
         "image": "/i/cards-default/7D.svg",
-        "rank": "7",
-        "suit": "diamonds"
+        "suit": "D",
+        "suitColor": "♦",
+        "suitAlt": "4♦",
+        "rank": "07",
+        "rankA": "07",
+        "rankFixed": "07 D"
       },
       "8 of diamonds": {
         "image": "/i/cards-default/8D.svg",
-        "rank": "8",
-        "suit": "diamonds"
+        "suit": "D",
+        "suitColor": "♦",
+        "suitAlt": "4♦",
+        "rank": "08",
+        "rankA": "08",
+        "rankFixed": "08 D"
       },
       "9 of diamonds": {
         "image": "/i/cards-default/9D.svg",
-        "rank": "9",
-        "suit": "diamonds"
+        "suit": "D",
+        "suitColor": "♦",
+        "suitAlt": "4♦",
+        "rank": "09",
+        "rankA": "09",
+        "rankFixed": "09 D"
       },
       "A of diamonds": {
         "image": "/i/cards-default/AD.svg",
-        "rank": "A",
-        "suit": "diamonds"
+        "suit": "D",
+        "suitColor": "♦",
+        "suitAlt": "4♦",
+        "rank": "01",
+        "rankA": "5A",
+        "rankFixed": "01 D"
       },
       "10 of diamonds": {
         "image": "/i/cards-default/TD.svg",
+        "suit": "D",
+        "suitColor": "♦",
+        "suitAlt": "4♦",
         "rank": "10",
-        "suit": "diamonds"
+        "rankA": "10",
+        "rankFixed": "10 D"
       },
       "J of diamonds": {
         "image": "/i/cards-default/JD.svg",
-        "rank": "J",
-        "suit": "diamonds"
+        "suit": "D",
+        "suitColor": "♦",
+        "suitAlt": "4♦",
+        "rank": "2J",
+        "rankA": "2J",
+        "rankFixed": "2J D"
       },
       "Q of diamonds": {
         "image": "/i/cards-default/QD.svg",
-        "rank": "Q",
-        "suit": "diamonds"
+        "suit": "D",
+        "suitColor": "♦",
+        "suitAlt": "4♦",
+        "rank": "3Q",
+        "rankA": "3Q",
+        "rankFixed": "3Q D"
       },
       "K of diamonds": {
         "image": "/i/cards-default/KD.svg",
-        "rank": "K",
-        "suit": "diamonds"
+        "suit": "D",
+        "suitColor": "♦",
+        "suitAlt": "4♦",
+        "rank": "4K",
+        "rankA": "4K",
+        "rankFixed": "4K D"
       },
       "2 of clubs": {
         "image": "/i/cards-default/2C.svg",
-        "rank": "2",
-        "suit": "clubs"
+        "suit": "C",
+        "suitColor": "♣",
+        "suitAlt": "1♣",
+        "rank": "02",
+        "rankA": "02",
+        "rankFixed": "02 C"
       },
       "3 of clubs": {
         "image": "/i/cards-default/3C.svg",
-        "rank": "3",
-        "suit": "clubs"
+        "suit": "C",
+        "suitColor": "♣",
+        "suitAlt": "1♣",
+        "rank": "03",
+        "rankA": "03",
+        "rankFixed": "03 C"
       },
       "4 of clubs": {
         "image": "/i/cards-default/4C.svg",
-        "rank": "4",
-        "suit": "clubs"
+        "suit": "C",
+        "suitColor": "♣",
+        "suitAlt": "1♣",
+        "rank": "04",
+        "rankA": "04",
+        "rankFixed": "04 C"
       },
       "5 of clubs": {
         "image": "/i/cards-default/5C.svg",
-        "rank": "5",
-        "suit": "clubs"
+        "suit": "C",
+        "suitColor": "♣",
+        "suitAlt": "1♣",
+        "rank": "05",
+        "rankA": "05",
+        "rankFixed": "05 C"
       },
       "6 of clubs": {
         "image": "/i/cards-default/6C.svg",
-        "rank": "6",
-        "suit": "clubs"
+        "suit": "C",
+        "suitColor": "♣",
+        "suitAlt": "1♣",
+        "rank": "06",
+        "rankA": "06",
+        "rankFixed": "06 C"
       },
       "7 of clubs": {
         "image": "/i/cards-default/7C.svg",
-        "rank": "7",
-        "suit": "clubs"
+        "suit": "C",
+        "suitColor": "♣",
+        "suitAlt": "1♣",
+        "rank": "07",
+        "rankA": "07",
+        "rankFixed": "07 C"
       },
       "8 of clubs": {
         "image": "/i/cards-default/8C.svg",
-        "rank": "8",
-        "suit": "clubs"
+        "suit": "C",
+        "suitColor": "♣",
+        "suitAlt": "1♣",
+        "rank": "08",
+        "rankA": "08",
+        "rankFixed": "08 C"
       },
       "9 of clubs": {
         "image": "/i/cards-default/9C.svg",
-        "rank": "9",
-        "suit": "clubs"
+        "suit": "C",
+        "suitColor": "♣",
+        "suitAlt": "1♣",
+        "rank": "09",
+        "rankA": "09",
+        "rankFixed": "09 C"
       },
       "A of clubs": {
         "image": "/i/cards-default/AC.svg",
-        "rank": "A",
-        "suit": "clubs"
+        "suit": "C",
+        "suitColor": "♣",
+        "suitAlt": "1♣",
+        "rank": "01",
+        "rankA": "5A",
+        "rankFixed": "01 C"
       },
       "10 of clubs": {
         "image": "/i/cards-default/TC.svg",
+        "suit": "C",
+        "suitColor": "♣",
+        "suitAlt": "1♣",
         "rank": "10",
-        "suit": "clubs"
+        "rankA": "10",
+        "rankFixed": "10 C"
       },
       "J of clubs": {
         "image": "/i/cards-default/JC.svg",
-        "rank": "J",
-        "suit": "clubs"
+        "suit": "C",
+        "suitColor": "♣",
+        "suitAlt": "1♣",
+        "rank": "2J",
+        "rankA": "2J",
+        "rankFixed": "2J C"
       },
       "Q of clubs": {
         "image": "/i/cards-default/QC.svg",
-        "rank": "Q",
-        "suit": "clubs"
+        "suit": "C",
+        "suitColor": "♣",
+        "suitAlt": "1♣",
+        "rank": "3Q",
+        "rankA": "3Q",
+        "rankFixed": "3Q C"
       },
       "K of clubs": {
         "image": "/i/cards-default/KC.svg",
-        "rank": "K",
-        "suit": "clubs"
+        "suit": "C",
+        "suitColor": "♣",
+        "suitAlt": "1♣",
+        "rank": "4K",
+        "rankA": "4K",
+        "rankFixed": "4K C"
       },
       "Joker 1": {
         "image": "/i/cards-default/1J.svg",
-        "rank": "J1"
+        "suit": "T",
+        "suitColor": "🃏",
+        "suitAlt": "5J",
+        "rank": "J1",
+        "rankA": "J1",
+        "rankFixed": "J1 T"
       },
       "Joker 2": {
         "image": "/i/cards-default/2J.svg",
-        "rank": "J2"
+        "suit": "T",
+        "suitColor": "🃏",
+        "suitAlt": "5J",
+        "rank": "J2",
+        "rankA": "J2",
+        "rankFixed": "J2 T"
       }
     },
     "faceTemplates": [

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -3218,10 +3218,21 @@ class DeckEditor {
     return /^\s*[a-zA-Z]+\s*$/.test(value) && this.parseColor(value) !== null;
   }
 
-  // Whether a property row should get the little color swatch + color picker: a color-named property
-  // (color, strokeColor, textColor, …) or one whose current value already looks like a color.
+  // A value that is on its way to becoming a color while it is being typed: an empty field, a half-typed hex
+  // ("#1a"), the start of an rgb()/hsl() notation, or plain letters (a keyword before it is finished). Without
+  // this the picker button of a color-named property would vanish and reappear under the cursor mid-keystroke.
+  isPartialColorValue(value) {
+    const text = String(value === undefined || value === null ? '' : value).trim();
+    return text == '' || /^#[0-9a-fA-F]{0,8}$/.test(text) || /^[a-zA-Z]+$/.test(text) || /^(rgba?|hsla?)\(/.test(text);
+  }
+
+  // Whether a property row should get the little color swatch + color picker: one whose current value looks
+  // like a color, or a color-named property (color, strokeColor, textColor, …) whose value could still become
+  // one. The name alone is not enough: a card type property named after a color can hold something that is no
+  // color at all - the standard deck sorts by suitColor: "♠" - and picking a color there would silently
+  // overwrite that value with a hex code.
   shouldOfferColorPicker(property, value) {
-    return /color/i.test(String(property)) || this.isColorValue(value);
+    return this.isColorValue(value) || (/color/i.test(String(property)) && this.isPartialColorValue(value));
   }
 
   // Whether a card type property is used as the "value" of an image/icon face object bound to it — such a

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -2389,6 +2389,15 @@ class DeckEditor {
         return;
       }
       const row = this.addTypedInput(property, typeProperties[property], onValueChanged, typeProps);
+      // The sorting properties of the standard decks say on hover what they are for - on the label too, which
+      // carries a tooltip of its own (the property name, for names the label column cuts off).
+      const hint = this.cardTypePropertyHint(property, typeProperties);
+      if(hint) {
+        row.dom.title = `${property} — ${hint}`;
+        const label = $('.deckEditorPropertyLabel', row.dom);
+        if(label)
+          label.title = row.dom.title;
+      }
       // A custom asset value, or a property bound to an image/icon face object's "value", gets a picker too.
       const boundKind = this.assetPickerKindForCardTypeProperty(property);
       if(boundKind || this.isAssetValue(typeProperties[property]))
@@ -3226,13 +3235,44 @@ class DeckEditor {
     return text == '' || /^#[0-9a-fA-F]{0,8}$/.test(text) || /^[a-zA-Z]+$/.test(text) || /^(rgba?|hsla?)\(/.test(text);
   }
 
-  // Whether a property row should get the little color swatch + color picker: one whose current value looks
-  // like a color, or a color-named property (color, strokeColor, textColor, …) whose value could still become
-  // one. The name alone is not enough: a card type property named after a color can hold something that is no
-  // color at all - the standard deck sorts by suitColor: "♠" - and picking a color there would silently
-  // overwrite that value with a hex code.
-  shouldOfferColorPicker(property, value) {
-    return this.isColorValue(value) || (/color/i.test(String(property)) && this.isPartialColorValue(value));
+  // Whether a property row should get the little color swatch + color picker. A value that is a color always
+  // gets one, and an empty color-named property (color, strokeColor, textColor, …) does too - the picker is
+  // how a color is put there. The name alone is not enough: a card type property named after a color can hold
+  // something that is no color at all - the standard deck sorts by suitColor: "♠" - and picking a color there
+  // would silently overwrite that value with a hex code.
+  // Anything half-typed in between only *keeps* a picker that is already showing (offeredBefore), so a color
+  // being retyped doesn't lose its button - and its open picker - between two keystrokes, while typing a word
+  // like "Spades" over a sort key never arms one.
+  shouldOfferColorPicker(property, value, offeredBefore = true) {
+    if(this.isColorValue(value))
+      return true;
+    if(!/color/i.test(String(property)))
+      return false;
+    const text = String(value === undefined || value === null ? '' : value).trim();
+    return text == '' || (offeredBefore && this.isPartialColorValue(text));
+  }
+
+  // What a card type property is there for, as a row tooltip. The standard decks give their cards a set of
+  // properties that exist purely so a routine can SORT by them (see generateCardDeckWidgets in editmode.js and
+  // assets/decks/standard.json), and their values are shaped for that order rather than for reading - without
+  // a word of explanation the panel just shows "suitAlt: 3♠" and "rankFixed: 02 S". Only a card type carrying
+  // that whole set is described this way, so a deck that uses "rank"/"suit" for its own readable values (the
+  // German and Spanish decks do) isn't told what its properties supposedly mean.
+  cardTypePropertyHint(property, typeProperties) {
+    const hints = {
+      suit: 'Sorting property: groups the cards of one suit together.',
+      suitColor: 'Sorting property: keeps the suits of the same color together. Despite its name it holds no CSS color here.',
+      suitAlt: 'Sorting property: a second suit order - the standard deck alternates black and red suits with it.',
+      rank: 'Sorting property: orders the cards by rank, ace low. Shaped so that sorting gets it right, not for printing on a card.',
+      rankA: 'Sorting property: like rank, but with the ace high.',
+      rankFixed: 'Sorting property: one fixed order for the whole deck - by rank, then by suit.'
+    };
+    const isSortingDeck = [ 'suitAlt', 'rankA', 'rankFixed' ].some(key=>typeProperties[key] !== undefined);
+    if(!isSortingDeck || !hints[property])
+      return null;
+    if(property == 'suitColor' && this.isColorValue(typeProperties[property]))
+      return 'The color of this card\'s suit. Sorting by it keeps the suits of the same color together.';
+    return hints[property];
   }
 
   // Whether a card type property is used as the "value" of an image/icon face object bound to it — such a
@@ -3311,10 +3351,16 @@ class DeckEditor {
     // The picker reads the field instead of the model so it opens on what is currently typed, even while the
     // edit that writes it through is still queued.
     const picker = new ColorInput({}, {}, null, { getValue: _=>field.value, listenTo: [] });
+    // A row that starts out without a picker doesn't get one from a half-typed value, only from a real color:
+    // see shouldOfferColorPicker.
+    let offer = this.shouldOfferColorPicker(property, field.value, false);
+    // A color-named row keeps the space for the button reserved even while it isn't showing one, so the field
+    // doesn't change width under the cursor when the value stops (or starts) looking like a color mid-edit.
+    const keepsRoom = /color/i.test(String(property));
     const updateSwatch = _=>{
-      const offer = this.shouldOfferColorPicker(property, field.value);
+      offer = this.shouldOfferColorPicker(property, field.value, offer);
       button.style.display = offer ? '' : 'none';
-      row.dom.classList.toggle('hasColorPicker', offer);
+      row.dom.classList.toggle('hasColorPicker', offer || keepsRoom);
       if(offer) {
         const color = this.parseColor(field.value);
         if(color)

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -3227,12 +3227,14 @@ class DeckEditor {
     return /^\s*[a-zA-Z]+\s*$/.test(value) && this.parseColor(value) !== null;
   }
 
-  // A value that is on its way to becoming a color while it is being typed: an empty field, a half-typed hex
-  // ("#1a"), the start of an rgb()/hsl() notation, or plain letters (a keyword before it is finished). Without
-  // this the picker button of a color-named property would vanish and reappear under the cursor mid-keystroke.
+  // A value that can only be on its way to becoming a color while it is being typed: a half-typed hex ("#1a")
+  // or the start of an rgb()/hsl() notation. Without this the picker button of a color-named property would
+  // vanish and reappear under the cursor between two keystrokes of a hex value. Half-typed keywords are
+  // deliberately not accepted: "Spades" is indistinguishable from "blu" halfway through, so letters would
+  // leave the picker armed on a value that is no color and never becomes one.
   isPartialColorValue(value) {
     const text = String(value === undefined || value === null ? '' : value).trim();
-    return text == '' || /^#[0-9a-fA-F]{0,8}$/.test(text) || /^[a-zA-Z]+$/.test(text) || /^(rgba?|hsla?)\(/.test(text);
+    return /^#[0-9a-fA-F]{0,8}$/.test(text) || /^(rgba?|hsla?)\(/.test(text);
   }
 
   // Whether a property row should get the little color swatch + color picker. A value that is a color always
@@ -3240,24 +3242,26 @@ class DeckEditor {
   // how a color is put there. The name alone is not enough: a card type property named after a color can hold
   // something that is no color at all - the standard deck sorts by suitColor: "♠" - and picking a color there
   // would silently overwrite that value with a hex code.
-  // Anything half-typed in between only *keeps* a picker that is already showing (offeredBefore), so a color
-  // being retyped doesn't lose its button - and its open picker - between two keystrokes, while typing a word
-  // like "Spades" over a sort key never arms one.
-  shouldOfferColorPicker(property, value, offeredBefore = true) {
+  // The answer depends on the current value alone, never on whether a picker was showing a keystroke ago: a
+  // rule that fed its own result back in would keep the picker armed on whatever is typed over a color next
+  // ("red" -> "S" -> "Spades"), which is the trap this is here to close. A half-typed hex or rgb() keeps its
+  // button between keystrokes because those shapes can't be anything but a color on its way in.
+  shouldOfferColorPicker(property, value) {
     if(this.isColorValue(value))
       return true;
     if(!/color/i.test(String(property)))
       return false;
     const text = String(value === undefined || value === null ? '' : value).trim();
-    return text == '' || (offeredBefore && this.isPartialColorValue(text));
+    return text == '' || this.isPartialColorValue(text);
   }
 
   // What a card type property is there for, as a row tooltip. The standard decks give their cards a set of
   // properties that exist purely so a routine can SORT by them (see generateCardDeckWidgets in editmode.js and
   // assets/decks/standard.json), and their values are shaped for that order rather than for reading - without
   // a word of explanation the panel just shows "suitAlt: 3♠" and "rankFixed: 02 S". Only a card type carrying
-  // that whole set is described this way, so a deck that uses "rank"/"suit" for its own readable values (the
-  // German and Spanish decks do) isn't told what its properties supposedly mean.
+  // the complete set is described this way: card type properties are author-defined, so a deck that happens to
+  // use one or two of these names for its own values (the German and Spanish decks use "rank"/"suit" for their
+  // readable ones, a hand-built deck may sort by a "rank" of its own) isn't told what its properties mean.
   cardTypePropertyHint(property, typeProperties) {
     const hints = {
       suit: 'Sorting property: groups the cards of one suit together.',
@@ -3267,7 +3271,7 @@ class DeckEditor {
       rankA: 'Sorting property: like rank, but with the ace high.',
       rankFixed: 'Sorting property: one fixed order for the whole deck - by rank, then by suit.'
     };
-    const isSortingDeck = [ 'suitAlt', 'rankA', 'rankFixed' ].some(key=>typeProperties[key] !== undefined);
+    const isSortingDeck = Object.keys(hints).every(key=>typeProperties[key] !== undefined);
     if(!isSortingDeck || !hints[property])
       return null;
     if(property == 'suitColor' && this.isColorValue(typeProperties[property]))
@@ -3351,14 +3355,12 @@ class DeckEditor {
     // The picker reads the field instead of the model so it opens on what is currently typed, even while the
     // edit that writes it through is still queued.
     const picker = new ColorInput({}, {}, null, { getValue: _=>field.value, listenTo: [] });
-    // A row that starts out without a picker doesn't get one from a half-typed value, only from a real color:
-    // see shouldOfferColorPicker.
-    let offer = this.shouldOfferColorPicker(property, field.value, false);
+    let offer = this.shouldOfferColorPicker(property, field.value);
     // A color-named row keeps the space for the button reserved even while it isn't showing one, so the field
     // doesn't change width under the cursor when the value stops (or starts) looking like a color mid-edit.
     const keepsRoom = /color/i.test(String(property));
     const updateSwatch = _=>{
-      offer = this.shouldOfferColorPicker(property, field.value, offer);
+      offer = this.shouldOfferColorPicker(property, field.value);
       button.style.display = offer ? '' : 'none';
       row.dom.classList.toggle('hasColorPicker', offer || keepsRoom);
       if(offer) {

--- a/tests/client/deckeditor-color-picker.test.js
+++ b/tests/client/deckeditor-color-picker.test.js
@@ -24,7 +24,7 @@ describe('which deck editor property rows offer a color picker', () => {
   });
 
   test('keeps offering it while a color is being typed into a color-named property', () => {
-    for(const halfTyped of [ '', '#', '#f0', 'rgb(255, 0', 're' ])
+    for(const halfTyped of [ '', '#', '#f0', 'rgb(255, 0', 'hsl(120,' ])
       expect(editor.shouldOfferColorPicker('color', halfTyped)).toBe(true);
   });
 
@@ -40,12 +40,16 @@ describe('which deck editor property rows offer a color picker', () => {
     expect(editor.shouldOfferColorPicker('suitAlt', '3♠')).toBe(false);
   });
 
-  test('a row that has no picker does not get one from a half-typed value, only from a real color', () => {
-    // typing a word into the standard deck's suitColor: "♠" must not arm the picker on the way
-    for(const typed of [ 'S', 'Sp', 'Spades', '#', '#f' ])
-      expect(editor.shouldOfferColorPicker('suitColor', typed, false)).toBe(false);
-    expect(editor.shouldOfferColorPicker('suitColor', 'red', false)).toBe(true);
-    expect(editor.shouldOfferColorPicker('suitColor', '', false)).toBe(true); // an empty one is waiting for a color
+  test('a word typed over a value never arms the picker, whatever the row showed before', () => {
+    // The answer must not depend on what the row showed a keystroke ago, or the picker would survive the whole
+    // way from a color to a word and could still overwrite it. Both sequences are typed into the same row:
+    const typeInto = (property, keystrokes)=>keystrokes.map(value=>editor.shouldOfferColorPicker(property, value));
+    // over the standard deck's sort key, clearing the field first (empty offers one - see the test above)
+    expect(typeInto('suitColor', [ '♠', '', 'S', 'Sp', 'Spa', 'Spades' ])).toEqual([ false, true, false, false, false, false ]);
+    // over a real color, which is where a rule carrying its own result forward stayed armed to the end
+    expect(typeInto('suitColor', [ 'red', 'S', 'Sp', 'Spades' ])).toEqual([ true, false, false, false ]);
+    // while a hex is retyped the button stays put, so an open picker isn't closed between two keystrokes
+    expect(typeInto('color', [ 'red', '', '#', '#f', '#ff0', '#ff000', '#ff0000' ])).toEqual([ true, true, true, true, true, true, true ]);
   });
 });
 
@@ -63,6 +67,19 @@ describe('what the card type panel says about a sorting property', () => {
     const spanish = { rank: '1', suit: 1, order: 1 }; // assets/decks/spanish.json
     for(const property of Object.keys(spanish))
       expect(editor.cardTypePropertyHint(property, spanish)).toBe(null);
+  });
+
+  test('says nothing about a card type that carries only part of the set', () => {
+    // an author-defined "rank" is not the standard deck's ace-low sort key just because a "rankFixed" is around
+    const own = { rank: 'high', rankFixed: 'custom', suitAlt: 'a' };
+    for(const property of Object.keys(own))
+      expect(editor.cardTypePropertyHint(property, own)).toBe(null);
+    // the tarot deck's suitColor really is a color, and it carries none of the other sorting properties
+    const tarot = { rank: '1', roman: 'I', suit: 5, suitColor: 'red', order: 15 }; // assets/decks/tarot.json
+    expect(editor.cardTypePropertyHint('suitColor', tarot)).toBe(null);
+    // one missing property is enough to stay quiet
+    const { rankA, ...withoutRankA } = standard;
+    expect(editor.cardTypePropertyHint('rank', withoutRankA)).toBe(null);
   });
 
   test('does not call a suitColor that really is a color a sorting property without saying so', () => {

--- a/tests/client/deckeditor-color-picker.test.js
+++ b/tests/client/deckeditor-color-picker.test.js
@@ -1,0 +1,42 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// The editor files are plain scripts that get concatenated by server/minify.mjs, so evaluate the source (up to
+// the instance it creates at the end, which would need the whole editor around it) and grab the class.
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const source = fs.readFileSync(path.join(dir, '../../client/js/editor/deckeditor.js'), 'utf8');
+const classes = source.slice(0, source.indexOf('const deckEditor = new DeckEditor()'));
+const DeckEditor = new Function('ToolbarButton', `${classes}\nreturn DeckEditor;`)(class {});
+
+// The color helpers only need "this", not an editor: the one thing they reach for outside themselves is
+// parseColor(), which probes a canvas jsdom doesn't paint - so answer the few keywords the tests use.
+const editor = Object.create(DeckEditor.prototype);
+const keywords = { red: 'rgb(255, 0, 0)', transparent: 'rgba(0, 0, 0, 0)' };
+editor.parseColor = value=>keywords[String(value).trim()] || null;
+
+describe('which deck editor property rows offer a color picker', () => {
+  test('offers it for values that are colors, whatever the property is called', () => {
+    expect(editor.shouldOfferColorPicker('color', '#ff0000')).toBe(true);
+    expect(editor.shouldOfferColorPicker('strokeColor', 'rgba(0,0,0,0.5)')).toBe(true);
+    expect(editor.shouldOfferColorPicker('backgroundColor', 'transparent')).toBe(true);
+    expect(editor.shouldOfferColorPicker('background', 'red')).toBe(true);
+  });
+
+  test('keeps offering it while a color is being typed into a color-named property', () => {
+    for(const halfTyped of [ '', '#', '#f0', 'rgb(255, 0', 're' ])
+      expect(editor.shouldOfferColorPicker('color', halfTyped)).toBe(true);
+  });
+
+  test('does not offer it for a color-named property holding something that is no color', () => {
+    // the standard deck sorts by these - one click in a picker would overwrite the sort key with a hex code
+    expect(editor.shouldOfferColorPicker('suitColor', '♠')).toBe(false);
+    expect(editor.shouldOfferColorPicker('suitColor', '🃏')).toBe(false);
+    expect(editor.shouldOfferColorPicker('color', 'url(/i/cards-default/2S.svg)')).toBe(false);
+  });
+
+  test('does not offer it for a property that is neither named after a color nor holds one', () => {
+    expect(editor.shouldOfferColorPicker('rankFixed', '02 S')).toBe(false);
+    expect(editor.shouldOfferColorPicker('suitAlt', '3♠')).toBe(false);
+  });
+});

--- a/tests/client/deckeditor-color-picker.test.js
+++ b/tests/client/deckeditor-color-picker.test.js
@@ -39,4 +39,34 @@ describe('which deck editor property rows offer a color picker', () => {
     expect(editor.shouldOfferColorPicker('rankFixed', '02 S')).toBe(false);
     expect(editor.shouldOfferColorPicker('suitAlt', '3♠')).toBe(false);
   });
+
+  test('a row that has no picker does not get one from a half-typed value, only from a real color', () => {
+    // typing a word into the standard deck's suitColor: "♠" must not arm the picker on the way
+    for(const typed of [ 'S', 'Sp', 'Spades', '#', '#f' ])
+      expect(editor.shouldOfferColorPicker('suitColor', typed, false)).toBe(false);
+    expect(editor.shouldOfferColorPicker('suitColor', 'red', false)).toBe(true);
+    expect(editor.shouldOfferColorPicker('suitColor', '', false)).toBe(true); // an empty one is waiting for a color
+  });
+});
+
+describe('what the card type panel says about a sorting property', () => {
+  const standard = { suit: 'S', suitColor: '♠', suitAlt: '3♠', rank: '02', rankA: '02', rankFixed: '02 S' };
+
+  test('describes each sorting property of a standard deck card type', () => {
+    for(const property of Object.keys(standard))
+      expect(editor.cardTypePropertyHint(property, standard)).toMatch(/^Sorting property: /);
+    expect(editor.cardTypePropertyHint('suitColor', standard)).toMatch(/no CSS color/);
+    expect(editor.cardTypePropertyHint('image', standard)).toBe(null);
+  });
+
+  test('says nothing about a deck that uses the same names for its own readable values', () => {
+    const spanish = { rank: '1', suit: 1, order: 1 }; // assets/decks/spanish.json
+    for(const property of Object.keys(spanish))
+      expect(editor.cardTypePropertyHint(property, spanish)).toBe(null);
+  });
+
+  test('does not call a suitColor that really is a color a sorting property without saying so', () => {
+    const withColor = { ...standard, suitColor: 'red' };
+    expect(editor.cardTypePropertyHint('suitColor', withColor)).toMatch(/color of this card's suit/i);
+  });
 });

--- a/tests/standard-deck.test.js
+++ b/tests/standard-deck.test.js
@@ -1,0 +1,99 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// assets/decks/standard.json is the template the deck editor's "Traditional deck" flow copies into a game. Its
+// card type properties are a hand-maintained copy of the table generateCardDeckWidgets() builds in
+// client/js/editmode.js, so both standard decks sort the same way - and nothing else exercises either of them.
+// A single typo (a diamond carrying the spades suitColor, a club whose rankFixed says "H") would ship as a
+// subtly wrong SORT in someone's game, so derive every value from the card type name and compare.
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const deck = JSON.parse(fs.readFileSync(path.join(dir, '../assets/decks/standard.json'), 'utf8')).deck;
+const cardTypes = deck.cardTypes;
+
+const suits = {
+  spades:   { letter: 'S', color: '♠', alt: '3♠' },
+  hearts:   { letter: 'H', color: '♥', alt: '2♥' },
+  diamonds: { letter: 'D', color: '♦', alt: '4♦' },
+  clubs:    { letter: 'C', color: '♣', alt: '1♣' }
+};
+const ranks = {
+  A:  { rank: '01', rankA: '5A', image: 'A' }, // ace low in rank, ace high in rankA
+  2:  { rank: '02', rankA: '02', image: '2' },
+  3:  { rank: '03', rankA: '03', image: '3' },
+  4:  { rank: '04', rankA: '04', image: '4' },
+  5:  { rank: '05', rankA: '05', image: '5' },
+  6:  { rank: '06', rankA: '06', image: '6' },
+  7:  { rank: '07', rankA: '07', image: '7' },
+  8:  { rank: '08', rankA: '08', image: '8' },
+  9:  { rank: '09', rankA: '09', image: '9' },
+  10: { rank: '10', rankA: '10', image: 'T' },
+  J:  { rank: '2J', rankA: '2J', image: 'J' },
+  Q:  { rank: '3Q', rankA: '3Q', image: 'Q' },
+  K:  { rank: '4K', rankA: '4K', image: 'K' }
+};
+
+function expectedCardType(name) {
+  const joker = name.match(/^Joker ([12])$/);
+  if(joker)
+    return { image: `/i/cards-default/${joker[1]}J.svg`, suit: 'T', suitColor: '🃏', suitAlt: '5J', rank: `J${joker[1]}`, rankA: `J${joker[1]}`, rankFixed: `J${joker[1]} T` };
+  const [ , rankName, suitName ] = name.match(/^(\S+) of (\S+)$/);
+  const suit = suits[suitName];
+  const rank = ranks[rankName];
+  return {
+    image: `/i/cards-default/${rank.image}${suit.letter}.svg`,
+    suit: suit.letter,
+    suitColor: suit.color,
+    suitAlt: suit.alt,
+    rank: rank.rank,
+    rankA: rank.rankA,
+    rankFixed: `${rank.rank} ${suit.letter}`
+  };
+}
+
+// SORT compares string keys with localeCompare (sortWidgets in client/js/main.js), so the card type names in
+// the order a given sort key puts them in.
+function sortedBy(property) {
+  return Object.keys(cardTypes).sort((a, b)=>cardTypes[a][property].localeCompare(cardTypes[b][property]));
+}
+
+// The suits/ranks a sort groups the deck into, in the order they appear: "the four suits in this order" without
+// caring how the cards inside a group are arranged.
+function groupOrder(names, groupOf) {
+  return names.map(groupOf).filter((group, i, all)=>group !== all[i-1]);
+}
+
+const suitOf = name=>name.replace(/^.* of /, '').replace(/^Joker.*/, 'jokers');
+const rankOf = name=>name.replace(/ of .*$/, '').replace(/^Joker.*/, 'jokers');
+
+describe('the standard deck template', () => {
+  test('has all 54 cards with the properties of the add widget overlay deck', () => {
+    expect(Object.keys(cardTypes).length).toBe(54);
+    for(const [ name, cardType ] of Object.entries(cardTypes))
+      expect([ name, cardType ]).toEqual([ name, expectedCardType(name) ]);
+  });
+
+  test('sorts by suit into C D H S with the jokers last', () => {
+    expect(groupOrder(sortedBy('suit'), suitOf)).toEqual([ 'clubs', 'diamonds', 'hearts', 'spades', 'jokers' ]);
+  });
+
+  test('sorts by suitColor keeping the black and the red suits together', () => {
+    expect(groupOrder(sortedBy('suitColor'), suitOf)).toEqual([ 'spades', 'clubs', 'hearts', 'diamonds', 'jokers' ]);
+  });
+
+  test('sorts by suitAlt alternating black and red', () => {
+    expect(groupOrder(sortedBy('suitAlt'), suitOf)).toEqual([ 'clubs', 'hearts', 'spades', 'diamonds', 'jokers' ]);
+  });
+
+  test('sorts by rank ace low and by rankA ace high, jokers last', () => {
+    const numbers = [ '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K' ];
+    expect(groupOrder(sortedBy('rank'), rankOf)).toEqual([ 'A', ...numbers, 'jokers' ]);
+    expect(groupOrder(sortedBy('rankA'), rankOf)).toEqual([ ...numbers, 'A', 'jokers' ]);
+  });
+
+  test('sorts by rankFixed by rank first, then by suit', () => {
+    const byRankFixed = sortedBy('rankFixed');
+    expect(groupOrder(byRankFixed, rankOf)).toEqual(groupOrder(sortedBy('rank'), rankOf));
+    expect(byRankFixed.slice(0, 4)).toEqual([ 'A of clubs', 'A of diamonds', 'A of hearts', 'A of spades' ]);
+  });
+});


### PR DESCRIPTION
## What

The **Standard playing cards** deck that the deck editor offers (*Add New Deck → Use an existing deck → Traditional deck*, defined in `assets/decks/standard.json`) only gave its cards `image`, `rank` and `suit`. The standard deck added through the **add widget overlay** (`generateCardDeckWidgets` in `client/js/editmode.js`) gives them six properties that exist purely so a game can sort a hand or a pile. This adds the missing ones, with the same values, so both standard decks sort identically.

| property | value | what sorting by it does |
|---|---|---|
| `suit` | `C` `D` `H` `S`, `T` for the jokers | groups the four suits, jokers last |
| `suitColor` | `♣` `♦` `♥` `♠` `🃏` | keeps the two black and the two red suits together |
| `suitAlt` | `1♣` `2♥` `3♠` `4♦` `5J` | alternates black and red |
| `rank` | `01`…`10`, `2J`, `3Q`, `4K`, `J1`/`J2` | ace low |
| `rankA` | same, but `5A` for the aces | ace high |
| `rankFixed` | `rank` + suit letter, e.g. `4K D` | one fixed order for the whole deck |

The readable card type names (`2 of spades`, `Joker 1`) and the card images are unchanged, so nothing that already uses this deck breaks — it is a template file for newly created decks, existing games carry their own copy of `cardTypes`.

Two things came out of the review of the data change and are in here as well:

- **The deck editor no longer offers a color picker for a color-named property that holds no color.** It put the swatch + picker on every property matching `/color/i`, so the new `suitColor: "♠"` row got one, and a single click in it would have overwritten the sort key with a hex code. Whether the picker is offered now depends on the current value alone: the value is a color, the field is empty (the picker is how a color gets in there), or a hex / `rgb()` / `hsl()` value is half-typed — shapes that can't be anything but a color on its way in, so the button doesn't flicker between two keystrokes. A word typed over a value (`red` → `S` → `Spades`) therefore loses the picker instead of keeping it, and real color rows are untouched: `color: transparent` on a face object still has its picker.
- **The card type panel says what the sorting properties are for.** A card type carrying **all six** of these properties now gives each of those rows a tooltip (`suitColor` — *"Sorting property: keeps the suits of the same color together. Despite its name it holds no CSS color here."*), so the codes are explained where they are met rather than only in the deck picker. Card type properties are author-defined, so anything short of the complete set stays silent: a deck that uses `rank`/`suit` for its own readable values (German, Spanish), or a hand-built card type with a `rank` and a `rankFixed` of its own, is not told that its `rank` sorts ace-low.
- **The deck's `description`** — shown in the Traditional deck dialog — mentions the sorting in one clause ("The cards carry extra properties so a hand or a pile can be sorted by suit or by rank."), the same shape as every other deck's entry.

## Why

Sorting was not just incomplete, it was wrong. With the old values `SORT` by `rank` produced `10, 2, 3, … 9, A, J, K, Q` (`localeCompare` on the plain strings), the jokers had no `suit` at all and therefore sorted *before* every real card, and `suitColor`, `suitAlt`, `rankA` and `rankFixed` were simply missing — so none of the sorting recipes the library card games rely on worked on a deck added this way. `library/games/Hearts/0.json` and `library/games/Spades/0.json`, for instance, carry exactly these six values in their own decks; a game built on the deck editor's standard deck could not sort the same way.

## Testing

- `npm test` (jest): 1280 tests pass, including two new suites:
  - `tests/standard-deck.test.js` derives every card type from its name and compares it against the file, then asserts the six documented sort orders — the table here is a hand-maintained copy of the one `generateCardDeckWidgets` builds, and nothing exercised either of them, so a typo in one of 324 lines would have shipped as a subtly wrong sort.
  - `tests/client/deckeditor-color-picker.test.js` covers which property rows offer the color picker and which card types get a sorting tooltip, including the keystroke-by-keystroke sequences `red` → `S` → `Spades` and `♠` → *(cleared)* → `Spades`, and a card type that carries only part of the set.
- The whole TestCafe `editor.js` suite (45 tests) passes, including the one that asserts a card type property added with type `color` *does* get the picker.
- In a real browser (Playwright/Chromium): added the deck through the deck editor's *Traditional deck* flow, confirmed all 54 cards get the six properties, that every sorting row carries its tooltip and that the `suitColor` row behaves like this, typed character by character with the button read out of the DOM after each keystroke ([card type panel](https://agent.virtualtabletop.io/reports/pr/1538991387469545602/cardtype-panel.png)):

  ```
  "♠" no picker | "" PICKER | "S" no | "Sp" no | "Spades" no | "♠" no
  "red" PICKER  | "S" no    | "Sp" no | "Spades" no
  "" PICKER | "#" PICKER | "#f" PICKER | "#ff0000" PICKER | "rgb(0, 0" PICKER | "rgb(0, 0, 255)" PICKER | "♠" no
  ```

  The field stays 206px wide through all of it. The Spanish deck's card type panel shows no sorting tooltips on its `rank`/`suit`/`suitColor` rows. `SORT` on each key against the created holder gives:

```
suit       2c 3c … Kc | 2d … Kd | 2h … Kh | 2s … Ks | Jk1 Jk2
suitColor  spades…, clubs…, hearts…, diamonds…, jokers      (black together, red together)
suitAlt    clubs…, hearts…, spades…, diamonds…, jokers      (alternating)
rank       Ac Ah As Ad 2c … Kd Jk1 Jk2                      (ace low)
rankA      2c … Kd Ac Ah As Ad Jk1 Jk2                      (ace high)
rankFixed  Ac Ad Ah As 2c 2d 2h 2s … Kc Kd Kh Ks Jk1 Jk2    (fixed order)
```

No new or renamed widget property, routine operation or parameter, so `validator/` (`cardTypes` is validated as `any`) and the `jeCommands` list in `client/js/jsonedit.js` need no change, and no UI affordance is added — the properties are edited in the deck editor's card type panel like any other card type property.

## Test room

The test room lives on this PR's test server, **not** in `library/tutorials/` — no tutorial and no library file is touched by this PR. It is authored to tutorial quality per `docs/tutorials.md` and ships as one game with two variants:

- **Properties - Card sorting — *Suits*** (`0.json`): one button each for `suit`, `suitColor` and `suitAlt`.
- **Properties - Card sorting — *Ranks*** (`1.json`): one button each for `rank`, `rankA` and `rankFixed`.

Each button shuffles the whole 54-card deck, sorts it by its property (plus a tie-breaker, so the cards inside a group are ordered instead of staying shuffled) and deals it out into a 13-wide grid — so sorting by a suit property puts exactly one suit per row and the two jokers on the last row.

Download: [Properties - Card sorting.vtt](https://agent.virtualtabletop.io/reports/pr/1538991387469545602/Properties%20-%20Card%20sorting.vtt) · screenshots: [Suits](https://agent.virtualtabletop.io/reports/pr/1538991387469545602/card-sorting-suits.png) · [Ranks](https://agent.virtualtabletop.io/reports/pr/1538991387469545602/card-sorting-ranks.png).

Tutorial-quality checks, for the record:

- **Template:** `library/tutorials/Properties - dragLimit` (the newest tutorial by `_meta.info.lastUpdate`, 2026-08-09), cross-read with `Types - Line` and `Types - Piles`.
- **`_meta.info` parity:** the same fields in the same order and shapes as the template — `name` in the `Properties - <Name>` category scheme, `mode: "Tutorial"`, `players: "1"`, `time: "0"`, `year: "2026"`, `language: "en-US"`, `showName: false`, `usesAIImagery: false`, empty `rules`/`bgg`/`attribution`/`skill`/`description`/`ruleText`/`helpText`/`similar*`, and `variant` `"Suits"` / `"Ranks"` sharing one `name` and `image`.
- **Layout:** the documented top-down bands on the 1600 x 1000 board — `title` (60px, centred), `overview` (25px paragraph), a row of three example buttons with captions directly underneath (22px), then the card grid; semantic ids (`title`, `overview`, `text1..4`, `button1..3`, `cell-<row>-<col>`, `deckHolder`/`deckHolderD`/`deckHolderP`/`deckHolderB`), explanatory text on `layer: -3` and `movable`/`movableInEdit` false, the conventional 111x40 **Recall & Shuffle** button parented to the deck holder, and no invented navigation chrome.
- **Library image:** a 530x530 square SVG in the tutorials' visual language — the same square badge, the `Properties` category word and the graduate cap taken verbatim from the template's image, plus a three-card symbol — embedded in the `.vtt` under `assets/<crc32>_<length>` and referenced as `_meta.info.image`. It sits next to the real tutorials in the game list without standing out.
- **Validated and walked:** `node validator/validate_gamefile_node.js` exits 0 with no output on both variants, and both were walked end to end in Chromium — all six buttons pressed, the dealt order read back out of the DOM (`suit` → one suit per row, jokers last; `rank` → four aces first; `rankA` → aces last; …), and the `.vtt` re-uploaded into a `pr-test-ai` room to confirm it loads with its preview image.

It can be moved into `library/tutorials/` and committed here if a maintainer wants it as a real tutorial — that is a call for a human, so the diff deliberately contains no library change.

## Out of scope

- The *custom deck* wizard (Suits and ranks) builds decks from user-defined suits and ranks, where `suitAlt`/`rankA`/`rankFixed` have no general meaning; it still emits only `suit`, `suitColor` and `rank`.
- The other seven traditional decks (`german`, `spanish`, `swiss`, `tarot`, `hanafuda`, `mahjong`, `dominoes`) use a different convention — numeric `suit` and `order`, a readable `rank` — and sorting them by `rank` still gives `1, 10, 11, 12, 2, …`. Only the standard deck has a de-facto convention to match (the library card games), so unifying the rest is a separate decision and a separate PR.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3125/pr-test (or any other room on that server)


