### PR TITLE
Cache the minified client bundles on disk and prebuild them before a restart

### DIFF
--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -1,6 +1,8 @@
+import crypto from 'crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import url from 'url';
 import util from 'util';
 import zlib from 'zlib';
 
@@ -83,154 +85,172 @@ function htmlMinifyOptions() {
   };
 }
 
-export default async function minifyHTML() {
-  const room = await compress('client/room.html', [
-    'client/css/layout.css',
+// The build reads these lists and the disk cache hashes them, so they live here instead of inline:
+// a file that is added to a bundle but not to the hash would be served from a stale cache entry
+// forever. The order is what ends up in the bundle - do not sort them.
+const ROOM_HTML = 'client/room.html';
+const EDITOR_HTML = 'client/editor.html';
+const FFLATE_JS = 'node_modules/fflate/umd/index.js';
+const SYMBOLS_JSON = 'assets/fonts/symbols.json';
 
-    'client/css/overlays/misc.css',
-    'client/css/overlays/players.css',
-    'client/css/overlays/states.css',
-    'client/css/overlays/connectionlost.css',
-    'client/css/overlays/about.css',
-    'client/css/overlays/welcome.css',
+const CLIENT_CSS = [
+  'client/css/layout.css',
 
-    'client/css/widgets/basicwidget.css',
-    'client/css/widgets/imagewidget.css',
-    'client/css/widgets/button.css',
-    'client/css/widgets/canvas.css',
-    'client/css/widgets/card.css',
-    'client/css/widgets/classes.css',
-    'client/css/widgets/deck.css',
-    'client/css/widgets/dice.css',
-    'client/css/widgets/holder.css',
-    'client/css/widgets/label.css',
-    'client/css/widgets/line.css',
-    'client/css/widgets/pile.css',
-    'client/css/widgets/scoreboard.css',
-    'client/css/widgets/seat.css',
-    'client/css/widgets/spinner.css',
-    'client/css/widgets/timer.css',
+  'client/css/overlays/misc.css',
+  'client/css/overlays/players.css',
+  'client/css/overlays/states.css',
+  'client/css/overlays/connectionlost.css',
+  'client/css/overlays/about.css',
+  'client/css/overlays/welcome.css',
 
-    'client/css/fonts.css',
-    'client/css/custom.css'
-  ], [
-    'node_modules/dompurify/dist/purify.js',
+  'client/css/widgets/basicwidget.css',
+  'client/css/widgets/imagewidget.css',
+  'client/css/widgets/button.css',
+  'client/css/widgets/canvas.css',
+  'client/css/widgets/card.css',
+  'client/css/widgets/classes.css',
+  'client/css/widgets/deck.css',
+  'client/css/widgets/dice.css',
+  'client/css/widgets/holder.css',
+  'client/css/widgets/label.css',
+  'client/css/widgets/line.css',
+  'client/css/widgets/pile.css',
+  'client/css/widgets/scoreboard.css',
+  'client/css/widgets/seat.css',
+  'client/css/widgets/spinner.css',
+  'client/css/widgets/timer.css',
 
-    'client/js/domhelpers.js',
-    'client/js/calculateLayout.js',
-    'client/js/connection.js',
-    'client/js/serverstate.js',
-    'client/js/legacymoderegistry.js',
-    'client/js/legacymodes.js',
-    'client/js/geometry.js',
-    'client/js/compute.js',
-    'client/js/expression.js',
-    'client/js/mousehandling.js',
-    'client/js/zoom.js',
-    'client/js/tracing.js',
-    'client/js/statemanaged.js',
-    'client/js/color.js',
-    'client/js/symbols.js',
-    'client/js/audio.js',
+  'client/css/fonts.css',
+  'client/css/custom.css'
+];
 
-    'client/js/overlays/players.js',
-    'client/js/overlays/states.js',
-    'client/js/overlays/welcome.js',
+const CLIENT_JS = [
+  'node_modules/dompurify/dist/purify.js',
 
-    'client/js/widgets/widget.js',
-    'client/js/widgets/imagewidget.js',
-    'client/js/widgets/basicwidget.js',
-    'client/js/widgets/button.js',
-    'client/js/widgets/canvas.js',
-    'client/js/widgets/card.js',
-    'client/js/widgets/deck.js',
-    'client/js/widgets/dice.js',
-    'client/js/widgets/holder.js',
-    'client/js/widgets/label.js',
-    'client/js/widgets/line.js',
-    'client/js/widgets/pile.js',
-    'client/js/widgets/scoreboard.js',
-    'client/js/widgets/seat.js',
-    'client/js/widgets/spinner.js',
-    'client/js/widgets/timer.js',
+  'client/js/domhelpers.js',
+  'client/js/calculateLayout.js',
+  'client/js/connection.js',
+  'client/js/serverstate.js',
+  'client/js/legacymoderegistry.js',
+  'client/js/legacymodes.js',
+  'client/js/geometry.js',
+  'client/js/compute.js',
+  'client/js/expression.js',
+  'client/js/mousehandling.js',
+  'client/js/zoom.js',
+  'client/js/tracing.js',
+  'client/js/statemanaged.js',
+  'client/js/color.js',
+  'client/js/symbols.js',
+  'client/js/audio.js',
 
-    'client/js/main.js'
-  ]);
+  'client/js/overlays/players.js',
+  'client/js/overlays/states.js',
+  'client/js/overlays/welcome.js',
 
-  const editorCSS = await compressCSS([
-    'client/css/editor/layout.css',
-    'client/css/editor/toolbar.css',
-    'client/css/editor/dragtoolbar.css',
-    'client/css/editor/sidebar.css',
-    'client/css/editor/sidebarModules.css',
-    'client/css/editor/sidebarProperties.css',
-    'client/css/editor/propertyInputs.css',
-    'client/css/editor/deckeditor.css',
-    'client/css/editor/controls/routine.css',
-    'client/css/editor/controls/selectionbar.css',
-    'client/css/editor/controls/popup.css',
-    'client/css/editor/controls/events.css',
+  'client/js/widgets/widget.js',
+  'client/js/widgets/imagewidget.js',
+  'client/js/widgets/basicwidget.js',
+  'client/js/widgets/button.js',
+  'client/js/widgets/canvas.js',
+  'client/js/widgets/card.js',
+  'client/js/widgets/deck.js',
+  'client/js/widgets/dice.js',
+  'client/js/widgets/holder.js',
+  'client/js/widgets/label.js',
+  'client/js/widgets/line.js',
+  'client/js/widgets/pile.js',
+  'client/js/widgets/scoreboard.js',
+  'client/js/widgets/seat.js',
+  'client/js/widgets/spinner.js',
+  'client/js/widgets/timer.js',
 
-    'client/css/editmode.css',
-    'client/css/jsonedit.css',
-    'client/css/tracing.css'
-  ]);
+  'client/js/main.js'
+];
 
-  let editorJS = await compressJS([  // keeps its exports: main.js imports this bundle
-    'client/js/editor/layout.js',
-    'client/js/editor/selection.js',
-    'client/js/editor/toolbarButton.js',
-    'client/js/editor/toolbar/new.js',
-    'client/js/editor/toolbar/save.js',
-    'client/js/editor/toolbar/darkmode.js',
-    'client/js/editor/toolbar/zoomout.js',
-    'client/js/editor/toolbar/display.js',
-    'client/js/editor/toolbar/fullscreen.js',
-    'client/js/editor/toolbar/close.js',
-    'client/js/editor/toolbar/undo.js',
-    'client/js/editor/toolbar/selectmode.js',
-    'client/js/editor/toolbar/add.js',
-    'client/js/editor/toolbar/delete.js',
-    'client/js/editor/toolbar/align.js',
-    'client/js/editor/toolbar/group.js',
-    'client/js/editor/toolbar/grid.js',
-    'client/js/editor/toolbar/deckeditor.js',
-    'client/js/editor/toolbar/tutorials.js',
-    'client/js/editor/toolbar/wiki.js',
-    'client/js/editor/dragButton.js',
-    'client/js/editor/dragbuttons/drag.js',
-    'client/js/editor/dragbuttons/settings.js',
-    'client/js/editor/dragbuttons/clone.js',
-    'client/js/editor/dragbuttons/spacing.js',
-    'client/js/editor/dragbuttons/rotate.js',
-    'client/js/editor/dragbuttons/move.js',
-    'client/js/editor/dragbuttons/resize.js',
-    'client/js/editor/sidebarModule.js',
-    'client/js/editor/propertyInputs.js',
-    'client/js/editor/controls/selectionbar.js',
-    'client/js/editor/controls/widgetselection.js',
-    'client/js/editor/cssEditor.js',
-    'client/js/editor/sidebar/properties.js',
-    'client/js/editor/sidebar/undo.js',
-    'client/js/editor/sidebar/json.js',
-    'client/js/editor/sidebar/assets.js',
-    'client/js/editor/sidebar/toolbox.js',
-    'client/js/editor/sidebar/gameSettings.js',
-    'client/js/editor/sidebar/widgets.js',
-    'client/js/editor/deckeditor.js',
+const EDITOR_CSS = [
+  'client/css/editor/layout.css',
+  'client/css/editor/toolbar.css',
+  'client/css/editor/dragtoolbar.css',
+  'client/css/editor/sidebar.css',
+  'client/css/editor/sidebarModules.css',
+  'client/css/editor/sidebarProperties.css',
+  'client/css/editor/propertyInputs.css',
+  'client/css/editor/deckeditor.css',
+  'client/css/editor/controls/routine.css',
+  'client/css/editor/controls/selectionbar.css',
+  'client/css/editor/controls/popup.css',
+  'client/css/editor/controls/events.css',
 
-    'client/js/editor/controls/routine.js',
-    'client/js/editor/controls/popup.js',
-    'client/js/editor/controls/events.js',
+  'client/css/editmode.css',
+  'client/css/jsonedit.css',
+  'client/css/tracing.css'
+];
 
-    'client/js/editmode.js',
-    'client/js/jsonedit.js',
-    'client/js/traceviewer.js',
+const EDITOR_JS = [
+  'client/js/editor/layout.js',
+  'client/js/editor/selection.js',
+  'client/js/editor/toolbarButton.js',
+  'client/js/editor/toolbar/new.js',
+  'client/js/editor/toolbar/save.js',
+  'client/js/editor/toolbar/darkmode.js',
+  'client/js/editor/toolbar/zoomout.js',
+  'client/js/editor/toolbar/display.js',
+  'client/js/editor/toolbar/fullscreen.js',
+  'client/js/editor/toolbar/close.js',
+  'client/js/editor/toolbar/undo.js',
+  'client/js/editor/toolbar/selectmode.js',
+  'client/js/editor/toolbar/add.js',
+  'client/js/editor/toolbar/delete.js',
+  'client/js/editor/toolbar/align.js',
+  'client/js/editor/toolbar/group.js',
+  'client/js/editor/toolbar/grid.js',
+  'client/js/editor/toolbar/deckeditor.js',
+  'client/js/editor/toolbar/tutorials.js',
+  'client/js/editor/toolbar/wiki.js',
+  'client/js/editor/dragButton.js',
+  'client/js/editor/dragbuttons/drag.js',
+  'client/js/editor/dragbuttons/settings.js',
+  'client/js/editor/dragbuttons/clone.js',
+  'client/js/editor/dragbuttons/spacing.js',
+  'client/js/editor/dragbuttons/rotate.js',
+  'client/js/editor/dragbuttons/move.js',
+  'client/js/editor/dragbuttons/resize.js',
+  'client/js/editor/sidebarModule.js',
+  'client/js/editor/propertyInputs.js',
+  'client/js/editor/controls/selectionbar.js',
+  'client/js/editor/controls/widgetselection.js',
+  'client/js/editor/cssEditor.js',
+  'client/js/editor/sidebar/properties.js',
+  'client/js/editor/sidebar/undo.js',
+  'client/js/editor/sidebar/json.js',
+  'client/js/editor/sidebar/assets.js',
+  'client/js/editor/sidebar/toolbox.js',
+  'client/js/editor/sidebar/gameSettings.js',
+  'client/js/editor/sidebar/widgets.js',
+  'client/js/editor/deckeditor.js',
 
-    'validator/validate_gamefile.js'
-  ], true);
+  'client/js/editor/controls/routine.js',
+  'client/js/editor/controls/popup.js',
+  'client/js/editor/controls/events.js',
 
-  const editorHTML = await htmlMinify(fs.readFileSync(path.resolve() + '/client/editor.html', {encoding:'utf8'}), htmlMinifyOptions());
+  'client/js/editmode.js',
+  'client/js/jsonedit.js',
+  'client/js/traceviewer.js',
+
+  'validator/validate_gamefile.js'
+];
+
+const INPUT_FILES = [ ROOM_HTML, ...CLIENT_CSS, ...CLIENT_JS, EDITOR_HTML, ...EDITOR_CSS, ...EDITOR_JS, FFLATE_JS, SYMBOLS_JSON ];
+
+export async function buildHTML() {
+  const room = await compress(ROOM_HTML, CLIENT_CSS, CLIENT_JS);
+
+  const editorCSS = await compressCSS(EDITOR_CSS);
+
+  let editorJS = await compressJS(EDITOR_JS, true);  // keeps its exports: main.js imports this bundle
+
+  const editorHTML = await htmlMinify(readInputFile(EDITOR_HTML).toString('utf8'), htmlMinifyOptions());
 
   editorJS = editorJS.replace(/["']\ \/\/\*\*\*\ CSS\ \*\*\*\/\/\ ["']/, _=>'`' + editorCSS.replace(/\\/g, '\\\\') + '`');
   editorJS = editorJS.replace(/["']\ \/\/\*\*\*\ HTML\ \*\*\*\/\/\ ["']/, _=>'`' + editorHTML + '`');
@@ -238,11 +258,11 @@ export default async function minifyHTML() {
   // fflate is the one client script that does not go through the bundles: it is loaded on demand
   // (loadZipLibrary in client/js/overlays/states.js) and served straight from node_modules. It
   // already arrives minified, but it was sent uncompressed.
-  const fflate = fs.readFileSync(path.resolve() + '/node_modules/fflate/umd/index.js');
+  const fflate = readInputFile(FFLATE_JS);
 
   // symbols.json is by far the biggest file the client fetches (the icon pickers read it in one go) and
   // express.static sends it as it is, so keep it gzipped here as well - it compresses to about a fifth
-  const symbols = fs.readFileSync(path.resolve() + '/assets/fonts/symbols.json');
+  const symbols = readInputFile(SYMBOLS_JSON);
 
   return {
     min: room.min,
@@ -253,6 +273,10 @@ export default async function minifyHTML() {
     fflateGzipped: await gzip(fflate),
     symbolsGzipped: await gzip(symbols)
   };
+}
+
+function readInputFile(file) {
+  return fs.readFileSync(path.resolve() + '/' + file);
 }
 
 async function compressCSS(cssFiles) {
@@ -319,7 +343,7 @@ async function compressJS(jsFiles, keepExports) {
 }
 
 async function compress(htmlFile, cssFiles, jsFiles) {
-  let htmlString = fs.readFileSync(path.resolve() + '/' + htmlFile, {encoding:'utf8'});
+  let htmlString = readInputFile(htmlFile).toString('utf8');
   htmlString = htmlString.replace(/\ \/\*\*\*\ TITLE\ \*\*\*\/\ /g, _=>Config.get('serverName'));
   htmlString = htmlString.replace(/\ \/\*\*\*\ EXTERNAL_URL\ \*\*\*\/\ /g, _=>Config.get('externalURL'));
   htmlString = htmlString.replace(/\ \/\*\*\*\ URL_PREFIX\ \*\*\*\/\ /g, _=>Config.get('urlPrefix'));
@@ -336,4 +360,170 @@ async function compress(htmlFile, cssFiles, jsFiles) {
     min: html,
     gzipped: await gzip(html)
   };
+}
+
+// The disk cache below turns the build into something a deploy can do ahead of time.
+//
+// Bump this when the stored shape changes, so that entries written by an older version are
+// ignored instead of being loaded as something they are not.
+const CACHE_FORMAT = 1;
+
+// How many builds to keep. A handful is enough to survive switching back and forth between two
+// branches or between a minified and a readable build.
+const CACHE_ENTRIES = 5;
+
+// The fields minifyHTML() returns, and the file each of them is stored in. Buffers are written as
+// they are, strings as UTF-8, so an entry is roughly the size of what it holds.
+const CACHE_FILES = [
+  { field: 'min',             file: 'room.html',       encoding: 'utf8' },
+  { field: 'gzipped',         file: 'room.html.gz'                      },
+  { field: 'editorJSmin',     file: 'edit.js',         encoding: 'utf8' },
+  { field: 'editorJSgzipped', file: 'edit.js.gz'                        },
+  { field: 'fflateMin',       file: 'fflate.js'                         },
+  { field: 'fflateGzipped',   file: 'fflate.js.gz'                      },
+  { field: 'symbolsGzipped',  file: 'symbols.json.gz'                   }
+];
+
+const TOOL_PACKAGES = [ 'terser', 'clean-css', 'html-minifier-terser' ];
+
+function toolVersion(name) {
+  return JSON.parse(fs.readFileSync(`${path.resolve()}/node_modules/${name}/package.json`, 'utf8')).version;
+}
+
+export function cacheDirectory() {
+  return Config.directory('save') + '/minify-cache';
+}
+
+// Everything a build depends on: the files that go into it, everything that gets injected into
+// it, the minifiers doing the work and the code driving them. Two checkouts that agree on all of
+// those produce the same bytes, and only then may an entry of one be used by the other.
+export function cacheKey() {
+  const hash = crypto.createHash('sha256');
+  const stamp = value => hash.update(String(value) + '\0');
+
+  stamp(`format ${CACHE_FORMAT}`);
+  for(const name of TOOL_PACKAGES)
+    stamp(`${name} ${toolVersion(name)}`);
+
+  stamp(`serverName ${Config.get('serverName')}`);
+  stamp(`externalURL ${Config.get('externalURL')}`);
+  stamp(`urlPrefix ${Config.get('urlPrefix')}`);
+  stamp(`minifyJavascript ${minifyJavascript()}`);
+  stamp(`clientConfig ${JSON.stringify(Config.getClientConfig())}`);
+
+  // this module decides what the input files turn into, so editing it invalidates the cache just
+  // like editing one of them - and it is read through its own URL because prebuild and server may
+  // run it from a different working directory than the one the input files are read from
+  stamp('server/minify.mjs');
+  hash.update(fs.readFileSync(url.fileURLToPath(import.meta.url)));
+  stamp('');
+
+  for(const file of INPUT_FILES) {
+    stamp(file);
+    hash.update(readInputFile(file));
+    stamp('');
+  }
+
+  return hash.digest('hex');
+}
+
+// Throws on anything unexpected - a missing, truncated or foreign entry is a miss, not a reason
+// to serve half a build.
+export function loadFromCache(directory, key) {
+  const entry = JSON.parse(fs.readFileSync(`${directory}/${key}/entry.json`, 'utf8'));
+  if(entry.format !== CACHE_FORMAT || entry.key !== key)
+    throw new Error('entry was written for a different build');
+
+  const build = {};
+  for(const { field, file, encoding } of CACHE_FILES) {
+    const content = fs.readFileSync(`${directory}/${key}/${file}`);
+    if(content.length !== entry.sizes[file])
+      throw new Error(`${file} is ${content.length} bytes instead of ${entry.sizes[file]}`);
+    build[field] = encoding ? content.toString(encoding) : content;
+  }
+  return build;
+}
+
+export function storeInCache(directory, key, build) {
+  const temporary = `${directory}/.tmp-${process.pid}-${key.slice(0, 8)}`;
+  fs.rmSync(temporary, { recursive: true, force: true });
+  fs.mkdirSync(temporary, { recursive: true });
+
+  try {
+    const sizes = {};
+    for(const { field, file, encoding } of CACHE_FILES) {
+      const content = encoding ? Buffer.from(build[field], encoding) : build[field];
+      fs.writeFileSync(`${temporary}/${file}`, content);
+      sizes[file] = content.length;
+    }
+    fs.writeFileSync(`${temporary}/entry.json`, JSON.stringify({ format: CACHE_FORMAT, key, sizes }));
+
+    // the rename is what makes the entry visible, in one step: a crash before it leaves a stale
+    // temporary directory behind - which pruneCache removes later - but never half an entry
+    fs.renameSync(temporary, `${directory}/${key}`);
+  } catch(e) {
+    fs.rmSync(temporary, { recursive: true, force: true });
+    if(!fs.existsSync(`${directory}/${key}`))  // a parallel build got there first, which is fine
+      throw e;
+  }
+}
+
+function pruneCache(directory) {
+  const names = fs.readdirSync(directory);
+
+  const entries = names.filter(name => /^[0-9a-f]{64}$/.test(name))
+    .map(name => ({ name, time: fs.statSync(`${directory}/${name}`).mtimeMs }))
+    .sort((a, b) => b.time - a.time);
+  for(const { name } of entries.slice(CACHE_ENTRIES))
+    fs.rmSync(`${directory}/${name}`, { recursive: true, force: true });
+
+  const anHourAgo = Date.now() - 60*60*1000;
+  for(const name of names.filter(name => name.startsWith('.tmp-')))
+    if(fs.statSync(`${directory}/${name}`).mtimeMs < anHourAgo)
+      fs.rmSync(`${directory}/${name}`, { recursive: true, force: true });
+}
+
+// Building the client bundles takes about half a minute on a production checkout and the result
+// only lives in memory, so every restart would pay for it again. server/prebuild.mjs calls this
+// while the old server is still serving, which fills the cache below; server.mjs then calls it
+// again at startup, finds the entry and is listening within seconds. A checkout that changed in
+// any way the build cares about misses the cache and builds exactly as before, and so does one
+// whose cache directory cannot be written - the cache never decides whether the server can start.
+export default async function minifyHTML() {
+  let directory, key;
+  try {
+    directory = cacheDirectory();
+    fs.mkdirSync(directory, { recursive: true });
+    fs.accessSync(directory, fs.constants.W_OK);
+    key = cacheKey();
+  } catch(e) {
+    Logging.log(`WARNING - Client bundles: cache unusable (${e.message}), building in memory`);
+    return await buildHTML();
+  }
+
+  const shortKey = key.slice(0, 8);
+
+  try {
+    const build = loadFromCache(directory, key);
+    fs.utimesSync(`${directory}/${key}`, new Date(), new Date());  // youngest by use, not by build
+    Logging.log(`Client bundles: cache hit ${shortKey}`);
+    return build;
+  } catch(e) {
+    if(e.code != 'ENOENT')
+      Logging.log(`WARNING - Client bundles: discarding cache entry ${shortKey} (${e.message})`);
+  }
+
+  const started = Date.now();
+  const build = await buildHTML();
+  const seconds = ((Date.now() - started) / 1000).toFixed(1);
+
+  try {
+    storeInCache(directory, key, build);
+    pruneCache(directory);
+    Logging.log(`Client bundles: cache miss, built in ${seconds} s, stored as ${shortKey}`);
+  } catch(e) {
+    Logging.log(`WARNING - Client bundles: cache miss, built in ${seconds} s, could not be stored (${e.message})`);
+  }
+
+  return build;
 }

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -264,14 +264,19 @@ export async function buildHTML() {
   // express.static sends it as it is, so keep it gzipped here as well - it compresses to about a fifth
   const symbols = readInputFile(SYMBOLS_JSON);
 
+  // none of these three depend on each other and zlib does its work in the libuv threadpool, so
+  // waiting for them together instead of one after the other shortens the tail of the build by
+  // roughly the two smaller ones. What comes out is the same either way.
+  const [ editorJSgzipped, fflateGzipped, symbolsGzipped ] = await Promise.all([ gzip(editorJS), gzip(fflate), gzip(symbols) ]);
+
   return {
     min: room.min,
     gzipped: room.gzipped,
     editorJSmin: editorJS,
-    editorJSgzipped: await gzip(editorJS),
+    editorJSgzipped,
     fflateMin: fflate,
-    fflateGzipped: await gzip(fflate),
-    symbolsGzipped: await gzip(symbols)
+    fflateGzipped,
+    symbolsGzipped
   };
 }
 

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -449,9 +449,19 @@ export function loadFromCache(directory, key) {
   return build;
 }
 
+function entryIsUsable(directory, key) {
+  try {
+    loadFromCache(directory, key);
+    return true;
+  } catch(e) {
+    return false;
+  }
+}
+
 export function storeInCache(directory, key, build) {
-  const temporary = `${directory}/.tmp-${process.pid}-${key.slice(0, 8)}`;
-  fs.rmSync(temporary, { recursive: true, force: true });
+  // the random part keeps two processes that happen to share a PID - which containers on a common
+  // save volume do - from writing into the half-built directory of the other
+  const temporary = `${directory}/.tmp-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
   fs.mkdirSync(temporary, { recursive: true });
 
   try {
@@ -462,6 +472,11 @@ export function storeInCache(directory, key, build) {
       sizes[file] = content.length;
     }
     fs.writeFileSync(`${temporary}/entry.json`, JSON.stringify({ format: CACHE_FORMAT, key, sizes }));
+
+    // an entry that is already there was written by a build that agrees with this one, so it is
+    // just as good - unless it does not load, in which case nothing else would ever repair it
+    if(fs.existsSync(`${directory}/${key}`) && !entryIsUsable(directory, key))
+      fs.rmSync(`${directory}/${key}`, { recursive: true, force: true });
 
     // the rename is what makes the entry visible, in one step: a crash before it leaves a stale
     // temporary directory behind - which pruneCache removes later - but never half an entry
@@ -475,16 +490,19 @@ export function storeInCache(directory, key, build) {
 
 function pruneCache(directory) {
   const names = fs.readdirSync(directory);
+  // another process pruning the same directory can take a name away between the readdir and the
+  // stat, which says the same thing as an old entry does: it is gone or on its way out
+  const modified = name => fs.statSync(`${directory}/${name}`, { throwIfNoEntry: false })?.mtimeMs;
 
   const entries = names.filter(name => /^[0-9a-f]{64}$/.test(name))
-    .map(name => ({ name, time: fs.statSync(`${directory}/${name}`).mtimeMs }))
+    .map(name => ({ name, time: modified(name) ?? 0 }))
     .sort((a, b) => b.time - a.time);
   for(const { name } of entries.slice(CACHE_ENTRIES))
     fs.rmSync(`${directory}/${name}`, { recursive: true, force: true });
 
   const anHourAgo = Date.now() - 60*60*1000;
   for(const name of names.filter(name => name.startsWith('.tmp-')))
-    if(fs.statSync(`${directory}/${name}`).mtimeMs < anHourAgo)
+    if(modified(name) < anHourAgo)
       fs.rmSync(`${directory}/${name}`, { recursive: true, force: true });
 }
 
@@ -508,14 +526,26 @@ export default async function minifyHTML() {
 
   const shortKey = key.slice(0, 8);
 
-  try {
-    const build = loadFromCache(directory, key);
-    fs.utimesSync(`${directory}/${key}`, new Date(), new Date());  // youngest by use, not by build
-    Logging.log(`Client bundles: cache hit ${shortKey}`);
-    return build;
-  } catch(e) {
-    if(e.code != 'ENOENT')
+  // having no entry for this key is the normal case and stays silent, but once entry.json is
+  // there the rest of the entry has to be readable as well - anything else is worth a warning
+  let cached = null;
+  if(fs.existsSync(`${directory}/${key}/entry.json`)) {
+    try {
+      cached = loadFromCache(directory, key);
+    } catch(e) {
       Logging.log(`WARNING - Client bundles: discarding cache entry ${shortKey} (${e.message})`);
+    }
+  }
+
+  if(cached) {
+    try {
+      fs.utimesSync(`${directory}/${key}`, new Date(), new Date());  // youngest by use, not by build
+    } catch(e) {
+      // an entry written by another user can be read but not re-stamped, which only costs it its
+      // place in the pruning order - it never invalidates a build that already loaded
+    }
+    Logging.log(`Client bundles: cache hit ${shortKey}`);
+    return cached;
   }
 
   const started = Date.now();
@@ -524,10 +554,17 @@ export default async function minifyHTML() {
 
   try {
     storeInCache(directory, key, build);
-    pruneCache(directory);
     Logging.log(`Client bundles: cache miss, built in ${seconds} s, stored as ${shortKey}`);
   } catch(e) {
     Logging.log(`WARNING - Client bundles: cache miss, built in ${seconds} s, could not be stored (${e.message})`);
+  }
+
+  // housekeeping of entries this build does not depend on, so whether it works says nothing about
+  // the entry that was just stored
+  try {
+    pruneCache(directory);
+  } catch(e) {
+    Logging.log(`WARNING - Client bundles: could not prune the cache (${e.message})`);
   }
 
   return build;

--- a/server/prebuild.mjs
+++ b/server/prebuild.mjs
@@ -1,0 +1,36 @@
+// Builds the minified client bundles and stores them in the disk cache that minifyHTML() reads,
+// without starting a server. Minifying takes about half a minute on a production checkout, which
+// a restart would otherwise spend before it can listen - long enough for a deploy script to give
+// up waiting and kill the server it just started.
+//
+//   node server/prebuild.mjs
+//
+// The deploy scripts (misc/server-scripts/puppeteer) run this after updating the checkout and
+// before stopping the old server, from the same working directory and with the same config.json
+// and environment the new server will start with - those decide both what is built and where the
+// cache lives, so anything else fills a cache the server will not look at. The new server then
+// finds the entry and is listening within seconds. Running it again after a hit does nothing.
+//
+// Exits 0 once the bundles were built, non-zero if the build failed. A cache that cannot be
+// written is reported but is not an error: the server still starts, it just builds them itself.
+
+import fs from 'fs';
+
+import Logging from './logging.mjs';
+import minifyHTML, { cacheDirectory, cacheKey } from './minify.mjs';
+
+const started = Date.now();
+
+try {
+  await minifyHTML();
+
+  const seconds = ((Date.now() - started) / 1000).toFixed(1);
+  const entry = `${cacheDirectory()}/${cacheKey()}`;
+  if(fs.existsSync(entry))
+    Logging.log(`Prebuild finished after ${seconds} s - the server will find its client bundles in ${entry}`);
+  else
+    Logging.log(`WARNING - Prebuild finished after ${seconds} s but stored nothing - the server will build the client bundles itself`);
+} catch(e) {
+  Logging.handleGenericException('prebuild', e);
+  process.exit(1);
+}

--- a/tests/server/minify-cache.test.js
+++ b/tests/server/minify-cache.test.js
@@ -154,6 +154,15 @@ describe('a stored client bundle cache entry', function() {
     expect(() => loadFromCache(directory, key)).toThrow();
   });
 
+  // Storing does not overwrite an entry that is already there, so an entry that lost a file would
+  // stay broken and cost every start a rebuild if it were treated like a good one.
+  test('replaces an entry that no longer loads', function() {
+    storeInCache(directory, key, build);
+    fs.rmSync(`${directory}/${key}/symbols.json.gz`);
+    storeInCache(directory, key, build);
+    expectSameBuild(loadFromCache(directory, key), build);
+  });
+
   test('is refused when its index is unreadable', function() {
     storeInCache(directory, key, build);
     fs.writeFileSync(`${directory}/${key}/entry.json`, '{ this is not json');
@@ -182,6 +191,23 @@ describe('minifyHTML with a cache directory', function() {
 
   test('hands out the identical build on the next call', async function() {
     expectSameBuild(await minifyHTML(), built);
+  }, 180000);
+
+  // Stamping an entry as recently used needs ownership of it, which a server that did not write
+  // it - the prebuild ran as the deploy user - does not have. That must not cost it the hit.
+  test('serves an entry it cannot stamp as used', async function() {
+    const utimesSync = fs.utimesSync;
+    let stamped = false;
+    fs.utimesSync = function() {
+      stamped = true;
+      throw Object.assign(new Error('EPERM: operation not permitted, utime'), { code: 'EPERM' });
+    };
+    try {
+      expectSameBuild(await minifyHTML(), built);
+      expect(stamped).toBe(true);  // the entry was read before the stamp failed, so this was a hit
+    } finally {
+      fs.utimesSync = utimesSync;
+    }
   }, 180000);
 
   // A cache that can break the server is worse than no cache at all, so anything unreadable has

--- a/tests/server/minify-cache.test.js
+++ b/tests/server/minify-cache.test.js
@@ -1,0 +1,231 @@
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import minifyHTML, { cacheDirectory, cacheKey, loadFromCache, storeInCache } from '../../server/minify.mjs';
+
+// The build is the expensive part of starting the server, so the cache has to be right about when
+// it may reuse an entry: a key that misses too often costs half a minute, one that hits when it
+// should not serves a client that does not match the checkout.
+
+function temporaryDirectory() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vtt-minify-cache-'));
+}
+
+// A checkout of symlinks into this one, with the given files replaced by content of their own.
+// Changing an input file in place would race with whatever else is building at the same time.
+function mirrorCheckout(overrides) {
+  const checkout = temporaryDirectory();
+  for(const name of [ 'assets', 'client', 'config.json', 'config.template.json', 'node_modules', 'validator' ])
+    fs.symlinkSync(`${path.resolve()}/${name}`, `${checkout}/${name}`);
+
+  for(const [ file, content ] of Object.entries(overrides)) {
+    const parts = file.split('/');
+    for(let depth = 1; depth < parts.length; depth++)
+      replaceLinkedDirectory(`${checkout}/${parts.slice(0, depth).join('/')}`);
+    fs.rmSync(`${checkout}/${file}`, { force: true });
+    fs.writeFileSync(`${checkout}/${file}`, content);
+  }
+  return checkout;
+}
+
+// Turns a symlinked directory into a real one holding a symlink per entry, so that a single file
+// inside it can be replaced without touching the directory it points at.
+function replaceLinkedDirectory(directory) {
+  if(!fs.lstatSync(directory).isSymbolicLink())
+    return;
+  const source = fs.readlinkSync(directory);
+  fs.unlinkSync(directory);
+  fs.mkdirSync(directory);
+  for(const name of fs.readdirSync(source))
+    fs.symlinkSync(`${source}/${name}`, `${directory}/${name}`);
+}
+
+function runNode(args, options) {
+  return spawnSync(process.execPath, args, {
+    cwd: options.cwd || path.resolve(),
+    env: { ...process.env, ...options.env },
+    encoding: 'utf8'
+  });
+}
+
+function cacheKeyIn(checkout, env) {
+  const load = `import(${JSON.stringify(path.resolve() + '/server/minify.mjs')}).then(m => console.log(m.cacheKey()))`;
+  const result = runNode([ '--input-type=module', '-e', load ], { cwd: checkout, env });
+  expect(result.stderr).toBe('');
+  return result.stdout.trim();
+}
+
+// Every field of a build as bytes, so that a string and a Buffer can be compared the same way.
+function asBytes(build) {
+  return Object.fromEntries(Object.entries(build).map(([ field, value ]) => [
+    field, Buffer.isBuffer(value) ? value : Buffer.from(String(value), 'utf8')
+  ]));
+}
+
+function expectSameBuild(actual, expected) {
+  expect(Object.keys(actual).sort()).toEqual(Object.keys(expected).sort());
+  const actualBytes = asBytes(actual);
+  const expectedBytes = asBytes(expected);
+  for(const field of Object.keys(expectedBytes))
+    expect(`${field}: ${actualBytes[field].toString('base64')}`).toBe(`${field}: ${expectedBytes[field].toString('base64')}`);
+}
+
+describe('the client bundle cache key', function() {
+  let checkouts;
+
+  beforeEach(function() {
+    checkouts = [];
+  });
+
+  afterEach(function() {
+    for(const checkout of checkouts)
+      fs.rmSync(checkout, { recursive: true, force: true });
+  });
+
+  function checkoutWith(overrides) {
+    const checkout = mirrorCheckout(overrides);
+    checkouts.push(checkout);
+    return checkout;
+  }
+
+  test('is the same for an unchanged checkout', function() {
+    expect(cacheKey()).toBe(cacheKey());
+  });
+
+  // The prebuild step runs in the checkout the server will start from, so a key that depended on
+  // where that checkout lives would never hit.
+  test('does not depend on the path of the checkout', function() {
+    expect(cacheKeyIn(checkoutWith({}))).toBe(cacheKey());
+  });
+
+  test('changes when an input file changes', function() {
+    const customCSS = fs.readFileSync(path.resolve() + '/client/css/custom.css', 'utf8');
+    expect(cacheKeyIn(checkoutWith({ 'client/css/custom.css': customCSS + '\nbody { --cache-key-test: 1; }\n' }))).not.toBe(cacheKey());
+  });
+
+  test('changes when a client config value changes', function() {
+    expect(cacheKeyIn(checkoutWith({}), { SERVERNAME: 'A Different Tabletop' })).not.toBe(cacheKey());
+  });
+
+  test('changes when minification is switched on', function() {
+    expect(cacheKeyIn(checkoutWith({}), { MINIFYJAVASCRIPT: 'true' })).not.toBe(cacheKey());
+  });
+});
+
+describe('a stored client bundle cache entry', function() {
+  const key = 'f'.repeat(64);
+  let directory;
+
+  beforeEach(function() {
+    directory = temporaryDirectory();
+  });
+
+  afterEach(function() {
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  // Buffers and strings are stored the same way, so the loaded entry has to hand the strings back
+  // as strings - the server sends min and editorJSmin as text and the rest as bytes.
+  const build = {
+    min: '<!doctype html><body>ä ☺</body>',
+    gzipped: Buffer.from([ 0x1f, 0x8b, 0x00, 0xff ]),
+    editorJSmin: 'const a="ü";\n',
+    editorJSgzipped: Buffer.from([ 0x1f, 0x8b, 0x01 ]),
+    fflateMin: Buffer.from('fflate'),
+    fflateGzipped: Buffer.from([ 0x00, 0x01, 0x02 ]),
+    symbolsGzipped: Buffer.from([ 0xff, 0xfe ])
+  };
+
+  test('round-trips every field', function() {
+    storeInCache(directory, key, build);
+    const loaded = loadFromCache(directory, key);
+    expectSameBuild(loaded, build);
+    for(const field of [ 'min', 'editorJSmin' ])
+      expect(typeof loaded[field]).toBe('string');
+    for(const field of [ 'gzipped', 'editorJSgzipped', 'fflateMin', 'fflateGzipped', 'symbolsGzipped' ])
+      expect(Buffer.isBuffer(loaded[field])).toBe(true);
+  });
+
+  test('is refused when one of its files was truncated', function() {
+    storeInCache(directory, key, build);
+    fs.writeFileSync(`${directory}/${key}/edit.js.gz`, Buffer.from([ 0x1f ]));
+    expect(() => loadFromCache(directory, key)).toThrow();
+  });
+
+  test('is refused when its index is unreadable', function() {
+    storeInCache(directory, key, build);
+    fs.writeFileSync(`${directory}/${key}/entry.json`, '{ this is not json');
+    expect(() => loadFromCache(directory, key)).toThrow();
+  });
+});
+
+describe('minifyHTML with a cache directory', function() {
+  let saveDirectory;
+  let built;
+
+  beforeAll(async function() {
+    saveDirectory = temporaryDirectory();
+    process.env.VTT_SAVE_DIR = saveDirectory;
+    built = await minifyHTML();
+  }, 180000);
+
+  afterAll(function() {
+    delete process.env.VTT_SAVE_DIR;
+    fs.rmSync(saveDirectory, { recursive: true, force: true });
+  });
+
+  test('stores the build it just made', function() {
+    expect(fs.existsSync(`${cacheDirectory()}/${cacheKey()}/entry.json`)).toBe(true);
+  });
+
+  test('hands out the identical build on the next call', async function() {
+    expectSameBuild(await minifyHTML(), built);
+  }, 180000);
+
+  // A cache that can break the server is worse than no cache at all, so anything unreadable has
+  // to end up as a plain rebuild.
+  test('rebuilds when the stored entry is corrupted', async function() {
+    fs.writeFileSync(`${cacheDirectory()}/${cacheKey()}/room.html.gz`, Buffer.from('truncated'));
+    expectSameBuild(await minifyHTML(), built);
+  }, 180000);
+});
+
+// The point of prebuild is that a deploy can pay for the build before the restart, so its exit
+// code is what tells the deploy script whether the new server will start quickly - or at all.
+describe('server/prebuild.mjs', function() {
+  function runPrebuild(options) {
+    return runNode([ path.resolve() + '/server/prebuild.mjs' ], options);
+  }
+
+  test('fills the cache on the first run and finds it on the second', function() {
+    const saveDirectory = temporaryDirectory();
+    try {
+      const first = runPrebuild({ env: { VTT_SAVE_DIR: saveDirectory } });
+      expect(first.stdout + first.stderr).toContain('cache miss');
+      expect(first.status).toBe(0);
+
+      const started = Date.now();
+      const second = runPrebuild({ env: { VTT_SAVE_DIR: saveDirectory } });
+      expect(second.stdout + second.stderr).toContain('cache hit');
+      expect(second.status).toBe(0);
+      expect(Date.now() - started).toBeLessThan(10000);  // reading an entry instead of building one
+    } finally {
+      fs.rmSync(saveDirectory, { recursive: true, force: true });
+    }
+  }, 180000);
+
+  test('exits non-zero when a client file does not parse', function() {
+    const saveDirectory = temporaryDirectory();
+    const checkout = mirrorCheckout({ 'client/js/audio.js': 'function ( {\n' });
+    try {
+      const result = runPrebuild({ cwd: checkout, env: { VTT_SAVE_DIR: saveDirectory, MINIFYJAVASCRIPT: 'true' } });
+      expect(result.status).not.toBe(0);
+      expect(result.stdout + result.stderr).toMatch(/ERROR - GENERIC prebuild/);
+    } finally {
+      fs.rmSync(checkout, { recursive: true, force: true });
+      fs.rmSync(saveDirectory, { recursive: true, force: true });
+    }
+  }, 180000);
+});

--- a/tests/server/minify.test.js
+++ b/tests/server/minify.test.js
@@ -51,7 +51,7 @@ describe('minifyHTML with minifyJavascript disabled', () => {
 
   beforeAll(async () => {
     build = await buildWith('false');  // an env override arrives as a string, not a boolean
-  }, 60000);
+  }, 180000);
 
   test('keeps the inline client JS readable', () => {
     const script = inlineClientJS(build);
@@ -80,7 +80,7 @@ describe('minifyHTML with minifyJavascript enabled', () => {
     // of what has to survive - or disappear from - the minified one come from
     readableBuild = await buildWith('false');
     build = await buildWith('true');
-  }, 60000);
+  }, 180000);
 
   test('minifies the inline client JS', () => {
     expect(inlineClientJS(build)).not.toMatch(readableJS);

--- a/tests/server/minify.test.js
+++ b/tests/server/minify.test.js
@@ -1,15 +1,18 @@
 import fs from 'fs';
 import zlib from 'zlib';
 
-import minifyHTML from '../../server/minify.mjs';
+import { buildHTML } from '../../server/minify.mjs';
 
 // A readable build keeps multi-line function bodies and blank lines, a minified one has neither.
 const readableJS = /function \w+\([\w, ]*\) \{\n/;
 
+// the build itself, not the cached path in front of it: what these tests check is what the
+// minifiers produce, and reading it back from an entry an earlier run stored would only ever
+// confirm that the cache round trip works
 async function buildWith(minifyJavascript) {
   process.env.MINIFYJAVASCRIPT = minifyJavascript;
   try {
-    return await minifyHTML();
+    return await buildHTML();
   } finally {
     delete process.env.MINIFYJAVASCRIPT;
   }


### PR DESCRIPTION
<!-- todo-human-input:start -->
## ⏳ To Do — waiting on a human maintainer

- [ ] **An approving review.** The branch was rebased onto current `main` (`08659629`), all 45 checks are green and a squash merge is queued with auto-merge — GitHub's branch policy only still wants one approval before it runs.

<!-- todo-human-input:end -->

Starting the server spends almost all of its time minifying the client bundles, and the result only lives in memory — so every restart pays for it again. On a production checkout a cold `node server.mjs` needs about 27 s before it logs `Listening on` (3.9 s with `MINIFYJAVASCRIPT=false`): terser with `passes: 2` over the ~2.4 MB client bundle (twice — once in `compressJS` and again inside html-minifier-terser), clean-css level 2 over ~440 KB of CSS, and four `gzip` calls at `Z_BEST_COMPRESSION`. That is long enough for a deploy to give up waiting for the new server and kill it, which on 2026-08-20 turned one deploy into ~95 restarts and about an hour of downtime.

This adds a disk cache for that build plus a prebuild step, so the expensive work happens **before** the restart, while the old server is still serving.

## What changed

**`server/minify.mjs`** — `minifyHTML()` is now a thin wrapper around the build:

- **Where:** `<save dir>/minify-cache/`, with the save dir taken from `Config.directory('save')`. `VTT_SAVE_DIR` is honoured, so MAIN, beta and every PR server get their own cache. Created on demand.
- **Key:** a sha256 over the content of every input file (all CSS and JS lists, `client/room.html`, `client/editor.html`, `client/css/custom.css`, `validator/validate_gamefile.js`, dompurify, fflate, `assets/fonts/symbols.json`), everything that gets injected into the output (`serverName`, `externalURL`, `urlPrefix`, the full `Config.getClientConfig()` and the normalised `minifyJavascript` flag), the versions of terser, clean-css and html-minifier-terser, a `CACHE_FORMAT` constant — and `server/minify.mjs` itself, so that editing the build code invalidates the cache the same way editing an input file does. The file lists moved into module-level constants that both the build and the hash read, so the two cannot drift apart; the order is unchanged.
- **Stored shape:** one directory per key holding exactly what `minifyHTML()` returns (`min`, `gzipped`, `editorJSmin`, `editorJSgzipped`, `fflateMin`, `fflateGzipped`, `symbolsGzipped`) as plain files — no base64 inflation — plus an `entry.json` with the format, the key and the byte size of every file. It is written to a temporary directory and renamed into place, so a crash mid-write can leave a stale temp directory (cleaned up later) but never half an entry. The five most recently used entries are kept.
- **Anything unexpected is a miss:** a missing, truncated, foreign or unparsable entry is discarded and the bundles are built as before. Same for a cache directory that cannot be created or written — that logs a warning and builds in memory. A cache problem can never stop the server from starting.
- **One log line** says which happened: `Client bundles: cache hit 9c9fd077` or `Client bundles: cache miss, built in 25.5 s, stored as 4e102254`.

**`server/prebuild.mjs`** (new) — builds and stores the bundles without opening a port or touching anything besides the cache directory. It loads Config exactly like the server does (`config.json` from the current directory, environment overrides), so the deploy scripts run it in the checkout the new server will start from, with the same config and environment. Exits 0 once the bundles were built, non-zero if the build failed; a cache that cannot be written is reported but is not an error, since the server still starts.

**Second commit** runs the gzip calls for the editor bundle, fflate and `symbols.json` concurrently instead of one after another. They do not depend on each other and zlib compresses in the libuv threadpool. The output is byte-for-byte identical; measured here it takes 361 ms instead of 484 ms.

No client-side change, and nothing about what is served changes.

## Measured

On this checkout with `MINIFYJAVASCRIPT=true`:

```
node server/prebuild.mjs   ->  cache miss, built in 25.5 s, stored as 4e102254   (26.1 s total)
node server/prebuild.mjs   ->  cache hit 4e102254                                 (0.5 s total)
node server.mjs            ->  cache hit 9c9fd077 ... Listening on 8333          (1.4 s to first response)
```

Changing `serverName` (or any input file, or `config.json`) and restarting without a prebuild logs a miss and builds as before. The bytes served from a cache hit were compared against a fresh uncached build — `min`, `gzipped`, `editorJSmin`, `editorJSgzipped`, `fflateMin`, `fflateGzipped` and `symbolsGzipped` are identical, and the `room.html`, `/edit.js` and `/scripts/fflate` the running server sends match the cached files exactly.

## Tests

`tests/server/minify-cache.test.js` covers: the same checkout produces the same key; a changed input file, a changed client config value and a changed `minifyJavascript` flag each produce a different one; the key does not depend on where the checkout lives; an entry round-trips every field byte-identically with strings coming back as strings and buffers as buffers; a truncated file or an unreadable `entry.json` is refused; `minifyHTML()` rebuilds instead of crashing when a stored entry is corrupted, and the rebuild is identical to the original; `prebuild.mjs` exits 0 and fills the cache on the first run, hits it on the second, and exits non-zero when a client file does not parse. The tests that need a checkout of their own build one out of symlinks in a temporary directory, so no file of the real one is ever modified, and they use a temporary `VTT_SAVE_DIR`.

The build hooks in the existing `tests/server/minify.test.js` got a longer timeout: two full builds already took most of the old minute, and they now compete for the same cores with the new test file.

`npm test` is green (38 suites, 1344 tests).

## For the deploy scripts

`misc/server-scripts/puppeteer/main-update.sh` and `beta-update.sh` already call `node server/prebuild.mjs` if the file exists, between updating the checkout and stopping the old server. This PR is the other half of that.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3132/pr-test (or any other room on that server)

