### PR TITLE
Fire holder enter and leave events once per move, whichever way the widget moved

### DIFF
--- a/client/css/editor/sidebarModules.css
+++ b/client/css/editor/sidebarModules.css
@@ -1932,6 +1932,13 @@ div.widget-name {
   color: var(--textColor);
 }
 
+/* a bulleted list in a tile's description text - the browser default indents it far past
+   the 21px column the rest of the text sits in */
+.settings-tile ul {
+  margin: 6px 0;
+  padding-left: 20px;
+}
+
 .boardSizeSetting .boardSizeHeader {
   font-weight: bold;
   margin-bottom: 8px;

--- a/client/js/legacymoderegistry.js
+++ b/client/js/legacymoderegistry.js
@@ -95,7 +95,7 @@ export const LEGACY_MODES = {
   disableHolderImageWidget: {
     since: 21,
     pr: 2634,
-    interactsWith: [],
+    interactsWith: [ 'legacyHolderEnterLeaveEvents' ],
     detect: function(state) {
       for(const id in state) {
         const properties = state[id];
@@ -113,6 +113,26 @@ export const LEGACY_MODES = {
       <b>New behavior</b>: Holders display image, icon and text properties directly. Games that built those manual workarounds can look broken because both are drawn at once.
       <br><br>
       This legacy mode disables the native image/icon/text support for holders, restoring the old behavior.
+      `
+  },
+  legacyHolderEnterLeaveEvents: {
+    since: 23,
+    pr: 3134,
+    interactsWith: [ 'disableHolderImageWidget' ],
+    detect: state => /"(enterRoutine|leaveRoutine|onEnter|onLeave)"\s*:/.test(JSON.stringify(state)),
+    label: 'Legacy holder enter/leave events',
+    summary: 'leaveRoutine fires twice per move, onLeave only for drags and MOVE.',
+    description: `
+      <b>Old behavior</b>: Two different places raised the leave event, so every drag and every <code>MOVE</code> called <code>leaveRoutine</code> twice - once when the widget was detached and once when it was really out of the holder. The <code>onLeave</code> properties were only applied on the second of those, which meant <code>SET parent</code> and <code>MOVEXY</code> never applied them at all. A card that joined a pile inside the holder it was already in raised a leave event with no matching enter, and a card dropped back into the holder it was picked up from ran <code>enterRoutine</code> without applying <code>onEnter</code>.
+      <br><br>
+      <b>New behavior</b>: A parent change raises at most one leave and one enter, whichever way the widget was moved. Each event applies its properties first and calls its routine afterwards, so the routine always sees the values the event wrote. Piles are transparent: joining, leaving or dissolving a pile inside a holder is not a move between containers and raises no event.
+      <br><br>
+      <b>Example:</b> a holder whose <code>leaveRoutine</code> counts the cards that left it.
+      <br><br>
+      Old result: dragging one card out counts <code>2</code><br>
+      New result: dragging one card out counts <code>1</code>
+      <br><br>
+      Enable this mode for a game that was built around the double call - or around <code>MOVEXY</code> not applying <code>onLeave</code>.
       `
   }
 };

--- a/client/js/legacymoderegistry.js
+++ b/client/js/legacymoderegistry.js
@@ -120,19 +120,23 @@ export const LEGACY_MODES = {
     pr: 3134,
     interactsWith: [ 'disableHolderImageWidget' ],
     detect: state => /"(enterRoutine|leaveRoutine|onEnter|onLeave|childrenPerOwner)"\s*:/.test(JSON.stringify(state)),
-    label: 'Legacy holder enter/leave events',
-    summary: 'leaveRoutine fires twice per move, onLeave only for drags and MOVE.',
+    label: 'Fire holder leave events twice',
+    summary: 'Holders raise the leave event twice per move, and apply onLeave only for drags and MOVE.',
     description: `
-      <b>Old behavior</b>: Two different places raised the leave event, so every drag and every <code>MOVE</code> called <code>leaveRoutine</code> twice - once when the widget was detached and once when it was really out of the holder. The <code>onLeave</code> properties were only applied on the second of those, which meant <code>SET parent</code> and <code>MOVEXY</code> never applied them at all. A card that joined a pile inside the holder it was already in raised a leave event with no matching enter, and a card dropped back into the holder it was picked up from ran <code>enterRoutine</code> without applying <code>onEnter</code>. A card taken out of a <code>childrenPerOwner</code> holder by <code>SET parent</code> or <code>MOVEXY</code> kept its owner.
+      <b>Old behavior</b>: A holder raises a <i>leave</i> when a widget stops being its child and an <i>enter</i> when one becomes its child. Two places raised the leave, so a drag or a <code>MOVE</code> called <code>leaveRoutine</code> twice, and <code>onLeave</code> was applied only on the second call.
       <br><br>
-      <b>New behavior</b>: A parent change raises at most one leave and one enter, whichever way the widget was moved. Each event applies its properties first and calls its routine afterwards, so the routine always sees the values the event wrote. Piles are transparent: joining, leaving or dissolving a pile inside another container is not a move between containers and raises no event. Picking a card up and dropping it back into the same holder is a real leave and a real enter, so both apply their properties. A <code>childrenPerOwner</code> holder releases the owner however the card left it, dragged or not - but a dragged card only once it is outside the holder's box, so rearranging a hand never uncovers a card.
-      <br><br>
+      <b>New behavior</b>: one leave and one enter per move, properties before routine. In detail:
+      <ul>
+        <li><code>leaveRoutine</code> runs once per departure, not twice</li>
+        <li><code>SET parent</code> and <code>MOVEXY</code> now apply <code>onLeave</code></li>
+        <li>dropping a card back into the holder it came from is a real leave and a real enter</li>
+        <li>a <code>childrenPerOwner</code> holder releases the owner however the card left it - a dragged card once it is outside the box, so rearranging a hand never uncovers it</li>
+        <li>joining or leaving a pile inside a holder raises nothing</li>
+      </ul>
       <b>Example:</b> a holder whose <code>leaveRoutine</code> counts the cards that left it.
       <br><br>
       Old result: dragging one card out counts <code>2</code><br>
       New result: dragging one card out counts <code>1</code>
-      <br><br>
-      Enable this mode for a game that was built around the double call - or around <code>MOVEXY</code> not applying <code>onLeave</code>.
       `
   }
 };

--- a/client/js/legacymoderegistry.js
+++ b/client/js/legacymoderegistry.js
@@ -120,13 +120,18 @@ export const LEGACY_MODES = {
     pr: 3134,
     interactsWith: [ 'disableHolderImageWidget' ],
     detect: function(state) {
-      if(/"(enterRoutine|leaveRoutine|onEnter|onLeave|childrenPerOwner)"\s*:/.test(JSON.stringify(state)))
+      const json = JSON.stringify(state);
+      if(/"(enterRoutine|leaveRoutine|onEnter|onLeave|childrenPerOwner)"\s*:/.test(json))
         return true;
-      // a stacked holder re-compacts on every departure now, which a game notices even when it
-      // uses none of the event names above
+      // A stacked holder re-compacts on every departure now, which a game notices even when it
+      // uses none of the event names above. A stack offset counts wherever it comes from: set
+      // by a routine while the game runs, or written on a widget - which does not have to be
+      // the holder itself, since it can be the template another widget inherits from or clones.
+      if(/"property"\s*:\s*"stackOffset[XY]"/.test(json))
+        return true;
       for(const id in state) {
         const properties = state[id];
-        if(!properties || properties.type != 'holder' || properties.alignChildren === false)
+        if(!properties || properties.alignChildren === false)
           continue;
         if([ properties.stackOffsetX, properties.stackOffsetY ].some(offset=>offset !== undefined && offset !== null && parseFloat(offset) != 0))
           return true;
@@ -146,6 +151,7 @@ export const LEGACY_MODES = {
         <li>a <code>childrenPerOwner</code> holder releases the owner however the card left it - a dragged card once it is outside the box, so rearranging a hand never uncovers it</li>
         <li>joining or leaving a pile inside a holder raises nothing</li>
         <li>a stacked holder closes the gap a card left however it left, <code>DELETE</code> included</li>
+        <li>the preview a <code>dropShadow</code> holder paints under the pointer raises nothing, so hovering over a holder no longer runs its routines</li>
       </ul>
       <b>Example:</b> a holder whose <code>leaveRoutine</code> counts the cards that left it.
       <br><br>

--- a/client/js/legacymoderegistry.js
+++ b/client/js/legacymoderegistry.js
@@ -119,7 +119,20 @@ export const LEGACY_MODES = {
     since: 23,
     pr: 3134,
     interactsWith: [ 'disableHolderImageWidget' ],
-    detect: state => /"(enterRoutine|leaveRoutine|onEnter|onLeave|childrenPerOwner)"\s*:/.test(JSON.stringify(state)),
+    detect: function(state) {
+      if(/"(enterRoutine|leaveRoutine|onEnter|onLeave|childrenPerOwner)"\s*:/.test(JSON.stringify(state)))
+        return true;
+      // a stacked holder re-compacts on every departure now, which a game notices even when it
+      // uses none of the event names above
+      for(const id in state) {
+        const properties = state[id];
+        if(!properties || properties.type != 'holder' || properties.alignChildren === false)
+          continue;
+        if([ properties.stackOffsetX, properties.stackOffsetY ].some(offset=>offset !== undefined && offset !== null && parseFloat(offset) != 0))
+          return true;
+      }
+      return false;
+    },
     label: 'Fire holder leave events twice',
     summary: 'Holders raise the leave event twice per move, and apply onLeave only for drags and MOVE.',
     description: `
@@ -132,6 +145,7 @@ export const LEGACY_MODES = {
         <li>dropping a card back into the holder it came from is a real leave and a real enter</li>
         <li>a <code>childrenPerOwner</code> holder releases the owner however the card left it - a dragged card once it is outside the box, so rearranging a hand never uncovers it</li>
         <li>joining or leaving a pile inside a holder raises nothing</li>
+        <li>a stacked holder closes the gap a card left however it left, <code>DELETE</code> included</li>
       </ul>
       <b>Example:</b> a holder whose <code>leaveRoutine</code> counts the cards that left it.
       <br><br>

--- a/client/js/legacymoderegistry.js
+++ b/client/js/legacymoderegistry.js
@@ -119,13 +119,13 @@ export const LEGACY_MODES = {
     since: 23,
     pr: 3134,
     interactsWith: [ 'disableHolderImageWidget' ],
-    detect: state => /"(enterRoutine|leaveRoutine|onEnter|onLeave)"\s*:/.test(JSON.stringify(state)),
+    detect: state => /"(enterRoutine|leaveRoutine|onEnter|onLeave|childrenPerOwner)"\s*:/.test(JSON.stringify(state)),
     label: 'Legacy holder enter/leave events',
     summary: 'leaveRoutine fires twice per move, onLeave only for drags and MOVE.',
     description: `
-      <b>Old behavior</b>: Two different places raised the leave event, so every drag and every <code>MOVE</code> called <code>leaveRoutine</code> twice - once when the widget was detached and once when it was really out of the holder. The <code>onLeave</code> properties were only applied on the second of those, which meant <code>SET parent</code> and <code>MOVEXY</code> never applied them at all. A card that joined a pile inside the holder it was already in raised a leave event with no matching enter, and a card dropped back into the holder it was picked up from ran <code>enterRoutine</code> without applying <code>onEnter</code>.
+      <b>Old behavior</b>: Two different places raised the leave event, so every drag and every <code>MOVE</code> called <code>leaveRoutine</code> twice - once when the widget was detached and once when it was really out of the holder. The <code>onLeave</code> properties were only applied on the second of those, which meant <code>SET parent</code> and <code>MOVEXY</code> never applied them at all. A card that joined a pile inside the holder it was already in raised a leave event with no matching enter, and a card dropped back into the holder it was picked up from ran <code>enterRoutine</code> without applying <code>onEnter</code>. A card taken out of a <code>childrenPerOwner</code> holder by <code>SET parent</code> or <code>MOVEXY</code> kept its owner.
       <br><br>
-      <b>New behavior</b>: A parent change raises at most one leave and one enter, whichever way the widget was moved. Each event applies its properties first and calls its routine afterwards, so the routine always sees the values the event wrote. Piles are transparent: joining, leaving or dissolving a pile inside a holder is not a move between containers and raises no event.
+      <b>New behavior</b>: A parent change raises at most one leave and one enter, whichever way the widget was moved. Each event applies its properties first and calls its routine afterwards, so the routine always sees the values the event wrote. Piles are transparent: joining, leaving or dissolving a pile inside another container is not a move between containers and raises no event. Picking a card up and dropping it back into the same holder is a real leave and a real enter, so both apply their properties. A <code>childrenPerOwner</code> holder releases the owner however the card left it, dragged or not - but a dragged card only once it is outside the holder's box, so rearranging a hand never uncovers a card.
       <br><br>
       <b>Example:</b> a holder whose <code>leaveRoutine</code> counts the cards that left it.
       <br><br>

--- a/client/js/widgets/holder.js
+++ b/client/js/widgets/holder.js
@@ -90,14 +90,9 @@ class Holder extends ImageWidget {
     return p;
   }
 
-  // childrenPerOwner makes the holder a per-player hand: what it receives becomes the receiving
-  // player's, and what leaves belongs to nobody again.
-  async applyEnter(child, oldParentID) {
-    if(child.get('type') != 'deck' && this.get('childrenPerOwner'))
-      await child.set('owner', child.targetPlayer||playerName);
-    await super.applyEnter(child, oldParentID);
-  }
-
+  // childrenPerOwner makes the holder a per-player hand, so what leaves it belongs to nobody
+  // again. The other half of that is in onChildAdd(), because becoming a child is what claims
+  // a widget, not the arrival event.
   async applyLeave(child) {
     if(child.get('type') != 'deck' && !child.isBeingRemoved && this.get('childrenPerOwner'))
       await child.set('owner', null);
@@ -158,16 +153,19 @@ class Holder extends ImageWidget {
     if(child.get('type') == 'deck')
       return;
 
-    // the legacy pipeline runs the enter half from here, which is why it applied onEnter to
-    // every parent change into the holder except one: a drop back into the holder the drag
-    // started in, which it recognised by the widget still remembering it as currentParent
-    if(legacyMode('legacyHolderEnterLeaveEvents')) {
-      if(this.get('childrenPerOwner'))
-        await child.set('owner', child.targetPlayer||playerName);
+    // A per-player hand claims every widget that becomes a direct child of it, which is not the
+    // same thing as an arrival: a hand that unpacks a dropped pile hands the cards over one by
+    // one, and none of those is a move between containers. The pile the cards came from is gone
+    // by the time the last one is out, so it is not claimed along with them.
+    if(this.get('childrenPerOwner') && !child.isBeingRemoved)
+      await child.set('owner', child.targetPlayer||playerName);
 
-      if(this != child.currentParent) // FIXME: this isn't exactly pretty
-        await this.applyEnterProperties(child);
-    }
+    // the legacy pipeline runs the property half of the arrival from here too, which is why it
+    // applied onEnter to every parent change into the holder except one: a drop back into the
+    // holder the drag started in, which it recognised by the widget still remembering it as
+    // currentParent
+    if(legacyMode('legacyHolderEnterLeaveEvents') && this != child.currentParent)
+      await this.applyEnterProperties(child);
   }
 
   async onChildAddAlign(child, oldParentID) {

--- a/client/js/widgets/holder.js
+++ b/client/js/widgets/holder.js
@@ -90,21 +90,57 @@ class Holder extends ImageWidget {
     return p;
   }
 
-  async dispenseCard(card) {
-    let toProcess = [ card ];
-    if(card.get('type') == 'pile')
-      toProcess = card.children();
+  // childrenPerOwner makes the holder a per-player hand: what it receives becomes the receiving
+  // player's, and what leaves belongs to nobody again.
+  async applyEnter(child, oldParentID) {
+    if(child.get('type') != 'deck' && this.get('childrenPerOwner'))
+      await child.set('owner', child.targetPlayer||playerName);
+    await super.applyEnter(child, oldParentID);
+  }
+
+  async applyLeave(child) {
+    if(child.get('type') != 'deck' && !child.isBeingRemoved && this.get('childrenPerOwner'))
+      await child.set('owner', null);
+    await super.applyLeave(child);
+  }
+
+  // onEnter and onLeave hold properties to apply to what entered or left. A pile is one widget
+  // for the event and a stack of cards for the properties, so they reach the cards it holds
+  // rather than the pile itself.
+  async applyEnterProperties(child) {
+    if(child.get('type') == 'deck')
+      return;
+
+    const toProcess = child.get('type') == 'pile' ? child.children() : [ child ];
+    for(const property in this.get('onEnter')) {
+      for(const w of toProcess) {
+        if(tracingEnabled)
+          sendTraceEvent('onEnter', { w: w.get('id'), child: child.get('id'), property, value: this.get('onEnter')[property], toProcess: toProcess.map(w=>w.get('id')) });
+        await w.set(property, this.get('onEnter')[property]);
+      }
+    }
+  }
+
+  async applyLeaveProperties(child) {
+    const toProcess = child.get('type') == 'pile' ? child.children() : [ child ];
     for(const w of toProcess) {
       if(!w.get('ignoreOnLeave')) {
         for(const property in this.get('onLeave')) {
           if(tracingEnabled)
-            sendTraceEvent('onLeave', { w: w.get('id'), child: card.get('id'), property, value: this.get('onLeave')[property], toProcess: toProcess.map(w=>w.get('id')) });
+            sendTraceEvent('onLeave', { w: w.get('id'), child: child.get('id'), property, value: this.get('onLeave')[property], toProcess: toProcess.map(w=>w.get('id')) });
           await w.set(property, this.get('onLeave')[property]);
         }
       }
     }
+    // a gap in a stacked holder closes as soon as the card that left it is gone
     if(this.get('alignChildren') && (this.get('stackOffsetX') || this.get('stackOffsetY')))
       await this.receiveCard(null);
+  }
+
+  // The leave half as the legacy pipeline ran it: from checkParent() once the widget really is
+  // outside the holder, and from a pile that handed a card back while sitting in one.
+  async dispenseCard(card) {
+    await this.applyLeaveProperties(card);
     if(Array.isArray(this.get('leaveRoutine')))
       await this.evaluateRoutine('leaveRoutine', {}, { child: [ card ] });
   }
@@ -122,20 +158,15 @@ class Holder extends ImageWidget {
     if(child.get('type') == 'deck')
       return;
 
-    if(this.get('childrenPerOwner'))
-      await child.set('owner', child.targetPlayer||playerName);
+    // the legacy pipeline runs the enter half from here, which is why it applied onEnter to
+    // every parent change into the holder except one: a drop back into the holder the drag
+    // started in, which it recognised by the widget still remembering it as currentParent
+    if(legacyMode('legacyHolderEnterLeaveEvents')) {
+      if(this.get('childrenPerOwner'))
+        await child.set('owner', child.targetPlayer||playerName);
 
-    if(this != child.currentParent) { // FIXME: this isn't exactly pretty
-      let toProcess = [ child ];
-      if(child.get('type') == 'pile')
-        toProcess = child.children();
-      for(const property in this.get('onEnter')) {
-        for(const w of toProcess) {
-          if(tracingEnabled)
-            sendTraceEvent('onEnter', { w: w.get('id'), child: child.get('id'), property, value: this.get('onEnter')[property], toProcess: toProcess.map(w=>w.get('id')) });
-          await w.set(property, this.get('onEnter')[property]);
-        }
-      }
+      if(this != child.currentParent) // FIXME: this isn't exactly pretty
+        await this.applyEnterProperties(child);
     }
   }
 

--- a/client/js/widgets/holder.js
+++ b/client/js/widgets/holder.js
@@ -139,6 +139,15 @@ class Holder extends ImageWidget {
     await this.closeStackGap();
   }
 
+  // A drop shadow is a preview and raises no leave, but it does take a slot in a stacked holder
+  // while it is there, and that slot has to close again when the pointer moves on. The legacy
+  // pipeline closes it from dispenseCard() instead, along with the rest of the shadow's leave.
+  async onChildRemove(child) {
+    await super.onChildRemove(child);
+    if(child.get('dropShadowOwner') && !legacyMode('legacyHolderEnterLeaveEvents'))
+      await this.closeStackGap();
+  }
+
   // a gap in a stacked holder closes as soon as the card that left it is gone
   async closeStackGap() {
     if(this.get('alignChildren') && (this.get('stackOffsetX') || this.get('stackOffsetY')))

--- a/client/js/widgets/holder.js
+++ b/client/js/widgets/holder.js
@@ -93,9 +93,18 @@ class Holder extends ImageWidget {
   // childrenPerOwner makes the holder a per-player hand, so what leaves it belongs to nobody
   // again. The other half of that is in onChildAdd(), because becoming a child is what claims
   // a widget, not the arrival event.
+  //
+  // A drag is the exception: it detaches the card at the pickup, long before it is anywhere
+  // else, and a card without an owner is one every other player can see. So a hand holds on to
+  // a dragged card until it is really out of its box, which is what checkParent() decides -
+  // rearranging a hand never exposes a card, because that drag never gets there.
   async applyLeave(child) {
-    if(child.get('type') != 'deck' && !child.isBeingRemoved && this.get('childrenPerOwner'))
+    if(child.get('type') != 'deck' && !child.isBeingRemoved && this.get('childrenPerOwner') && child.currentParent !== this)
       await child.set('owner', null);
+    // a widget on its way out of the room has no properties left to apply, but the gap it
+    // leaves in a stacked holder closes all the same
+    if(child.isBeingRemoved)
+      await this.closeStackGap();
     await super.applyLeave(child);
   }
 
@@ -127,13 +136,18 @@ class Holder extends ImageWidget {
         }
       }
     }
-    // a gap in a stacked holder closes as soon as the card that left it is gone
+    await this.closeStackGap();
+  }
+
+  // a gap in a stacked holder closes as soon as the card that left it is gone
+  async closeStackGap() {
     if(this.get('alignChildren') && (this.get('stackOffsetX') || this.get('stackOffsetY')))
       await this.receiveCard(null);
   }
 
   // The leave half as the legacy pipeline ran it: from checkParent() once the widget really is
-  // outside the holder, and from a pile that handed a card back while sitting in one.
+  // outside the holder, and from a pile that handed a card back while sitting in one. Nothing
+  // outside legacy mode calls this - applyLeave() is where a leave happens now.
   async dispenseCard(card) {
     await this.applyLeaveProperties(card);
     if(Array.isArray(this.get('leaveRoutine')))

--- a/client/js/widgets/holder.js
+++ b/client/js/widgets/holder.js
@@ -94,12 +94,13 @@ class Holder extends ImageWidget {
   // again. The other half of that is in onChildAdd(), because becoming a child is what claims
   // a widget, not the arrival event.
   //
-  // A drag is the exception: it detaches the card at the pickup, long before it is anywhere
-  // else, and a card without an owner is one every other player can see. So a hand holds on to
-  // a dragged card until it is really out of its box, which is what checkParent() decides -
-  // rearranging a hand never exposes a card, because that drag never gets there.
+  // Two exceptions. A drag detaches the card at the pickup, long before it is anywhere else,
+  // and a card without an owner is one every other player can see - so a hand holds on to a
+  // card that is still on the cursor until checkParent() decides it is really out of the box,
+  // which is why rearranging a hand never exposes a card. And MOVEXY has resetOwner, an
+  // explicit "put this on the table but keep it owned", which the leave must not override.
   async applyLeave(child) {
-    if(child.get('type') != 'deck' && !child.isBeingRemoved && this.get('childrenPerOwner') && child.currentParent !== this)
+    if(child.get('type') != 'deck' && !child.isBeingRemoved && this.get('childrenPerOwner') && !child.get('dragging') && !child.keepOwner)
       await child.set('owner', null);
     // a widget on its way out of the room has no properties left to apply, but the gap it
     // leaves in a stacked holder closes all the same

--- a/client/js/widgets/line.js
+++ b/client/js/widgets/line.js
@@ -673,7 +673,7 @@ export class Line extends Widget {
   // of the line, gets the onEnter properties applied and triggers enterRoutine
   // (which Widget.onPropertyChange does for every parent change).
   async onChildAdd(child, oldParentID) {
-    const entering = this != child.currentParent;
+    const enteringInLegacyMode = legacyMode('legacyHolderEnterLeaveEvents') && this != child.currentParent;
     await super.onChildAdd(child, oldParentID);
     // a rename re-adds the same stop under a new id; it carries no positioning
     // change, so skip the layout pass a real add/remove would trigger
@@ -685,7 +685,7 @@ export class Line extends Widget {
       await this.addStop(child.id, this.positionAtPoint(this.childCenter(child)));
     if(this.stopList().some(entry=>entry.widget == child.id))
       await this.layoutStops();
-    if(legacyMode('legacyHolderEnterLeaveEvents') && entering)
+    if(enteringInLegacyMode)
       await this.applyEnterLeave(child, 'onEnter');
   }
 
@@ -708,10 +708,10 @@ export class Line extends Widget {
   // Leaving the line again is the mirror of that: checkParent calls this hook -
   // named after the holder method it stands in for - once a widget is really
   // out, so the stop comes off the list and onLeave is applied. leaveRoutine is
-  // triggered by the parent change itself.
+  // triggered by the parent change itself. Nothing outside legacy mode calls
+  // this - applyLeaveProperties() is where a leave happens now.
   async dispenseCard(child) {
-    await this.removeStop(child.id);
-    await this.applyEnterLeave(child, 'onLeave');
+    await this.applyLeaveProperties(child);
   }
 
   // onEnter / onLeave hold properties to apply to the widget that entered or

--- a/client/js/widgets/line.js
+++ b/client/js/widgets/line.js
@@ -685,8 +685,19 @@ export class Line extends Widget {
       await this.addStop(child.id, this.positionAtPoint(this.childCenter(child)));
     if(this.stopList().some(entry=>entry.widget == child.id))
       await this.layoutStops();
-    if(entering)
+    if(legacyMode('legacyHolderEnterLeaveEvents') && entering)
       await this.applyEnterLeave(child, 'onEnter');
+  }
+
+  // The property half of the consolidated enter/leave pipeline - a line applies the same
+  // onEnter/onLeave a holder does, and drops the widget from its stop list on the way out.
+  async applyEnterProperties(child) {
+    await this.applyEnterLeave(child, 'onEnter');
+  }
+
+  async applyLeaveProperties(child) {
+    await this.removeStop(child.id);
+    await this.applyEnterLeave(child, 'onLeave');
   }
 
   // the middle of a child in the line's own coordinate frame

--- a/client/js/widgets/pile.js
+++ b/client/js/widgets/pile.js
@@ -267,7 +267,9 @@ export class Pile extends Widget {
       await removeWidgetLocal(this.get('id'));
     }
 
-    if(this.parent && this.parent.get('type') == 'holder')
+    // a card handed back by a pile inside a holder counts as leaving that holder, which the
+    // consolidated pipeline derives from the parent change itself (see enterLeaveContainer)
+    if(legacyMode('legacyHolderEnterLeaveEvents') && this.parent && this.parent.get('type') == 'holder')
       await this.parent.dispenseCard(child);
   }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -39,13 +39,14 @@ const readOnlyProperties = new Set([
   '_localOriginAbsoluteY'
 ]);
 
-// The widget whose enter and leave events a child of `parent` belongs to. A pile is transparent
-// here: it is a stack of cards inside whatever holds it, not a container a card can enter or
-// leave on its own, so a card that joins or leaves a pile inside its holder stays in that
-// holder. Returns null for a widget that sits on the table.
+// The widget whose enter and leave events a child of `parent` belongs to. A pile inside a
+// holder is transparent: it is a stack of cards in that holder, not a container a card can
+// enter or leave on its own, so a card that joins or leaves it stays in the holder. A pile on
+// the table has nothing behind it and is its own container. Returns null for a widget that
+// sits on the table itself.
 function enterLeaveContainer(parent) {
-  if(parent && parent.get('type') == 'pile')
-    return widgets.has(parent.get('parent')) ? widgets.get(parent.get('parent')) : null;
+  if(parent && parent.get('type') == 'pile' && widgets.has(parent.get('parent')))
+    return widgets.get(parent.get('parent'));
   return parent || null;
 }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -3165,17 +3165,20 @@ export class Widget extends StateManaged {
     const newParent = newValue && widgets.has(newValue) ? widgets.get(newValue) : null;
     const leaveTarget = enterLeaveContainer(oldParent);
     const enterTarget = enterLeaveContainer(newParent);
-    const changesContainer = leaveTarget !== enterTarget;
+    // a drop shadow is a preview of where the dragged widget would land: it is parented into the
+    // holder under the pointer and taken out again while the drag is still going on, so it takes
+    // part in the layout but enters and leaves nothing
+    const raisesEvents = leaveTarget !== enterTarget && !this.get('dropShadowOwner');
 
     if(oldParent)
       await oldParent.onChildRemove(this);
     // a pile is created with its parent already set and destroyed once it holds one card, so
     // neither end of its life is a widget entering or leaving the holder it forms in
-    if(leaveTarget && changesContainer && !(this.isBeingRemoved && this.get('type') == 'pile'))
+    if(leaveTarget && raisesEvents && !(this.isBeingRemoved && this.get('type') == 'pile'))
       await leaveTarget.applyLeave(this);
     if(newParent)
       await newParent.onChildAdd(this, oldValue);
-    if(enterTarget && changesContainer)
+    if(enterTarget && raisesEvents)
       await enterTarget.applyEnter(this, oldValue);
   }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2097,9 +2097,12 @@ export class Widget extends StateManaged {
               await c.setPosition(a.x, a.y, a.z || c.get('z'));
               if(a.resetOwner)
                 await c.set('owner', null);
+              else
+                c.keepOwner = true;
               if(a.snapToGrid)
                 await c.snapToGrid();
               await c.set('parent', null);
+              delete c.keepOwner;
             }
           });
           if(routineLogging) {
@@ -3105,6 +3108,10 @@ export class Widget extends StateManaged {
 
     await this.updatePiles();
     delete this.pileUpdateFromDrag;
+    // currentParent only means "the container this drag started in". A drag that ends inside
+    // that container never gets to the branch in checkParent() that forgets it, so the drag has
+    // to drop it here - a leftover would tell the next move that a drag is still going on.
+    delete this.currentParent;
   }
 
   async hideShadowWidget() {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -39,6 +39,16 @@ const readOnlyProperties = new Set([
   '_localOriginAbsoluteY'
 ]);
 
+// The widget whose enter and leave events a child of `parent` belongs to. A pile is transparent
+// here: it is a stack of cards inside whatever holds it, not a container a card can enter or
+// leave on its own, so a card that joins or leaves a pile inside its holder stays in that
+// holder. Returns null for a widget that sits on the table.
+function enterLeaveContainer(parent) {
+  if(parent && parent.get('type') == 'pile')
+    return widgets.has(parent.get('parent')) ? widgets.get(parent.get('parent')) : null;
+  return parent || null;
+}
+
 function inputFieldValueForPlayer(value, player, playerIndex) {
   if(!value || typeof value != 'object' || Array.isArray(value))
     return value;
@@ -458,14 +468,19 @@ export class Widget extends StateManaged {
     return this.children().filter(c=>!c.get('owner') || c.get('owner')==playerName);
   }
 
+  // Detach a dragged widget from the container it was picked up in, once it no longer overlaps
+  // it (or right away when the caller forces it). Clearing the parent is what raises the leave
+  // event; this method only forgets where the drag came from.
   async checkParent(forceDetach) {
     if(this.currentParent && (forceDetach || !overlap(this.domElement, this.currentParent.domElement))) {
       await this.set('parent', null);
       await this.set('hoverParent', null);
-      if(this.currentParent.get('childrenPerOwner'))
-        await this.set('owner',  null);
-      if(this.currentParent.dispenseCard)
-        await this.currentParent.dispenseCard(this);
+      if(legacyMode('legacyHolderEnterLeaveEvents')) {
+        if(this.currentParent.get('childrenPerOwner'))
+          await this.set('owner',  null);
+        if(this.currentParent.dispenseCard)
+          await this.currentParent.dispenseCard(this);
+      }
       delete this.currentParent;
     }
   }
@@ -3135,6 +3150,79 @@ export class Widget extends StateManaged {
     this.applyZ();
   }
 
+  // One parent change, at most one leave and one enter. Every way of moving a widget - a drag,
+  // MOVE, MOVEXY, SET parent, CLONE, RECALL, the JSON editor - ends up writing `parent`, so
+  // this is the single place both halves of an event happen: first the properties the container
+  // applies (onLeave / onEnter, childrenPerOwner), then its routine, which therefore always
+  // reads the values the event has already written.
+  //
+  // Which container an event belongs to is decided by enterLeaveContainer(), so a parent change
+  // that keeps the widget in the same holder - joining, leaving or dissolving a pile inside it -
+  // raises no event at all.
+  async applyParentChange(oldValue, newValue) {
+    const oldParent = oldValue && widgets.has(oldValue) ? widgets.get(oldValue) : null;
+    const newParent = newValue && widgets.has(newValue) ? widgets.get(newValue) : null;
+    const leaveTarget = enterLeaveContainer(oldParent);
+    const enterTarget = enterLeaveContainer(newParent);
+    const changesContainer = leaveTarget !== enterTarget;
+
+    if(oldParent)
+      await oldParent.onChildRemove(this);
+    // a pile is created with its parent already set and destroyed once it holds one card, so
+    // neither end of its life is a widget entering or leaving the holder it forms in
+    if(leaveTarget && changesContainer && !(this.isBeingRemoved && this.get('type') == 'pile'))
+      await leaveTarget.applyLeave(this);
+    if(newParent)
+      await newParent.onChildAdd(this, oldValue);
+    if(enterTarget && changesContainer)
+      await enterTarget.applyEnter(this, oldValue);
+  }
+
+  // What a parent change did before the enter/leave pipeline was consolidated: leaveRoutine
+  // straight from here (and a second time from checkParent, through dispenseCard), onEnter and
+  // enterRoutine from the receiving side, and no onLeave for anything that did not go through
+  // a drag or moveToHolder.
+  async applyLegacyParentChange(oldValue, newValue) {
+    if(oldValue) {
+      const oldParent = widgets.get(oldValue);
+      await oldParent.onChildRemove(this);
+      if(this.get('type') != 'holder' && Array.isArray(oldParent.get('leaveRoutine')))
+        await oldParent.evaluateRoutine('leaveRoutine', {}, { child: [ this ] });
+    }
+    if(newValue) {
+      const newParent = widgets.get(newValue);
+      await newParent.onChildAdd(this, oldValue);
+      if(Array.isArray(newParent.get('enterRoutine')))
+        await newParent.evaluateRoutine('enterRoutine', { oldParentID: oldValue === undefined ? null : oldValue }, { child: [ this ] });
+    }
+  }
+
+  // The two halves of an enter event, in the order a game can rely on: the properties this
+  // container applies to what it received, then its enterRoutine. Holders and lines add their
+  // property half by overriding applyEnterProperties().
+  async applyEnter(child, oldParentID) {
+    await this.applyEnterProperties(child);
+    if(Array.isArray(this.get('enterRoutine')))
+      await this.evaluateRoutine('enterRoutine', { oldParentID: oldParentID === undefined ? null : oldParentID }, { child: [ child ] });
+  }
+
+  async applyLeave(child) {
+    // a widget on its way out of the room has nothing left to apply properties to, but the
+    // holder still gets told that it left
+    if(!child.isBeingRemoved)
+      await this.applyLeaveProperties(child);
+    if(child.get('type') != 'holder' && Array.isArray(this.get('leaveRoutine')))
+      await this.evaluateRoutine('leaveRoutine', {}, { child: [ child ] });
+  }
+
+  // The property half of an event. A plain widget has none - holders and lines override these
+  // with their onEnter/onLeave handling.
+  async applyEnterProperties(child) {
+  }
+
+  async applyLeaveProperties(child) {
+  }
+
   async onPropertyChange(property, oldValue, newValue) {
     if(property == 'parent') {
       // deleting a stop takes it off the lines that list it; a rename is a
@@ -3142,18 +3230,10 @@ export class Widget extends StateManaged {
       if(this.isBeingRemoved && !this.isBeingRenamed)
         for(const line of linesWithStop(this.id))
           await line.removeStop(this.id);
-      if(oldValue) {
-        const oldParent = widgets.get(oldValue);
-        await oldParent.onChildRemove(this);
-        if(this.get('type') != 'holder' && Array.isArray(oldParent.get('leaveRoutine')))
-          await oldParent.evaluateRoutine('leaveRoutine', {}, { child: [ this ] });
-      }
-      if(newValue) {
-        const newParent = widgets.get(newValue);
-        await newParent.onChildAdd(this, oldValue);
-        if(Array.isArray(newParent.get('enterRoutine')))
-          await newParent.evaluateRoutine('enterRoutine', { oldParentID: oldValue === undefined ? null : oldValue }, { child: [ this ] });
-      }
+      if(legacyMode('legacyHolderEnterLeaveEvents'))
+        await this.applyLegacyParentChange(oldValue, newValue);
+      else
+        await this.applyParentChange(oldValue, newValue);
       if(!this.disablePileUpdateAfterParentChange)
         await this.updatePiles();
     }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -39,11 +39,11 @@ const readOnlyProperties = new Set([
   '_localOriginAbsoluteY'
 ]);
 
-// The widget whose enter and leave events a child of `parent` belongs to. A pile inside a
-// holder is transparent: it is a stack of cards in that holder, not a container a card can
-// enter or leave on its own, so a card that joins or leaves it stays in the holder. A pile on
-// the table has nothing behind it and is its own container. Returns null for a widget that
-// sits on the table itself.
+// The widget whose enter and leave events a child of `parent` belongs to. A pile inside
+// another widget is transparent: it is a stack of cards in that widget, not a container a card
+// can enter or leave on its own, so a card that joins or leaves it stays in whatever holds the
+// pile. A pile on the table has nothing behind it and is its own container. Returns null for a
+// widget that sits on the table itself.
 function enterLeaveContainer(parent) {
   if(parent && parent.get('type') == 'pile' && widgets.has(parent.get('parent')))
     return widgets.get(parent.get('parent'));
@@ -471,17 +471,17 @@ export class Widget extends StateManaged {
 
   // Detach a dragged widget from the container it was picked up in, once it no longer overlaps
   // it (or right away when the caller forces it). Clearing the parent is what raises the leave
-  // event; this method only forgets where the drag came from.
+  // event; this method only forgets where the drag came from - and hands a per-player hand the
+  // card back, which happens here rather than with the rest of the event because a card is only
+  // out of a hand once it is out of its box (see Holder.applyLeave).
   async checkParent(forceDetach) {
     if(this.currentParent && (forceDetach || !overlap(this.domElement, this.currentParent.domElement))) {
       await this.set('parent', null);
       await this.set('hoverParent', null);
-      if(legacyMode('legacyHolderEnterLeaveEvents')) {
-        if(this.currentParent.get('childrenPerOwner'))
-          await this.set('owner',  null);
-        if(this.currentParent.dispenseCard)
-          await this.currentParent.dispenseCard(this);
-      }
+      if(this.currentParent.get('childrenPerOwner'))
+        await this.set('owner',  null);
+      if(legacyMode('legacyHolderEnterLeaveEvents') && this.currentParent.dispenseCard)
+        await this.currentParent.dispenseCard(this);
       delete this.currentParent;
     }
   }
@@ -3041,8 +3041,8 @@ export class Widget extends StateManaged {
       if(!this.get('fixedParent'))
         await this.moveToHolder(line);
     } else if(from && from.get('type') == 'line' && !this.get('fixedParent')) {
-      // dropping it off the line hands it back to the room, which lets the line
-      // dispense it: onLeave is applied and the stop comes off the list
+      // dropping it off the line hands it back to the room, which is the line's
+      // leave event: onLeave is applied and the stop comes off the list
       this.currentParent = from;
       await this.checkParent(true);
     }

--- a/server/fileupdater.mjs
+++ b/server/fileupdater.mjs
@@ -1,6 +1,6 @@
 import { LEGACY_MODES } from '../client/js/legacymoderegistry.js';
 
-export const VERSION = 22;
+export const VERSION = 23;
 
 export default function FileUpdater(state) {
   const v = state._meta.version;

--- a/tests/client/engine/bundle-widgets.js
+++ b/tests/client/engine/bundle-widgets.js
@@ -12,6 +12,8 @@
 // what the tests are about.
 
 import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
 
 import { asArray, mapAssetURLs } from '../../../client/js/domhelpers.js';
 import { compareDropTarget, dropTargets, exceedsDropLimit, getMaxZ, getSVG, resetMaxZ, showOverlay, shuffleWidgets, sortWidgets, updateMaxZ } from '../../../client/js/main.js';
@@ -29,8 +31,12 @@ export function resetGeneratedIDs() {
   generatedIDs = 0;
 }
 
+// jsdom replaces the global URL with its own, which fs does not accept as a path - so the
+// directory is resolved once, through Node's own url module
+const widgetsDirectory = join(dirname(fileURLToPath(import.meta.url)), '../../../client/js/widgets');
+
 function bundleSource(file) {
-  return readFileSync(new URL(`../../../client/js/widgets/${file}`, import.meta.url), 'utf8');
+  return readFileSync(join(widgetsDirectory, file), 'utf8');
 }
 
 function bundleClass(file, name) {

--- a/tests/client/engine/bundle-widgets.js
+++ b/tests/client/engine/bundle-widgets.js
@@ -1,0 +1,131 @@
+// Real Holder and Pile classes inside jsdom.
+//
+// imagewidget.js and holder.js are not modules: the shipped bundle concatenates every client
+// file into one scope, so their classes are plain globals with no export. Evaluating them the
+// same way the bundle does is what makes a holder testable in Layer A at all - the alternative
+// is one TestCafe fixture per assertion, and holder events have far too many combinations for
+// that to be affordable.
+//
+// What the room provides and jsdom does not is stubbed here: rendering (icons, SVG, text
+// fitting) does nothing, while everything that decides *structure* - drop target matching,
+// the widget map, adding and removing widgets - is the real implementation, because that is
+// what the tests are about.
+
+import { readFileSync } from 'fs';
+
+import { asArray, mapAssetURLs } from '../../../client/js/domhelpers.js';
+import { compareDropTarget, dropTargets, exceedsDropLimit, getMaxZ, getSVG, resetMaxZ, showOverlay, shuffleWidgets, sortWidgets, updateMaxZ } from '../../../client/js/main.js';
+import { addWidget, batchEnd, batchStart, flushDelta, widgetFilter, widgets } from '../../../client/js/serverstate.js';
+import { legacyMode } from '../../../client/js/legacymodes.js';
+import { Widget } from '../../../client/js/widgets/widget.js';
+import { Label } from '../../../client/js/widgets/label.js';
+
+let widgetClasses = null;
+let generatedIDs = 0;
+
+// Generated ids appear in assertions (a pile a drop created is somebody's parent), so the
+// counter restarts with every room rather than counting up across a whole file.
+export function resetGeneratedIDs() {
+  generatedIDs = 0;
+}
+
+function bundleSource(file) {
+  return readFileSync(new URL(`../../../client/js/widgets/${file}`, import.meta.url), 'utf8');
+}
+
+function bundleClass(file, name) {
+  return new Function(`${bundleSource(file)}\nreturn ${name};`)();
+}
+
+function classForType(type) {
+  return widgetClasses[type] || Widget;
+}
+
+// The two serverstate functions the widget code reaches for as globals. addWidgetLocal is how
+// updatePiles() creates a pile; removeWidgetLocal is how DELETE and a pile that has shrunk to
+// one card take a widget out again - and taking it out is a parent change, which is exactly
+// what the enter/leave pipeline reacts to.
+async function addWidgetLocal(definition) {
+  const id = definition.id || `generated-${++generatedIDs}`;
+  addWidget(Object.assign({}, definition, { id }), new (classForType(definition.type))(id));
+  return id;
+}
+
+async function removeWidgetLocal(widgetID, keepChildren) {
+  const widget = widgets.get(widgetID);
+  if(!widget || widget.inRemovalQueue)
+    return;
+
+  const toRemove = [];
+  (function collect(id) {
+    if(!keepChildren)
+      for(const [ childID, child ] of widgets)
+        if(!child.inRemovalQueue && child.get('parent') == id)
+          collect(childID);
+    widgets.get(id).inRemovalQueue = true;
+    toRemove.push(widgets.get(id));
+  })(widgetID);
+
+  for(const w of toRemove) {
+    w.isBeingRemoved = true;
+    await w.onPropertyChange('parent', w.get('parent'), null);
+    w.applyRemove();
+    widgets.delete(w.get('id'));
+    dropTargets.delete(w.get('id'));
+  }
+}
+
+// Everything the bundle declares and jsdom does not have. Called once; the classes are cached
+// because re-evaluating them would give every fixture a different Holder prototype.
+export async function bundleWidgetClasses() {
+  if(widgetClasses)
+    return widgetClasses;
+
+  Object.assign(globalThis, {
+    Widget,
+    legacyMode,
+    widgets,
+    widgetFilter,
+    dropTargets,
+    compareDropTarget,
+    exceedsDropLimit,
+    getMaxZ,
+    resetMaxZ,
+    updateMaxZ,
+    showOverlay,
+    shuffleWidgets,
+    sortWidgets,
+    getSVG,
+    batchStart,
+    batchEnd,
+    flushDelta,
+    asArray,
+    mapAssetURLs,
+    addWidgetLocal,
+    removeWidgetLocal,
+    playerName: 'jestPlayer',
+    tracingEnabled: false,
+    jeRoutineLogging: false,
+    sendTraceEvent: () => {},
+    setDeltaCause: () => {},
+    setText: () => {},
+    setTextAndAdjustFontSize: () => {},
+    generateSymbolsDiv: () => document.createElement('div'),
+    getIconDetails: () => null,
+    getValidDropTargets: () => [],
+    $: () => null
+  });
+
+  globalThis.ImageWidget = bundleClass('imagewidget.js', 'ImageWidget');
+  // updatePiles() in widget.js reads pile.js's defaultPileSnapRange, which the bundle shares as
+  // one scope but an imported module keeps private. Take it from the source so it cannot drift.
+  globalThis.defaultPileSnapRange = Number(bundleSource('pile.js').match(/defaultPileSnapRange = (\d+)/)[1]);
+  const { Pile } = await import('../../../client/js/widgets/pile.js');
+  widgetClasses = {
+    widget: Widget,
+    label: Label,
+    holder: bundleClass('holder.js', 'Holder'),
+    pile: Pile
+  };
+  return widgetClasses;
+}

--- a/tests/client/engine/enterleave.test.js
+++ b/tests/client/engine/enterleave.test.js
@@ -520,6 +520,25 @@ describe('piles', () => {
     ]);
   });
 
+  // A pile on the table has no holder behind it, so it is a container of its own and its own
+  // routines are what a card entering or leaving it raises.
+  // away from the origin, so a card that leaves it keeps coordinates far enough away for
+  // updatePiles() not to put it straight back
+  const tracedPile = { type: 'pile', x: 500, y: 500, enterRoutine: traceRoutine('enter pile1'), leaveRoutine: traceRoutine('leave pile1') };
+
+  test('a card leaving a pile on the table raises that pile\'s leave event', async () => {
+    // three cards, so taking one out does not dissolve the pile in the same breath
+    setupRoom(room({ pile1: tracedPile, c1: { type: 'card', parent: 'pile1' }, c2: { type: 'card', parent: 'pile1' }, c3: { type: 'card', parent: 'pile1' } }));
+    await clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'SET', property: 'parent', value: null } ]);
+    expect(trace()).toEqual([ 'leave pile1 c1[parent=null mark=null owner=null]' ]);
+  });
+
+  test('a card joining a pile on the table raises that pile\'s enter event', async () => {
+    setupRoom(room({ pile1: tracedPile, c2: { type: 'card', parent: 'pile1' }, c3: { type: 'card', parent: 'pile1' } }));
+    await clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'SET', property: 'parent', value: 'pile1' } ]);
+    expect(trace()).toEqual([ 'enter pile1 c1[parent=pile1 mark=null owner=null]' ]);
+  });
+
   test('a preventPiles holder unpacks a dropped pile without extra events', async () => {
     setupRoom(room({ pile1: { type: 'pile' }, c1: { type: 'card', parent: 'pile1' }, c2: { type: 'card', parent: 'pile1' } },
       { preventPiles: true }));

--- a/tests/client/engine/enterleave.test.js
+++ b/tests/client/engine/enterleave.test.js
@@ -1,0 +1,579 @@
+import { widgets } from '../../../client/js/serverstate.js';
+import { setupRoom, useBundleWidgets } from './harness.js';
+
+// Holder enter/leave events, one assertion per combination of "how did the widget move" and
+// "what is the holder configured to do about it". Both answers are written down: the modern
+// one the engine gives now, and the one the legacyHolderEnterLeaveEvents mode restores.
+//
+// The trace is a string a holder's enterRoutine/leaveRoutine appends to, carrying the widget
+// the event was about and the properties it had *at that moment* - which is the whole point:
+// `mark=null` means the routine ran before the property half of its own event, and `parent=`
+// says whether the move was already written when the routine looked.
+//
+// What Layer A can and cannot say: routine-driven moves (MOVE, MOVEXY, SET, CLONE, RECALL,
+// DELETE) run the real operation, so those cases are exact. A drag has no layout in jsdom, so
+// dragWidget() below replays the parent bookkeeping the drag performs rather than the drag
+// itself - the real pointer path is covered by tests/testcafe/holderevents.js and
+// tests/testcafe/enterleave.js. Coordinates are never asserted here (see harness.js).
+//
+// One more jsdom gap has a visible consequence: widget.parent, the link pile.js reads to hand
+// a card back to the holder it sits in, is written by applyDeltaToDOM(), which only runs for a
+// delta coming back from a server. The legacy pipeline used that link, so legacy expectations
+// for cards leaving a pile *inside* a holder live in the TestCafe fixtures instead.
+
+beforeAll(() => useBundleWidgets());
+
+const FIELDS = [ 'parent', 'mark', 'owner' ];
+
+// One trace entry: the tag, the id of the widget in the `child` collection and the fields read
+// off it. Reading the log through ${PROPERTY trace OF log} rather than a variable is what makes
+// entries accumulate across the separate routine invocations the engine makes.
+function traceRoutine(tag, fields = FIELDS) {
+  return [
+    { func: 'GET', collection: 'child', property: 'id', variable: 'childID' },
+    ...fields.map(property => ({ func: 'GET', collection: 'child', property, variable: `f_${property}` })),
+    { func: 'SELECT', property: 'id', value: 'log', collection: 'log' },
+    { func: 'SET', collection: 'log', property: 'trace',
+      value: `\${PROPERTY trace OF log}${tag} \${childID}[${fields.map(p=>`${p}=\${f_${p}}`).join(' ')}];` }
+  ];
+}
+
+function holder(id, properties = {}, fields = FIELDS) {
+  return Object.assign({
+    type: 'holder',
+    onEnter: { mark: `enter-${id}` },
+    onLeave: { mark: `leave-${id}` },
+    enterRoutine: traceRoutine(`enter ${id}`, fields),
+    leaveRoutine: traceRoutine(`leave ${id}`, fields)
+  }, properties);
+}
+
+// A room with two traced holders, a card on the table and a button to run routines from.
+function room(overrides = {}, holderOptions = {}, fields = FIELDS) {
+  const state = {
+    trigger: { type: 'button' },
+    log: { type: 'widget', trace: '' },
+    handA: holder('handA', holderOptions, fields),
+    handB: holder('handB', holderOptions, fields),
+    c1: { type: 'card' }
+  };
+  for(const [ id, properties ] of Object.entries(overrides))
+    state[id] = state[id] ? Object.assign({}, state[id], properties) : properties;
+  return state;
+}
+
+function trace() {
+  return String(widgets.get('log').get('trace') || '').split(';').filter(entry => entry);
+}
+
+// The parent bookkeeping a drag performs, without the pointer: moveStart() detaches the widget,
+// move() lets checkParent() drop it once it is out of the holder's box, and moveEnd() hands it
+// to the holder it was released over. `leavesBox: false` is a drag that never left the holder
+// it started in, which is the one case where the two differ.
+async function dragWidget(id, { to = null, leavesBox = true } = {}) {
+  const widget = widgets.get(id);
+  const ancestor = widget.get('_ancestor');
+
+  if(widgets.has(ancestor))
+    widget.currentParent = widgets.get(ancestor);
+  widget.disablePileUpdateAfterParentChange = true;
+  await widget.set('parent', null);
+  delete widget.disablePileUpdateAfterParentChange;
+
+  if(leavesBox)
+    await widget.checkParent(true);
+
+  widget.pileUpdateFromDrag = true;
+  if(to)
+    await widget.moveToHolder(widgets.get(to));
+  await widget.updatePiles();
+  delete widget.pileUpdateFromDrag;
+  delete widget.currentParent;
+}
+
+async function clickRoutine(routine) {
+  await widgets.get('trigger').evaluateRoutine(routine, {}, {});
+}
+
+// Run the same scenario in both combinations and assert both traces. A case that is supposed to
+// be unaffected by the mode passes the same array twice, which is what makes "this behaviour did
+// not change" an assertion rather than an omission.
+function scenario(name, build, action, expectations) {
+  for(const [ combination, expected ] of Object.entries(expectations)) {
+    const legacy = combination == 'legacy' ? { legacyHolderEnterLeaveEvents: true } : {};
+    test(`${name} [${combination}]`, async () => {
+      setupRoom(build(), { legacy });
+      await action();
+      expect(trace()).toEqual(expected);
+    });
+  }
+}
+
+// ------------------------------------------------------------------------------------------
+// Dragging
+// ------------------------------------------------------------------------------------------
+
+describe('dragging', () => {
+  scenario('a card from the table into a holder enters once',
+    () => room(),
+    () => dragWidget('c1', { to: 'handB' }),
+    {
+      modern: [ 'enter handB c1[parent=handB mark=enter-handB owner=null]' ],
+      legacy: [ 'enter handB c1[parent=handB mark=enter-handB owner=null]' ]
+    });
+
+  scenario('a card out of a holder onto the table leaves once',
+    () => room({ c1: { type: 'card', parent: 'handA' } }),
+    () => dragWidget('c1'),
+    {
+      // one departure, with onLeave applied before the routine reads it
+      modern: [ 'leave handA c1[parent=null mark=leave-handA owner=null]' ],
+      // the two firing sites of issue #480: the detach and the dispense
+      legacy: [
+        'leave handA c1[parent=null mark=null owner=null]',
+        'leave handA c1[parent=null mark=leave-handA owner=null]'
+      ]
+    });
+
+  scenario('a card from one holder to another leaves and enters once each',
+    () => room({ c1: { type: 'card', parent: 'handA' } }),
+    () => dragWidget('c1', { to: 'handB' }),
+    {
+      modern: [
+        'leave handA c1[parent=null mark=leave-handA owner=null]',
+        'enter handB c1[parent=handB mark=enter-handB owner=null]'
+      ],
+      legacy: [
+        'leave handA c1[parent=null mark=null owner=null]',
+        'leave handA c1[parent=null mark=leave-handA owner=null]',
+        'enter handB c1[parent=handB mark=enter-handB owner=null]'
+      ]
+    });
+
+  scenario('a card dragged within its holder leaves and enters it again',
+    () => room({ c1: { type: 'card', parent: 'handA' } }),
+    () => dragWidget('c1', { to: 'handA', leavesBox: false }),
+    {
+      // the properties and the routines agree that the card left and came back
+      modern: [
+        'leave handA c1[parent=null mark=leave-handA owner=null]',
+        'enter handA c1[parent=handA mark=enter-handA owner=null]'
+      ],
+      // the legacy pipeline recognised the return by currentParent and skipped onEnter, so the
+      // routine said "entered" while the properties said nothing had happened
+      legacy: [
+        'leave handA c1[parent=null mark=null owner=null]',
+        'enter handA c1[parent=handA mark=null owner=null]'
+      ]
+    });
+
+  scenario('a card dragged out of a holder and back before the drop',
+    () => room({ c1: { type: 'card', parent: 'handA' } }),
+    () => dragWidget('c1', { to: 'handA' }),
+    {
+      modern: [
+        'leave handA c1[parent=null mark=leave-handA owner=null]',
+        'enter handA c1[parent=handA mark=enter-handA owner=null]'
+      ],
+      legacy: [
+        'leave handA c1[parent=null mark=null owner=null]',
+        'leave handA c1[parent=null mark=leave-handA owner=null]',
+        'enter handA c1[parent=handA mark=enter-handA owner=null]'
+      ]
+    });
+
+  scenario('a holder without routines fires nothing',
+    () => room({ handA: { enterRoutine: null, leaveRoutine: null, onEnter: {}, onLeave: {} }, handB: { enterRoutine: null, leaveRoutine: null, onEnter: {}, onLeave: {} }, c1: { type: 'card', parent: 'handA' } }),
+    () => dragWidget('c1', { to: 'handB' }),
+    { modern: [], legacy: [] });
+});
+
+// ------------------------------------------------------------------------------------------
+// Routines that move widgets
+// ------------------------------------------------------------------------------------------
+
+describe('MOVE', () => {
+  scenario('from one holder to another',
+    () => room({ c1: { type: 'card', parent: 'handA' } }),
+    () => clickRoutine([ { func: 'MOVE', from: 'handA', to: 'handB', count: 1 } ]),
+    {
+      modern: [
+        'leave handA c1[parent=null mark=leave-handA owner=null]',
+        'enter handB c1[parent=handB mark=enter-handB owner=null]'
+      ],
+      // moveToHolder() detaches through checkParent(), so MOVE inherited the doubled leave -
+      // and its second call ran after the card had already arrived in handB
+      legacy: [
+        'leave handA c1[parent=null mark=null owner=null]',
+        'leave handA c1[parent=null mark=leave-handA owner=null]',
+        'enter handB c1[parent=handB mark=enter-handB owner=null]'
+      ]
+    });
+
+  scenario('of a collection into a holder',
+    () => room({ c1: { type: 'card', parent: 'handA' } }),
+    () => clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'MOVE', to: 'handB' } ]),
+    {
+      modern: [
+        'leave handA c1[parent=null mark=leave-handA owner=null]',
+        'enter handB c1[parent=handB mark=enter-handB owner=null]'
+      ],
+      legacy: [
+        'leave handA c1[parent=null mark=null owner=null]',
+        'leave handA c1[parent=null mark=leave-handA owner=null]',
+        'enter handB c1[parent=handB mark=enter-handB owner=null]'
+      ]
+    });
+
+  scenario('from the table into a holder only enters',
+    () => room(),
+    () => clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'MOVE', to: 'handB' } ]),
+    {
+      modern: [ 'enter handB c1[parent=handB mark=enter-handB owner=null]' ],
+      legacy: [ 'enter handB c1[parent=handB mark=enter-handB owner=null]' ]
+    });
+
+  scenario('into the holder the widget is already in fires nothing',
+    () => room({ c1: { type: 'card', parent: 'handA' } }),
+    () => clickRoutine([ { func: 'MOVE', from: 'handA', to: 'handA', count: 1 } ]),
+    { modern: [], legacy: [] });
+
+  scenario('to a seat moves into that seat\'s hand',
+    () => room({
+      c1: { type: 'card', parent: 'handA' },
+      seat1: { type: 'seat', hand: 'handB', player: 'jestPlayer' },
+      handB: { childrenPerOwner: true }
+    }),
+    () => clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'MOVE', to: 'seat1' } ]),
+    {
+      modern: [
+        'leave handA c1[parent=null mark=leave-handA owner=null]',
+        'enter handB c1[parent=handB mark=enter-handB owner=jestPlayer]'
+      ],
+      legacy: [
+        'leave handA c1[parent=null mark=null owner=null]',
+        'leave handA c1[parent=null mark=leave-handA owner=null]',
+        'enter handB c1[parent=handB mark=enter-handB owner=jestPlayer]'
+      ]
+    });
+});
+
+describe('MOVEXY', () => {
+  scenario('out of a holder applies onLeave and leaves once',
+    () => room({ c1: { type: 'card', parent: 'handA' } }),
+    () => clickRoutine([ { func: 'MOVEXY', from: 'handA', x: 600, y: 300 } ]),
+    {
+      // issue #1371: the departure is the same event however the widget was moved
+      modern: [ 'leave handA c1[parent=null mark=leave-handA owner=null]' ],
+      // the legacy pipeline never reached dispenseCard() here, so onLeave was skipped entirely
+      legacy: [ 'leave handA c1[parent=null mark=null owner=null]' ]
+    });
+
+  scenario('of a widget that is already on the table fires nothing',
+    () => room({ c1: { type: 'card' } }),
+    () => clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'MOVEXY', from: 'handA', x: 10, y: 10 } ]),
+    { modern: [], legacy: [] });
+});
+
+describe('SET parent', () => {
+  scenario('from one holder to another leaves and enters',
+    () => room({ c1: { type: 'card', parent: 'handA' } }),
+    () => clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'SET', property: 'parent', value: 'handB' } ]),
+    {
+      // issue #1836: onLeave is applied whichever way the parent changed. The parent is already
+      // the destination when the routines run, because SET writes it before the event.
+      modern: [
+        'leave handA c1[parent=handB mark=leave-handA owner=null]',
+        'enter handB c1[parent=handB mark=enter-handB owner=null]'
+      ],
+      legacy: [
+        'leave handA c1[parent=handB mark=null owner=null]',
+        'enter handB c1[parent=handB mark=enter-handB owner=null]'
+      ]
+    });
+
+  scenario('to null leaves',
+    () => room({ c1: { type: 'card', parent: 'handA' } }),
+    () => clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'SET', property: 'parent', value: null } ]),
+    {
+      modern: [ 'leave handA c1[parent=null mark=leave-handA owner=null]' ],
+      legacy: [ 'leave handA c1[parent=null mark=null owner=null]' ]
+    });
+
+  scenario('from the table into a holder enters',
+    () => room(),
+    () => clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'SET', property: 'parent', value: 'handB' } ]),
+    {
+      modern: [ 'enter handB c1[parent=handB mark=enter-handB owner=null]' ],
+      legacy: [ 'enter handB c1[parent=handB mark=enter-handB owner=null]' ]
+    });
+});
+
+describe('other operations', () => {
+  scenario('CLONE into another holder enters',
+    () => room({ c1: { type: 'card', parent: 'handA' } }),
+    () => clickRoutine([
+      { func: 'SELECT', property: 'id', value: 'c1' },
+      { func: 'CLONE', count: 1, properties: { id: 'clone1', parent: 'handB' } }
+    ]),
+    {
+      modern: [ 'enter handB clone1[parent=handB mark=enter-handB owner=null]' ],
+      legacy: [ 'enter handB clone1[parent=handB mark=enter-handB owner=null]' ]
+    });
+
+  scenario('CLONE inside a holder piles the copy onto the original',
+    () => room({ c1: { type: 'card', parent: 'handA' } }),
+    () => clickRoutine([
+      { func: 'SELECT', property: 'id', value: 'c1' },
+      { func: 'CLONE', count: 1, properties: { id: 'clone1' } }
+    ]),
+    {
+      // the copy arrives in handA, and the pile the two of them form inside it is not a
+      // second move: issue #1094
+      modern: [ 'enter handA clone1[parent=handA mark=enter-handA owner=null]' ],
+      legacy: [
+        'enter handA clone1[parent=handA mark=enter-handA owner=null]',
+        'leave handA c1[parent=generated-1 mark=null owner=null]',
+        'leave handA clone1[parent=generated-1 mark=enter-handA owner=null]'
+      ]
+    });
+
+  scenario('DELETE of a card in a holder leaves without applying onLeave',
+    () => room({ c1: { type: 'card', parent: 'handA' } }),
+    () => clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'DELETE' } ]),
+    {
+      // a widget on its way out of the room has nothing left to apply properties to, but the
+      // holder is still told that it lost a card
+      modern: [ 'leave handA c1[parent=handA mark=null owner=null]' ],
+      legacy: [ 'leave handA c1[parent=handA mark=null owner=null]' ]
+    });
+
+  scenario('a card that never changes parent fires nothing',
+    () => room({ c1: { type: 'card', parent: 'handA' } }),
+    () => clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'SET', property: 'x', value: 42 } ]),
+    { modern: [], legacy: [] });
+});
+
+// ------------------------------------------------------------------------------------------
+// The holder properties that change what an event does
+// ------------------------------------------------------------------------------------------
+
+describe('holder properties', () => {
+  scenario('childrenPerOwner claims what enters and releases what leaves',
+    () => room({ handA: { childrenPerOwner: true }, handB: { childrenPerOwner: true }, c1: { type: 'card', parent: 'handA', owner: 'jestPlayer' } }),
+    () => dragWidget('c1', { to: 'handB' }),
+    {
+      modern: [
+        'leave handA c1[parent=null mark=leave-handA owner=null]',
+        'enter handB c1[parent=handB mark=enter-handB owner=jestPlayer]'
+      ],
+      // the owner was still set when the first of the two legacy calls ran: checkParent() reset
+      // it between them
+      legacy: [
+        'leave handA c1[parent=null mark=null owner=jestPlayer]',
+        'leave handA c1[parent=null mark=leave-handA owner=null]',
+        'enter handB c1[parent=handB mark=enter-handB owner=jestPlayer]'
+      ]
+    });
+
+  scenario('childrenPerOwner also releases a card taken out by SET parent',
+    () => room({ handA: { childrenPerOwner: true }, c1: { type: 'card', parent: 'handA', owner: 'jestPlayer' } }),
+    () => clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'SET', property: 'parent', value: null } ]),
+    {
+      modern: [ 'leave handA c1[parent=null mark=leave-handA owner=null]' ],
+      // the owner reset lived in checkParent(), which a SET never reaches
+      legacy: [ 'leave handA c1[parent=null mark=null owner=jestPlayer]' ]
+    });
+
+  scenario('ignoreOnLeave skips the property half but not the routine',
+    () => room({ c1: { type: 'card', parent: 'handA', ignoreOnLeave: true } }),
+    () => dragWidget('c1'),
+    {
+      modern: [ 'leave handA c1[parent=null mark=null owner=null]' ],
+      legacy: [
+        'leave handA c1[parent=null mark=null owner=null]',
+        'leave handA c1[parent=null mark=null owner=null]'
+      ]
+    });
+
+  scenario('onEnter and onLeave with several properties are all applied before the routine',
+    () => room({
+      handB: { onEnter: { mark: 'enter-handB', activeFace: 1 } },
+      c1: { type: 'card' }
+    }, {}, [ 'mark', 'activeFace' ]),
+    () => dragWidget('c1', { to: 'handB' }),
+    {
+      modern: [ 'enter handB c1[mark=enter-handB activeFace=1]' ],
+      legacy: [ 'enter handB c1[mark=enter-handB activeFace=1]' ]
+    });
+
+  scenario('a holder moved out of another widget does not run its leaveRoutine',
+    () => room({ handB: { parent: 'handA' } }),
+    () => clickRoutine([ { func: 'SELECT', property: 'id', value: 'handB' }, { func: 'SET', property: 'parent', value: null } ]),
+    {
+      // holders are furniture, not cards - a holder changing parent has never been a departure
+      modern: [],
+      legacy: []
+    });
+
+  scenario('a deck is exempt from onEnter',
+    () => room({ d1: { type: 'deck' } }, {}, [ 'mark' ]),
+    () => clickRoutine([ { func: 'SELECT', property: 'id', value: 'd1' }, { func: 'SET', property: 'parent', value: 'handB' } ]),
+    {
+      modern: [ 'enter handB d1[mark=null]' ],
+      legacy: [ 'enter handB d1[mark=null]' ]
+    });
+});
+
+// ------------------------------------------------------------------------------------------
+// Piles
+// ------------------------------------------------------------------------------------------
+//
+// A pile is a stack of cards inside whatever holds it, not a container of its own. Every case
+// below is one consequence of that, and the modern answers are the ones issue #1094 asks for.
+// The legacy answers of the cases that involve pile.js reading widget.parent are covered in
+// tests/testcafe/enterleave.js instead - see the note at the top of this file.
+
+describe('piles', () => {
+  const withPile = (holderProperties = {}) => room({
+    handB: holderProperties,
+    pile1: { type: 'pile', parent: 'handB' },
+    c1: { type: 'card', parent: 'pile1' },
+    c2: { type: 'card', parent: 'pile1' }
+  });
+
+  test('a card leaving a pile inside a holder leaves the holder once', async () => {
+    setupRoom(withPile());
+    await clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'SET', property: 'parent', value: null } ]);
+    expect(trace()).toEqual([ 'leave handB c1[parent=null mark=leave-handB owner=null]' ]);
+  });
+
+  test('a card joining a pile inside its holder raises no event', async () => {
+    setupRoom(room({
+      handB: {},
+      pile1: { type: 'pile', parent: 'handB' },
+      c2: { type: 'card', parent: 'pile1' },
+      c3: { type: 'card', parent: 'pile1' },
+      c1: { type: 'card', parent: 'handB' }
+    }));
+    await clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'SET', property: 'parent', value: 'pile1' } ]);
+    expect(trace()).toEqual([]);
+  });
+
+  test('a card entering a holder and joining a pile in it enters exactly once', async () => {
+    setupRoom(room({
+      handB: {},
+      pile1: { type: 'pile', parent: 'handB' },
+      c2: { type: 'card', parent: 'pile1' },
+      c3: { type: 'card', parent: 'pile1' }
+    }));
+    await clickRoutine([
+      { func: 'SELECT', property: 'id', value: 'c1' },
+      { func: 'SET', property: 'parent', value: 'handB' },
+      { func: 'SET', property: 'parent', value: 'pile1' }
+    ]);
+    expect(trace()).toEqual([ 'enter handB c1[parent=handB mark=enter-handB owner=null]' ]);
+  });
+
+  test('a pile dissolving in its holder raises no event for the card that stays', async () => {
+    setupRoom(withPile());
+    await clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'SET', property: 'parent', value: null } ]);
+    // c2 ends up directly in handB, and the pile is gone - neither is a departure or an arrival
+    expect(widgets.get('c2').get('parent')).toBe('handB');
+    expect(widgets.has('pile1')).toBe(false);
+    expect(trace()).toEqual([ 'leave handB c1[parent=null mark=leave-handB owner=null]' ]);
+  });
+
+  test('a pile dragged into a holder enters once and marks every card in it', async () => {
+    setupRoom(room({ pile1: { type: 'pile' }, c1: { type: 'card', parent: 'pile1' }, c2: { type: 'card', parent: 'pile1' } }));
+    await dragWidget('pile1', { to: 'handB' });
+    expect(trace()).toEqual([ 'enter handB pile1[parent=handB mark=null owner=null]' ]);
+    expect(widgets.get('c1').get('mark')).toBe('enter-handB');
+    expect(widgets.get('c2').get('mark')).toBe('enter-handB');
+  });
+
+  test('a pile dragged out of a holder leaves once and marks every card in it', async () => {
+    setupRoom(withPile());
+    await dragWidget('pile1');
+    expect(trace()).toEqual([ 'leave handB pile1[parent=null mark=null owner=null]' ]);
+    expect(widgets.get('c1').get('mark')).toBe('leave-handB');
+    expect(widgets.get('c2').get('mark')).toBe('leave-handB');
+  });
+
+  test('two cards forming a pile inside a holder raise no event', async () => {
+    setupRoom(room({
+      // Two properties a real card carries and a harness card does not: updatePiles() merges
+      // only widgets whose owner is strictly equal (moveToHolder writes null), and it reads
+      // onPileCreation for the limit of the pile it would create - {} is the Card default.
+      c1: { type: 'card', parent: 'handB', x: 10, y: 10, owner: null, onPileCreation: {} },
+      c2: { type: 'card', parent: 'handB', x: 10, y: 10, owner: null, onPileCreation: {} }
+    }, { alignChildren: false }));
+    await dragWidget('c1', { to: 'handB', leavesBox: false });
+    const pile = [ ...widgets.values() ].find(w => w.get('type') == 'pile');
+    expect(pile).toBeDefined();
+    expect(pile.get('parent')).toBe('handB');
+    // picking the card up and dropping it again is the whole event story; the pile the drop
+    // forms out of the two cards is not a third move
+    expect(trace()).toEqual([
+      'leave handB c1[parent=null mark=leave-handB owner=null]',
+      'enter handB c1[parent=handB mark=enter-handB owner=null]'
+    ]);
+  });
+
+  test('a preventPiles holder unpacks a dropped pile without extra events', async () => {
+    setupRoom(room({ pile1: { type: 'pile' }, c1: { type: 'card', parent: 'pile1' }, c2: { type: 'card', parent: 'pile1' } },
+      { preventPiles: true }));
+    await dragWidget('pile1', { to: 'handB' });
+    expect(widgets.get('c1').get('parent')).toBe('handB');
+    expect(widgets.get('c2').get('parent')).toBe('handB');
+    expect(trace()).toEqual([ 'enter handB pile1[parent=handB mark=null owner=null]' ]);
+  });
+});
+
+// ------------------------------------------------------------------------------------------
+// Ordering invariants
+// ------------------------------------------------------------------------------------------
+
+describe('ordering', () => {
+  test('a leave is complete before the enter of the same move starts', async () => {
+    setupRoom(room({
+      c1: { type: 'card', parent: 'handA' },
+      handA: { leaveRoutine: [
+        { func: 'SELECT', property: 'id', value: 'log', collection: 'log' },
+        { func: 'SET', collection: 'log', property: 'trace', value: '${PROPERTY trace OF log}leave-start;' },
+        { func: 'SET', collection: 'log', property: 'trace', value: '${PROPERTY trace OF log}leave-end;' }
+      ] },
+      handB: { enterRoutine: [
+        { func: 'SELECT', property: 'id', value: 'log', collection: 'log' },
+        { func: 'SET', collection: 'log', property: 'trace', value: '${PROPERTY trace OF log}enter;' }
+      ] }
+    }));
+    await clickRoutine([ { func: 'MOVE', from: 'handA', to: 'handB', count: 1 } ]);
+    expect(trace()).toEqual([ 'leave-start', 'leave-end', 'enter' ]);
+  });
+
+  test('the enterRoutine of a holder is told where the widget came from', async () => {
+    setupRoom(room({
+      c1: { type: 'card', parent: 'handA' },
+      handB: { enterRoutine: [
+        { func: 'SELECT', property: 'id', value: 'log', collection: 'log' },
+        { func: 'SET', collection: 'log', property: 'oldParent', value: '${oldParentID}' }
+      ] }
+    }));
+    await clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'SET', property: 'parent', value: 'handB' } ]);
+    expect(widgets.get('log').get('oldParent')).toBe('handA');
+  });
+
+  test('a drag tells the receiving holder nothing about the origin', async () => {
+    setupRoom(room({
+      c1: { type: 'card', parent: 'handA' },
+      handB: { enterRoutine: [
+        { func: 'SELECT', property: 'id', value: 'log', collection: 'log' },
+        { func: 'SET', collection: 'log', property: 'oldParent', value: '${oldParentID}' }
+      ] }
+    }));
+    await dragWidget('c1', { to: 'handB' });
+    // the drag detaches the widget before it lands, so there is no old parent left to name
+    expect(widgets.get('log').get('oldParent')).toBe(null);
+  });
+});

--- a/tests/client/engine/enterleave.test.js
+++ b/tests/client/engine/enterleave.test.js
@@ -69,8 +69,9 @@ function trace() {
 // The parent bookkeeping a drag performs, without the pointer: moveStart() detaches the widget,
 // move() lets checkParent() drop it once it is out of the holder's box, and moveEnd() hands it
 // to the holder it was released over. `leavesBox: false` is a drag that never left the holder
-// it started in, which is the one case where the two differ.
-async function dragWidget(id, { to = null, leavesBox = true } = {}) {
+// it started in, which is the one case where the two differ. `whileDragging` is called at the
+// point the widget hangs on the cursor, which is where a drag is visible to the other players.
+async function dragWidget(id, { to = null, leavesBox = true, whileDragging = null } = {}) {
   const widget = widgets.get(id);
   const ancestor = widget.get('_ancestor');
 
@@ -82,6 +83,9 @@ async function dragWidget(id, { to = null, leavesBox = true } = {}) {
 
   if(leavesBox)
     await widget.checkParent(true);
+
+  if(whileDragging)
+    whileDragging(widget);
 
   widget.pileUpdateFromDrag = true;
   if(to)
@@ -363,8 +367,10 @@ describe('holder properties', () => {
     () => room({ handA: { childrenPerOwner: true }, handB: { childrenPerOwner: true }, c1: { type: 'card', parent: 'handA', owner: 'jestPlayer' } }),
     () => dragWidget('c1', { to: 'handB' }),
     {
+      // a hand lets go of a dragged card when it is out of its box, which is after the leave
+      // event but before the card can land anywhere else
       modern: [
-        'leave handA c1[parent=null mark=leave-handA owner=null]',
+        'leave handA c1[parent=null mark=leave-handA owner=jestPlayer]',
         'enter handB c1[parent=handB mark=enter-handB owner=jestPlayer]'
       ],
       // the owner was still set when the first of the two legacy calls ran: checkParent() reset
@@ -384,6 +390,31 @@ describe('holder properties', () => {
       // the owner reset lived in checkParent(), which a SET never reaches
       legacy: [ 'leave handA c1[parent=null mark=null owner=jestPlayer]' ]
     });
+
+  // A per-owner hand is the one place where "when did the widget leave" is visible to somebody
+  // other than the player doing the moving: without an owner a card loses the `foreign` class
+  // and is rendered on every other screen. A drag detaches the card at the pickup, so these two
+  // pin down that the hand only lets go of it in checkParent().
+  for(const combination of [ 'modern', 'legacy' ]) {
+    const legacy = combination == 'legacy' ? { legacyHolderEnterLeaveEvents: true } : {};
+    const hand = () => room({ handA: { childrenPerOwner: true }, c1: { type: 'card', parent: 'handA', owner: 'jestPlayer' } });
+
+    test(`a card rearranged inside a per-owner hand stays owned for the whole drag [${combination}]`, async () => {
+      setupRoom(hand(), { legacy });
+      let ownerWhileDragging;
+      await dragWidget('c1', { to: 'handA', leavesBox: false, whileDragging: w=>ownerWhileDragging = w.get('owner') });
+      expect(ownerWhileDragging).toBe('jestPlayer');
+      expect(widgets.get('c1').get('owner')).toBe('jestPlayer');
+    });
+
+    test(`a card dragged out of a per-owner hand is released when it leaves the box [${combination}]`, async () => {
+      setupRoom(hand(), { legacy });
+      let ownerWhileDragging;
+      await dragWidget('c1', { whileDragging: w=>ownerWhileDragging = w.get('owner') });
+      expect(ownerWhileDragging).toBe(null);
+      expect(widgets.get('c1').get('owner')).toBe(null);
+    });
+  }
 
   scenario('ignoreOnLeave skips the property half but not the routine',
     () => room({ c1: { type: 'card', parent: 'handA', ignoreOnLeave: true } }),

--- a/tests/client/engine/enterleave.test.js
+++ b/tests/client/engine/enterleave.test.js
@@ -66,15 +66,17 @@ function trace() {
   return String(widgets.get('log').get('trace') || '').split(';').filter(entry => entry);
 }
 
-// The parent bookkeeping a drag performs, without the pointer: moveStart() detaches the widget,
-// move() lets checkParent() drop it once it is out of the holder's box, and moveEnd() hands it
-// to the holder it was released over. `leavesBox: false` is a drag that never left the holder
-// it started in, which is the one case where the two differ. `whileDragging` is called at the
-// point the widget hangs on the cursor, which is where a drag is visible to the other players.
+// The bookkeeping a drag performs, without the pointer: moveStart() marks the widget as being
+// dragged and detaches it, move() lets checkParent() drop it once it is out of the holder's box,
+// and moveEnd() drops the drag marks again and hands the widget to the holder it was released
+// over. `leavesBox: false` is a drag that never left the holder it started in, which is the one
+// case where the two differ. `whileDragging` is called at the point the widget hangs on the
+// cursor, which is where a drag is visible to the other players.
 async function dragWidget(id, { to = null, leavesBox = true, whileDragging = null } = {}) {
   const widget = widgets.get(id);
   const ancestor = widget.get('_ancestor');
 
+  await widget.set('dragging', 'jestPlayer');
   if(widgets.has(ancestor))
     widget.currentParent = widgets.get(ancestor);
   widget.disablePileUpdateAfterParentChange = true;
@@ -87,6 +89,7 @@ async function dragWidget(id, { to = null, leavesBox = true, whileDragging = nul
   if(whileDragging)
     whileDragging(widget);
 
+  await widget.set('dragging', null);
   widget.pileUpdateFromDrag = true;
   if(to)
     await widget.moveToHolder(widgets.get(to));
@@ -414,7 +417,27 @@ describe('holder properties', () => {
       expect(ownerWhileDragging).toBe(null);
       expect(widgets.get('c1').get('owner')).toBe(null);
     });
+
+    // The hand holds on to a card that is on the cursor, so "a drag is in progress" has to stop
+    // being true the moment the drag ends - including the drag that ended inside the hand it
+    // started in, which never gets anywhere near checkParent().
+    test(`a rearrange inside a per-owner hand does not stop the next SET parent from releasing the card [${combination}]`, async () => {
+      setupRoom(hand(), { legacy });
+      await dragWidget('c1', { to: 'handA', leavesBox: false });
+      await clickRoutine([ { func: 'SELECT', property: 'id', value: 'c1' }, { func: 'SET', property: 'parent', value: null } ]);
+      expect(widgets.get('c1').get('owner')).toBe(combination == 'legacy' ? 'jestPlayer' : null);
+    });
   }
+
+  scenario('MOVEXY keeps the owner of a card taken out of a per-owner hand when resetOwner is off',
+    () => room({ handA: { childrenPerOwner: true }, c1: { type: 'card', parent: 'handA', owner: 'jestPlayer' } }),
+    () => clickRoutine([ { func: 'MOVEXY', from: 'handA', x: 100, y: 100, resetOwner: false } ]),
+    {
+      // resetOwner is the operation's explicit "put this on the table but keep it owned", so the
+      // leave the parent write raises must not take the owner away behind its back
+      modern: [ 'leave handA c1[parent=null mark=leave-handA owner=jestPlayer]' ],
+      legacy: [ 'leave handA c1[parent=null mark=null owner=jestPlayer]' ]
+    });
 
   scenario('ignoreOnLeave skips the property half but not the routine',
     () => room({ c1: { type: 'card', parent: 'handA', ignoreOnLeave: true } }),

--- a/tests/client/engine/enterleave.test.js
+++ b/tests/client/engine/enterleave.test.js
@@ -447,6 +447,23 @@ describe('holder properties', () => {
       legacy: []
     });
 
+  scenario('a drop shadow passes through a holder without raising anything',
+    () => room({ shadow: { type: 'card', dropShadowOwner: 'jestPlayer' } }),
+    async () => {
+      await clickRoutine([ { func: 'SELECT', property: 'id', value: 'shadow' }, { func: 'SET', property: 'parent', value: 'handB' } ]);
+      await clickRoutine([ { func: 'SELECT', property: 'id', value: 'shadow' }, { func: 'SET', property: 'parent', value: null } ]);
+    },
+    {
+      // the preview a drag paints in the holder under the pointer is a real widget for the
+      // layout and nothing at all for the events - hovering over a holder must not run the
+      // routines that a drop into it would
+      modern: [],
+      legacy: [
+        'enter handB shadow[parent=handB mark=enter-handB owner=null]',
+        'leave handB shadow[parent=null mark=enter-handB owner=null]'
+      ]
+    });
+
   scenario('a deck is exempt from onEnter',
     () => room({ d1: { type: 'deck' } }, {}, [ 'mark' ]),
     () => clickRoutine([ { func: 'SELECT', property: 'id', value: 'd1' }, { func: 'SET', property: 'parent', value: 'handB' } ]),

--- a/tests/client/engine/enterleave.test.js
+++ b/tests/client/engine/enterleave.test.js
@@ -539,6 +539,15 @@ describe('piles', () => {
     expect(trace()).toEqual([ 'enter pile1 c1[parent=pile1 mark=null owner=null]' ]);
   });
 
+  test('a per-owner holder claims every card of a pile it unpacks', async () => {
+    setupRoom(room({ pile1: { type: 'pile' }, c1: { type: 'card', parent: 'pile1' }, c2: { type: 'card', parent: 'pile1' } },
+      { preventPiles: true, childrenPerOwner: true }));
+    await dragWidget('pile1', { to: 'handB' });
+    // the cards become children of the holder one by one, which is not an arrival from outside -
+    // so the owner cannot hang off the enter event
+    expect([ widgets.get('c1').get('owner'), widgets.get('c2').get('owner') ]).toEqual([ 'jestPlayer', 'jestPlayer' ]);
+  });
+
   test('a preventPiles holder unpacks a dropped pile without extra events', async () => {
     setupRoom(room({ pile1: { type: 'pile' }, c1: { type: 'card', parent: 'pile1' }, c2: { type: 'card', parent: 'pile1' } },
       { preventPiles: true }));

--- a/tests/client/engine/harness.js
+++ b/tests/client/engine/harness.js
@@ -12,6 +12,7 @@ import { legacyMode } from '../../../client/js/legacymodes.js';
 import { fullLegacyCombination } from '../../../client/js/legacymoderegistry.js';
 import { Widget } from '../../../client/js/widgets/widget.js';
 import { Label } from '../../../client/js/widgets/label.js';
+import { bundleWidgetClasses, resetGeneratedIDs } from './bundle-widgets.js';
 
 // widget.js and color.js reach legacyMode() as a global because the room bundle concatenates
 // every client module into one scope. jsdom has no bundle, so wire it up once.
@@ -52,7 +53,13 @@ globalThis.DOMMatrix = globalThis.DOMMatrix || HarnessDOMMatrix;
 // Only the widget modules that carry their own imports can be loaded outside the bundle;
 // everything else falls back to the base class, which is what the routine operations act on
 // anyway. Behaviour that lives in a subclass belongs in a TestCafe fixture.
-const widgetClasses = { widget: Widget, label: Label };
+let widgetClasses = { widget: Widget, label: Label };
+
+// ... unless the fixture is about that subclass. A file that calls this gets the real Holder
+// and Pile, evaluated the way the bundle does it - see bundle-widgets.js for what that costs.
+export async function useBundleWidgets() {
+  widgetClasses = await bundleWidgetClasses();
+}
 
 export function setLegacyModes(modes) {
   for(const [ name, value ] of Object.entries(fullLegacyCombination(modes)))
@@ -82,6 +89,7 @@ export function setupRoom(state, { legacy = {} } = {}) {
 }
 
 export function removeAllWidgets() {
+  resetGeneratedIDs();
   for(const id of [ ...widgets.keys() ]) {
     widgets.get(id).applyRemove();
     widgets.delete(id);

--- a/tests/client/line-widget.test.js
+++ b/tests/client/line-widget.test.js
@@ -2,6 +2,8 @@ import { widgets, addWidget, batchStart, batchEnd, widgetFilter, flushDelta } fr
 import { Widget } from '../../client/js/widgets/widget.js';
 import { compareDropTarget, exceedsDropLimit } from '../../client/js/main.js';
 
+import { legacyMode } from '../../client/js/legacymodes.js';
+
 import { removeWidget } from './client-util.js';
 
 // line.js relies on the concatenated global scope of the shipped bundle rather than
@@ -20,6 +22,7 @@ beforeAll(async () => {
   globalThis.getMaxZ = () => 0;
   globalThis.updateMaxZ = () => {};
   globalThis.playerName = 'jestPlayer';
+  globalThis.legacyMode = legacyMode;
   ({ Line } = await import('../../client/js/widgets/line.js'));
 });
 

--- a/tests/client/pile-droplimit.test.js
+++ b/tests/client/pile-droplimit.test.js
@@ -1,5 +1,7 @@
 import { widgets } from '../../client/js/serverstate.js';
 
+import { legacyMode } from '../../client/js/legacymodes.js';
+
 import { createWidget, removeWidget } from './client-util.js';
 
 // updatePiles() reads pile.js's defaultPileSnapRange and creates a new pile
@@ -16,6 +18,7 @@ beforeAll(() => {
     return id;
   };
   globalThis.playerName = 'jestPlayer';
+  globalThis.legacyMode = legacyMode;
   globalThis.getMaxZ = () => 0;
   globalThis.updateMaxZ = () => {};
 });

--- a/tests/server/fileupdater.test.js
+++ b/tests/server/fileupdater.test.js
@@ -102,7 +102,7 @@ describe('legacy mode detection', () => {
     // a mode nothing can turn on would be dead weight in the sidebar and in the matrix
     const everything = at(1, {
       b: { id: 'b', type: 'button', clickRoutine: [ 'var a = 1' ] },
-      h: { id: 'h', type: 'holder', color: 'red' },
+      h: { id: 'h', type: 'holder', color: 'red', onEnter: { activeFace: 1 } },
       d: { id: 'd', type: 'deck', faceTemplates: [ { objects: [ { type: 'html', value: 'x' } ] } ] }
     });
     expect(Object.keys(flagsFor(everything)).sort()).toEqual([ ...ALL_LEGACY_MODES ].sort());
@@ -214,18 +214,20 @@ function migrated(widget, version = VERSION - 1) {
 }
 
 describe('the dragLimit sides written as null', () => {
+  // the v22 step, so the file has to be older than that rather than just older than the current version
+  const migratedFrom21 = widget => migrated(widget, 21);
   test('become the 0 they always clamped to', () => {
-    expect(migrated({ dragLimit: { minX: null, maxY: 10 } }).dragLimit).toEqual({ minX: 0, maxY: 10 });
-    expect(migrated({ dragLimit: { minX: null, maxX: null, minY: null, maxY: null } }).dragLimit)
+    expect(migratedFrom21({ dragLimit: { minX: null, maxY: 10 } }).dragLimit).toEqual({ minX: 0, maxY: 10 });
+    expect(migratedFrom21({ dragLimit: { minX: null, maxX: null, minY: null, maxY: null } }).dragLimit)
       .toEqual({ minX: 0, maxX: 0, minY: 0, maxY: 0 });
   });
 
   test('leave every other limit as it was written', () => {
-    expect(migrated({ dragLimit: { minX: 0, maxX: '${PROPERTY width OF board}', condition: 'y > x' } }).dragLimit)
+    expect(migratedFrom21({ dragLimit: { minX: 0, maxX: '${PROPERTY width OF board}', condition: 'y > x' } }).dragLimit)
       .toEqual({ minX: 0, maxX: '${PROPERTY width OF board}', condition: 'y > x' });
-    expect(migrated({ dragLimit: {} }).dragLimit).toEqual({});
-    expect(migrated({ dragLimit: 'nonsense' }).dragLimit).toBe('nonsense');
-    expect(migrated({}).dragLimit).toBe(undefined);
+    expect(migratedFrom21({ dragLimit: {} }).dragLimit).toEqual({});
+    expect(migratedFrom21({ dragLimit: 'nonsense' }).dragLimit).toBe('nonsense');
+    expect(migratedFrom21({}).dragLimit).toBe(undefined);
   });
 
   test('are left alone in a file that was written with the new meaning', () => {

--- a/tests/server/fileupdater.test.js
+++ b/tests/server/fileupdater.test.js
@@ -63,6 +63,26 @@ describe('legacy mode detection', () => {
     expect(flagsFor(at(20, { h: { id: 'h', type: 'holder' } })).disableHolderImageWidget).toBe(undefined);
   });
 
+  test('a v22 save with a stacked holder gets legacyHolderEnterLeaveEvents', () => {
+    // it names none of the event properties, but its children re-compact on every departure now
+    expect(flagsFor(at(22, { h: { id: 'h', type: 'holder', stackOffsetY: 40 } }))).toEqual({ legacyHolderEnterLeaveEvents: true });
+  });
+
+  test('a stacked holder written as an expression counts as stacked', () => {
+    expect(flagsFor(at(22, { h: { id: 'h', type: 'holder', stackOffsetX: '${PROPERTY offset OF board}' } })))
+      .toEqual({ legacyHolderEnterLeaveEvents: true });
+  });
+
+  test('a holder that stacks nothing does not get legacyHolderEnterLeaveEvents', () => {
+    expect(flagsFor(at(22, { h: { id: 'h', type: 'holder', stackOffsetY: 0 } }))).toEqual({});
+  });
+
+  test('a stacked holder that does not align its children does not get it either', () => {
+    // without alignChildren the holder never repositions what stayed, so the gap it leaves is
+    // wherever the player put the cards
+    expect(flagsFor(at(22, { h: { id: 'h', type: 'holder', stackOffsetY: 40, alignChildren: false } }))).toEqual({});
+  });
+
   test('a mode is not applied to a save that is already at or past its version', () => {
     // a v20 save predates v21, so the holder mode applies, but the var modes (v18) do not
     const state = at(20, {

--- a/tests/server/fileupdater.test.js
+++ b/tests/server/fileupdater.test.js
@@ -83,6 +83,22 @@ describe('legacy mode detection', () => {
     expect(flagsFor(at(22, { h: { id: 'h', type: 'holder', stackOffsetY: 40, alignChildren: false } }))).toEqual({});
   });
 
+  test('a holder that only becomes stacked at runtime gets legacyHolderEnterLeaveEvents', () => {
+    // the offset is a value inside a routine rather than a property of the holder, so only the
+    // textual pass can see it
+    expect(flagsFor(at(22, {
+      h: { id: 'h', type: 'holder' },
+      b: { id: 'b', type: 'button', clickRoutine: [ { func: 'SET', property: 'stackOffsetY', value: 40 } ] }
+    }))).toEqual({ legacyHolderEnterLeaveEvents: true });
+  });
+
+  test('a template a holder inherits its stack offset from counts as stacked', () => {
+    expect(flagsFor(at(22, {
+      template: { id: 'template', type: 'basic', stackOffsetY: 40 },
+      h: { id: 'h', type: 'holder', inheritFrom: { template: '*' } }
+    }))).toEqual({ legacyHolderEnterLeaveEvents: true });
+  });
+
   test('a mode is not applied to a save that is already at or past its version', () => {
     // a v20 save predates v21, so the holder mode applies, but the var modes (v18) do not
     const state = at(20, {

--- a/tests/testcafe/enterleave.js
+++ b/tests/testcafe/enterleave.js
@@ -252,53 +252,76 @@ test('A preventPiles holder unpacks a dropped pile without extra events', async 
 // Holders that are not plain top-left stackers
 // ---------------------------------------------------------------------------------------------
 
-test('A stacked holder closes the gap when a card is taken out', async t => {
-  const state = fixtureState({ handB: { stackOffsetY: 40 } }, { enterFields: [ 'parent' ], leaveFields: [ 'parent' ] });
+// Three cards in one column of a stacked holder, and a button to run an operation from.
+function stackedHolder(clickRoutine = []) {
+  const state = fixtureState({ handB: { stackOffsetY: 40 }, go: { clickRoutine } },
+    { enterFields: [ 'parent' ], leaveFields: [ 'parent' ] });
   Object.assign(state.card1, { parent: 'handB', x: 4, y: 4 });
   state.card2 = card('card2', { parent: 'handB', x: 4, y: 44 });
   state.card3 = card('card3', { parent: 'handB', x: 4, y: 84 });
-  await openRoom(t, MODERN, state);
+  return state;
+}
+
+// The positions the two cards that stayed ended up at, once the third one is out.
+async function remainingStack(done) {
+  const after = await stateWhen(done);
+  return Object.values(after).filter(w=>w.parent == 'handB').map(w=>w.y).sort((a, b)=>a-b);
+}
+
+test('A stacked holder closes the gap when a card is taken out', async t => {
+  await openRoom(t, MODERN, stackedHolder());
   await dragPath(t, CARD, [ { dx: 0, dy: -500 } ]);
 
   // the departure re-compacts the holder, so the two cards that stayed sit at the first two
   // stack positions rather than leaving a hole where the third one was
-  const after = await stateWhen(s=>Object.values(s).filter(w=>w.parent == 'handB').length == 2);
-  const remaining = Object.values(after).filter(w=>w.parent == 'handB').map(w=>w.y).sort((a, b)=>a-b);
-  await t.expect(remaining).eql([ 4, 44 ], 'the two cards that stayed sit at the first two stack positions');
+  await t.expect(await remainingStack(s=>!s[CARD].parent)).eql([ 4, 44 ], 'the gap closed');
 });
 
 test('MOVEXY out of a stacked holder closes the gap as well', async t => {
-  const state = fixtureState({
-    handB: { stackOffsetY: 40 },
-    go: { clickRoutine: [ { func: 'MOVEXY', from: 'handB', x: 700, y: 200 } ] }
-  }, { enterFields: [ 'parent' ], leaveFields: [ 'parent' ] });
-  Object.assign(state.card1, { parent: 'handB', x: 4, y: 4 });
-  state.card2 = card('card2', { parent: 'handB', x: 4, y: 44 });
-  state.card3 = card('card3', { parent: 'handB', x: 4, y: 84 });
-  await openRoom(t, MODERN, state);
+  await openRoom(t, MODERN, stackedHolder([ { func: 'MOVEXY', from: 'handB', x: 700, y: 200 } ]));
   await clickGo(t);
 
-  const after = await stateWhen(s=>Object.values(s).filter(w=>w.parent == 'handB').length == 2);
-  const remaining = Object.entries(after).filter(([ , w ])=>w.parent == 'handB').map(([ , w ])=>w.y);
-  await t.expect(remaining.sort((a, b)=>a-b)).eql([ 4, 44 ]);
+  await t.expect(await remainingStack(s=>Object.values(s).filter(w=>w.parent == 'handB').length == 2)).eql([ 4, 44 ], 'the gap closed');
 });
 
 test('DELETE closes the gap in a stacked holder as well', async t => {
-  const state = fixtureState({
-    handB: { stackOffsetY: 40 },
-    go: { clickRoutine: [ { func: 'SELECT', property: 'id', value: CARD }, { func: 'DELETE' } ] }
-  }, { enterFields: [ 'parent' ], leaveFields: [ 'parent' ] });
-  Object.assign(state.card1, { parent: 'handB', x: 4, y: 4 });
-  state.card2 = card('card2', { parent: 'handB', x: 4, y: 44 });
-  state.card3 = card('card3', { parent: 'handB', x: 4, y: 84 });
-  await openRoom(t, MODERN, state);
+  await openRoom(t, MODERN, stackedHolder([ { func: 'SELECT', property: 'id', value: CARD }, { func: 'DELETE' } ]));
   await clickGo(t);
 
   // a card removed from the room applies no onLeave - it is gone - but the holder it was taken
   // out of is still one card shorter and re-stacks what is left
-  const after = await stateWhen(s=>!s[CARD]);
-  const remaining = Object.values(after).filter(w=>w.parent == 'handB').map(w=>w.y).sort((a, b)=>a-b);
-  await t.expect(remaining).eql([ 4, 44 ], 'the two cards that stayed sit at the first two stack positions');
+  await t.expect(await remainingStack(s=>!s[CARD])).eql([ 4, 44 ], 'the gap closed');
+});
+
+// The legacy pipeline raised a leave only for a drag or a MOVE, so an operation that never
+// reached dispenseCard() left the hole where the card had been - which is what an old game
+// positioned the rest of its board around.
+test('Legacy: DELETE leaves the hole in a stacked holder open', async t => {
+  await openRoom(t, LEGACY, stackedHolder([ { func: 'SELECT', property: 'id', value: CARD }, { func: 'DELETE' } ]));
+  await clickGo(t);
+
+  await t.expect(await remainingStack(s=>!s[CARD])).eql([ 44, 84 ], 'nothing moved up into the gap');
+});
+
+test('Legacy: SET parent leaves the hole in a stacked holder open as well', async t => {
+  await openRoom(t, LEGACY, stackedHolder([ { func: 'SELECT', property: 'id', value: CARD }, { func: 'SET', property: 'parent', value: null } ]));
+  await clickGo(t);
+
+  await t.expect(await remainingStack(s=>!s[CARD].parent)).eql([ 44, 84 ], 'nothing moved up into the gap');
+});
+
+test('A stacked holder with dropShadow closes the preview gap again when the pointer moves on', async t => {
+  const state = stackedHolder();
+  state.handB.dropShadow = true;
+  Object.assign(state.card1, { parent: null, x: 700, y: 60 });
+  state.card2.y = 4;
+  state.card3.y = 44;
+  await openRoom(t, MODERN, state);
+  await dragPath(t, CARD, [ { onto: 'handB' }, { dx: 0, dy: -450 } ]);
+
+  // the shadow takes a slot in the stack while it is over the holder, so the two cards that
+  // were there sit one row lower - and go back up as soon as the preview is gone
+  await t.expect(await remainingStack(s=>!s[CARD].parent)).eql([ 4, 44 ], 'the preview left no gap behind');
 });
 
 test('An alignChildren:false holder keeps the drop coordinate and still enters', async t => {

--- a/tests/testcafe/enterleave.js
+++ b/tests/testcafe/enterleave.js
@@ -1,0 +1,355 @@
+import { setName, setupTestEnvironment } from './test-util.js';
+import { dragPath, openRoom, stateWhen } from './interaction-util.js';
+import { CARD, card, clickGo, expectTrace, fixtureState, holder, readTrace } from './holderevent-util.js';
+
+setupTestEnvironment();
+
+// The legacyHolderEnterLeaveEvents half of the holder-event story, plus the combinations that
+// need more than two plain holders.
+//
+// Two things are asserted here that holderevents.js cannot say on its own:
+//
+//   1. The legacy mode really does restore the old pipeline. Every trace in the first section is
+//      the one this repository recorded before the pipeline was consolidated, so a game that was
+//      built around leaveRoutine firing twice keeps working by switching the mode on.
+//   2. The cases where the two pipelines disagree about *piles*. A pile is transparent for
+//      enter and leave now - joining, leaving or dissolving one inside a holder is not a move
+//      between containers - and every issue in that family (#480, #1094) shows up as a
+//      difference between the two combinations below.
+//
+// tests/client/engine/enterleave.test.js covers the same ground far more cheaply for everything
+// that does not need a real pointer; what is here needs the browser.
+
+const MODERN = 'modern';
+const LEGACY = 'only-legacyHolderEnterLeaveEvents';
+
+// ---------------------------------------------------------------------------------------------
+// The legacy mode restores the pipeline it replaced
+// ---------------------------------------------------------------------------------------------
+
+test('Legacy: dragging a card out of a holder fires leaveRoutine twice', async t => {
+  await openRoom(t, LEGACY, fixtureState({ card1: { parent: 'handA', x: 4, y: 4 } }));
+  await dragPath(t, CARD, [ { dx: 500, dy: -400 } ]);
+
+  // Two code paths called the same routine for one drag: moveStart() detached the widget, which
+  // called leaveRoutine before anything else about the departure had happened (mark=null), and
+  // checkParent() later dispensed it, which applied onLeave and called leaveRoutine again.
+  await expectTrace(t, [
+    'leave handA[parent=null mark=null owner=null]',
+    'leave handA[parent=null mark=leave-handA owner=null]'
+  ]);
+});
+
+test('Legacy: dragging a card from one holder to another', async t => {
+  await openRoom(t, LEGACY, fixtureState({ card1: { parent: 'handA', x: 4, y: 4 } }));
+  await dragPath(t, CARD, [ { onto: 'handB' } ]);
+
+  await expectTrace(t, [
+    'leave handA[parent=null mark=null owner=null]',
+    'leave handA[parent=null mark=leave-handA owner=null]',
+    'enter handB[parent=handB mark=enter-handB owner=null]'
+  ]);
+});
+
+test('Legacy: dragging a card within its holder runs enterRoutine without applying onEnter', async t => {
+  await openRoom(t, LEGACY, fixtureState({ card1: { parent: 'handA', x: 4, y: 4 } }));
+  await dragPath(t, CARD, [ { dx: 150, dy: 0 } ]);
+
+  // onChildAdd() skipped onEnter when the widget landed back on the holder it was dragged off
+  // (`this != child.currentParent`), so the properties and the routine disagreed about whether
+  // an entry had happened - mark=null next to an `enter` entry is exactly that disagreement.
+  await expectTrace(t, [
+    'leave handA[parent=null mark=null owner=null]',
+    'enter handA[parent=handA mark=null owner=null]'
+  ]);
+});
+
+test('Legacy: dragging a card out of a holder and back before dropping it', async t => {
+  await openRoom(t, LEGACY, fixtureState({ card1: { parent: 'handA', x: 4, y: 4 } }));
+  await dragPath(t, CARD, [ { dx: 0, dy: -400 }, { onto: 'handA' } ]);
+
+  await expectTrace(t, [
+    'leave handA[parent=null mark=null owner=null]',
+    'leave handA[parent=null mark=leave-handA owner=null]',
+    'enter handA[parent=handA mark=enter-handA owner=null]'
+  ]);
+});
+
+test('Legacy: MOVE from one holder to another leaves twice', async t => {
+  await openRoom(t, LEGACY, fixtureState({
+    card1: { parent: 'handA', x: 4, y: 4 },
+    go: { clickRoutine: [ { func: 'MOVE', from: 'handA', to: 'handB', count: 1 } ] }
+  }));
+  await clickGo(t);
+
+  // the second call ran after the card had already arrived in handB
+  await expectTrace(t, [
+    'leave handA[parent=null mark=null owner=null]',
+    'leave handA[parent=null mark=leave-handA owner=null]',
+    'enter handB[parent=handB mark=enter-handB owner=null]'
+  ]);
+});
+
+test('Legacy: MOVEXY out of a holder does not apply onLeave', async t => {
+  await openRoom(t, LEGACY, fixtureState({
+    card1: { parent: 'handA', x: 4, y: 4 },
+    go: { clickRoutine: [ { func: 'MOVEXY', from: 'handA', x: 600, y: 300 } ] }
+  }));
+  await clickGo(t);
+
+  // issue #1371: the operation never reached dispenseCard(), so the card came out of the holder
+  // without the properties the holder applies to everything that leaves it
+  await expectTrace(t, [
+    'leave handA[parent=null mark=null owner=null]'
+  ]);
+});
+
+test('Legacy: SET parent does not apply onLeave', async t => {
+  await openRoom(t, LEGACY, fixtureState({
+    card1: { parent: 'handA', x: 4, y: 4 },
+    go: { clickRoutine: [ { func: 'SELECT', property: 'id', value: CARD }, { func: 'SET', property: 'parent', value: 'handB' } ] }
+  }));
+  await clickGo(t);
+
+  // issue #1836: a game that moved cards with SET saw a different event sequence than one that
+  // used MOVE, and the difference was invisible until a card came out of a holder the wrong way
+  await expectTrace(t, [
+    'leave handA[parent=handB mark=null owner=null]',
+    'enter handB[parent=handB mark=enter-handB owner=null]'
+  ]);
+});
+
+test('Legacy: ignoreOnLeave still leaves twice', async t => {
+  await openRoom(t, LEGACY, fixtureState({ card1: { parent: 'handA', x: 4, y: 4, ignoreOnLeave: true } }));
+  await dragPath(t, CARD, [ { dx: 500, dy: -400 } ]);
+
+  await expectTrace(t, [
+    'leave handA[parent=null mark=null owner=null]',
+    'leave handA[parent=null mark=null owner=null]'
+  ]);
+});
+
+test('Legacy: a dropShadow holder runs a doubled leave for the shadow widget too', async t => {
+  await openRoom(t, LEGACY, fixtureState({ handB: { dropShadow: true } }, { enterFields: [ 'parent' ], leaveFields: [ 'parent' ] }));
+  await dragPath(t, CARD, [ { onto: 'handB' } ]);
+
+  await expectTrace(t, [
+    'enter handB[parent=null]',
+    'leave handB[parent=null]',
+    'leave handB[parent=null]',
+    'enter handB[parent=handB]'
+  ]);
+});
+
+test('Legacy: the holder image mode does not change the event order', async t => {
+  await openRoom(t, 'pair-disableHolderImageWidget+legacyHolderEnterLeaveEvents', fixtureState({ card1: { parent: 'handA', x: 4, y: 4 } }));
+  await dragPath(t, CARD, [ { onto: 'handB' } ]);
+
+  // the two modes are declared as interacting because both live on the holder - this is the
+  // assertion behind that declaration
+  await expectTrace(t, [
+    'leave handA[parent=null mark=null owner=null]',
+    'leave handA[parent=null mark=leave-handA owner=null]',
+    'enter handB[parent=handB mark=enter-handB owner=null]'
+  ]);
+});
+
+// ---------------------------------------------------------------------------------------------
+// Piles
+// ---------------------------------------------------------------------------------------------
+
+// The holders in this section name the widget each event was about, because a pile turns one
+// drop into several parent changes and "which widget" is the whole question.
+const pileHolders = { watchChild: true };
+
+test('Dropping a card onto a card inside a holder is one arrival', async t => {
+  const state = fixtureState({}, pileHolders);
+  state.card2 = card('card2', { parent: 'handB' });
+  await openRoom(t, MODERN, state);
+  await dragPath(t, CARD, [ { onto: 'card2' } ]);
+
+  const after = await stateWhen(s=>Object.values(s).some(w=>w.type == 'pile'));
+  await t.expect(Object.values(after).find(w=>w.type == 'pile').parent).eql('handB', 'the pile is in the holder');
+  await expectTrace(t, [ 'enter handB card1[parent=handB mark=enter-handB owner=null]' ]);
+});
+
+test('Legacy: dropping a card onto a card inside a holder leaves the holder twice over', async t => {
+  const state = fixtureState({}, pileHolders);
+  state.card2 = card('card2', { parent: 'handB' });
+  await openRoom(t, LEGACY, state);
+  await dragPath(t, CARD, [ { onto: 'card2' } ]);
+
+  // issue #1094: the pile the drop forms is a new parent for both cards, and every one of those
+  // parent changes was a departure from the holder - with no matching arrival
+  const trace = await readTrace(t, 3);
+  await t.expect(trace[0]).eql('enter handB card1[parent=handB mark=enter-handB owner=null]');
+  await t.expect(trace.length).eql(3, `two leaves follow the arrival: ${JSON.stringify(trace)}`);
+  await t.expect(trace.slice(1).every(entry=>entry.startsWith('leave handB'))).ok(JSON.stringify(trace));
+});
+
+test('Dragging a card out of a pile inside a holder leaves the holder once', async t => {
+  const state = fixtureState({}, pileHolders);
+  state.pile1 = { id: 'pile1', type: 'pile', parent: 'handB', x: 4, y: 4 };
+  Object.assign(state.card1, { parent: 'pile1', x: 0, y: 0 });
+  state.card2 = card('card2', { parent: 'pile1', x: 0, y: 0 });
+  state.card3 = card('card3', { parent: 'pile1', x: 0, y: 0 });
+  await openRoom(t, MODERN, state);
+  // the cards sit on top of each other, so the pointer takes whichever one is on top - the
+  // assertion is about how many events one card leaving raises, not about which card it was
+  await dragPath(t, CARD, [ { dx: 0, dy: -400 } ]);
+
+  const trace = await readTrace(t, 1);
+  await t.expect(trace.length).eql(1, JSON.stringify(trace));
+  await t.expect(trace[0]).match(/^leave handB card\d\[parent=null mark=leave-handB owner=null\]$/, trace[0]);
+});
+
+test('The last card of a pile in a holder stays without entering or leaving', async t => {
+  const state = fixtureState({}, pileHolders);
+  state.pile1 = { id: 'pile1', type: 'pile', parent: 'handB', x: 4, y: 4 };
+  Object.assign(state.card1, { parent: 'pile1', x: 0, y: 0 });
+  state.card2 = card('card2', { parent: 'pile1', x: 0, y: 0 });
+  await openRoom(t, MODERN, state);
+  await dragPath(t, CARD, [ { dx: 0, dy: -400 } ]);
+
+  // taking the second-to-last card out dissolves the pile, which hands the remaining card back
+  // to the holder it is already in - not a departure, and not an arrival
+  const after = await stateWhen(s=>!s.pile1);
+  const parents = [ after.card1.parent, after.card2.parent ].sort();
+  await t.expect(parents).eql([ 'handB', undefined ], 'one card left, the other is in the holder');
+  const trace = await readTrace(t, 1);
+  await t.expect(trace.length).eql(1, JSON.stringify(trace));
+  await t.expect(trace[0]).match(/^leave handB card\d\[parent=null mark=leave-handB owner=null\]$/, trace[0]);
+});
+
+test('Dragging a pile out of a holder leaves once and applies onLeave to every card', async t => {
+  const state = fixtureState({}, pileHolders);
+  state.pile1 = { id: 'pile1', type: 'pile', parent: 'handB', x: 4, y: 4 };
+  Object.assign(state.card1, { parent: 'pile1', x: 0, y: 0 });
+  state.card2 = card('card2', { parent: 'pile1', x: 0, y: 0 });
+  await openRoom(t, MODERN, state);
+  await dragPath(t, 'pile1', [ { dx: 0, dy: -400 } ]);
+
+  const after = await stateWhen(s=>(s.card1||{}).mark);
+  await t.expect(after.card1.mark).eql('leave-handB', 'onLeave reached the first card');
+  await t.expect(after.card2.mark).eql('leave-handB', 'onLeave reached the second card');
+  await expectTrace(t, [ 'leave handB pile1[parent=null mark=null owner=null]' ]);
+});
+
+test('A preventPiles holder unpacks a dropped pile without extra events', async t => {
+  const state = fixtureState({ handB: { preventPiles: true } }, pileHolders);
+  state.pile1 = { id: 'pile1', type: 'pile', x: 600, y: 250 };
+  Object.assign(state.card1, { parent: 'pile1', x: 0, y: 0 });
+  state.card2 = card('card2', { parent: 'pile1', x: 0, y: 0 });
+  await openRoom(t, MODERN, state);
+  await dragPath(t, 'pile1', [ { onto: 'handB' } ]);
+
+  const after = await stateWhen(s=>(s.card1||{}).parent == 'handB');
+  await t.expect(after.card2.parent).eql('handB', 'both cards ended up in the holder');
+  await expectTrace(t, [ 'enter handB pile1[parent=handB mark=null owner=null]' ]);
+});
+
+// ---------------------------------------------------------------------------------------------
+// Holders that are not plain top-left stackers
+// ---------------------------------------------------------------------------------------------
+
+test('A stacked holder closes the gap when a card is taken out', async t => {
+  const state = fixtureState({ handB: { stackOffsetY: 40 } }, { enterFields: [ 'parent' ], leaveFields: [ 'parent' ] });
+  Object.assign(state.card1, { parent: 'handB', x: 4, y: 4 });
+  state.card2 = card('card2', { parent: 'handB', x: 4, y: 44 });
+  state.card3 = card('card3', { parent: 'handB', x: 4, y: 84 });
+  await openRoom(t, MODERN, state);
+  await dragPath(t, CARD, [ { dx: 0, dy: -500 } ]);
+
+  // the departure re-compacts the holder, so the two cards that stayed sit at the first two
+  // stack positions rather than leaving a hole where the third one was
+  const after = await stateWhen(s=>Object.values(s).filter(w=>w.parent == 'handB').length == 2);
+  const remaining = Object.values(after).filter(w=>w.parent == 'handB').map(w=>w.y).sort((a, b)=>a-b);
+  await t.expect(remaining).eql([ 4, 44 ], 'the two cards that stayed sit at the first two stack positions');
+});
+
+test('MOVEXY out of a stacked holder closes the gap as well', async t => {
+  const state = fixtureState({
+    handB: { stackOffsetY: 40 },
+    go: { clickRoutine: [ { func: 'MOVEXY', from: 'handB', x: 700, y: 200 } ] }
+  }, { enterFields: [ 'parent' ], leaveFields: [ 'parent' ] });
+  Object.assign(state.card1, { parent: 'handB', x: 4, y: 4 });
+  state.card2 = card('card2', { parent: 'handB', x: 4, y: 44 });
+  state.card3 = card('card3', { parent: 'handB', x: 4, y: 84 });
+  await openRoom(t, MODERN, state);
+  await clickGo(t);
+
+  const after = await stateWhen(s=>Object.values(s).filter(w=>w.parent == 'handB').length == 2);
+  const remaining = Object.entries(after).filter(([ , w ])=>w.parent == 'handB').map(([ , w ])=>w.y);
+  await t.expect(remaining.sort((a, b)=>a-b)).eql([ 4, 44 ]);
+});
+
+test('An alignChildren:false holder keeps the drop coordinate and still enters', async t => {
+  const state = fixtureState({ handB: { alignChildren: false } }, { enterFields: [ 'parent', 'mark' ], leaveFields: [ 'parent', 'mark' ] });
+  state.card1.parent = 'handA';
+  await openRoom(t, MODERN, state);
+  await dragPath(t, CARD, [ { onto: 'handB' } ]);
+
+  await expectTrace(t, [
+    'leave handA[parent=null mark=leave-handA]',
+    'enter handB[parent=handB mark=enter-handB]'
+  ]);
+});
+
+// ---------------------------------------------------------------------------------------------
+// Seats and per-owner hands
+// ---------------------------------------------------------------------------------------------
+
+test('Dragging a card out of a per-owner hand releases it before leaveRoutine runs', async t => {
+  await openRoom(t, MODERN, fixtureState({ handA: { childrenPerOwner: true }, card1: { parent: 'handA', x: 4, y: 4, owner: 'Alice' } }));
+  await setName(t, 'Alice');
+  await dragPath(t, CARD, [ { dx: 500, dy: -400 } ]);
+
+  await expectTrace(t, [ 'leave handA[parent=null mark=leave-handA owner=null]' ]);
+});
+
+test('Legacy: the per-owner hand released the card between its two leave calls', async t => {
+  await openRoom(t, LEGACY, fixtureState({ handA: { childrenPerOwner: true }, card1: { parent: 'handA', x: 4, y: 4, owner: 'Alice' } }));
+  await setName(t, 'Alice');
+  await dragPath(t, CARD, [ { dx: 500, dy: -400 } ]);
+
+  await expectTrace(t, [
+    'leave handA[parent=null mark=null owner=Alice]',
+    'leave handA[parent=null mark=leave-handA owner=null]'
+  ]);
+});
+
+test('MOVE to a seat runs the hand\'s enterRoutine with the owner already set', async t => {
+  const state = fixtureState({
+    handB: { childrenPerOwner: true },
+    card1: { parent: 'handA', x: 4, y: 4 },
+    go: { clickRoutine: [ { func: 'SELECT', property: 'id', value: CARD }, { func: 'MOVE', to: 'seat1' } ] }
+  });
+  state.seat1 = { id: 'seat1', type: 'seat', hand: 'handB', x: 1150, y: 500, index: 1 };
+  await openRoom(t, MODERN, state);
+  await setName(t, 'Alice');
+  // MOVE to a seat needs somebody sitting on it, or it has no hand to move the card into
+  await t.click('#w_seat1');
+  await clickGo(t);
+
+  await expectTrace(t, [
+    'leave handA[parent=null mark=leave-handA owner=null]',
+    'enter handB[parent=handB mark=enter-handB owner=Alice]'
+  ]);
+});
+
+// ---------------------------------------------------------------------------------------------
+// A holder inside a holder
+// ---------------------------------------------------------------------------------------------
+
+test('A card dropped into a holder that sits in another holder enters only the inner one', async t => {
+  const state = fixtureState({ handB: { alignChildren: false } });
+  state.inner = holder('inner', { parent: 'handB', x: 20, y: 20, width: 200, height: 150 });
+  state.card1.parent = 'handA';
+  await openRoom(t, MODERN, state);
+  await dragPath(t, CARD, [ { onto: 'inner' } ]);
+
+  await expectTrace(t, [
+    'leave handA[parent=null mark=leave-handA owner=null]',
+    'enter inner[parent=inner mark=enter-inner owner=null]'
+  ]);
+});

--- a/tests/testcafe/enterleave.js
+++ b/tests/testcafe/enterleave.js
@@ -369,6 +369,38 @@ test('Rearranging a card inside a per-owner hand never takes its owner away', as
   await t.expect(after[CARD].owner).eql('Alice', 'the card is still in Alice\'s hand');
 });
 
+test('A rearrange inside a per-owner hand leaves nothing behind that keeps the next card owned', async t => {
+  await openRoom(t, MODERN, fixtureState({
+    handA: { childrenPerOwner: true },
+    card1: { parent: 'handA', x: 4, y: 4, owner: 'Alice' },
+    go: { clickRoutine: [ { func: 'SELECT', property: 'id', value: CARD }, { func: 'SET', property: 'parent', value: null } ] }
+  }));
+  await setName(t, 'Alice');
+  await dragPath(t, CARD, [ { dx: 150, dy: 0 } ]);
+  await clickGo(t);
+
+  // A rearrange is the one drag that never reaches checkParent(), so it is the one that can
+  // leave "a drag is in progress" set behind it. A card played out of the hand afterwards has
+  // to lose its owner all the same - otherwise it lies on the table invisible to everybody else.
+  const after = await stateWhen(s=>!s[CARD].parent);
+  await t.expect(after[CARD].owner).notOk('the card played out of the hand belongs to nobody');
+});
+
+test('MOVEXY with resetOwner off keeps the owner of a card taken out of a per-owner hand', async t => {
+  await openRoom(t, MODERN, fixtureState({
+    handA: { childrenPerOwner: true },
+    card1: { parent: 'handA', x: 4, y: 4, owner: 'Alice' },
+    go: { clickRoutine: [ { func: 'MOVEXY', from: 'handA', x: 700, y: 200, resetOwner: false } ] }
+  }));
+  await setName(t, 'Alice');
+  await clickGo(t);
+
+  // dealing a card onto the table that only its owner may see is what the parameter is for
+  await expectTrace(t, [ 'leave handA[parent=null mark=leave-handA owner=Alice]' ]);
+  const after = await stateWhen(s=>!s[CARD].parent);
+  await t.expect(after[CARD].owner).eql('Alice', 'the card on the table is still Alice\'s');
+});
+
 test('Legacy: the per-owner hand released the card between its two leave calls', async t => {
   await openRoom(t, LEGACY, fixtureState({ handA: { childrenPerOwner: true }, card1: { parent: 'handA', x: 4, y: 4, owner: 'Alice' } }));
   await setName(t, 'Alice');

--- a/tests/testcafe/enterleave.js
+++ b/tests/testcafe/enterleave.js
@@ -283,6 +283,24 @@ test('MOVEXY out of a stacked holder closes the gap as well', async t => {
   await t.expect(remaining.sort((a, b)=>a-b)).eql([ 4, 44 ]);
 });
 
+test('DELETE closes the gap in a stacked holder as well', async t => {
+  const state = fixtureState({
+    handB: { stackOffsetY: 40 },
+    go: { clickRoutine: [ { func: 'SELECT', property: 'id', value: CARD }, { func: 'DELETE' } ] }
+  }, { enterFields: [ 'parent' ], leaveFields: [ 'parent' ] });
+  Object.assign(state.card1, { parent: 'handB', x: 4, y: 4 });
+  state.card2 = card('card2', { parent: 'handB', x: 4, y: 44 });
+  state.card3 = card('card3', { parent: 'handB', x: 4, y: 84 });
+  await openRoom(t, MODERN, state);
+  await clickGo(t);
+
+  // a card removed from the room applies no onLeave - it is gone - but the holder it was taken
+  // out of is still one card shorter and re-stacks what is left
+  const after = await stateWhen(s=>!s[CARD]);
+  const remaining = Object.values(after).filter(w=>w.parent == 'handB').map(w=>w.y).sort((a, b)=>a-b);
+  await t.expect(remaining).eql([ 4, 44 ], 'the two cards that stayed sit at the first two stack positions');
+});
+
 test('An alignChildren:false holder keeps the drop coordinate and still enters', async t => {
   const state = fixtureState({ handB: { alignChildren: false } }, { enterFields: [ 'parent', 'mark' ], leaveFields: [ 'parent', 'mark' ] });
   state.card1.parent = 'handA';
@@ -299,12 +317,33 @@ test('An alignChildren:false holder keeps the drop coordinate and still enters',
 // Seats and per-owner hands
 // ---------------------------------------------------------------------------------------------
 
-test('Dragging a card out of a per-owner hand releases it before leaveRoutine runs', async t => {
+test('Dragging a card out of a per-owner hand releases it once it is out of the box', async t => {
   await openRoom(t, MODERN, fixtureState({ handA: { childrenPerOwner: true }, card1: { parent: 'handA', x: 4, y: 4, owner: 'Alice' } }));
   await setName(t, 'Alice');
   await dragPath(t, CARD, [ { dx: 500, dy: -400 } ]);
 
-  await expectTrace(t, [ 'leave handA[parent=null mark=leave-handA owner=null]' ]);
+  // the hand still holds the card while the drag is over it, so leaveRoutine reads the owner it
+  // had; the release follows a moment later, when the card is really outside
+  await expectTrace(t, [ 'leave handA[parent=null mark=leave-handA owner=Alice]' ]);
+  // an owner back at its default is not serialized at all, so the state simply stops naming one
+  const after = await stateWhen(s=>!s[CARD].owner);
+  await t.expect(after[CARD].owner).notOk('the card on the table belongs to nobody');
+});
+
+test('Rearranging a card inside a per-owner hand never takes its owner away', async t => {
+  await openRoom(t, MODERN, fixtureState({ handA: { childrenPerOwner: true }, card1: { parent: 'handA', x: 4, y: 4, owner: 'Alice' } }));
+  await setName(t, 'Alice');
+  await dragPath(t, CARD, [ { dx: 150, dy: 0 } ]);
+
+  // A card without an owner is one every other player can see. The drag detaches it at the
+  // pickup, so both halves of this rearrange have to find it still owned - otherwise the other
+  // players watch Alice sort her hand.
+  await expectTrace(t, [
+    'leave handA[parent=null mark=leave-handA owner=Alice]',
+    'enter handA[parent=handA mark=enter-handA owner=Alice]'
+  ]);
+  const after = await stateWhen(s=>s[CARD].parent == 'handA');
+  await t.expect(after[CARD].owner).eql('Alice', 'the card is still in Alice\'s hand');
 });
 
 test('Legacy: the per-owner hand released the card between its two leave calls', async t => {

--- a/tests/testcafe/holderevent-util.js
+++ b/tests/testcafe/holderevent-util.js
@@ -1,0 +1,94 @@
+import { getStateObject } from './test-util.js';
+import { stateWhen } from './interaction-util.js';
+
+// The probe game the holder-event fixtures drive, shared by holderevents.js (what the engine
+// does now) and enterleave.js (what the legacyHolderEnterLeaveEvents mode restores, plus the
+// combinations that need more than two holders).
+//
+// How the trace works: every routine appends one entry to a log widget, and each entry carries
+// the properties of the widget the event is about, read at that moment. The holders write
+// distinguishable marks through onEnter/onLeave, so an entry saying `mark=null` means "this
+// routine ran before the property half of the event", and `parent=handB` means "the parent was
+// already written when this routine ran".
+
+export const CARD = 'card1';
+
+// The fields an entry records. Coordinates are only meaningful where the case makes them
+// deterministic - a routine that fires in the middle of a drag sees wherever the pointer was -
+// so they are opt-in per holder.
+export const DEFAULT_FIELDS = [ 'parent', 'mark', 'owner' ];
+
+function observation(fields, id) {
+  return fields.map(property=>`${property}=\${PROPERTY ${property} OF ${id}}`).join(' ');
+}
+
+// One trace entry, appended to the log widget's `trace` property. Reading the log through
+// ${PROPERTY trace OF log} rather than a variable is what makes it accumulate across the
+// separate routine invocations the engine makes.
+export function traceRoutine(tag, fields, id = CARD) {
+  return [
+    { func: 'SELECT', property: 'id', value: 'log', collection: 'log' },
+    { func: 'SET', collection: 'log', property: 'trace', value: `\${PROPERTY trace OF log}${tag}[${observation(fields, id)}];` }
+  ];
+}
+
+// A trace that names the widget the event was about instead of watching a fixed one - what the
+// pile cases need, where the event can be about a card or about the pile holding it.
+export function traceChildRoutine(tag, fields = DEFAULT_FIELDS) {
+  return [
+    { func: 'GET', collection: 'child', property: 'id', variable: 'childID' },
+    ...fields.map(property => ({ func: 'GET', collection: 'child', property, variable: `f_${property}` })),
+    { func: 'SELECT', property: 'id', value: 'log', collection: 'log' },
+    { func: 'SET', collection: 'log', property: 'trace',
+      value: `\${PROPERTY trace OF log}${tag} \${childID}[${fields.map(p=>`${p}=\${f_${p}}`).join(' ')}];` }
+  ];
+}
+
+export function holder(id, properties = {}, { enterFields = DEFAULT_FIELDS, leaveFields = DEFAULT_FIELDS, watchChild = false } = {}) {
+  return Object.assign({
+    id, type: 'holder', width: 350, height: 250,
+    onEnter: { mark: `enter-${id}` },
+    onLeave: { mark: `leave-${id}` },
+    enterRoutine: watchChild ? traceChildRoutine(`enter ${id}`, enterFields) : traceRoutine(`enter ${id}`, enterFields),
+    leaveRoutine: watchChild ? traceChildRoutine(`leave ${id}`, leaveFields) : traceRoutine(`leave ${id}`, leaveFields)
+  }, properties);
+}
+
+// Two holders far enough apart that a drag between them leaves the first one's box, a card on
+// the table, a log widget and a button for the routine-driven cases.
+export function fixtureState(overrides = {}, holderOptions = {}) {
+  const state = {
+    deck:  { id: 'deck', type: 'deck', cardTypes: { plain: {} }, x: 1450, y: 20 },
+    card1: { id: CARD, type: 'card', deck: 'deck', cardType: 'plain', x: 700, y: 60 },
+    log:   { id: 'log', type: 'basic', x: 700, y: 900, width: 80, height: 80, trace: '' },
+    go:    { id: 'go', type: 'button', x: 700, y: 420, width: 100, height: 60, text: 'go' },
+    handA: holder('handA', { x: 80,   y: 650 }, holderOptions),
+    handB: holder('handB', { x: 1150, y: 650 }, holderOptions)
+  };
+  for(const [ id, properties ] of Object.entries(overrides))
+    state[id] = state[id] ? Object.assign(state[id], properties) : Object.assign({ id }, properties);
+  return state;
+}
+
+// A second card of the same deck, for the cases that need two.
+export function card(id, properties = {}) {
+  return Object.assign({ id, type: 'card', deck: 'deck', cardType: 'plain' }, properties);
+}
+
+// Read the log until it holds as many entries as the case expects, then give the engine a
+// moment to add one more: a case that fires three routines where the test expects two has to go
+// red rather than pass on a snapshot taken between them.
+export async function readTrace(t, expectedLength) {
+  const entries = state=>String((state.log||{}).trace||'').split(';').filter(entry=>entry);
+  const state = await stateWhen(s=>entries(s).length >= expectedLength);
+  await t.wait(400);
+  return entries(await getStateObject());
+}
+
+export async function expectTrace(t, expected, message) {
+  await t.expect(await readTrace(t, expected.length)).eql(expected, message);
+}
+
+export async function clickGo(t) {
+  await t.click('#w_go');
+}

--- a/tests/testcafe/holderevents.js
+++ b/tests/testcafe/holderevents.js
@@ -1,93 +1,19 @@
 import { getStateObject, setName, setupTestEnvironment } from './test-util.js';
 import { dragPath, openRoom, stateWhen } from './interaction-util.js';
+import { CARD, card, clickGo, expectTrace, fixtureState, readTrace } from './holderevent-util.js';
 
 setupTestEnvironment();
 
 // Holder events: what fires, in which order, and what the widget looks like while it fires.
 //
-// #1212 wrote down what holder events *should* do - parent cleared, beforeLeaveRoutine,
-// onLeave, leaveRoutine, then on the other side parent set, onEnter, alignment, piles resolved,
-// afterLeaveRoutine, enterRoutine - and nobody has ever asserted what they actually do. The
-// order is the interesting part: a routine that reads the widget it was handed sees a different
-// answer depending on whether it runs before or after the properties are written, and games
-// encode whichever answer they observed.
+// #1212 wrote down what holder events should do - the properties of the departure, then the
+// leaving holder's routine, then the arrival and the receiving holder's routine - and this file
+// pins what a real pointer and a real routine actually produce. Every move raises at most one
+// leave and one enter, and each of them applies its properties before it calls its routine.
 //
-// So this file pins the status quo. Several of the traces below are *not* what #1212 asks for,
-// and they are recorded as they are, with the difference named at the case. That makes the
-// eventual move towards the described order a visible, reviewable diff (and tells whoever
-// writes the legacy mode for it exactly which games' assumptions are at stake), while any
-// unintended change to the current order fails a test the day it is made.
-//
-// How the trace works: every routine appends one entry to a log widget, and each entry carries
-// the properties of the widget the event is about, read at that moment. Two holders write
-// distinguishable marks through onEnter/onLeave, so an entry saying `mark=null` means "this
-// routine ran before the property half of the event", and `parent=handB` means "the parent was
-// already written when this routine ran".
-
-const CARD = 'card1';
-
-// The fields an entry records. Coordinates are only meaningful where the case makes them
-// deterministic - a routine that fires in the middle of a drag sees wherever the pointer was -
-// so they are opt-in per holder.
-const DEFAULT_FIELDS = [ 'parent', 'mark', 'owner' ];
-
-function observation(fields, id) {
-  return fields.map(property=>`${property}=\${PROPERTY ${property} OF ${id}}`).join(' ');
-}
-
-// One trace entry, appended to the log widget's `trace` property. Reading the log through
-// ${PROPERTY trace OF log} rather than a variable is what makes it accumulate across the
-// separate routine invocations the engine makes.
-function traceRoutine(tag, fields, id = CARD) {
-  return [
-    { func: 'SELECT', property: 'id', value: 'log', collection: 'log' },
-    { func: 'SET', collection: 'log', property: 'trace', value: `\${PROPERTY trace OF log}${tag}[${observation(fields, id)}];` }
-  ];
-}
-
-function holder(id, properties = {}, { enterFields = DEFAULT_FIELDS, leaveFields = DEFAULT_FIELDS } = {}) {
-  return Object.assign({
-    id, type: 'holder', width: 350, height: 250,
-    onEnter: { mark: `enter-${id}` },
-    onLeave: { mark: `leave-${id}` },
-    enterRoutine: traceRoutine(`enter ${id}`, enterFields),
-    leaveRoutine: traceRoutine(`leave ${id}`, leaveFields)
-  }, properties);
-}
-
-// Two holders far enough apart that a drag between them leaves the first one's box, a card on
-// the table, a log widget and a button for the routine-driven cases.
-function fixtureState(overrides = {}, holderOptions = {}) {
-  const state = {
-    deck:  { id: 'deck', type: 'deck', cardTypes: { plain: {} }, x: 1450, y: 20 },
-    card1: { id: CARD, type: 'card', deck: 'deck', cardType: 'plain', x: 700, y: 60 },
-    log:   { id: 'log', type: 'basic', x: 700, y: 900, width: 80, height: 80, trace: '' },
-    go:    { id: 'go', type: 'button', x: 700, y: 420, width: 100, height: 60, text: 'go' },
-    handA: holder('handA', { x: 80,   y: 650 }, holderOptions),
-    handB: holder('handB', { x: 1150, y: 650 }, holderOptions)
-  };
-  for(const [ id, properties ] of Object.entries(overrides))
-    state[id] = state[id] ? Object.assign(state[id], properties) : Object.assign({ id }, properties);
-  return state;
-}
-
-// Read the log until it holds as many entries as the case expects, then give the engine a
-// moment to add one more: a case that fires three routines where the test expects two has to go
-// red rather than pass on a snapshot taken between them.
-async function readTrace(t, expectedLength) {
-  const entries = state=>String((state.log||{}).trace||'').split(';').filter(entry=>entry);
-  const state = await stateWhen(s=>entries(s).length >= expectedLength);
-  await t.wait(400);
-  return entries(await getStateObject());
-}
-
-async function expectTrace(t, expected) {
-  await t.expect(await readTrace(t, expected.length)).eql(expected);
-}
-
-async function clickGo(t) {
-  await t.click('#w_go');
-}
+// tests/testcafe/enterleave.js is the other half: the same traces with the
+// legacyHolderEnterLeaveEvents mode on, which restores the pipeline this replaced, plus the
+// combinations that need more than the two holders holderevent-util.js sets up.
 
 // ---------------------------------------------------------------------------------------------
 // Dragging
@@ -102,23 +28,13 @@ test('Dragging a card into a holder: parent, onEnter and alignment are all done 
   await expectTrace(t, [ 'enter handB[parent=handB mark=enter-handB owner=null x=4 y=4]' ]);
 });
 
-test('Dragging a card out of a holder fires leaveRoutine twice', async t => {
+test('Dragging a card out of a holder fires leaveRoutine once', async t => {
   await openRoom(t, 'modern', fixtureState({ card1: { parent: 'handA', x: 4, y: 4 } }));
   await dragPath(t, CARD, [ { dx: 500, dy: -400 } ]);
 
-  // The #1212 headline. Two different code paths call the same routine for one drag:
-  //
-  //   1. moveStart() sets parent to null to detach the widget, and onPropertyChange('parent')
-  //      calls the old parent's leaveRoutine directly (widget.js:2766) - before anything else
-  //      about the departure has happened, so onLeave has not been applied yet (mark=null).
-  //   2. move() calls checkParent(), which detaches for real once the widget no longer overlaps
-  //      the holder: dispenseCard() applies onLeave and calls leaveRoutine again.
-  //
-  // The issue proposes splitting these into beforeLeaveRoutine and leaveRoutine, which would
-  // make the two calls deliberate and distinguishable. Until then, a game that counts cards in
-  // its leaveRoutine counts one drag twice.
+  // Picking the card up detaches it, and that parent change is the departure: onLeave is applied
+  // and leaveRoutine runs once, reading a card the event has already finished writing.
   await expectTrace(t, [
-    'leave handA[parent=null mark=null owner=null]',
     'leave handA[parent=null mark=leave-handA owner=null]'
   ]);
 });
@@ -127,34 +43,27 @@ test('Dragging a card from one holder to another', async t => {
   await openRoom(t, 'modern', fixtureState({ card1: { parent: 'handA', x: 4, y: 4 } }));
   await dragPath(t, CARD, [ { onto: 'handB' } ]);
 
-  // #1212 asks for beforeLeave / onLeave+leave / enter, with an afterLeaveRoutine after the
-  // arrival. What happens is the doubled leave above, and then the arrival - so the leaving
-  // holder is completely finished before the receiving one starts, and nothing runs after the
-  // card has landed on behalf of the holder it came from.
+  // The leaving holder is completely finished before the receiving one starts. #1212 also asks
+  // for an afterLeaveRoutine once the card has landed, which does not exist yet - nothing runs
+  // on behalf of handA after the arrival.
   await expectTrace(t, [
-    'leave handA[parent=null mark=null owner=null]',
     'leave handA[parent=null mark=leave-handA owner=null]',
     'enter handB[parent=handB mark=enter-handB owner=null]'
   ]);
 });
 
-test('Dragging a card within its holder still fires the whole leave-and-enter cycle', async t => {
+test('Dragging a card within its holder fires the whole leave-and-enter cycle', async t => {
   await openRoom(t, 'modern', fixtureState({ card1: { parent: 'handA', x: 4, y: 4 } }));
   // 150 board units to the right, which keeps the card inside handA the whole time
   await dragPath(t, CARD, [ { dx: 150, dy: 0 } ]);
 
   // #1212 wants this to be beforeLeaveRoutine + leaveCancelledRoutine, i.e. for the game to be
-  // able to tell "the card never actually left" from a real departure. Today the card leaves
-  // and arrives: the detaching leaveRoutine fires (the holder never stops overlapping, so the
-  // second, onLeave-carrying call does not), and the drop runs enterRoutine.
-  //
-  // onEnter is *not* applied though - onChildAdd() skips it when the widget lands back on the
-  // holder it was dragged off (`this != child.currentParent`, holder.js:128). So this is the one
-  // case today where the properties and the routine disagree about whether an entry happened,
-  // and mark=null is how a game can tell the two apart at all.
+  // able to tell "the card never actually left" from a real departure. What it is instead is a
+  // departure and an arrival, both complete: the card left the holder when it was picked up and
+  // entered it again when it was dropped, so the properties and the routines agree.
   await expectTrace(t, [
-    'leave handA[parent=null mark=null owner=null]',
-    'enter handA[parent=handA mark=null owner=null]'
+    'leave handA[parent=null mark=leave-handA owner=null]',
+    'enter handA[parent=handA mark=enter-handA owner=null]'
   ]);
 });
 
@@ -163,10 +72,9 @@ test('Dragging a card out of a holder and back before dropping it', async t => {
   await dragPath(t, CARD, [ { dx: 0, dy: -400 }, { onto: 'handA' } ]);
 
   // The case #1212 calls "leaveCancelledRoutine with a flag indicating that leaveRoutine was
-  // called". Today it is indistinguishable from a card that came from somewhere else: two
-  // leaves and an enter, exactly like the holder-to-holder drag.
+  // called". It is indistinguishable from a card that came from somewhere else: one leave and
+  // one enter, exactly like the holder-to-holder drag.
   await expectTrace(t, [
-    'leave handA[parent=null mark=null owner=null]',
     'leave handA[parent=null mark=leave-handA owner=null]',
     'enter handA[parent=handA mark=enter-handA owner=null]'
   ]);
@@ -174,7 +82,7 @@ test('Dragging a card out of a holder and back before dropping it', async t => {
 
 test('A card dragged onto a full holder is refused and stays on the table', async t => {
   const state = fixtureState({ handB: { dropLimit: 1 } });
-  state.card2 = { id: 'card2', type: 'card', deck: 'deck', cardType: 'plain', parent: 'handB' };
+  state.card2 = card('card2', { parent: 'handB' });
   await openRoom(t, 'modern', state);
   await dragPath(t, CARD, [ { onto: 'handB' } ]);
 
@@ -210,7 +118,7 @@ test('alignChildren false leaves the drop coordinate alone', async t => {
 
 test('A stacked holder rearranges its children before enterRoutine and after onLeave', async t => {
   const state = fixtureState({ handB: { stackOffsetX: 40 } }, { enterFields: [ 'parent', 'mark', 'x' ], leaveFields: [ 'parent', 'mark', 'x' ] });
-  state.card2 = { id: 'card2', type: 'card', deck: 'deck', cardType: 'plain', parent: 'handB' };
+  state.card2 = card('card2', { parent: 'handB' });
   await openRoom(t, 'modern', state);
   await dragPath(t, CARD, [ { onto: 'handB' } ]);
 
@@ -222,7 +130,6 @@ test('ignoreOnLeave skips the property half of the departure but not the routine
   await dragPath(t, CARD, [ { dx: 500, dy: -400 } ]);
 
   await expectTrace(t, [
-    'leave handA[parent=null mark=null owner=null]',
     'leave handA[parent=null mark=null owner=null]'
   ]);
 });
@@ -238,7 +145,6 @@ test('A holder with dropShadow runs its enter and leave events for the shadow wi
   await expectTrace(t, [
     'enter handB[parent=null]',
     'leave handB[parent=null]',
-    'leave handB[parent=null]',
     'enter handB[parent=handB]'
   ]);
 });
@@ -249,7 +155,7 @@ test('A holder with dropShadow runs its enter and leave events for the shadow wi
 
 test('Dropping a card onto a card inside a holder applies onEnter to both', async t => {
   const state = fixtureState({}, { enterFields: [ 'parent', 'mark' ], leaveFields: [ 'parent', 'mark' ] });
-  state.card2 = { id: 'card2', type: 'card', deck: 'deck', cardType: 'plain', parent: 'handB' };
+  state.card2 = card('card2', { parent: 'handB' });
   await openRoom(t, 'modern', state);
   await dragPath(t, CARD, [ { onto: 'card2' } ]);
 
@@ -263,7 +169,7 @@ test('Dragging a pile into a holder applies onEnter to every card in it', async 
   const state = fixtureState();
   state.pile1 = { id: 'pile1', type: 'pile', x: 600, y: 250 };
   state.card1.parent = 'pile1';
-  state.card2 = { id: 'card2', type: 'card', deck: 'deck', cardType: 'plain', parent: 'pile1' };
+  state.card2 = card('card2', { parent: 'pile1' });
   await openRoom(t, 'modern', state);
   await dragPath(t, 'pile1', [ { onto: 'handB' } ]);
 
@@ -287,12 +193,9 @@ test('MOVE from one holder to another', async t => {
   }));
   await clickGo(t);
 
-  // #1212 wants onLeave + leaveRoutine, then the arrival, then afterLeaveRoutine and
-  // enterRoutine. What the engine does is the same doubled leave as the drag (moveToHolder()
-  // detaches through the same two paths), and the second one runs *after* the card has already
-  // arrived in handB - so a leaveRoutine reading its child's parent sees the destination.
+  // A routine-driven move produces the same trace as the drag above: MOVE goes through
+  // moveToHolder(), which detaches the card first, and the detach is the departure.
   await expectTrace(t, [
-    'leave handA[parent=null mark=null owner=null]',
     'leave handA[parent=null mark=leave-handA owner=null]',
     'enter handB[parent=handB mark=enter-handB owner=null]'
   ]);
@@ -306,7 +209,6 @@ test('MOVE of a collection into a holder', async t => {
   await clickGo(t);
 
   await expectTrace(t, [
-    'leave handA[parent=null mark=null owner=null]',
     'leave handA[parent=null mark=leave-handA owner=null]',
     'enter handB[parent=handB mark=enter-handB owner=null]'
   ]);
@@ -319,28 +221,24 @@ test('MOVEXY out of a holder', async t => {
   }));
   await clickGo(t);
 
-  // MOVEXY writes parent directly instead of going through checkParent(), so dispenseCard()
-  // never runs: onLeave is not applied (mark stays null) and leaveRoutine fires once rather
-  // than twice. #1212 asks for onLeave + leaveRoutine + afterLeaveRoutine here, so this is the
-  // operation furthest from the description - and the difference to MOVE, which does apply
-  // onLeave, is invisible in a game until a card comes out of a holder the wrong way.
+  // MOVEXY writes parent directly rather than going through checkParent(), and the departure is
+  // the parent change itself - so it applies onLeave exactly like MOVE and the drag do (#1371).
   await expectTrace(t, [
-    'leave handA[parent=null mark=null owner=null]'
+    'leave handA[parent=null mark=leave-handA owner=null]'
   ]);
 });
 
-test('SET parent is the plain property write and fires only the parent-change half', async t => {
+test('SET parent raises the same departure and arrival as a drag', async t => {
   await openRoom(t, 'modern', fixtureState({
     card1: { parent: 'handA', x: 4, y: 4 },
     go: { clickRoutine: [ { func: 'SELECT', property: 'id', value: CARD }, { func: 'SET', property: 'parent', value: 'handB' } ] }
   }));
   await clickGo(t);
 
-  // No dispenseCard() on this path, so onLeave is never applied and leaveRoutine fires once
-  // instead of twice. A game that moves cards with SET therefore sees a different event
-  // sequence than one that uses MOVE, which is worth knowing before the order is changed.
+  // SET writes the destination before the event runs, which is why the departing routine reads
+  // parent=handB - but it is still a departure, so onLeave is applied first (#1836).
   await expectTrace(t, [
-    'leave handA[parent=handB mark=null owner=null]',
+    'leave handA[parent=handB mark=leave-handA owner=null]',
     'enter handB[parent=handB mark=enter-handB owner=null]'
   ]);
 });
@@ -398,34 +296,31 @@ test('enterRoutine and leaveRoutine are handed the widget in the child collectio
 });
 
 // ---------------------------------------------------------------------------------------------
-// The same ordering with every legacy mode on
+// The rendering legacy modes do not reach the event methods
 // ---------------------------------------------------------------------------------------------
 //
-// None of the four modes is about holder events, so the answer has to be the same in both
-// combinations - which is exactly why it is worth asserting: disableHolderImageWidget swaps the
-// holder's prototype, and a prototype swap that reached the event methods would show up here
-// and nowhere else.
+// disableHolderImageWidget swaps the holder's prototype, which is the one legacy mode that could
+// reach the event methods by accident - so the modern trace has to survive it. The mode that is
+// about holder events, legacyHolderEnterLeaveEvents, has its own fixture in enterleave.js.
 
-test('The holder-to-holder order is the same with every legacy mode on', async t => {
-  await openRoom(t, 'legacy-all', fixtureState({ card1: { parent: 'handA', x: 4, y: 4 } }));
+test('The holder-to-holder order survives disableHolderImageWidget', async t => {
+  await openRoom(t, 'only-disableHolderImageWidget', fixtureState({ card1: { parent: 'handA', x: 4, y: 4 } }));
   await dragPath(t, CARD, [ { onto: 'handB' } ]);
 
   await expectTrace(t, [
-    'leave handA[parent=null mark=null owner=null]',
     'leave handA[parent=null mark=leave-handA owner=null]',
     'enter handB[parent=handB mark=enter-handB owner=null]'
   ]);
 });
 
-test('The MOVE order is the same with every legacy mode on', async t => {
-  await openRoom(t, 'legacy-all', fixtureState({
+test('The MOVE order survives disableHolderImageWidget', async t => {
+  await openRoom(t, 'only-disableHolderImageWidget', fixtureState({
     card1: { parent: 'handA', x: 4, y: 4 },
     go: { clickRoutine: [ { func: 'MOVE', from: 'handA', to: 'handB', count: 1 } ] }
   }));
   await clickGo(t);
 
   await expectTrace(t, [
-    'leave handA[parent=null mark=null owner=null]',
     'leave handA[parent=null mark=leave-handA owner=null]',
     'enter handB[parent=handB mark=enter-handB owner=null]'
   ]);

--- a/tests/testcafe/holderevents.js
+++ b/tests/testcafe/holderevents.js
@@ -134,19 +134,27 @@ test('ignoreOnLeave skips the property half of the departure but not the routine
   ]);
 });
 
-test('A holder with dropShadow runs its enter and leave events for the shadow widget as well', async t => {
+test('A holder with dropShadow raises nothing for the shadow widget', async t => {
   await openRoom(t, 'modern', fixtureState({ handB: { dropShadow: true } }, { enterFields: [ 'parent' ], leaveFields: [ 'parent' ] }));
   await dragPath(t, CARD, [ { onto: 'handB' } ]);
 
   // The shadow is a real widget that is put into the holder and taken out again while the drag
-  // is still going on, so the holder's routines run for something the player never dropped. The
-  // trace is about card1, which is why the shadow's own entries read parent=null: at that
-  // moment the card is still being dragged.
-  await expectTrace(t, [
-    'enter handB[parent=null]',
-    'leave handB[parent=null]',
-    'enter handB[parent=handB]'
-  ]);
+  // is still going on, but it only paints where the card would land. The holder's routines run
+  // once, for the card the player actually dropped.
+  await expectTrace(t, [ 'enter handB[parent=handB]' ]);
+});
+
+test('Hovering a dropShadow holder and dropping elsewhere changes nothing', async t => {
+  await openRoom(t, 'modern', fixtureState({ handB: { dropShadow: true } }, { enterFields: [ 'parent' ], leaveFields: [ 'parent' ] }));
+  await dragPath(t, CARD, [ { onto: 'handB' }, { dx: 0, dy: -450 } ]);
+
+  // A holder routine can score, deal, delete or move widgets, so previewing a drop the player
+  // then thinks better of has to leave the room exactly as it was: no trace, no onEnter mark
+  // and the card back on the table.
+  await t.expect(await readTrace(t, 0)).eql([], 'the preview raised no event');
+  const after = await getStateObject();
+  await t.expect(after[CARD].mark).eql(undefined, 'onEnter never reached the card');
+  await t.expect(after[CARD].parent).notEql('handB', 'the card is not in the holder');
 });
 
 // ---------------------------------------------------------------------------------------------

--- a/tests/testcafe/interaction-util.js
+++ b/tests/testcafe/interaction-util.js
@@ -25,7 +25,7 @@ export const surfaceGeometry = ClientFunction(_=>{
 // path work: mousedown has to land on the widget, and the later moves have to be accepted
 // wherever the pointer happens to be. The client listens on window, so the event only has to
 // bubble - and it reads clientX/clientY, so nothing else about it matters.
-const dispatchMouse = ClientFunction((type, clientX, clientY) => {
+export const dispatchMouse = ClientFunction((type, clientX, clientY) => {
   const element = document.elementFromPoint(clientX, clientY) || document.body;
   element.dispatchEvent(new MouseEvent(type, { clientX, clientY, bubbles: true, cancelable: true, button: 0, buttons: type == 'mouseup' ? 0 : 1 }));
 });
@@ -74,7 +74,10 @@ async function clientPoint(waypoint, start, geometry) {
 // testing the *rendered* position of the dragged widget, and a widget that is animating towards
 // a coordinate it was teleported to is still somewhere else when that test runs. A last
 // repeated move after the widget has caught up makes the answer independent of the animation.
-export async function dragPath(t, id, waypoints, { settle = 100, steps = 8 } = {}) {
+// `hold: true` stops after the last waypoint without releasing the button and returns the point
+// the pointer sits at, so a caller can look at the board while a widget still hangs on the
+// cursor - the only moment a second client sees a drag in progress. Finish it with releaseDrag().
+export async function dragPath(t, id, waypoints, { settle = 100, steps = 8, hold = false } = {}) {
   const geometry = await surfaceGeometry();
   const box = await Selector(`#w_${id}`).boundingClientRect;
   const start = { x: box.left + box.width/2, y: box.top + box.height/2 };
@@ -94,5 +97,11 @@ export async function dragPath(t, id, waypoints, { settle = 100, steps = 8 } = {
     await dispatchMouse('mousemove', last.x, last.y);
     await t.wait(settle);
   }
+  if(hold)
+    return last;
   await dispatchMouse('mouseup', last.x, last.y);
+}
+
+export async function releaseDrag(point) {
+  await dispatchMouse('mouseup', point.x, point.y);
 }

--- a/tests/testcafe/multiclient.js
+++ b/tests/testcafe/multiclient.js
@@ -1,7 +1,7 @@
 import { ClientFunction, Selector } from 'testcafe';
 
 import { prepareClient, roomURL, setupTestEnvironment } from './test-util.js';
-import { openRoom, stateWhen } from './interaction-util.js';
+import { dragPath, openRoom, releaseDrag, stateWhen } from './interaction-util.js';
 
 setupTestEnvironment();
 
@@ -153,6 +153,38 @@ test('A card owned by one player is foreign to the other', async t => {
   await t.switchToWindow(second);
   await t.expect(Selector('#w_mine').exists).ok();
   await t.expect(isForeign('mine')).eql(true, 'the other player does not');
+
+  await t.closeWindow(second);
+});
+
+test('Rearranging a per-owner hand keeps the card hidden from the other player', async t => {
+  await openClient(t, 'Alice');
+  await openRoom(t, 'modern', twoPlayerState());
+  const first = await t.getCurrentWindow();
+  const second = await openSecondClient(t, 'Bob');
+
+  await t.switchToWindow(first);
+  await openRoom(t, 'modern', twoPlayerState({
+    deck: { type: 'deck', cardTypes: { plain: {} }, x: 1450, y: 20 },
+    hand: { type: 'holder', x: 400, y: 600, width: 500, height: 250, childrenPerOwner: true, dropTarget: { type: 'card' } },
+    mine: { type: 'card', deck: 'deck', cardType: 'plain', parent: 'hand', x: 4, y: 4, owner: 'Alice' }
+  }));
+
+  // The card is detached from the hand at the pickup, so this asserts in the middle of the
+  // gesture: a hand that let go of its owner there would uncover the card on Bob's screen for
+  // as long as Alice keeps sorting.
+  const held = await dragPath(t, 'mine', [ { dx: 150, dy: 0 } ], { hold: true });
+
+  await t.switchToWindow(second);
+  await t.expect(isForeign('mine')).eql(true, 'Bob does not see the card Alice is moving inside her hand');
+
+  await t.switchToWindow(first);
+  await releaseDrag(held);
+  const state = await stateWhen(s=>(s.mine||{}).parent == 'hand');
+  await t.expect(state.mine.owner).eql('Alice', 'and it is still hers after the drop');
+
+  await t.switchToWindow(second);
+  await t.expect(isForeign('mine')).eql(true, 'Bob still does not see it');
 
   await t.closeWindow(second);
 });


### PR DESCRIPTION
A widget moving into or out of a holder now raises **at most one leave and one enter**, and each of them applies its properties before it calls its routine — whichever way the widget was moved. Until now two different places raised the same leave event, and the operations that only went through one of them applied half of it, which is what the five issues below are about.

## What was wrong

`moveStart()` cleared the widget's `parent`, and `onPropertyChange('parent')` called the old parent's `leaveRoutine` right away — before anything else about the departure had happened. A moment later `checkParent()` detached the widget for real and `Holder.dispenseCard()` applied `onLeave` and called `leaveRoutine` **again**. Everything else was the same table read from a different column:

- a drag and a `MOVE` called `leaveRoutine` twice (#480),
- `SET parent` and `MOVEXY` never reached `dispenseCard()`, so they applied no `onLeave` at all (#1836, #1371),
- a card that joined a pile inside the holder it was already in raised a leave with no matching enter (#1094),
- and a card dropped back into the holder it was picked up from ran `enterRoutine` without applying `onEnter`.

## The model that replaces it

1. **The parent change is the only firing site.** A drag, `MOVE`, `MOVEXY`, `SET parent`, `CLONE`, `RECALL`, `DELETE` and the JSON editor all end up writing `parent`, and that write *is* the event.
2. **Properties first, routine second.** A leave applies the `onLeave` properties, re-compacts a stacked holder, then calls `leaveRoutine`; an enter applies `childrenPerOwner`'s owner and the `onEnter` properties, then calls `enterRoutine`. A routine always reads the values its own event wrote.
3. **A leave is complete before the matching enter starts.**
4. **A pile is transparent inside whatever holds it.** The container an event belongs to is the parent, or the parent's parent when the parent is a pile — so forming, joining, leaving or dissolving a pile inside a holder raises nothing, and taking a card out of one leaves the holder exactly once. A pile *on the table* has nothing behind it and stays a container of its own, so its own `enterRoutine`/`leaveRoutine` fire as before.
5. **A widget on its way out of the room gets no properties.** `DELETE` still tells the holder that it lost a card — and a stacked holder still closes the gap it left — there is just nothing left to apply `onLeave` to.
6. **A per-owner hand lets go of a dragged card only when the card is outside it.** `childrenPerOwner` is the one part of a leave that is visible to the *other* players: a card without an owner loses the `foreign` class, which is what hides everyone else's hand. A drag detaches the widget at the pickup, long before it is anywhere else, so the hand keeps the card until `checkParent()` decides it is really out of the box — rearranging a hand never uncovers a card. Every other way of taking a card out (`SET parent`, `MOVEXY`, `MOVE`) releases it with the rest of the leave — except when `MOVEXY` says `resetOwner: false`, which is the operation's explicit "put this on the table but keep it owned".
7. **A drop-shadow preview is not a move.** A holder with `dropShadow` paints a clone of the dragged widget where the card would land, and that clone is parented into the holder and taken out again while the drag is still going on. It used to run `enterRoutine`, `leaveRoutine`, `onEnter` and `onLeave` for a drop the player had not made — so merely hovering over a holder could score, deal or delete. A parent change of a widget carrying `dropShadowOwner` now raises nothing; the preview still takes its slot in a stacked holder, and that slot closes again from `onChildRemove()` when the pointer moves on.

Unchanged on purpose: a *holder* changing parent still does not run the parent's `leaveRoutine`, a `deck` is still exempt from `onEnter` and `childrenPerOwner`, `ignoreOnLeave` still skips the property half but not the routine, and a pile is still one widget for the routines and a stack of cards for the properties.

Closes #480. Closes #1094. Closes #1371. Closes #1836.

This adopts the parts of #1212 that need no new API. The `beforeLeaveRoutine`, `afterLeaveRoutine` and `leaveCancelledRoutine` it proposes are new routine properties and belong in their own PR with their own editor and validator support, so #1212 stays open. The one remaining difference to its description is that `leaveRoutine` runs after the `parent` write rather than before it — which is what makes a single hook possible at all.

## Backwards compatibility

New legacy mode **`legacyHolderEnterLeaveEvents`** (file version 22 → 23). The file updater switches it on for every save older than version 23 that either mentions `enterRoutine`, `leaveRoutine`, `onEnter`, `onLeave` or `childrenPerOwner`, or stacks children anywhere — a widget carrying a non-zero `stackOffsetX`/`stackOffsetY` (which may be the template a holder inherits from or clones rather than the holder itself), or a routine that sets one while the game runs. A stacked holder notices the re-compaction even when it uses none of the event names. Existing games therefore keep the pipeline they were built against. The detector is deliberately over-inclusive, as `docs/compat.md` asks: `childrenPerOwner` is in the list because the owner half of the change is not gated by any of the four routine/property names. The Game Settings sidebar picks the checkbox up from the registry automatically. Its tile is labelled **Fire holder leave events twice** and lists the seven differences as bullets — [1280×800](https://agent.virtualtabletop.io/reports/pr/1539994146897399808/holder-events-legacy-tile.png), [390×844](https://agent.virtualtabletop.io/reports/pr/1539994146897399808/holder-events-legacy-tile-phone.png).

A game author who wants the new pipeline unchecks it and looks for seven things:

- a `leaveRoutine` that counted or dealt now runs once per departure instead of twice;
- `SET parent` and `MOVEXY` now apply `onLeave`;
- picking a card up and dropping it back into the *same* holder is a real leave and a real enter, so both apply their properties (previously neither did);
- a `childrenPerOwner` holder now releases the owner for `SET parent` and `MOVEXY` as well, not only for drags and `MOVE` — `MOVEXY`'s own `resetOwner: false` still keeps it, in both pipelines;
- a stacked holder now closes the gap a card left however it left — `SET parent`, `MOVEXY` and `DELETE` included, where the old pipeline left the hole open;
- hovering a `dropShadow` holder no longer runs its `enterRoutine`/`leaveRoutine` or applies `onEnter`/`onLeave` for the preview;
- and the `_ancestor` workaround for #1094 is dead code.

The drop-shadow half is the one entry on that list that is a plain bug rather than a design decision, and it is gated like the rest: `legacyHolderEnterLeaveEvents` restores the old engine as a whole, so a migrated game keeps the preview's events until its author unchecks the mode. A game *can* observe them — a holder whose `enterRoutine` lights something up while a card hovers over it is the plausible case — so it is not something the migration takes away silently.

## Tests

- `tests/client/engine/enterleave.test.js` — 76 jsdom assertions over dragging, `MOVE` (holder / collection / seat), `MOVEXY`, `SET parent`, `CLONE`, `DELETE`, `childrenPerOwner`, `ignoreOnLeave`, drop shadows, multi-property `onEnter`, decks, holders inside holders, pile formation and dissolution and the ordering invariants — each with the mode off *and* on.
- `tests/client/engine/bundle-widgets.js` — new: evaluates the real `Holder`, `ImageWidget` and `Pile` classes inside jsdom the way the shipped bundle concatenates them, so a holder assertion costs a few lines instead of a browser fixture.
- `tests/testcafe/holderevents.js` — the existing fixture that pinned the old behaviour, updated to the new traces. Its diff is the review of this change. It also pins that hovering a `dropShadow` holder and then dropping somewhere else leaves the room exactly as it was.
- `tests/testcafe/enterleave.js` — new: every legacy trace with the mode on (proving old games keep working), the pile cases that need a real pointer, stacked and `preventPiles` holders, seats and per-owner hands — including a rearrange inside a per-owner hand, which is the case where the owner must survive the whole drag and where the drag must leave nothing behind that keeps the *next* card owned, `MOVEXY`'s `resetOwner: false`, and the stacked-holder layout with the mode on and off.
- `tests/server/fileupdater.test.js` — the stacked-holder half of the detector: the bare stacked holder, the offset written as an expression, the offset a routine sets at runtime, the template a holder inherits it from, and the two that must *not* trigger it (`stackOffsetY: 0`, `alignChildren: false`).
- `tests/testcafe/holderevent-util.js` — new: the probe game both browser fixtures drive.
- `tests/testcafe/multiclient.js` — one case added: a second browser window watches Alice rearrange her per-owner hand, and the card stays `foreign` there for the whole gesture. `dragPath()` gained a `hold` option so a fixture can assert in the middle of a drag.

Locally: `npm test` green (1569); TestCafe green on `enterleave.js`, `holderevents.js`, `legacymatrix.js`, `interactions.js`, `multiclient.js`, `card.js`, `draglimit.js` and `routines.js`, plus a `corpusreplay.js` sample of the public library.

## Report and demo rooms

A detailed HTML report — the model, the before/after trace of every case, and what each of the five issues turns into — is at
https://agent.virtualtabletop.io/reports/pr/1539994146897399808/lm1-holder-enter-leave.html

Three manual test rooms ship as **Properties - Holder events** in this PR's `pr-test-ai` test-server room, with a live event log and buttons that toggle the properties while you play:

- **Dragging** — `childrenPerOwner`, `preventPiles`, `stackOffsetY`, `alignChildren`, `dropShadow`, `ignoreOnLeave` ([screenshot](https://agent.virtualtabletop.io/reports/pr/1539994146897399808/holder-events-dragging.png))
- **Routines** — one button per operation: `MOVE`, `MOVEXY`, `SET parent`, `CLONE`, `DELETE`, `RECALL`, `FLIP` ([screenshot](https://agent.virtualtabletop.io/reports/pr/1539994146897399808/holder-events-routines.png))
- **Piles & hands** — a holder that takes piles, one that refuses them, a per-seat hand and a seat ([screenshot](https://agent.virtualtabletop.io/reports/pr/1539994146897399808/holder-events-piles-and-hands.png))

They are authored to tutorial quality but are deliberately **not** part of the diff: the public library stays untouched. They can be added to `library/tutorials/` on request. Each room's overview says that switching *Fire holder leave events twice* on in Game settings shows the pipeline this replaced, which is the fastest way to see the difference.

The wiki's *Legacy-Mode* page and the holder pages will want a line about the new mode.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3134/pr-test (or any other room on that server)

