### PR TITLE
Write imported PCIO and TTS games at the current file version so they get no legacy modes

### DIFF
--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -267,10 +267,13 @@ export default async function convertPCIO(content) {
 
     const text = options.noTextStyle ? null : widget.mainTextStyle;
     if(text && typeof text == 'object') {
-      if(text.size)
-        textCSS['font-size'] = `${Math.round(text.size)}px`;
-      if(text.size && text.lineHeight)
-        textCSS['line-height'] = `${Math.round(text.size*text.lineHeight)}px`;
+      // options.textSize is the size the text is actually drawn at where that is
+      // not the size of the style itself - a counter enlarges its value
+      const size = options.textSize || text.size;
+      if(size)
+        textCSS['font-size'] = `${Math.round(size)}px`;
+      if(size && text.lineHeight)
+        textCSS['line-height'] = `${Math.round(size*text.lineHeight)}px`;
       if(text.align)
         textCSS['text-align'] = text.align;
       Object.assign(textCSS, textFill(text.mainFill, !!options.textSelector, widget));
@@ -499,6 +502,47 @@ export default async function convertPCIO(content) {
   function roundCounter(variable, step) {
     const decimals = typeof step == 'number' ? (String(step).split('.')[1] || '').length : 0;
     return decimals ? [ `var ${variable} = \${${variable}} toFixed ${decimals}` ] : [];
+  }
+
+  // PCIO does not lay a counter out from the width and height in the file - it
+  // ignores both and builds the box from the size of the value: room for the
+  // widest number the bounds allow (at least 52px) plus a 44px button at each
+  // end, and a line of the value's own font, never shorter than those buttons.
+  // The value itself is drawn a quarter larger while it is shorter than four
+  // characters.
+  function counterLayout(widget) {
+    const style   = widget.mainTextStyle || {};
+    const size    = +style.size || 21;
+    const buttons = widget.counterShowButtons !== false;
+
+    // the bounds every PCIO counter has, which are what its box is wide enough for
+    const min = Math.max(-1e10, Math.min(1e10, isNaN(parseFloat(widget.counterMin)) ? -9999 : parseFloat(widget.counterMin)));
+    let   max = Math.max(-1e10, Math.min(1e10, isNaN(parseFloat(widget.counterMax)) ?  9999 : parseFloat(widget.counterMax)));
+    if(min >= max)
+      max = min + 1;
+    const characters = Math.max(String(Math.abs(min)).length + (min < 0 ? 0.5 : 0), String(max).length);
+
+    const value      = counterValue(widget);
+    const boosted    = widget.counterBoostFontSize !== false && String(value).length < 4 ? Math.min(size*1.25, 150) : size;
+    const fontSize   = Math.round(boosted);
+    const lineHeight = Math.round(fontSize*(style.lineHeight || 1));
+    return {
+      buttons,
+      buttonSize: 32,
+      buttonMargin: 6,
+      fontSize,
+      lineHeight,
+      width:  Math.max(52, characters*0.62*size) + (buttons ? 88 : 0),
+      // PCIO lets a value taller than the box overflow it while a VTT label cuts
+      // it off, so the box is never shorter than the line the value takes
+      height: Math.max(buttons ? 44 : 0, size, lineHeight + 2)
+    };
+  }
+
+  // the value a counter starts at, kept inside its bounds the way PCIO does
+  function counterValue(widget) {
+    const bounds = counterBounds[widget.id];
+    return bounds ? Math.min(Math.max(+widget.counterValue || 0, bounds.min), bounds.max) : widget.counterValue;
   }
 
   // the operations that keep a variable within the bounds of a counter
@@ -1086,40 +1130,34 @@ export default async function convertPCIO(content) {
     } else if(widget.type == 'counter') {
       w.type = 'label';
       w.y = (w.y || 0) + 5;
-      w.width = widget.width || 140;
-      w.height = widget.height || 44;
+      const counter = counterLayout(widget);
+      w.width = counter.width;
+      w.height = counter.height;
       const bounds = counterBounds[widget.id];
-      w.text = bounds ? Math.min(Math.max(+widget.counterValue || 0, bounds.min), bounds.max) : widget.counterValue;
+      w.text = counterValue(widget);
       if(widget.allowPlayerEditValue !== false)
         w.editable = true;
       // the text style belongs on the value, not on the caption and +/- buttons
       pcioStyle(widget, w, [], {
         textSelector: ' > textarea',
-        text: (widget.mainTextStyle || {}).size ? {} : { 'font-size': '30px' }
+        textSize: counter.fontSize,
+        text: { 'font-size': `${counter.fontSize}px`, 'line-height': `${counter.lineHeight}px` }
       });
       if(bounds && !isNaN(parseFloat(widget.counterValue)) && w.text != parseFloat(widget.counterValue))
         warn(`Counter ${widgetName(widget)} was outside its ${boundsText(bounds)} and starts at ${w.text} instead of ${widget.counterValue}.`);
       if(bounds && widget.allowPlayerEditValue !== false)
         warnAbout(`bounds ${boundsText(bounds)}`, widget, (names, count)=>`Typing a value into the counter${count > 1 ? 's' : ''} ${names} is not restricted to ${count > 1 ? 'their' : 'its'} ${boundsText(bounds)} - the buttons and the automations that change ${count > 1 ? 'them' : 'it'} are.`);
 
-      // the +/- buttons are sized from the counter, so its box has to have room
-      // for one line of the value before they are created
-      w.height = Math.max(w.height, labelMinHeight(w));
-
       const counterStep = Math.abs(+widget.counterStep) || 1;
-
-      // square buttons in the corners of the counter, shrunk to fit next to each
-      // other on a counter too narrow for two of them at the height's size
-      const buttonSize = Math.max(0, Math.min(w.height - 8, Math.floor((w.width - 12)/2)));
 
       function addCounterButton(suffix, x, text, value) {
         output[widget.id + suffix] = {
           id: widget.id + suffix,
           parent: widget.id,
-          x: 4,
-          y: -2,
-          width: buttonSize,
-          height: buttonSize,
+          x: counter.buttonMargin,
+          y: Math.round((counter.height - counter.buttonSize)/2),
+          width: counter.buttonSize,
+          height: counter.buttonSize,
           type: 'button',
           movableInEdit: false,
           text,
@@ -1137,9 +1175,9 @@ export default async function convertPCIO(content) {
         if(x)
           output[widget.id + suffix].x += x;
       }
-      if(widget.counterShowButtons !== false) {
-        addCounterButton('_decrementButton', 0,                        '-', -counterStep);
-        addCounterButton('_incrementButton', w.width - 8 - buttonSize, '+',  counterStep);
+      if(counter.buttons) {
+        addCounterButton('_decrementButton', 0, '-', -counterStep);
+        addCounterButton('_incrementButton', counter.width - 2*counter.buttonMargin - counter.buttonSize, '+', counterStep);
       }
 
       if(widget.label) {
@@ -1715,10 +1753,13 @@ export default async function convertPCIO(content) {
           const quantity = numberArgument(routine, args.quantity, 1);
           const fill = args.fillAdd && args.fillAdd.value == 'fill' && quantity !== 'all';
 
+          // a hand PCIO does not show is nowhere to move objects to, and without
+          // any destination left there is nothing to move
+          const destinations = args.to.value.filter(id=>!byID[id] || byID[id].type != 'hand' || byID[id].enabled !== false);
+          if(!destinations.length)
+            return;
           // PCIO starts dealing at the n-th of its destinations
-          const destinations = args.to.value.slice();
-          if(destinations.length)
-            destinations.push(...destinations.splice(0, (+(args.startingOffset || {}).value || 0) % destinations.length));
+          destinations.push(...destinations.splice(0, (+(args.startingOffset || {}).value || 0) % destinations.length));
 
           c = importWidgetQuery(routine, args, 'from', 'from', 'collection', {
             func:  'MOVE',
@@ -1738,12 +1779,6 @@ export default async function convertPCIO(content) {
             delete c.count;
           if(c.to.length == 1)
             c.to = c.to[0];
-          if(c.to == 'hand') {
-            delete c.to;
-            c.func = 'MOVEXY';
-            // the objects land on the table but stay the property of whoever held them
-            c.resetOwner = false;
-          }
           if(moveFlip && moveFlip != 'none')
             c.face = moveFlip == 'faceDown' ? 0 : 1;
 
@@ -1821,7 +1856,8 @@ export default async function convertPCIO(content) {
             return;
 
           // a deck that sits on the table has no holder to recall into, so its cards are
-          // gathered on its position instead - the ones a player owns stay that player's
+          // gathered on its position instead - a recall takes them back from their owner
+          // as much as it takes them out of a holder
           for(const deckID of decks) {
             if(!byID[deckID].parent) {
               output.tempHolderForDeckRecall = {
@@ -1844,8 +1880,7 @@ export default async function convertPCIO(content) {
                 from: 'tempHolderForDeckRecall',
                 x: byID[deckID].x + (86-(byID[deckID].cardWidth ||103))/2,
                 y: byID[deckID].y + (86-(byID[deckID].cardHeight||160))/2,
-                count: 'all',
-                resetOwner: false
+                count: 'all'
               });
             }
           }

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -629,8 +629,11 @@ export default async function convertPCIO(content) {
       if(widget.kinged)
         w.activeFace = 1;
     } else if(widget.type == 'gamePiece' && widget.pieceType == 'classic') {
-      w.width  = 90;
-      w.height = 90;
+      // the PCIO piece is a 90x90 box while the pawn shape only fills 56x84 of it
+      w.width  = 56;
+      w.height = 84;
+      w.x = (w.x || 0) + 17;
+      w.y = (w.y || 0) + 3;
       w.classes = 'classicPiece';
       w.color = pieceColors[widget.color] || pieceColors.default;
     } else if(widget.type == 'gamePiece' && widget.pieceType == 'pin') {
@@ -1719,6 +1722,8 @@ export default async function convertPCIO(content) {
           if(c.to == 'hand') {
             delete c.to;
             c.func = 'MOVEXY';
+            // the objects land on the table but stay the property of whoever held them
+            c.resetOwner = false;
           }
           if(moveFlip && moveFlip != 'none')
             c.face = moveFlip == 'faceDown' ? 0 : 1;
@@ -1796,6 +1801,8 @@ export default async function convertPCIO(content) {
           if(!decks.length)
             return;
 
+          // a deck that sits on the table has no holder to recall into, so its cards are
+          // gathered on its position instead - the ones a player owns stay that player's
           for(const deckID of decks) {
             if(!byID[deckID].parent) {
               output.tempHolderForDeckRecall = {
@@ -1818,7 +1825,8 @@ export default async function convertPCIO(content) {
                 from: 'tempHolderForDeckRecall',
                 x: byID[deckID].x + (86-(byID[deckID].cardWidth ||103))/2,
                 y: byID[deckID].y + (86-(byID[deckID].cardHeight||160))/2,
-                count: 'all'
+                count: 'all',
+                resetOwner: false
               });
             }
           }
@@ -2218,8 +2226,7 @@ export default async function convertPCIO(content) {
       // striped block where the widget used to be
       const typeName = pcioTypeNames[widget.type] || widget.type;
       w.width = widget.width || 100;
-      // a label shorter than one line of text shows nothing at all
-      w.height = Math.max(widget.height || 100, 18);
+      w.height = widget.height || 100;
       w.type = 'label';
       w.text = `${typeName} not imported`;
       w.css ='background: repeating-linear-gradient(45deg, red, red 10px, darkred 10px, darkred 20px); color: white; text-shadow: 0 0 4px black;';
@@ -2236,6 +2243,16 @@ export default async function convertPCIO(content) {
   for(const seatID in turnAtSeat)
     if(output[seatID])
       output[seatID].turn = true;
+
+  // a label whose box is shorter than one line of its text shows nothing at all
+  for(const w of Object.values(output)) {
+    if(w.type != 'label')
+      continue;
+    const match = JSON.stringify(w.css || '').match(/font-size"?:"? *([0-9]+) *px/);
+    const minHeight = (match ? +match[1] : 16) + 2;
+    if((w.height || 20) < minHeight)
+      w.height = minHeight;
+  }
 
   for(const group of Object.values(groupedWarnings))
     warn(group.message(widgetNames(group.names), group.names.length));

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -319,6 +319,13 @@ export default async function convertPCIO(content) {
       w.height = widget.height;
   }
 
+  // a label whose box is shorter than one line of its text shows nothing at all,
+  // so this is the smallest height that one line of its own font still fits into
+  function labelMinHeight(w) {
+    const sizes = [ ...JSON.stringify(w.css || '').matchAll(/(?:font-size|line-height)"?:"? *([0-9.]+) *px/g) ].map(match=>+match[1]);
+    return Math.max(16, ...sizes) + 2;
+  }
+
   // The objects an automation works on: either a holder parameter on the
   // operation itself or a SELECT into a collection. Returns null for a query
   // that matches nothing so that the caller can skip the whole step, which is
@@ -733,6 +740,8 @@ export default async function convertPCIO(content) {
       w.childrenPerOwner = true;
       w.dropShadow = true;
       w.hidePlayerCursors = true;
+      // an empty holder is a blank band otherwise
+      w.text = widget.label || 'Your hand';
       w.width = widget.width || 1500;
       w.height = widget.height || 180;
       if(widget.allowedDecks && widget.allowedDecks.length)
@@ -1090,6 +1099,10 @@ export default async function convertPCIO(content) {
         warn(`Counter ${widgetName(widget)} was outside its ${boundsText(bounds)} and starts at ${w.text} instead of ${widget.counterValue}.`);
       if(bounds && widget.allowPlayerEditValue !== false)
         warnAbout(`bounds ${boundsText(bounds)}`, widget, (names, count)=>`Typing a value into the counter${count > 1 ? 's' : ''} ${names} is not restricted to ${count > 1 ? 'their' : 'its'} ${boundsText(bounds)} - the buttons and the automations that change ${count > 1 ? 'them' : 'it'} are.`);
+
+      // the +/- buttons are sized from the counter, so its box has to have room
+      // for one line of the value before they are created
+      w.height = Math.max(w.height, labelMinHeight(w));
 
       const counterStep = Math.abs(+widget.counterStep) || 1;
 
@@ -2244,13 +2257,12 @@ export default async function convertPCIO(content) {
     if(output[seatID])
       output[seatID].turn = true;
 
-  // a label whose box is shorter than one line of its text shows nothing at all
+  // grow every label that ended up shorter than one line of its own text
   for(const w of Object.values(output)) {
     if(w.type != 'label')
       continue;
-    const match = JSON.stringify(w.css || '').match(/font-size"?:"? *([0-9]+) *px/);
-    const minHeight = (match ? +match[1] : 16) + 2;
-    if((w.height || 20) < minHeight)
+    const minHeight = labelMinHeight(w);
+    if((w.height ?? 20) < minHeight)
       w.height = minHeight;
   }
 

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -319,8 +319,9 @@ export default async function convertPCIO(content) {
       w.height = widget.height;
   }
 
-  // a label whose box is shorter than one line of its text shows nothing at all,
-  // so this is the smallest height that one line of its own font still fits into
+  // a label whose box is shorter than one line of its text shows nothing at all, so this is
+  // the smallest height that one line of its own font still fits into - never below the 16px
+  // a label in the default font needs, however tiny the font it was styled with is
   function labelMinHeight(w) {
     const sizes = [ ...JSON.stringify(w.css || '').matchAll(/(?:font-size|line-height)"?:"? *([0-9.]+) *px/g) ].map(match=>+match[1]);
     return Math.max(16, ...sizes) + 2;
@@ -740,8 +741,9 @@ export default async function convertPCIO(content) {
       w.childrenPerOwner = true;
       w.dropShadow = true;
       w.hidePlayerCursors = true;
-      // an empty holder is a blank band otherwise
-      w.text = widget.label || 'Your hand';
+      // an empty holder is a blank band otherwise. Only the main hand is captioned as one:
+      // a PCIO table can carry any number of further private zones next to it
+      w.text = widget.label || (widget.id == 'hand' ? 'Your hand' : 'Private');
       w.width = widget.width || 1500;
       w.height = widget.height || 180;
       if(widget.allowedDecks && widget.allowedDecks.length)
@@ -1106,14 +1108,18 @@ export default async function convertPCIO(content) {
 
       const counterStep = Math.abs(+widget.counterStep) || 1;
 
+      // square buttons in the corners of the counter, shrunk to fit next to each
+      // other on a counter too narrow for two of them at the height's size
+      const buttonSize = Math.max(0, Math.min(w.height - 8, Math.floor((w.width - 12)/2)));
+
       function addCounterButton(suffix, x, text, value) {
         output[widget.id + suffix] = {
           id: widget.id + suffix,
           parent: widget.id,
           x: 4,
           y: -2,
-          width: w.height - 8,
-          height: w.height - 8,
+          width: buttonSize,
+          height: buttonSize,
           type: 'button',
           movableInEdit: false,
           text,
@@ -1132,8 +1138,8 @@ export default async function convertPCIO(content) {
           output[widget.id + suffix].x += x;
       }
       if(widget.counterShowButtons !== false) {
-        addCounterButton('_decrementButton', 0,                  '-', -counterStep);
-        addCounterButton('_incrementButton', w.width - w.height, '+',  counterStep);
+        addCounterButton('_decrementButton', 0,                        '-', -counterStep);
+        addCounterButton('_incrementButton', w.width - 8 - buttonSize, '+',  counterStep);
       }
 
       if(widget.label) {

--- a/server/pcioimport.mjs
+++ b/server/pcioimport.mjs
@@ -2,6 +2,7 @@ import fs from 'fs';
 import CRC32 from 'crc-32';
 
 import Config from './config.mjs';
+import { VERSION } from './fileupdater.mjs';
 import Logging from './logging.mjs';
 import Zip from './zip.mjs';
 
@@ -568,7 +569,7 @@ export default async function convertPCIO(content) {
         importerTemp: 'PCIO',
         importerTime: +new Date()
       },
-      version: 4
+      version: VERSION
     }
   };
 
@@ -727,6 +728,8 @@ export default async function convertPCIO(content) {
       }
       w.inheritChildZ = true;
       w.childrenPerOwner = true;
+      w.dropShadow = true;
+      w.hidePlayerCursors = true;
       w.width = widget.width || 1500;
       w.height = widget.height || 180;
       if(widget.allowedDecks && widget.allowedDecks.length)
@@ -1009,6 +1012,18 @@ export default async function convertPCIO(content) {
         for(const key in w.cardTypes[type])
           w.cardTypes[type][key] = mapName(w.cardTypes[type][key], nativeDiceDecks[widget.id]);
         w.cardTypes[type].sortingOrder = ++sortingOrder;
+      }
+
+      // PCIO marks a face object that takes its content from a card type property with
+      // valueType/value, which VirtualTabletop writes as a dynamicProperties entry instead
+      for(const face of w.faceTemplates) {
+        for(const object of face.objects) {
+          if(object.valueType != 'static' && object.value) {
+            object.dynamicProperties = Object.assign({}, object.dynamicProperties, { value: object.value });
+            delete object.value;
+          }
+          delete object.valueType;
+        }
       }
     } else if(widget.type == 'card' || widget.type == 'piece' || widget.type == 'chooser') {
       if(!byID[widget.deck]) // orphan card without deck
@@ -2203,7 +2218,8 @@ export default async function convertPCIO(content) {
       // striped block where the widget used to be
       const typeName = pcioTypeNames[widget.type] || widget.type;
       w.width = widget.width || 100;
-      w.height = widget.height || 100;
+      // a label shorter than one line of text shows nothing at all
+      w.height = Math.max(widget.height || 100, 18);
       w.type = 'label';
       w.text = `${typeName} not imported`;
       w.css ='background: repeating-linear-gradient(45deg, red, red 10px, darkred 10px, darkred 20px); color: white; text-shadow: 0 0 4px black;';

--- a/server/ttsimport.mjs
+++ b/server/ttsimport.mjs
@@ -682,7 +682,8 @@ function addNotecard(o, imp, parent) {
     height: clamp(rows*15 + 16, 60, 500),
     movable: true,
     html: (title ? `<b>${escapeHTML(title)}</b><br>${body ? '<br>' : ''}` : '') + escapeHTML(body).replace(/\n/g, '<br>'),
-    css: 'background: #fdf8d8; color: #333333; border-radius: 4px; font-size: 13px; padding: 6px 8px; box-sizing: border-box; overflow-wrap: break-word; overflow: hidden'
+    // the text is escaped and joined with <br>, so the runs of spaces the author typed have to survive
+    css: 'background: #fdf8d8; color: #333333; border-radius: 4px; font-size: 13px; padding: 6px 8px; box-sizing: border-box; overflow-wrap: break-word; overflow: hidden; white-space: pre-wrap'
   };
 
   return { [widget.id]: place(o, widget) };

--- a/server/ttsimport.mjs
+++ b/server/ttsimport.mjs
@@ -1006,7 +1006,7 @@ async function convertTTS(content, linkContent, workshop={}) {
       childrenPerOwner: true,
       dropShadow: true,
       hidePlayerCursors: true,
-      text: 'Hand', // an empty holder is a blank band otherwise
+      text: 'Your hand', // an empty holder is a blank band otherwise
       x: 50,
       y: 820,
       width: 1500,

--- a/server/ttsimport.mjs
+++ b/server/ttsimport.mjs
@@ -4,6 +4,7 @@ import CRC32 from 'crc-32';
 import { BSON } from 'bson';
 
 import Config from './config.mjs';
+import { VERSION } from './fileupdater.mjs';
 import Logging from './logging.mjs';
 import Zip from './zip.mjs';
 
@@ -1002,6 +1003,8 @@ async function convertTTS(content, linkContent, workshop={}) {
       dropOffsetY: 14,
       stackOffsetX: 40,
       childrenPerOwner: true,
+      dropShadow: true,
+      hidePlayerCursors: true,
       text: 'Hand', // an empty holder is a blank band otherwise
       x: 50,
       y: 820,
@@ -1045,7 +1048,7 @@ async function convertTTS(content, linkContent, workshop={}) {
     Logging.log(`TTS import: ${warnings.length} import notes: ${warnings.join(' ')}`);
   }
 
-  widgets._meta = { info, version: 5 };
+  widgets._meta = { info, version: VERSION };
 
   return widgets;
 }

--- a/tests/server/fileupdater-util.js
+++ b/tests/server/fileupdater-util.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 
-import FileUpdater from '../../server/fileupdater.mjs';
+import FileUpdater, { VERSION } from '../../server/fileupdater.mjs';
 
 // A game's legacy modes are whatever the file updater assigns when the game is loaded, not what
 // is written in the file: the checked-in JSON of every library game is pre-updater, so reading
@@ -13,4 +13,27 @@ export function flagsForGame(state) {
 
 export function flagsForGameFile(path) {
   return flagsForGame(JSON.parse(fs.readFileSync(path, 'utf8')));
+}
+
+// The version the importer check migrates from. Every migration newer than it has been
+// confirmed to leave the importers' output alone, so it stays put when VERSION moves: the
+// migrations a bump adds then run over what the importers write and have to be no-ops there
+// too. Raising it takes a deliberate look at the migration it skips - the older ones are not
+// idempotent on their own output (v20 appends white-space: pre-wrap a second time), which is
+// why replaying all of them is not the invariant.
+export const IMPORT_MIGRATION_BASE = 21;
+
+// The importers write the current file version, so nothing they produce may be rewritten on
+// load: a migration that would still have changed it never runs again. FileUpdater hands a
+// state that already is at VERSION straight back, so the check migrates a copy stamped at
+// IMPORT_MIGRATION_BASE instead and fails as soon as a migration is added whose result the
+// importer does not produce by itself.
+export function expectNoLegacyModes(state) {
+  expect(state._meta.version).toBe(VERSION);
+  expect(state._meta.gameSettings).toBeUndefined();
+  // NaN and undefined do not survive the save file, so compare what is actually stored
+  const stored = JSON.parse(JSON.stringify(state));
+  const olderVersion = JSON.parse(JSON.stringify(stored));
+  olderVersion._meta.version = IMPORT_MIGRATION_BASE;
+  expect(FileUpdater(olderVersion)).toEqual(stored);
 }

--- a/tests/server/pcio-import.test.js
+++ b/tests/server/pcio-import.test.js
@@ -724,12 +724,26 @@ describe('PCIO importer', () => {
   it('grows a label whose box is shorter than one line of its own text', async () => {
     const state = await importWidgets([
       { id: 'counter', type: 'counter',     x: 0, y: 100, height: 10, counterValue: 3 },
-      { id: 'unknown', type: 'videoPlayer', x: 0, y: 200, height:  5 }
+      { id: 'unknown', type: 'videoPlayer', x: 0, y: 200, height:  5 },
+      { id: 'spaced',  type: 'counter',     x: 0, y: 300, height: 24, counterValue: 3,
+        mainTextStyle: { size: 20, lineHeight: 1.6 } }
     ], 8);
 
     // the value of a counter is written in 30px, the placeholder in the default 16px
     expect(state.counter.height).toBe(32);
     expect(state.unknown.height).toBe(18);
+    // a line of 20px text in a 1.6 line height is 32px tall
+    expect(state.spaced.height).toBe(34);
+  });
+
+  it('sizes the buttons of a counter from the height its value needs', async () => {
+    const state = await importWidgets([
+      { id: 'counter', type: 'counter', x: 0, y: 100, height: 10, counterValue: 3 }
+    ], 8);
+
+    // 32px tall value, so the buttons are square with the 4px margin on both sides
+    expect(state.counter_decrementButton).toMatchObject({ x: 4, width: 24, height: 24 });
+    expect(state.counter_incrementButton).toMatchObject({ x: 112, width: 24, height: 24 });
   });
 
   it('imports a turn button at the size PCIO gives it', async () => {
@@ -1016,12 +1030,19 @@ describe('PCIO importer', () => {
     });
   });
 
-  it('gives a hand the drop shadow and the hidden cursors of a VirtualTabletop hand', async () => {
+  it('gives a hand the drop shadow, the hidden cursors and the caption of a VirtualTabletop hand', async () => {
     const state = await importWidgets([ { id: 'hand', type: 'hand', x: 0, y: 800 } ], 8);
 
     expect(state.hand.childrenPerOwner).toBe(true);
     expect(state.hand.dropShadow).toBe(true);
     expect(state.hand.hidePlayerCursors).toBe(true);
+    expect(state.hand.text).toBe('Your hand');
+  });
+
+  it('captions a hand with the name it was given in PlayingCards.io', async () => {
+    const state = await importWidgets([ { id: 'hand', type: 'hand', x: 0, y: 800, label: 'Your cards' } ], 8);
+
+    expect(state.hand.text).toBe('Your cards');
   });
 
   it('writes the file at the current version so that no legacy mode is turned on for it', async () => {

--- a/tests/server/pcio-import.test.js
+++ b/tests/server/pcio-import.test.js
@@ -15,13 +15,18 @@ async function importWidgets(widgets, schemaVersion, files={}) {
 }
 
 // the importer writes the current file version, so nothing it produces may be rewritten
-// on load: a migration that would still have changed it never runs again
+// on load: a migration that would still have changed it never runs again. FileUpdater hands
+// back a state that already is at VERSION untouched, so the check migrates a copy stamped
+// with the version before it - that runs the newest migration on what the importer writes
+// and fails as soon as one is added which the importer does not produce the result of.
 function expectNoLegacyModes(state) {
   expect(state._meta.version).toBe(VERSION);
   expect(state._meta.gameSettings).toBeUndefined();
   // NaN and undefined do not survive the save file, so compare what is actually stored
-  const stored = JSON.stringify(state);
-  expect(FileUpdater(JSON.parse(stored))).toEqual(JSON.parse(stored));
+  const stored = JSON.parse(JSON.stringify(state));
+  const previousVersion = JSON.parse(JSON.stringify(stored));
+  previousVersion._meta.version = VERSION - 1;
+  expect(FileUpdater(previousVersion)).toEqual(stored);
 }
 
 const deck = {

--- a/tests/server/pcio-import.test.js
+++ b/tests/server/pcio-import.test.js
@@ -1,4 +1,4 @@
-import FileUpdater, { VERSION } from '../../server/fileupdater.mjs';
+import { expectNoLegacyModes } from './fileupdater-util.js';
 import convertPCIO from '../../server/pcioimport.mjs';
 import Zip from '../../server/zip.mjs';
 
@@ -12,21 +12,6 @@ async function importWidgets(widgets, schemaVersion, files={}) {
   const state = await convertPCIO(await Zip.create(entries));
   expectNoLegacyModes(state);
   return state;
-}
-
-// the importer writes the current file version, so nothing it produces may be rewritten
-// on load: a migration that would still have changed it never runs again. FileUpdater hands
-// back a state that already is at VERSION untouched, so the check migrates a copy stamped
-// with the version before it - that runs the newest migration on what the importer writes
-// and fails as soon as one is added which the importer does not produce the result of.
-function expectNoLegacyModes(state) {
-  expect(state._meta.version).toBe(VERSION);
-  expect(state._meta.gameSettings).toBeUndefined();
-  // NaN and undefined do not survive the save file, so compare what is actually stored
-  const stored = JSON.parse(JSON.stringify(state));
-  const previousVersion = JSON.parse(JSON.stringify(stored));
-  previousVersion._meta.version = VERSION - 1;
-  expect(FileUpdater(previousVersion)).toEqual(stored);
 }
 
 const deck = {
@@ -751,6 +736,16 @@ describe('PCIO importer', () => {
     expect(state.counter_incrementButton).toMatchObject({ x: 112, width: 24, height: 24 });
   });
 
+  it('keeps the two buttons of a narrow counter next to each other', async () => {
+    const state = await importWidgets([
+      { id: 'counter', type: 'counter', x: 0, y: 100, width: 40, height: 10, counterValue: 3 }
+    ], 8);
+
+    // two 24px buttons would overlap on a 40px counter and cover the value between them
+    expect(state.counter_decrementButton).toMatchObject({ x: 4, width: 14, height: 14 });
+    expect(state.counter_incrementButton).toMatchObject({ x: 22, width: 14, height: 14 });
+  });
+
   it('imports a turn button at the size PCIO gives it', async () => {
     const state = await importWidgets([
       { id: 'turn', type: 'turnButton', x: 0, y: 0, label: 'End Turn', clickRoutine: { steps: [] } }
@@ -838,6 +833,50 @@ describe('PCIO importer', () => {
     const moves = state.button.clickRoutine.filter(operation=>operation.func == 'MOVEXY');
     expect(moves.length).toBe(2);
     expect(moves.map(operation=>operation.resetOwner)).toEqual([ false, false ]);
+  });
+
+  it('moves as many objects as the counter says and none at all when it says zero', async () => {
+    const dealing = args=>[
+      { id: 'source', type: 'holder', x: 0, y: 0 },
+      { id: 'target', type: 'holder', x: 200, y: 0 },
+      { id: 'hand', type: 'hand', x: 0, y: 800 },
+      { id: 'counter', type: 'counter', x: 400, y: 0, counterValue: 2 },
+      {
+        id: 'button', type: 'automationButton', label: 'Deal', x: 0, y: 300,
+        clickRoutine: { steps: [ { id: 'a', branches: [ { func: 'MOVE_CARDS_BETWEEN_HOLDERS', args: Object.assign({
+          from:     { type: 'literal', value: [ 'source' ] },
+          quantity: { counterId: 'counter' }
+        }, args) } ] } ] }
+      }
+    ];
+
+    // the count is the counter itself. A file old enough for the count migration has the
+    // operation wrapped in an IF that moves *everything* when the count comes out as 0,
+    // while PlayingCards.io moves nothing then - which is what the plain operation does
+    const toHand = await importWidgets(dealing({ to: { type: 'literal', value: [ 'hand' ] } }), 8);
+    expect(toHand.button.clickRoutine).toEqual([
+      { func: 'MOVEXY', count: '${PROPERTY text OF counter}', from: 'source', resetOwner: false }
+    ]);
+
+    // moving the objects in one go rather than one at a time, and turning them afterwards
+    const wholePile = await importWidgets(dealing({
+      to:             { type: 'literal', value: [ 'target' ] },
+      moveMethod:     { type: 'literal', value: 'all' },
+      changeRotation: { type: 'literal', value: 'cw' }
+    }), 8);
+    expect(wholePile.button.clickRoutine).toEqual([
+      { func: 'MOVE',   count: '${PROPERTY text OF counter}', from: 'source', to: 'target' },
+      { func: 'ROTATE', count: '${PROPERTY text OF counter}', holder: 'target', angle: 90 }
+    ]);
+
+    // the same case with the zero spelled out in the file
+    const nothing = await importWidgets(dealing({
+      to:       { type: 'literal', value: [ 'hand' ] },
+      quantity: { type: 'literal', value: 0 }
+    }), 8);
+    expect(nothing.button.clickRoutine).toEqual([
+      { func: 'MOVEXY', count: 0, from: 'source', resetOwner: false }
+    ]);
   });
 
   it('puts objects under the ones a pile already holds, starting at the given destination', async () => {
@@ -1045,9 +1084,16 @@ describe('PCIO importer', () => {
   });
 
   it('captions a hand with the name it was given in PlayingCards.io', async () => {
-    const state = await importWidgets([ { id: 'hand', type: 'hand', x: 0, y: 800, label: 'Your cards' } ], 8);
+    const state = await importWidgets([
+      { id: 'hand',    type: 'hand', x: 0, y: 800, label: 'Your cards' },
+      { id: 'hand2',   type: 'hand', x: 0, y: 600, label: 'Tricks you won' },
+      { id: 'hand3',   type: 'hand', x: 0, y: 400 }
+    ], 8);
 
     expect(state.hand.text).toBe('Your cards');
+    expect(state.hand2.text).toBe('Tricks you won');
+    // only the main hand is the player's hand - the other private zones say what they are
+    expect(state.hand3.text).toBe('Private');
   });
 
   it('writes the file at the current version so that no legacy mode is turned on for it', async () => {

--- a/tests/server/pcio-import.test.js
+++ b/tests/server/pcio-import.test.js
@@ -601,9 +601,10 @@ describe('PCIO importer', () => {
         mainTextStyle: { size: 26, mainFill: { type: 'color', color: '#1b5e20' } } }
     ], 8);
 
+    // PCIO draws a value shorter than four characters a quarter larger than its style
     expect(state.counter.css).toEqual({
       default: 'background: #dcedc8',
-      ' > textarea': { 'font-size': '26px', color: '#1b5e20' }
+      ' > textarea': { 'font-size': '33px', 'line-height': '33px', color: '#1b5e20' }
     });
     expect(state.counter_label.css).toBeUndefined();
     expect(state.counter_incrementButton.css).toBeUndefined();
@@ -626,7 +627,7 @@ describe('PCIO importer', () => {
     };
     expect(state.label.css[' textarea']).toEqual(Object.assign({ 'letter-spacing': '-1px' }, gradientCSS));
     expect(state.label.css.default.color).toBeUndefined();
-    expect(state.counter.css[' > textarea']).toEqual(Object.assign({ 'font-size': '26px' }, gradientCSS));
+    expect(state.counter.css[' > textarea']).toEqual(Object.assign({ 'font-size': '33px', 'line-height': '33px' }, gradientCSS));
     // the button paints its own background, which clipping the text would eat
     expect(state.button.css).toBe('font-size: 20px');
     expect(state._meta.info.importerWarnings).toEqual([
@@ -713,37 +714,58 @@ describe('PCIO importer', () => {
 
   it('grows a label whose box is shorter than one line of its own text', async () => {
     const state = await importWidgets([
-      { id: 'counter', type: 'counter',     x: 0, y: 100, height: 10, counterValue: 3 },
-      { id: 'unknown', type: 'videoPlayer', x: 0, y: 200, height:  5 },
-      { id: 'spaced',  type: 'counter',     x: 0, y: 300, height: 24, counterValue: 3,
-        mainTextStyle: { size: 20, lineHeight: 1.6 } }
+      { id: 'unknown', type: 'videoPlayer', x: 0, y: 200, height:  5 }
     ], 8);
 
-    // the value of a counter is written in 30px, the placeholder in the default 16px
-    expect(state.counter.height).toBe(32);
+    // the striped placeholder is written in the default 16px
     expect(state.unknown.height).toBe(18);
-    // a line of 20px text in a 1.6 line height is 32px tall
-    expect(state.spaced.height).toBe(34);
   });
 
-  it('sizes the buttons of a counter from the height its value needs', async () => {
+  it('lays a counter out the way PCIO does instead of from the size in the file', async () => {
     const state = await importWidgets([
-      { id: 'counter', type: 'counter', x: 0, y: 100, height: 10, counterValue: 3 }
+      { id: 'counter', type: 'counter', x: 0, y: 100, width: 40, height: 10, counterValue: 3 },
+      { id: 'plain',   type: 'counter', x: 0, y: 200, counterValue: 3 },
+      { id: 'bounded', type: 'counter', x: 0, y: 300, counterValue: 3, counterMin: 0, counterMax: 10 },
+      { id: 'bare',    type: 'counter', x: 0, y: 400, counterValue: 3, counterShowButtons: false }
     ], 8);
 
-    // 32px tall value, so the buttons are square with the 4px margin on both sides
-    expect(state.counter_decrementButton).toMatchObject({ x: 4, width: 24, height: 24 });
-    expect(state.counter_incrementButton).toMatchObject({ x: 112, width: 24, height: 24 });
+    // PCIO ignores the width and height of a counter: its box is as wide as the
+    // widest value its bounds allow, at least 52px, plus 44px per button, and one
+    // line of the value tall, at least as tall as the buttons
+    expect(state.counter).toMatchObject({ width: state.plain.width, height: 44 });
+    expect(state.plain.width).toBeCloseTo(4.5*0.62*21 + 88);
+    // -9999..9999 needs room for 4.5 characters, 0..10 only for two, so the 52px win
+    expect(state.bounded.width).toBe(140);
+    expect(state.bare).toMatchObject({ width: state.plain.width - 88, height: 28 });
+    expect(state.bare_decrementButton).toBeUndefined();
   });
 
-  it('keeps the two buttons of a narrow counter next to each other', async () => {
+  it('puts a 32px button into each end of a counter the way PCIO draws them', async () => {
     const state = await importWidgets([
-      { id: 'counter', type: 'counter', x: 0, y: 100, width: 40, height: 10, counterValue: 3 }
+      { id: 'counter', type: 'counter', x: 0, y: 100, width: 40, height: 10, counterValue: 3 },
+      { id: 'tall',    type: 'counter', x: 0, y: 200, counterValue: 3, mainTextStyle: { size: 40, lineHeight: 1.6 } }
     ], 8);
 
-    // two 24px buttons would overlap on a 40px counter and cover the value between them
-    expect(state.counter_decrementButton).toMatchObject({ x: 4, width: 14, height: 14 });
-    expect(state.counter_incrementButton).toMatchObject({ x: 22, width: 14, height: 14 });
+    // 44px of the box belong to each button, of which PCIO paints the middle 32px
+    expect(state.counter_decrementButton).toMatchObject({ x: 6, y: 6, width: 32, height: 32 });
+    expect(state.counter_incrementButton).toMatchObject({ x: state.counter.width - 38, y: 6, width: 32, height: 32 });
+    // a value that needs a taller box keeps its buttons in the middle of it
+    expect(state.tall.height).toBe(82);
+    expect(state.tall_decrementButton).toMatchObject({ x: 6, y: 25, width: 32, height: 32 });
+  });
+
+  it('writes the value of a counter in the size PCIO draws it at', async () => {
+    const state = await importWidgets([
+      { id: 'short', type: 'counter', x: 0, y: 100, counterValue: 3 },
+      { id: 'long',  type: 'counter', x: 0, y: 200, counterValue: 1234 },
+      { id: 'flat',  type: 'counter', x: 0, y: 300, counterValue: 3, counterBoostFontSize: false }
+    ], 8);
+
+    // PCIO writes a counter in 21px and enlarges it by a quarter while its value
+    // is shorter than four characters
+    expect(state.short.css[' > textarea']['font-size']).toBe('26px');
+    expect(state.long.css[' > textarea']['font-size']).toBe('21px');
+    expect(state.flat.css[' > textarea']['font-size']).toBe('21px');
   });
 
   it('imports a turn button at the size PCIO gives it', async () => {
@@ -808,7 +830,7 @@ describe('PCIO importer', () => {
     expect(state.button.clickRoutine).toEqual([ { func: 'MOVE', from: 'source', to: 'target', count: 'all' } ]);
   });
 
-  it('leaves the objects with their owner when it takes them out of a hand', async () => {
+  it('moves objects into the hand and hands recalled ones back to everyone', async () => {
     const state = await importWidgets([
       { id: 'source', type: 'holder', x: 0, y: 0 },
       { id: 'hand', type: 'hand', x: 0, y: 800 },
@@ -817,9 +839,10 @@ describe('PCIO importer', () => {
         id: 'button', type: 'automationButton', label: 'Hand', x: 0, y: 300,
         clickRoutine: { steps: [
           { id: 'a', branches: [ { func: 'MOVE_CARDS_BETWEEN_HOLDERS', args: {
-            from:     { type: 'literal', value: [ 'source' ] },
-            to:       { type: 'literal', value: [ 'hand' ] },
-            quantity: { type: 'literal', value: 1 }
+            from:       { type: 'literal', value: [ 'source' ] },
+            to:         { type: 'literal', value: [ 'hand' ] },
+            quantity:   { type: 'literal', value: 1 },
+            moveMethod: { type: 'literal', value: 'all' }
           } } ] },
           { id: 'b', branches: [ { func: 'RECALL_CARDS', args: {
             decks: { type: 'literal', value: [ 'deck' ] }
@@ -828,11 +851,30 @@ describe('PCIO importer', () => {
       }
     ], 8);
 
-    // moving to the hand and recalling a deck that has no holder both drop the objects
-    // onto the table - the ones a player owns stay that player's
-    const moves = state.button.clickRoutine.filter(operation=>operation.func == 'MOVEXY');
-    expect(moves.length).toBe(2);
-    expect(moves.map(operation=>operation.resetOwner)).toEqual([ false, false ]);
+    // objects moved to a hand become the private property of whoever pressed the
+    // button, which is what a hand is on PlayingCards.io
+    expect(state.button.clickRoutine[0]).toEqual({ func: 'MOVE', from: 'source', to: 'hand' });
+    // a deck without a holder is recalled onto its own position, and a recall takes
+    // the objects back from their owner
+    const recall = state.button.clickRoutine.find(operation=>operation.func == 'MOVEXY');
+    expect(recall.resetOwner).toBeUndefined();
+  });
+
+  it('leaves out a move to a hand that PlayingCards.io does not show', async () => {
+    const state = await importWidgets([
+      { id: 'source', type: 'holder', x: 0, y: 0 },
+      { id: 'hand', type: 'hand', x: 0, y: 800, enabled: false },
+      {
+        id: 'button', type: 'automationButton', label: 'Hand', x: 0, y: 300,
+        clickRoutine: { steps: [ { id: 'a', branches: [ { func: 'MOVE_CARDS_BETWEEN_HOLDERS', args: {
+          from:     { type: 'literal', value: [ 'source' ] },
+          to:       { type: 'literal', value: [ 'hand' ] },
+          quantity: { type: 'literal', value: 1 }
+        } } ] } ] }
+      }
+    ], 8);
+
+    expect(state.button.clickRoutine).toEqual([]);
   });
 
   it('moves as many objects as the counter says and none at all when it says zero', async () => {
@@ -853,9 +895,12 @@ describe('PCIO importer', () => {
     // the count is the counter itself. A file old enough for the count migration has the
     // operation wrapped in an IF that moves *everything* when the count comes out as 0,
     // while PlayingCards.io moves nothing then - which is what the plain operation does
-    const toHand = await importWidgets(dealing({ to: { type: 'literal', value: [ 'hand' ] } }), 8);
+    const toHand = await importWidgets(dealing({
+      to:         { type: 'literal', value: [ 'hand' ] },
+      moveMethod: { type: 'literal', value: 'all' }
+    }), 8);
     expect(toHand.button.clickRoutine).toEqual([
-      { func: 'MOVEXY', count: '${PROPERTY text OF counter}', from: 'source', resetOwner: false }
+      { func: 'MOVE', count: '${PROPERTY text OF counter}', from: 'source', to: 'hand' }
     ]);
 
     // moving the objects in one go rather than one at a time, and turning them afterwards
@@ -871,11 +916,12 @@ describe('PCIO importer', () => {
 
     // the same case with the zero spelled out in the file
     const nothing = await importWidgets(dealing({
-      to:       { type: 'literal', value: [ 'hand' ] },
-      quantity: { type: 'literal', value: 0 }
+      to:         { type: 'literal', value: [ 'target' ] },
+      moveMethod: { type: 'literal', value: 'all' },
+      quantity:   { type: 'literal', value: 0 }
     }), 8);
     expect(nothing.button.clickRoutine).toEqual([
-      { func: 'MOVEXY', count: 0, from: 'source', resetOwner: false }
+      { func: 'MOVE', count: 0, from: 'source', to: 'target' }
     ]);
   });
 

--- a/tests/server/pcio-import.test.js
+++ b/tests/server/pcio-import.test.js
@@ -9,7 +9,19 @@ async function importWidgets(widgets, schemaVersion, files={}) {
   // a null content means a folder entry, which is stored as an empty entry ending in a slash
   for(const [ name, content ] of Object.entries(files))
     entries[content === null ? `${name}/` : name] = content === null ? new Uint8Array(0) : content;
-  return await convertPCIO(await Zip.create(entries));
+  const state = await convertPCIO(await Zip.create(entries));
+  expectNoLegacyModes(state);
+  return state;
+}
+
+// the importer writes the current file version, so nothing it produces may be rewritten
+// on load: a migration that would still have changed it never runs again
+function expectNoLegacyModes(state) {
+  expect(state._meta.version).toBe(VERSION);
+  expect(state._meta.gameSettings).toBeUndefined();
+  // NaN and undefined do not survive the save file, so compare what is actually stored
+  const stored = JSON.stringify(state);
+  expect(FileUpdater(JSON.parse(stored))).toEqual(JSON.parse(stored));
 }
 
 const deck = {
@@ -698,6 +710,28 @@ describe('PCIO importer', () => {
     expect(state.long.height).toBeGreaterThan(60);
   });
 
+  it('puts a classic game piece into the box its pawn shape fills', async () => {
+    const state = await importWidgets([
+      { id: 'pawn',   type: 'gamePiece', pieceType: 'classic', color: 'red',  x: 300, y: 300 },
+      { id: 'origin', type: 'gamePiece', pieceType: 'classic', color: 'blue' }
+    ], 8);
+
+    // PCIO gives the piece a 90x90 box while the pawn only fills 56x84 of it, at 17,3
+    expect(state.pawn).toMatchObject({ x: 317, y: 303, width: 56, height: 84, classes: 'classicPiece' });
+    expect(state.origin).toMatchObject({ x: 17, y: 3, width: 56, height: 84 });
+  });
+
+  it('grows a label whose box is shorter than one line of its own text', async () => {
+    const state = await importWidgets([
+      { id: 'counter', type: 'counter',     x: 0, y: 100, height: 10, counterValue: 3 },
+      { id: 'unknown', type: 'videoPlayer', x: 0, y: 200, height:  5 }
+    ], 8);
+
+    // the value of a counter is written in 30px, the placeholder in the default 16px
+    expect(state.counter.height).toBe(32);
+    expect(state.unknown.height).toBe(18);
+  });
+
   it('imports a turn button at the size PCIO gives it', async () => {
     const state = await importWidgets([
       { id: 'turn', type: 'turnButton', x: 0, y: 0, label: 'End Turn', clickRoutine: { steps: [] } }
@@ -758,6 +792,33 @@ describe('PCIO importer', () => {
     ], 8);
 
     expect(state.button.clickRoutine).toEqual([ { func: 'MOVE', from: 'source', to: 'target', count: 'all' } ]);
+  });
+
+  it('leaves the objects with their owner when it takes them out of a hand', async () => {
+    const state = await importWidgets([
+      { id: 'source', type: 'holder', x: 0, y: 0 },
+      { id: 'hand', type: 'hand', x: 0, y: 800 },
+      { id: 'deck', type: 'cardDeck', x: 100, y: 0, cardTypes: { a: { label: 'A' } }, faceTemplate: { objects: [] } },
+      {
+        id: 'button', type: 'automationButton', label: 'Hand', x: 0, y: 300,
+        clickRoutine: { steps: [
+          { id: 'a', branches: [ { func: 'MOVE_CARDS_BETWEEN_HOLDERS', args: {
+            from:     { type: 'literal', value: [ 'source' ] },
+            to:       { type: 'literal', value: [ 'hand' ] },
+            quantity: { type: 'literal', value: 1 }
+          } } ] },
+          { id: 'b', branches: [ { func: 'RECALL_CARDS', args: {
+            decks: { type: 'literal', value: [ 'deck' ] }
+          } } ] }
+        ] }
+      }
+    ], 8);
+
+    // moving to the hand and recalling a deck that has no holder both drop the objects
+    // onto the table - the ones a player owns stay that player's
+    const moves = state.button.clickRoutine.filter(operation=>operation.func == 'MOVEXY');
+    expect(moves.length).toBe(2);
+    expect(moves.map(operation=>operation.resetOwner)).toEqual([ false, false ]);
   });
 
   it('puts objects under the ones a pile already holds, starting at the given destination', async () => {
@@ -964,6 +1025,8 @@ describe('PCIO importer', () => {
   });
 
   it('writes the file at the current version so that no legacy mode is turned on for it', async () => {
+    // importWidgets checks the version and the round trip through FileUpdater for every
+    // import of this suite - this one holds the widgets the legacy modes look for
     const state = await importWidgets([
       { id: 'counter', type: 'counter', x: 0, y: 0, counterValue: 1, counterMin: 0 },
       { id: 'hand', type: 'hand', x: 0, y: 800 }
@@ -972,10 +1035,6 @@ describe('PCIO importer', () => {
     // the var expressions of the counter buttons are what the legacy modes for the old var
     // semantics look for in an old file
     expect(JSON.stringify(state)).toContain('var pcioCounter');
-    expect(state._meta.version).toBe(VERSION);
-    expect(state._meta.gameSettings).toBeUndefined();
-    // loading the imported file leaves it exactly as it is
-    expect(FileUpdater(JSON.parse(JSON.stringify(state)))).toEqual(state);
   });
 
   it('imports a file whose schema version is missing or unreadable', async () => {

--- a/tests/server/pcio-import.test.js
+++ b/tests/server/pcio-import.test.js
@@ -1,3 +1,4 @@
+import FileUpdater, { VERSION } from '../../server/fileupdater.mjs';
 import convertPCIO from '../../server/pcioimport.mjs';
 import Zip from '../../server/zip.mjs';
 
@@ -944,6 +945,37 @@ describe('PCIO importer', () => {
     expect(state._meta.info.importerWarnings).toEqual([
       'Asset userassets/huge.png is bigger than 10 MiB and was not imported.'
     ]);
+  });
+
+  it('writes face objects that follow a card type property as dynamic properties', async () => {
+    const state = await importWidgets([ deck, { id: 'card', type: 'card', deck: 'deck', cardType: 'a', x: 0, y: 0 } ], 8);
+
+    expect(state.deck.faceTemplates[0].objects[1]).toEqual({
+      type: 'image', x: 0, y: 0, width: 103, height: 160, dynamicProperties: { value: 'image' }
+    });
+  });
+
+  it('gives a hand the drop shadow and the hidden cursors of a VirtualTabletop hand', async () => {
+    const state = await importWidgets([ { id: 'hand', type: 'hand', x: 0, y: 800 } ], 8);
+
+    expect(state.hand.childrenPerOwner).toBe(true);
+    expect(state.hand.dropShadow).toBe(true);
+    expect(state.hand.hidePlayerCursors).toBe(true);
+  });
+
+  it('writes the file at the current version so that no legacy mode is turned on for it', async () => {
+    const state = await importWidgets([
+      { id: 'counter', type: 'counter', x: 0, y: 0, counterValue: 1, counterMin: 0 },
+      { id: 'hand', type: 'hand', x: 0, y: 800 }
+    ], 8);
+
+    // the var expressions of the counter buttons are what the legacy modes for the old var
+    // semantics look for in an old file
+    expect(JSON.stringify(state)).toContain('var pcioCounter');
+    expect(state._meta.version).toBe(VERSION);
+    expect(state._meta.gameSettings).toBeUndefined();
+    // loading the imported file leaves it exactly as it is
+    expect(FileUpdater(JSON.parse(JSON.stringify(state)))).toEqual(state);
   });
 
   it('imports a file whose schema version is missing or unreadable', async () => {

--- a/tests/server/ttsimport.test.js
+++ b/tests/server/ttsimport.test.js
@@ -274,7 +274,7 @@ describe('TTS import: files', () => {
 
     // the caption of the hand is what the legacy mode for holders without image support
     // looks for in an old file - it would hide the very text the importer just wrote
-    expect(widgets.hand.text).toBe('Hand');
+    expect(widgets.hand.text).toBe('Your hand');
   });
 
   it('keeps the widget IDs of two imports that run at the same time apart', async () => {

--- a/tests/server/ttsimport.test.js
+++ b/tests/server/ttsimport.test.js
@@ -17,8 +17,19 @@ function png(width, height) {
 
 async function convert(save) {
   const widgets = (await TTS.fromBSON(BSON.serialize(save))).TTS['0.json'];
+  expectNoLegacyModes(widgets);
   delete widgets._meta;
   return widgets;
+}
+
+// the importer writes the current file version, so nothing it produces may be rewritten
+// on load: a migration that would still have changed it never runs again
+function expectNoLegacyModes(state) {
+  expect(state._meta.version).toBe(VERSION);
+  expect(state._meta.gameSettings).toBeUndefined();
+  // NaN and undefined do not survive the save file, so compare what is actually stored
+  const stored = JSON.stringify(state);
+  expect(FileUpdater(JSON.parse(stored))).toEqual(JSON.parse(stored));
 }
 
 // what the importer could not bring over - the game details show it as import notes
@@ -229,6 +240,17 @@ describe('TTS import: stacks', () => {
   });
 });
 
+describe('TTS import: notecards', () => {
+  it('keeps the line breaks and the runs of spaces the author typed', async () => {
+    const widgets = await convert(objects(
+      { Name: 'Notecard', GUID: 'note', Transform: { posX: 0, posZ: 0 }, Nickname: 'Title', Description: 'a   b\nsecond line' }
+    ));
+
+    expect(widgets.note.html).toBe('<b>Title</b><br><br>a   b<br>second line');
+    expect(widgets.note.css).toContain('white-space: pre-wrap');
+  });
+});
+
 describe('TTS import: files', () => {
   it('converts a save from a workshop upload zip', async () => {
     const zip = await Zip.create({
@@ -242,19 +264,17 @@ describe('TTS import: files', () => {
   });
 
   it('writes the file at the current version so that no legacy mode is turned on for it', async () => {
-    const state = (await TTS.fromBSON(BSON.serialize({
+    // convert() checks the version and the round trip through FileUpdater for every
+    // conversion of this suite - this one holds the widgets the legacy modes look for
+    const widgets = await convert({
       SaveName: 'test',
       Hands: { Enable: true },
       ObjectStates: [ die('a', 0), { Name: 'HandTrigger', GUID: 'h1', FogColor: 'Red' } ]
-    }))).TTS['0.json'];
+    });
 
     // the caption of the hand is what the legacy mode for holders without image support
     // looks for in an old file - it would hide the very text the importer just wrote
-    expect(state.hand.text).toBe('Hand');
-    expect(state._meta.version).toBe(VERSION);
-    expect(state._meta.gameSettings).toBeUndefined();
-    // loading the imported file leaves it exactly as it is
-    expect(FileUpdater(JSON.parse(JSON.stringify(state)))).toEqual(state);
+    expect(widgets.hand.text).toBe('Hand');
   });
 
   it('keeps the widget IDs of two imports that run at the same time apart', async () => {

--- a/tests/server/ttsimport.test.js
+++ b/tests/server/ttsimport.test.js
@@ -1,6 +1,6 @@
 import { BSON } from 'bson';
 
-import FileUpdater, { VERSION } from '../../server/fileupdater.mjs';
+import { expectNoLegacyModes } from './fileupdater-util.js';
 import TTS from '../../server/ttsimport.mjs';
 import Zip from '../../server/zip.mjs';
 
@@ -20,21 +20,6 @@ async function convert(save) {
   expectNoLegacyModes(widgets);
   delete widgets._meta;
   return widgets;
-}
-
-// the importer writes the current file version, so nothing it produces may be rewritten
-// on load: a migration that would still have changed it never runs again. FileUpdater hands
-// back a state that already is at VERSION untouched, so the check migrates a copy stamped
-// with the version before it - that runs the newest migration on what the importer writes
-// and fails as soon as one is added which the importer does not produce the result of.
-function expectNoLegacyModes(state) {
-  expect(state._meta.version).toBe(VERSION);
-  expect(state._meta.gameSettings).toBeUndefined();
-  // NaN and undefined do not survive the save file, so compare what is actually stored
-  const stored = JSON.parse(JSON.stringify(state));
-  const previousVersion = JSON.parse(JSON.stringify(stored));
-  previousVersion._meta.version = VERSION - 1;
-  expect(FileUpdater(previousVersion)).toEqual(stored);
 }
 
 // what the importer could not bring over - the game details show it as import notes

--- a/tests/server/ttsimport.test.js
+++ b/tests/server/ttsimport.test.js
@@ -1,5 +1,6 @@
 import { BSON } from 'bson';
 
+import FileUpdater, { VERSION } from '../../server/fileupdater.mjs';
 import TTS from '../../server/ttsimport.mjs';
 import Zip from '../../server/zip.mjs';
 
@@ -240,6 +241,22 @@ describe('TTS import: files', () => {
     expect(widgets._meta.info.importerTemp).toBe('TTS');
   });
 
+  it('writes the file at the current version so that no legacy mode is turned on for it', async () => {
+    const state = (await TTS.fromBSON(BSON.serialize({
+      SaveName: 'test',
+      Hands: { Enable: true },
+      ObjectStates: [ die('a', 0), { Name: 'HandTrigger', GUID: 'h1', FogColor: 'Red' } ]
+    }))).TTS['0.json'];
+
+    // the caption of the hand is what the legacy mode for holders without image support
+    // looks for in an old file - it would hide the very text the importer just wrote
+    expect(state.hand.text).toBe('Hand');
+    expect(state._meta.version).toBe(VERSION);
+    expect(state._meta.gameSettings).toBeUndefined();
+    // loading the imported file leaves it exactly as it is
+    expect(FileUpdater(JSON.parse(JSON.stringify(state)))).toEqual(state);
+  });
+
   it('keeps the widget IDs of two imports that run at the same time apart', async () => {
     // two objects with the same GUID: the second one has to get an ID of its own
     const twins = SaveName=>({ SaveName, ObjectStates: [ die('twin', -2), die('twin', 2) ] });
@@ -437,6 +454,18 @@ describe('TTS import: seats', () => {
 
     expect(typed(widgets, 'seat').map(s=>s.color)).toEqual([ '#da1917', '#118ed7' ]);
     expect(widgets.hand.type).toBe('holder');
+  });
+
+  it('gives the hand the drop shadow and the hidden cursors of a VirtualTabletop hand', async () => {
+    const widgets = await convert({
+      SaveName: 'test',
+      Hands: { Enable: true },
+      ObjectStates: [ die('a', 0), { Name: 'HandTrigger', GUID: 'h1', FogColor: 'Red' } ]
+    });
+
+    expect(widgets.hand.childrenPerOwner).toBe(true);
+    expect(widgets.hand.dropShadow).toBe(true);
+    expect(widgets.hand.hidePlayerCursors).toBe(true);
   });
 
   it('fits the seats onto the surface even with a hand zone per TTS color', async () => {

--- a/tests/server/ttsimport.test.js
+++ b/tests/server/ttsimport.test.js
@@ -23,13 +23,18 @@ async function convert(save) {
 }
 
 // the importer writes the current file version, so nothing it produces may be rewritten
-// on load: a migration that would still have changed it never runs again
+// on load: a migration that would still have changed it never runs again. FileUpdater hands
+// back a state that already is at VERSION untouched, so the check migrates a copy stamped
+// with the version before it - that runs the newest migration on what the importer writes
+// and fails as soon as one is added which the importer does not produce the result of.
 function expectNoLegacyModes(state) {
   expect(state._meta.version).toBe(VERSION);
   expect(state._meta.gameSettings).toBeUndefined();
   // NaN and undefined do not survive the save file, so compare what is actually stored
-  const stored = JSON.stringify(state);
-  expect(FileUpdater(JSON.parse(stored))).toEqual(JSON.parse(stored));
+  const stored = JSON.parse(JSON.stringify(state));
+  const previousVersion = JSON.parse(JSON.stringify(stored));
+  previousVersion._meta.version = VERSION - 1;
+  expect(FileUpdater(previousVersion)).toEqual(stored);
 }
 
 // what the importer could not bring over - the game details show it as import notes


### PR DESCRIPTION
Games imported from a PlayingCards.io or Tabletop Simulator file started out with legacy modes switched on, so brand new imports behaved like games from before those bugs were fixed. This makes both importers write their output at the current file version, which is what they actually produce - and, where dropping a migration raised the question of what the imported game *should* do, answers it from what the source platform does.

### The bug

`server/pcioimport.mjs` stamped its output with `_meta.version: 4` and `server/ttsimport.mjs` with `5` - the file versions they were written against, never updated since. Loading such a file runs every `FileUpdater` migration from there to `VERSION`, and those include the steps that enable a legacy mode for games that predate a behavior change:

* every PCIO import contains `var` expressions (counters, spinners, turn buttons), so it tripped the detectors of `convertNumericVarParametersToNumbers` and `useOneAsDefaultForVarParameters` and started with **both var legacy modes active** - old var semantics in a game written by today's importer, which is what the report below ran into,
* every TTS import with a hand zone carries a holder with `text: 'Hand'`, so it tripped `disableHolderImageWidget` and started with **holder image support disabled** - hiding the very caption the importer had just written.

Legacy modes exist so that games saved *before* a change keep working. A file an importer wrote a second ago was never played under the old semantics, so it must not get any of them.

### The change

Both importers write `_meta.version: VERSION`, so a fresh import is loaded as what it is: a new file.

Stamping the current version also means the migrations that silently corrected importer output on load no longer run, so those corrections are written by the importers themselves:

* **face objects** that follow a card type property become `dynamicProperties` instead of PCIO's `valueType`/`value` (v5),
* **hands** get `dropShadow` and `hidePlayerCursors` - what v12/v14 used to add and what edit mode's "add hand" button sets,
* a **classic PCIO game piece** is written at 56x84 at x+17/y+3, the box its pawn shape actually fills, instead of the 90x90 PCIO box that v6 used to shrink. A 90x90 box stretches the `classicPiece` mask (`viewBox='0 0 60 90' preserveAspectRatio='none'`) about 1.5x horizontally: ![classic piece geometry](https://agent.virtualtabletop.io/reports/pr/1540040772802584646/classic-piece-geometry.png)
* **every label** the PCIO importer emits is grown to at least one line of its own font size (v13), not just the striped placeholder,
* a **TTS notecard** gets `white-space: pre-wrap` (v20) so the runs of spaces and the line breaks its author typed survive.

Two of the dropped migrations turned out to have been correcting the importer *towards* something PlayingCards.io does not do, so the importer writes what PlayingCards.io does instead - see below.

### Measured against what PlayingCards.io actually does

Their client ships as one bundle (`https://playingcards.io/build/bundle.js`), so the questions below are answered by reading and running their code rather than by comparing the import with its previous output.

* **Moving a number of objects that is only known when the button is pressed** ("deal as many cards as this counter says") keeps its plain `MOVE`/`MOVEXY`/`ROTATE`. v16 wrapped exactly that shape into an `IF` whose `else` branch moved **everything** when the number came out as 0, so a counter at 0 dumped the whole pile onto the table. PlayingCards.io declares the quantity as `numberMinimum: 1` with "all objects" as the constant 1300 - a 0 can only ever arrive from a counter or an automation question at run time, and `MOVE_CARDS_BETWEEN_HOLDERS.run` then loops `while(sum(quota) > 0)` and moves nothing at all. Lifting their function out of the bundle and running it confirms it: 0 → nothing, 2 → two, 1300 → everything. The plain operation the importer writes does the same, and there is a test for the counter-driven count and for a 0 spelled out in the file.
* **A recall hands the objects back to everyone.** v11 used to add `resetOwner: false` to the `MOVEXY` a recall of a deck without a holder emits, so recalled objects stayed the property of whoever had them in their hand. PlayingCards.io clears the owner of every object it recalls, in a holder or on the deck's own position, so the import does too.
* **A move into the hand ends up in the hand.** A move whose destination is the hand widget was written as a `MOVEXY` without coordinates, which drops the objects in the top left corner of the table. PlayingCards.io accepts only holders and seats as destinations - a hand is dropped from the list, so such a step moves nothing there. The import now moves the objects into the hand, where they become the private property of whoever pressed the button, which is what a hand means on both platforms; a hand that PlayingCards.io does not show is no destination at all and the step is left out. (Moves to a *seat* already matched: PCIO sets `owner` to that seat's player and parks the object in the hand, which is what VTT's `MOVE` to a seat does.)
* **A counter is laid out the way PlayingCards.io lays it out.** A counter has no stored size there: the box is computed from the size of its value - room for the widest number its bounds allow (at least 52px) plus 44px for each of the two buttons, one line tall but never shorter than the buttons - and the value is drawn a quarter larger while it is shorter than four characters. The `width`/`height` a `.pcio` file carries for a counter are numbers PCIO ignores, so the importer ignores them too and computes the same box, with a 32px button in each end. An imported counter is therefore never too short for its own value and never too narrow for its buttons, whatever the file says.

![the counters of the demo table](https://agent.virtualtabletop.io/reports/pr/1540040772802584646/pcio-import-demo-counters.png)

### The hand zone is captioned

A PCIO import ended in an unlabeled 1400x180 white band across the bottom of the table, and a hand's own PlayingCards.io label was dropped on the way in. The hand now carries that label as its caption, falling back to *"Your hand"* for the table's main hand and *"Private"* for a further private zone. PlayingCards.io does not name its hand either, but its empty hand is not blank: it shows grey centred text - *"Cards placed here are only visible to you."* - which fades out as soon as a card is in it. The TTS hand says *"Your hand"* as well now instead of *"Hand"*, which reads as the name of a zone rather than as "this band is private to you". The caption only became visible at all with this PR, because `disableHolderImageWidget` used to hide it.

A demo table is on the test server as **PCIO import demo** ([download](https://agent.virtualtabletop.io/reports/pr/1540040772802584646/PCIO%20import%20demo.vtt)) - the raw output of importing a `.pcio` with four counters (one whose file box is 40x10, one bounded, one styled at 40px with a 1.6 line height, one without buttons), a deck, a hand and three buttons: deal as many cards as the counter says, move one into the hand, recall everything. It is a demo, not a library game and not a tutorial. Set the counter to 0 and press the deal button: nothing is dealt, where the migrated form dealt the whole pile.

![the demo table](https://agent.virtualtabletop.io/reports/pr/1540040772802584646/pcio-import-demo-full.png)

Existing rooms are unaffected: files imported before this change are still at version 4/5 and still get their legacy modes when loaded.

### Verified

`npm test` (1362 tests, including the new ones). Both importer test suites share one helper that checks every import they do against the migrations: the imported state must come out of `FileUpdater` unchanged when it is handed in stamped at `IMPORT_MIGRATION_BASE`, the oldest version from which every migration is known to leave importer output alone. (Handing it in at the current version proves nothing - `FileUpdater` returns such a state untouched.) Every migration added later therefore runs against every importer fixture, however many versions a release adds at once, and fails the tests if the importer does not already write what it produces.

Beyond the suites, both importers were run over a fixture covering every widget type and automation step they know, and their output diffed against `FileUpdater(<the same output stamped back to version 4/5>)`, i.e. against exactly what `main` hands to the client today, so that every difference is a deliberate one rather than an accident.

In the browser, on the demo table: the counter at 3 deals three cards and at 0 deals none, "one into my hand" puts the card in the player's own hand, "recall everything" brings all thirteen cards back to the draw pile including the one that was in the hand, and the console stays clean. Manually, by importing the same `.pcio` file into a room on `main` and on this branch: on `main` Game Settings shows *"2 of 2 legacy modes active for this game"*, on this branch *"No legacy modes are active for this game"*.

### Reported on Discord

> Ok yeah, there are two set on the game... I imported this from a playingcards.io file, maybe it set those on import?

— moshek, [#Gin Rummy](https://discord.com/channels/770758631146782780/1538606143000158248/1540040452294709349), after `x.trim is not a function` errors in a game that worked identically in another room.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3137/pr-test (or any other room on that server)
