### PR TITLE
Tick timers from the wall clock and hand the ticking on when a client leaves

### DIFF
--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -113,12 +113,12 @@ export function rand() {
   return number;
 }
 
-// converts "minutes:seconds" or "minutes:seconds.fraction" strings to milliseconds
-// (rounded to the nearest millisecond); returns any other value unchanged
+// converts "minutes:seconds" and "hours:minutes:seconds" strings, with or without a fraction of a
+// second, to milliseconds (rounded to the nearest millisecond); returns any other value unchanged
 export function timeToMS(value) {
-  const match = typeof value == 'string' && value.match(/^(-?)(\d+):(\d+(?:\.\d+)?)$/);
+  const match = typeof value == 'string' && value.match(/^(-?)(?:(\d+):)?(\d+):(\d+(?:\.\d+)?)$/);
   if(match)
-    return (match[1] ? -1 : 1) * Math.round((+match[2]*60 + +match[3])*1000);
+    return (match[1] ? -1 : 1) * Math.round(((+match[2] || 0)*3600 + +match[3]*60 + +match[4])*1000);
   return value;
 }
 

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -9126,7 +9126,7 @@ class PropertiesModule extends SidebarModule {
     });
   }
 
-  // a text input showing a milliseconds property as mm:ss
+  // a text input showing a milliseconds property as mm:ss, with an hours field from an hour on
   renderTimerTimeInput(widget, labelText, property, target, options = {}) {
     const wrap = div(target, 'propertyInput timeInput');
     const label = document.createElement('label');
@@ -9137,7 +9137,7 @@ class PropertiesModule extends SidebarModule {
 
     const input = document.createElement('input');
     input.type = 'text';
-    input.placeholder = 'mm:ss';
+    input.placeholder = '[h:]mm:ss';
     input.onchange = () => {
       const ms = parseTimerInput(input.value);
       if(ms === undefined || (ms === null && !options.nullable)) {

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1038,19 +1038,24 @@ function formatTimerMs(ms) {
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds - minutes * 60;
   const secondsString = (seconds < 10 ? '0' : '') + (Number.isInteger(seconds) ? seconds : +seconds.toFixed(3));
-  return `${negative ? '-' : ''}${minutes}:${secondsString}`;
+  // an hour or more gets an hours field, the same way the timer widget shows it
+  const hours = Math.floor(minutes / 60);
+  const minutesString = hours ? `${hours}:${String(minutes - hours*60).padStart(2, '0')}` : `${minutes}`;
+  return `${negative ? '-' : ''}${minutesString}:${secondsString}`;
 }
 
-// accepts "mm:ss", "m:ss.s" or plain seconds; returns milliseconds,
+// accepts "mm:ss", "m:ss.s", "h:mm:ss" or plain seconds; returns milliseconds,
 // null for empty input and undefined for unparseable input
 function parseTimerInput(text) {
   const trimmed = String(text).trim();
   if(trimmed === '')
     return null;
-  const match = trimmed.match(/^(-)?(?:(\d+):)?(\d+(?:\.\d+)?)$/);
+  const match = trimmed.match(/^(-)?(?:(\d+):)?(?:(\d+):)?(\d+(?:\.\d+)?)$/);
   if(!match)
     return undefined;
-  return Math.round(((+match[2] || 0) * 60 + +match[3]) * 1000) * (match[1] ? -1 : 1);
+  // one number in front of the seconds is the minutes, two are hours and minutes
+  const [ hours, minutes ] = match[3] === undefined ? [ 0, +match[2] || 0 ] : [ +match[2], +match[3] ];
+  return Math.round(((hours * 60 + minutes) * 60 + +match[4]) * 1000) * (match[1] ? -1 : 1);
 }
 
 function parseFontSize(fontSize) {

--- a/client/js/editor/sidebar/widgets.js
+++ b/client/js/editor/sidebar/widgets.js
@@ -894,6 +894,8 @@ class WidgetsModule extends SidebarModule {
                 case 'timer': previewWidget = new Timer(tempId); break;
                 default: previewWidget = new BasicWidget(tempId); break;
               }
+              // the preview is not part of the room, so nothing it renders may be written back
+              previewWidget.isReadonlyCopy = true;
               previewWidget.domElement.style.transformOrigin = 'top left';
               tempWidgetInstances.set(tempId, previewWidget);
             }
@@ -928,7 +930,10 @@ class WidgetsModule extends SidebarModule {
           e.dataTransfer.setDragImage(previewContainer, 0, 0);
 
           setTimeout(() => {
-            for (const tempId of tempWidgetInstances.keys()) {
+            for (const [ tempId, previewWidget ] of tempWidgetInstances) {
+              // the preview is torn down the way a widget leaving the room is, so that whatever it
+              // registered while it rendered - a running timer, a listener - is released with it
+              previewWidget.applyRemove();
               widgets.delete(tempId);
             }
             document.body.removeChild(previewContainer);
@@ -1132,6 +1137,8 @@ class WidgetsModule extends SidebarModule {
               case 'timer': previewWidget = new Timer(tempId); break;
               default: previewWidget = new BasicWidget(tempId); break;
             }
+            // the preview is not part of the room, so nothing it renders may be written back
+            previewWidget.isReadonlyCopy = true;
             previewWidget.domElement.style.transformOrigin = 'top left';
             tempWidgetInstances.set(tempId, previewWidget);
           }
@@ -1166,7 +1173,10 @@ class WidgetsModule extends SidebarModule {
         e.dataTransfer.setDragImage(previewContainer, 0, 0);
 
         setTimeout(() => {
-          for (const tempId of tempWidgetInstances.keys()) {
+          for (const [ tempId, previewWidget ] of tempWidgetInstances) {
+            // the preview is torn down the way a widget leaving the room is, so that whatever it
+            // registered while it rendered - a running timer, a listener - is released with it
+            previewWidget.applyRemove();
             widgets.delete(tempId);
           }
           document.body.removeChild(previewContainer);

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -24,9 +24,14 @@ export {
 // Work that exactly one client in the room may do - ticking a running timer - falls to the primary
 // session. The server numbers sessions in connection order, so every client picks the same one
 // without talking to the others, and the next session inherits the job as soon as that one
-// disconnects. While the session list is unknown, every client considers itself primary: doing the
-// work twice is something its caller has to cope with anyway (during a handover two clients hold
-// the job for a moment), not doing it at all is not.
+// disconnects.
+export function primarySessionOf(sessions) {
+  return (sessions || []).reduce((oldest, s)=>oldest === null || s.sessionID < oldest ? s.sessionID : oldest, null);
+}
+
+// While the session list is unknown, every client considers itself primary: doing the work twice is
+// something its caller has to cope with anyway (during a handover two clients hold the job for a
+// moment), not doing it at all is not.
 export function isPrimarySession() {
   return primarySessionID === null || primarySessionID === mySessionID;
 }
@@ -130,7 +135,7 @@ function showInviteStatus(text, isError) {
 
 function fillPlayerList(players, active, sessions) {
   activePlayers = [...new Set(active)];
-  primarySessionID = (sessions || []).reduce((oldest, s)=>oldest === null || s.sessionID < oldest ? s.sessionID : oldest, null);
+  primarySessionID = primarySessionOf(sessions);
   activeColors = activePlayers.map(playerName=>players[playerName]);
   removeFromDOM('#playersTable tbody > tr, #playerCursors > .cursor');
 

--- a/client/js/overlays/players.js
+++ b/client/js/overlays/players.js
@@ -8,6 +8,7 @@ let activePlayers = [];
 let activeColors = [];
 let mouseCoords = [];
 let mySessionID = null;
+let primarySessionID = null;
 let metaUpdateResolves = [];
 let inviteStatusTimeout = null;
 localStorage.setItem('playerName', playerName);
@@ -18,6 +19,16 @@ export {
   activePlayers,
   activeColors,
   mouseCoords
+}
+
+// Work that exactly one client in the room may do - ticking a running timer - falls to the primary
+// session. The server numbers sessions in connection order, so every client picks the same one
+// without talking to the others, and the next session inherits the job as soon as that one
+// disconnects. While the session list is unknown, every client considers itself primary: doing the
+// work twice is something its caller has to cope with anyway (during a handover two clients hold
+// the job for a moment), not doing it at all is not.
+export function isPrimarySession() {
+  return primarySessionID === null || primarySessionID === mySessionID;
 }
 
 function getPlayerDetails() {
@@ -119,6 +130,7 @@ function showInviteStatus(text, isError) {
 
 function fillPlayerList(players, active, sessions) {
   activePlayers = [...new Set(active)];
+  primarySessionID = (sessions || []).reduce((oldest, s)=>oldest === null || s.sessionID < oldest ? s.sessionID : oldest, null);
   activeColors = activePlayers.map(playerName=>players[playerName]);
   removeFromDOM('#playersTable tbody > tr, #playerCursors > .cursor');
 

--- a/client/js/widgets/timer.js
+++ b/client/js/widgets/timer.js
@@ -1,3 +1,9 @@
+// A running timer is written by one client only so that its shared millisecond count moves on once
+// per interval no matter how many people watch it. Normally that is the primary session, but a tab
+// that its browser has frozen or throttled stops writing without disconnecting, so every other
+// client takes over once the value has not moved for a whole interval plus this grace period.
+const timerTakeoverGrace = 3000;
+
 export class Timer extends Widget {
   constructor(id) {
     super(id);
@@ -20,32 +26,45 @@ export class Timer extends Widget {
     });
   }
 
+  // the value the elapsed time is measured from and the moment it was current. The last update
+  // this client saw doubles as the sign of life of whoever is writing the timer.
+  anchorTicking(milliseconds) {
+    this.tickTime = this.lastMillisecondsUpdate = Date.now();
+    this.tickMilliseconds = milliseconds;
+    delete this.tickedMilliseconds;
+  }
+
   applyDeltaToDOM(delta) {
     super.applyDeltaToDOM(delta);
     if(delta.milliseconds !== undefined) {
       const s = Math.floor(Math.abs(delta.milliseconds)/1000);
       setText(this.domElement, `${delta.milliseconds < 0 ? '-' : ''}${Math.floor(s/60)}:${Math.floor(s%60)}`.replace(/:(\d)$/, ':0$1'));
+
+      if(delta.milliseconds !== this.tickedMilliseconds) {
+        const now = Date.now();
+        this.lastMillisecondsUpdate = now;
+        // an update that says what this client would have written itself leaves its base alone, so
+        // that the part of the interval that has not elapsed yet survives; anything else - a routine
+        // adding time, another client with a clock of its own - becomes the new base
+        if(delta.milliseconds !== this.millisecondsAt(now))
+          this.anchorTicking(delta.milliseconds);
+      }
     }
 
-    if(this.interval && (delta.paused !== undefined || delta.precision !== undefined)) {
+    if(delta.paused !== undefined || delta.precision !== undefined || delta.countdown !== undefined) {
       this.stopTimer();
-      if(!this.get('paused'))
-        this.startTimer();
+      this.updateTicking();
     }
   }
 
   applyInitialDelta(delta) {
     super.applyInitialDelta(delta);
-    if(delta.paused === false && activePlayers.length == 1)
-      this.startTimer();
+    this.updateTicking();
   }
 
   applyRemove() {
     super.applyRemove();
-    if(this.interval) {
-      console.log('remove clear');
-      this.stopTimer();
-    }
+    this.stopTimer();
   }
 
   classes(includeTemporary=true) {
@@ -85,17 +104,24 @@ export class Timer extends Widget {
     return getSVG(this.get('image'), replaces, _=>this.domElement.style.cssText = this.css());
   }
 
+  // whole intervals that have passed since the base, and the value they add up to - deriving it
+  // from the wall clock instead of adding one interval per tick is what keeps a throttled or
+  // suspended tab from falling behind: however many intervals its browser skipped, the next tick
+  // lands on the time that really passed
+  intervalsSince(now) {
+    return Math.floor((now - this.tickTime)/this.getPrecision());
+  }
+
+  millisecondsAt(now) {
+    return this.tickMilliseconds + Math.max(this.intervalsSince(now), 0)*this.getPrecision()*(this.get('countdown') ? -1 : 1);
+  }
+
   async onPropertyChange(property, oldValue, newValue) {
     await super.onPropertyChange(property, oldValue, newValue);
 
     if(property == 'milliseconds') {
       const end = timeToMS(this.get('end'));
       await this.set('alert', end !== null && ((this.get('countdown') && newValue<=end) || (!this.get('countdown') && newValue>=end)));
-    }
-
-    if(property == 'paused' && newValue !== true) {
-      this.stopTimer();
-      this.startTimer();
     }
   }
 
@@ -118,7 +144,19 @@ export class Timer extends Widget {
   }
 
   async tick() {
-    await this.set('milliseconds', this.get('milliseconds') + this.getPrecision()*(this.get('countdown') ? -1 : 1));
+    const now = Date.now();
+    const intervals = this.intervalsSince(now);
+    if(intervals < 1)
+      return;
+    // lastMillisecondsUpdate only moves for values somebody else wrote, so a client that had to
+    // take over keeps the timer running until the one that should be writing shows up again
+    if(!isPrimarySession() && now - this.lastMillisecondsUpdate < this.getPrecision() + timerTakeoverGrace)
+      return;
+
+    this.tickedMilliseconds = this.millisecondsAt(now);
+    this.tickTime += intervals*this.getPrecision();
+    this.tickMilliseconds = this.tickedMilliseconds;
+    await this.set('milliseconds', this.tickedMilliseconds);
   }
 
   async setPaused(mode) {
@@ -131,11 +169,24 @@ export class Timer extends Widget {
   }
 
   startTimer() {
-    this.interval = setInterval(_=>this.tick(), this.getPrecision());
+    // a preview of a widget outside the room (the editor renders those) must not write state
+    if(this.isReadonlyCopy)
+      return;
+    this.anchorTicking(this.get('milliseconds'));
+    // checking at least once a second keeps a takeover from a stalled client from being delayed by
+    // a long precision - the value itself only ever moves in whole intervals
+    this.interval = setInterval(_=>this.tick(), Math.min(this.getPrecision(), 1000));
   }
 
   stopTimer() {
     clearInterval(this.interval);
     delete this.interval;
+  }
+
+  updateTicking() {
+    if(this.get('paused'))
+      this.stopTimer();
+    else if(!this.interval)
+      this.startTimer();
   }
 }

--- a/client/js/widgets/timer.js
+++ b/client/js/widgets/timer.js
@@ -242,6 +242,10 @@ export class Timer extends Widget {
   // tick that writes nothing - for the moment two clients write, the other one got there first -
   // must not leave that cause behind for whatever the player does next.
   async writeTick(milliseconds) {
+    // a widget of this id that is not this one is a copy the editor renders - a drag preview builds
+    // itself as a widget of its own - and nothing it derives may be written to the room
+    if(widgets.get(this.id) !== this)
+      return;
     this.tickMilliseconds = milliseconds;
     if(milliseconds === this.get('milliseconds'))
       return;

--- a/client/js/widgets/timer.js
+++ b/client/js/widgets/timer.js
@@ -195,10 +195,14 @@ export class Timer extends Widget {
       // "milliseconds == 100" has to be given that value - so a timer something watches moves on by
       // one interval per tick however many intervals its browser skipped. The ones it skipped are
       // time the timer did not count, as they have always been, rather than values it jumps over.
-      // Its base never trails the clock by more than the interval just taken, so that the tick after
-      // a frozen tab wakes up is paced by the precision again instead of racing through a backlog.
-      this.tickTime = Math.max(this.tickTime, now - this.getPrecision()) + this.getPrecision();
-      await this.writeTick(this.tickMilliseconds + this.intervalStep());
+      // The base moves on by exactly the interval that was taken, so that the jitter of the
+      // browser's callbacks - which are never early, only late - can not drop a tick. It may trail
+      // the clock by two whole intervals before it is pulled along, which is far beyond that jitter
+      // and keeps a tab that has just woken up from racing through the backlog.
+      this.tickTime = Math.max(this.tickTime, now - 2*this.getPrecision()) + this.getPrecision();
+      // measured from the value the timer actually holds, not from the base the wall clock is
+      // derived from: taking over from another client means carrying on from what it last wrote
+      await this.writeTick(this.get('milliseconds') + this.intervalStep());
     } else {
       // nothing in the room can tell which values it passed through, so it lands straight on the
       // time that really passed instead of falling behind by every interval the browser skipped

--- a/client/js/widgets/timer.js
+++ b/client/js/widgets/timer.js
@@ -1,9 +1,11 @@
 // A running timer is written by one client only so that its shared millisecond count moves on once
-// per interval no matter how many people watch it. Normally that is the primary session, but a tab
-// that its browser has frozen or throttled stops writing without disconnecting, so every other
-// client takes over once the value has not moved for a whole interval plus this grace period. For
-// the moment two of them write, both derive the same number from the same wall clock, so the count
-// stays true - but each of them runs the timer's routines for the tick it writes.
+// per interval no matter how many people watch it. That client is the one whose player started the
+// timer, so that the timer's routines keep running for that player. Anybody else steps in only once
+// the value has stood still for a whole interval plus this grace period - a tab that its browser has
+// frozen or throttled stops writing without disconnecting - and a timer nobody in the room started
+// goes to the primary session straight away. For the moment two clients write, both derive the same
+// number from the same wall clock, so the count stays true - but each of them runs the timer's
+// routines for the tick it writes.
 const timerTakeoverGrace = 3000;
 
 export class Timer extends Widget {
@@ -56,6 +58,14 @@ export class Timer extends Widget {
       }
     }
 
+    // a timer that stops or starts puts the writing up for election again, and a start goes to the
+    // client whose own change it is - the one whose player started the timer
+    if(delta.paused !== undefined) {
+      this.startedTicking = delta.paused === false && this.locallyPausedTo === false;
+      this.startedWhileHere = delta.paused === false;
+      delete this.locallyPausedTo;
+    }
+
     if(delta.paused !== undefined || delta.precision !== undefined || delta.countdown !== undefined) {
       this.stopTimer();
       this.updateTicking();
@@ -64,6 +74,9 @@ export class Timer extends Widget {
 
   applyInitialDelta(delta) {
     super.applyInitialDelta(delta);
+    // a timer that was already running when this client got the room was started by nobody who is
+    // here, so there is no client to leave the writing to
+    delete this.startedWhileHere;
     this.updateTicking();
   }
 
@@ -117,8 +130,13 @@ export class Timer extends Widget {
     return Math.floor((now - this.tickTime)/this.getPrecision());
   }
 
+  // what one interval adds to the value - a countdown subtracts it
+  intervalStep() {
+    return this.getPrecision()*(this.get('countdown') ? -1 : 1);
+  }
+
   millisecondsAt(now) {
-    return this.tickMilliseconds + Math.max(this.intervalsSince(now), 0)*this.getPrecision()*(this.get('countdown') ? -1 : 1);
+    return this.tickMilliseconds + Math.max(this.intervalsSince(now), 0)*this.intervalStep();
   }
 
   async onPropertyChange(property, oldValue, newValue) {
@@ -162,30 +180,83 @@ export class Timer extends Widget {
     const intervals = this.intervalsSince(now);
     if(intervals < 1)
       return;
-    // lastMillisecondsUpdate only moves for values somebody else wrote, so a client that had to
-    // take over keeps the timer running until it leaves and the primary session picks the job up
-    // again. Waiting out the grace period only keeps this client from writing, not from showing the
-    // time - the value comes from the wall clock, so a stalled writer freezes nobody's display
-    if(!isPrimarySession() && now - this.lastMillisecondsUpdate < this.getPrecision() + timerTakeoverGrace) {
-      this.renderMilliseconds(this.millisecondsAt(now));
+    if(!this.writesTicks(now)) {
+      // leaving the writing to somebody else does not keep this client from showing the time: the
+      // value comes from the wall clock, so a stalled writer freezes nobody's display. A timer
+      // something watches does not catch up, though, so the clock would run its display ahead of the
+      // value it is going to take - that one shows what it was last told.
+      if(!this.valueIsWatched())
+        this.renderMilliseconds(this.millisecondsAt(now));
       return;
     }
 
-    // consecutive ticks share one undo entry instead of filling the protocol one second at a time
+    if(this.valueIsWatched()) {
+      // a routine can be watching for an exact value - a countdown that changes the turn at
+      // "milliseconds == 100" has to be given that value - so a timer something watches moves on by
+      // one interval per tick however many intervals its browser skipped. The ones it skipped are
+      // time the timer did not count, as they have always been, rather than values it jumps over.
+      // Its base never trails the clock by more than the interval just taken, so that the tick after
+      // a frozen tab wakes up is paced by the precision again instead of racing through a backlog.
+      this.tickTime = Math.max(this.tickTime, now - this.getPrecision()) + this.getPrecision();
+      await this.writeTick(this.tickMilliseconds + this.intervalStep());
+    } else {
+      // nothing in the room can tell which values it passed through, so it lands straight on the
+      // time that really passed instead of falling behind by every interval the browser skipped
+      this.tickTime += intervals*this.getPrecision();
+      await this.writeTick(this.tickMilliseconds + intervals*this.intervalStep());
+    }
+  }
+
+  // whether anything in the room is given every value the timer passes through: a routine on the
+  // timer itself, or another widget listening for updates
+  valueIsWatched() {
+    return Array.isArray(this.get('millisecondsChangeRoutine')) || Array.isArray(this.get('changeRoutine'))
+        || (StateManaged.globalUpdateListeners.milliseconds || []).length > 0
+        || (StateManaged.globalUpdateListeners['*'] || []).length > 0;
+  }
+
+  // Which client writes the timer. The one whose player started it does, so that the timer's
+  // routines keep running for that player.
+  writesTicks(now) {
+    if(this.startedTicking)
+      return true;
+
+    const grace = this.getPrecision() + timerTakeoverGrace;
+    const silence = now - this.lastMillisecondsUpdate;
+    // a timer that was started while this client was in the room belongs to the client that started
+    // it, and as long as that one keeps writing nobody else does
+    if(this.startedWhileHere && silence < grace)
+      return false;
+    // a timer nobody here started - one that was already running when this client got the room - and
+    // one whose writer has fallen silent go to the primary session, so that exactly one client takes
+    // them over. The rest of the room waits out a second grace period, which only ever elapses if
+    // the primary session is itself the one that stalled.
+    return isPrimarySession() || silence >= 2*grace;
+  }
+
+  // Consecutive ticks share one undo entry instead of filling the protocol one second at a time. A
+  // tick that writes nothing - for the moment two clients write, the other one got there first -
+  // must not leave that cause behind for whatever the player does next.
+  async writeTick(milliseconds) {
+    this.tickMilliseconds = milliseconds;
+    if(milliseconds === this.get('milliseconds'))
+      return;
+    this.tickedMilliseconds = milliseconds;
     setDeltaCause('timer ticked');
-    this.tickedMilliseconds = this.millisecondsAt(now);
-    this.tickTime += intervals*this.getPrecision();
-    this.tickMilliseconds = this.tickedMilliseconds;
-    await this.set('milliseconds', this.tickedMilliseconds);
+    await this.set('milliseconds', milliseconds);
   }
 
   async setPaused(mode) {
-    if(mode == 'pause' || mode == 'reset')
-      await this.set('paused',  true);
-    else if(mode == 'start')
-      await this.set('paused',  false);
-    else
-      await this.set('paused',  !this.get('paused'));
+    const paused = mode == 'pause' || mode == 'reset' ? true : mode == 'start' ? false : !this.get('paused');
+
+    // Starting a timer here makes this the client that writes it, so that its routines run for the
+    // player who started it rather than for whoever the room's oldest connection belongs to. The
+    // claim is noted for applyDeltaToDOM to pick up rather than made here, because the change comes
+    // back either from inside set() or, for a routine, only when its batch of changes ends - a
+    // change that is already the current value sends nothing, so it must not leave a claim behind.
+    if(this.get('paused') !== paused)
+      this.locallyPausedTo = paused;
+    await this.set('paused', paused);
   }
 
   startTimer() {

--- a/client/js/widgets/timer.js
+++ b/client/js/widgets/timer.js
@@ -1,7 +1,9 @@
 // A running timer is written by one client only so that its shared millisecond count moves on once
 // per interval no matter how many people watch it. Normally that is the primary session, but a tab
 // that its browser has frozen or throttled stops writing without disconnecting, so every other
-// client takes over once the value has not moved for a whole interval plus this grace period.
+// client takes over once the value has not moved for a whole interval plus this grace period. For
+// the moment two of them write, both derive the same number from the same wall clock, so the count
+// stays true - but each of them runs the timer's routines for the tick it writes.
 const timerTakeoverGrace = 3000;
 
 export class Timer extends Widget {
@@ -24,6 +26,10 @@ export class Timer extends Widget {
       start: 0,
       end: null
     });
+
+    // the wall clock base exists from the start, so that the value can be derived before the first
+    // update anchors it
+    this.anchorTicking(this.get('milliseconds'));
   }
 
   // the value the elapsed time is measured from and the moment it was current. The last update
@@ -37,8 +43,7 @@ export class Timer extends Widget {
   applyDeltaToDOM(delta) {
     super.applyDeltaToDOM(delta);
     if(delta.milliseconds !== undefined) {
-      const s = Math.floor(Math.abs(delta.milliseconds)/1000);
-      setText(this.domElement, `${delta.milliseconds < 0 ? '-' : ''}${Math.floor(s/60)}:${Math.floor(s%60)}`.replace(/:(\d)$/, ':0$1'));
+      this.renderMilliseconds(delta.milliseconds);
 
       if(delta.milliseconds !== this.tickedMilliseconds) {
         const now = Date.now();
@@ -125,6 +130,11 @@ export class Timer extends Widget {
     }
   }
 
+  renderMilliseconds(milliseconds) {
+    const s = Math.floor(Math.abs(milliseconds)/1000);
+    setText(this.domElement, `${milliseconds < 0 ? '-' : ''}${Math.floor(s/60)}:${Math.floor(s%60)}`.replace(/:(\d)$/, ':0$1'));
+  }
+
   async setMilliseconds(value, mode) {
     let ms = timeToMS(this.get('start'));
 
@@ -149,10 +159,16 @@ export class Timer extends Widget {
     if(intervals < 1)
       return;
     // lastMillisecondsUpdate only moves for values somebody else wrote, so a client that had to
-    // take over keeps the timer running until the one that should be writing shows up again
-    if(!isPrimarySession() && now - this.lastMillisecondsUpdate < this.getPrecision() + timerTakeoverGrace)
+    // take over keeps the timer running until it leaves and the primary session picks the job up
+    // again. Waiting out the grace period only keeps this client from writing, not from showing the
+    // time - the value comes from the wall clock, so a stalled writer freezes nobody's display
+    if(!isPrimarySession() && now - this.lastMillisecondsUpdate < this.getPrecision() + timerTakeoverGrace) {
+      this.renderMilliseconds(this.millisecondsAt(now));
       return;
+    }
 
+    // consecutive ticks share one undo entry instead of filling the protocol one second at a time
+    setDeltaCause('timer ticked');
     this.tickedMilliseconds = this.millisecondsAt(now);
     this.tickTime += intervals*this.getPrecision();
     this.tickMilliseconds = this.tickedMilliseconds;

--- a/client/js/widgets/timer.js
+++ b/client/js/widgets/timer.js
@@ -212,7 +212,11 @@ export class Timer extends Widget {
   }
 
   // whether anything in the room is given every value the timer passes through: a routine on the
-  // timer itself, or another widget listening for updates
+  // timer itself, or another widget listening for updates. The listener registries are room-wide -
+  // a globalUpdateRoutine is told about every widget - so one of them anywhere in the game puts
+  // every timer on the one-interval-per-tick path. That is deliberate: no value may be skipped for
+  // a routine that might be looking for it, and the registries say nothing about which widget an
+  // update came from.
   valueIsWatched() {
     return Array.isArray(this.get('millisecondsChangeRoutine')) || Array.isArray(this.get('changeRoutine'))
         || (StateManaged.globalUpdateListeners.milliseconds || []).length > 0
@@ -222,11 +226,18 @@ export class Timer extends Widget {
   // Which client writes the timer. The one whose player started it does, so that the timer's
   // routines keep running for that player.
   writesTicks(now) {
+    const grace = this.getPrecision() + timerTakeoverGrace;
+    const silence = now - this.lastMillisecondsUpdate;
+    // a tab that comes back from being frozen to find the value moving without it gives up its
+    // claim, so that it does not put another interval on top of what the client that took over
+    // writes. It takes both to lose the claim - having stopped writing for long enough to be taken
+    // over, and having been overtaken since - so a one-off change from somebody else, a routine
+    // adding time, leaves the writing where it is.
+    if(this.startedTicking && now - this.lastTickWrite >= grace && this.lastMillisecondsUpdate > this.lastTickWrite)
+      delete this.startedTicking;
     if(this.startedTicking)
       return true;
 
-    const grace = this.getPrecision() + timerTakeoverGrace;
-    const silence = now - this.lastMillisecondsUpdate;
     // a timer that was started while this client was in the room belongs to the client that started
     // it, and as long as that one keeps writing nobody else does
     if(this.startedWhileHere && silence < grace)
@@ -247,6 +258,7 @@ export class Timer extends Widget {
     if(widgets.get(this.id) !== this)
       return;
     this.tickMilliseconds = milliseconds;
+    this.lastTickWrite = Date.now();
     if(milliseconds === this.get('milliseconds'))
       return;
     this.tickedMilliseconds = milliseconds;
@@ -272,6 +284,9 @@ export class Timer extends Widget {
     if(this.isReadonlyCopy)
       return;
     this.anchorTicking(this.get('milliseconds'));
+    // the moment this client last wrote a tick itself - it starts out as the moment it started
+    // ticking, so that a claim on the writing is not dropped before the first tick
+    this.lastTickWrite = Date.now();
     // checking at least once a second keeps a takeover from a stalled client from being delayed by
     // a long precision - the value itself only ever moves in whole intervals
     this.interval = setInterval(_=>this.tick(), Math.min(this.getPrecision(), 1000));

--- a/client/js/widgets/timer.js
+++ b/client/js/widgets/timer.js
@@ -130,9 +130,13 @@ export class Timer extends Widget {
     }
   }
 
+  // below an hour the value reads as it always has, m:ss with unbounded minutes; from an hour on it
+  // gets an hours field, so that a timer somebody left running says 1:00:00 instead of 60:00
   renderMilliseconds(milliseconds) {
     const s = Math.floor(Math.abs(milliseconds)/1000);
-    setText(this.domElement, `${milliseconds < 0 ? '-' : ''}${Math.floor(s/60)}:${Math.floor(s%60)}`.replace(/:(\d)$/, ':0$1'));
+    const pad = value => String(value).padStart(2, '0');
+    const time = s < 3600 ? `${Math.floor(s/60)}:${pad(s%60)}` : `${Math.floor(s/3600)}:${pad(Math.floor(s/60)%60)}:${pad(s%60)}`;
+    setText(this.domElement, `${milliseconds < 0 ? '-' : ''}${time}`);
   }
 
   async setMilliseconds(value, mode) {

--- a/library/tutorials/Types - Timer/0.json
+++ b/library/tutorials/Types - Timer/0.json
@@ -25,7 +25,7 @@
       "time": "",
       "attribution": "The clock face, by temas, is in the Public Domain under CC0, and is available at https://openclipart.org/detail/134335/diy-clock-face-by-temas-134335.\n\nThe stopwatch face is the based on the clock face, but the numbers were modified by LawDawg96.  It is released to the Public Domain under CC0.\n\nThe hour and minute hands are in the Public Domain under CC0, and are available at https://freesvg.org/minute-hand-mitchell-joh.",
       "showName": false,
-      "lastUpdate": 1787287344505,
+      "lastUpdate": 1787323839668,
       "skill": "",
       "description": "",
       "similarImage": "",
@@ -42,7 +42,7 @@
     }
   },
   "ekxj": {
-    "text": "This tutorial demonstrates the basic operations of the timer widget. A running timer belongs to the room, not to the player who started it: it keeps running when that player closes their tab, and another player carries it on. Time passes only while somebody is in the room; a tab left in the background shows the time that really passed when you come back. In the JSON editor, timers take either milliseconds or minutes:seconds for start and end as well as for the value and seconds parameters of the TIMER function.",
+    "text": "This tutorial demonstrates the basic operations of the timer widget. A running timer belongs to the room, not to the player who started it: it keeps running when that player closes their tab, and another player carries it on. Time passes only while somebody is in the room; a tab left in the background shows the time that really passed when you come back. In the JSON editor, timers take milliseconds, minutes:seconds or hours:minutes:seconds for start and end as well as for TIMER's value and seconds parameters.",
     "css": "font-size: 20px",
     "height": 50,
     "width": 900,

--- a/library/tutorials/Types - Timer/0.json
+++ b/library/tutorials/Types - Timer/0.json
@@ -25,7 +25,7 @@
       "time": "",
       "attribution": "The clock face, by temas, is in the Public Domain under CC0, and is available at https://openclipart.org/detail/134335/diy-clock-face-by-temas-134335.\n\nThe stopwatch face is the based on the clock face, but the numbers were modified by LawDawg96.  It is released to the Public Domain under CC0.\n\nThe hour and minute hands are in the Public Domain under CC0, and are available at https://freesvg.org/minute-hand-mitchell-joh.",
       "showName": false,
-      "lastUpdate": 1785122716095,
+      "lastUpdate": 1787287344505,
       "skill": "",
       "description": "",
       "similarImage": "",
@@ -42,7 +42,7 @@
     }
   },
   "ekxj": {
-    "text": "This tutorial demonstrates the basic operations of the timer widget. Remember, one important limitation of the timer is that it is controlled by the player that started the timer. If that person leaves the room or the player's internet connection is disrupted while the timer is running, the timer will stop. In the JSON editor, timers support using either milliseconds or minutes:seconds format for the start and end properties of the timer widget as well as the value and seconds parameters of the TIMER function.",
+    "text": "This tutorial demonstrates the basic operations of the timer widget. A running timer belongs to the room, not to the player who started it: it keeps running when that player closes their tab, and another player carries it on. Time passes only while somebody is in the room; a tab left in the background shows the time that really passed when you come back. In the JSON editor, timers take either milliseconds or minutes:seconds for start and end as well as for the value and seconds parameters of the TIMER function.",
     "css": "font-size: 20px",
     "height": 50,
     "width": 900,
@@ -96,7 +96,7 @@
     "css": "background-size: 80% 80%"
   },
   "u4ka": {
-    "text": "This is the basic timer widget, which can be added from the Add Widget button on the left side of the screen. The timer will stop and start by either pressing on the numbers of the timer itself or on the play/pause symbol. The timer defaults to counting in one second increments (shown as 1000 milliseconds in the JSON) and counting up. You can edit some of the settings using the Edit Mode button to the left and additional changes can be made using the JSON editor. You can also interact with the controls or the JSON using any type of Routine or Call function.",
+    "text": "This is the basic timer widget, which can be added with the + button in the toolbar at the top of the screen while edit mode is on. The timer will stop and start by either pressing on the numbers of the timer itself or on the play/pause symbol. The timer defaults to counting in one second increments (shown as 1000 milliseconds in the JSON) and counting up. An hour or more reads 1:00:00 rather than 60:00. You can edit some of the settings using the Edit Mode button to the left and additional changes can be made using the JSON editor. You can also interact with the controls or the JSON using any type of Routine or Call function.",
     "css": "font-size: 20px",
     "width": 1200,
     "x": 275,
@@ -282,7 +282,7 @@
     "css": "background-size: 80% 80%"
   },
   "tli4": {
-    "text": "This timer has its precision property set to 500 milliseconds (the lowest possible setting is 100; lower values in the JSON are possible, but will round up to 100 for all calculations).  That means the JSON will update every 1/2 second (look using the JSON editor to confirm), but the on screen number display will only update every second. This feature can be used with changeRoutines to automate changes very rapidly. For example, the background color of the small holder below the timer is changing to a random color every 500 milliseconds.",
+    "text": "This timer has its precision property set to 500 milliseconds (the lowest possible setting is 100; lower values in the JSON are possible, but will round up to 100 for all calculations).  That means the JSON will update every 1/2 second (look using the JSON editor to confirm), but the on screen number display will only update every second. This feature can be used with changeRoutines to automate changes very rapidly. For example, the background color of the small holder below the timer is changing to a random color every 500 milliseconds. A timer that a routine follows like this is given every step it takes, so after a tab has been away it carries on from where it was instead of catching up.",
     "css": "font-size: 20px",
     "width": 1200,
     "x": 275,

--- a/tests/client/primary-session.test.js
+++ b/tests/client/primary-session.test.js
@@ -1,0 +1,28 @@
+import { isPrimarySession, primarySessionOf } from '../../client/js/overlays/players.js';
+
+// the server numbers sessions in connection order, so the lowest id is the connection that has been
+// in the room longest - the one every client agrees does the work only one of them may do
+describe('primarySessionOf', () => {
+  test('picks the session that connected first', () => {
+    expect(primarySessionOf([ { sessionID: 7, player: 'Bob' }, { sessionID: 3, player: 'Alice' } ])).toBe(3);
+  });
+
+  test('compares numerically', () => {
+    expect(primarySessionOf([ { sessionID: 10, player: 'Bob' }, { sessionID: 9, player: 'Alice' } ])).toBe(9);
+  });
+
+  test('picks one of two sessions of the same player', () => {
+    expect(primarySessionOf([ { sessionID: 5, player: 'Alice' }, { sessionID: 4, player: 'Alice' } ])).toBe(4);
+  });
+
+  test('has no primary session while the list is empty or unknown', () => {
+    expect(primarySessionOf([])).toBe(null);
+    expect(primarySessionOf(undefined)).toBe(null);
+  });
+});
+
+describe('isPrimarySession', () => {
+  test('every client considers itself primary before it knows the session list', () => {
+    expect(isPrimarySession()).toBe(true);
+  });
+});

--- a/tests/client/property-inputs.test.js
+++ b/tests/client/property-inputs.test.js
@@ -889,6 +889,13 @@ describe('timer time helpers', () => {
     expect(cssHelpers.formatTimerMs(null)).toBe('');
   });
 
+  test('formatTimerMs renders an hour or more as h:mm:ss', () => {
+    expect(cssHelpers.formatTimerMs(3600000)).toBe('1:00:00');
+    expect(cssHelpers.formatTimerMs(3661000)).toBe('1:01:01');
+    expect(cssHelpers.formatTimerMs(11587000)).toBe('3:13:07');
+    expect(cssHelpers.formatTimerMs(-11587000)).toBe('-3:13:07');
+  });
+
   test('parseTimerInput accepts mm:ss and plain seconds', () => {
     expect(cssHelpers.parseTimerInput('1:01')).toBe(61000);
     expect(cssHelpers.parseTimerInput('90')).toBe(90000);
@@ -898,8 +905,16 @@ describe('timer time helpers', () => {
     expect(cssHelpers.parseTimerInput('abc')).toBe(undefined);
   });
 
+  test('parseTimerInput accepts h:mm:ss', () => {
+    expect(cssHelpers.parseTimerInput('1:00:00')).toBe(3600000);
+    expect(cssHelpers.parseTimerInput('3:13:07')).toBe(11587000);
+    expect(cssHelpers.parseTimerInput('-3:13:07')).toBe(-11587000);
+    expect(cssHelpers.parseTimerInput('0:90:00')).toBe(5400000);
+    expect(cssHelpers.parseTimerInput('1:2:3:4')).toBe(undefined);
+  });
+
   test('formatTimerMs and parseTimerInput round-trip', () => {
-    for(const ms of [ 0, 1000, 61000, 5500, 3600000, -90000 ])
+    for(const ms of [ 0, 1000, 61000, 5500, 3600000, 11587000, -90000, -11587500 ])
       expect(cssHelpers.parseTimerInput(cssHelpers.formatTimerMs(ms))).toBe(ms);
   });
 });

--- a/tests/client/time-to-ms.test.js
+++ b/tests/client/time-to-ms.test.js
@@ -13,8 +13,15 @@ describe("Scenarios: Converting time strings to milliseconds", () => {
     expect(timeToMS("0:59.9996")).toBe(60000);
   });
 
+  test("converts hours:minutes:seconds strings to milliseconds", () => {
+    expect(timeToMS("1:00:00")).toBe(3600000);
+    expect(timeToMS("0:01:30")).toBe(90000);
+    expect(timeToMS("3:13:07.5")).toBe(11587500);
+  });
+
   test("converts negative times", () => {
     expect(timeToMS("-1:30")).toBe(-90000);
+    expect(timeToMS("-1:00:00")).toBe(-3600000);
   });
 
   test("leaves other values unchanged", () => {
@@ -22,6 +29,6 @@ describe("Scenarios: Converting time strings to milliseconds", () => {
     expect(timeToMS("start")).toBe("start");
     expect(timeToMS(null)).toBe(null);
     expect(timeToMS(undefined)).toBe(undefined);
-    expect(timeToMS("1:30:00")).toBe("1:30:00");
+    expect(timeToMS("1:00:00:00")).toBe("1:00:00:00");
   });
 });

--- a/tests/client/timer-tick.test.js
+++ b/tests/client/timer-tick.test.js
@@ -144,6 +144,15 @@ describe('Timer ticking', () => {
       written.mockRestore();
     });
 
+    test('its display follows the clock while it waits for the updates to come back', async () => {
+      const written = jest.spyOn(timer, 'set');
+      await jest.advanceTimersByTimeAsync(2000);
+      expect(written).not.toHaveBeenCalled();
+      expect(timer.get('milliseconds')).toBe(3000);
+      expect(timer.domElement.textContent).toBe('0:05');
+      written.mockRestore();
+    });
+
     test('it takes over once the updates stop coming in', async () => {
       await jest.advanceTimersByTimeAsync(4000);
       expect(timer.get('milliseconds')).toBe(7000);

--- a/tests/client/timer-tick.test.js
+++ b/tests/client/timer-tick.test.js
@@ -161,4 +161,34 @@ describe('Timer ticking', () => {
       expect(timer.get('milliseconds')).toBe(8000);
     });
   });
+
+  describe('the value it displays', () => {
+    let timer;
+    beforeEach(() => timer = createTimer({ id: 'displayed' }));
+    afterEach(() => removeWidget('displayed'));
+
+    function shown(milliseconds) {
+      timer.renderMilliseconds(milliseconds);
+      return timer.domElement.textContent;
+    }
+
+    test('reads as minutes and seconds below an hour', () => {
+      expect(shown(0)).toBe('0:00');
+      expect(shown(5000)).toBe('0:05');
+      expect(shown(65000)).toBe('1:05');
+      expect(shown(3599000)).toBe('59:59');
+    });
+
+    test('gains an hours field from an hour on', () => {
+      expect(shown(3600000)).toBe('1:00:00');
+      expect(shown(3661000)).toBe('1:01:01');
+      // a tab that slept for three hours
+      expect(shown(11587000)).toBe('3:13:07');
+    });
+
+    test('keeps the minus sign of a countdown that ran past its end', () => {
+      expect(shown(-65000)).toBe('-1:05');
+      expect(shown(-11587000)).toBe('-3:13:07');
+    });
+  });
 });

--- a/tests/client/timer-tick.test.js
+++ b/tests/client/timer-tick.test.js
@@ -5,7 +5,7 @@ import { StateManaged } from '../../client/js/statemanaged.js';
 import { Widget } from '../../client/js/widgets/widget.js';
 import { setText, timeToMS } from '../../client/js/domhelpers.js';
 
-import { removeWidget } from './client-util.js';
+import { createWidget, removeWidget } from './client-util.js';
 
 // timer.js relies on the concatenated global scope of the shipped bundle rather than on imports,
 // so expose the identifiers it references before importing it.
@@ -222,6 +222,59 @@ describe('Timer ticking', () => {
       removeWidget('batched');
     });
 
+    test('stops writing once a frozen tab comes back to somebody else ticking', async () => {
+      isPrimary = false;
+      const timer = createTimer({ id: 'frozenStarter' });
+      await timer.setPaused('start');
+      await jest.advanceTimersByTimeAsync(2000);
+      expect(timer.get('milliseconds')).toBe(2000);
+
+      // its browser froze the tab, so the primary session took the timer over
+      jest.setSystemTime(Date.now() + 10000);
+      timer.applyDelta({ milliseconds: 12000 });
+
+      const written = jest.spyOn(timer, 'set');
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(written).not.toHaveBeenCalled();
+      expect(timer.get('milliseconds')).toBe(12000);
+      written.mockRestore();
+      removeWidget('frozenStarter');
+    });
+
+    test('stops writing a watched timer that fell behind the clock in somebody else\'s hands', async () => {
+      isPrimary = false;
+      const timer = createTimer({ id: 'frozenWatched', millisecondsChangeRoutine: [] });
+      await timer.setPaused('start');
+      await jest.advanceTimersByTimeAsync(2000);
+      expect(timer.get('milliseconds')).toBe(2000);
+
+      // its browser froze the tab; the client that took over passes on one interval per tick, so
+      // the value it writes trails the time that really passed
+      jest.setSystemTime(Date.now() + 10000);
+      timer.applyDelta({ milliseconds: 5000 });
+
+      const written = jest.spyOn(timer, 'set');
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(written).not.toHaveBeenCalled();
+      expect(timer.get('milliseconds')).toBe(5000);
+      written.mockRestore();
+      removeWidget('frozenWatched');
+    });
+
+    test('keeps the writing when somebody else only adds time', async () => {
+      isPrimary = false;
+      const timer = createTimer({ id: 'topped' });
+      await timer.setPaused('start');
+      await jest.advanceTimersByTimeAsync(2000);
+
+      // another client's routine puts a minute on the clock without taking the ticking over
+      timer.applyDelta({ milliseconds: 62000 });
+
+      await jest.advanceTimersByTimeAsync(2000);
+      expect(timer.get('milliseconds')).toBe(64000);
+      removeWidget('topped');
+    });
+
     test('hands the writing back once somebody else restarts the timer', async () => {
       isPrimary = false;
       const timer = createTimer({ id: 'handed' });
@@ -254,6 +307,23 @@ describe('Timer ticking', () => {
     expect(timer.get('milliseconds')).toBe(4000);
     written.mockRestore();
     removeWidget('routine');
+  });
+
+  test('a globalUpdateRoutine in the room makes every timer pass on its values', async () => {
+    const watcher = createWidget({ id: 'logger', type: 'basic' });
+    watcher.applyDelta({ globalUpdateRoutine: [] });
+    const timer = createTimer({ id: 'logged', paused: false });
+    await jest.advanceTimersByTimeAsync(1000);
+    const written = jest.spyOn(timer, 'set');
+
+    // the browser stopped running the interval for half a minute
+    jest.setSystemTime(Date.now() + 30000);
+    await jest.advanceTimersByTimeAsync(2000);
+
+    expect(written.mock.calls.filter(c=>c[0] == 'milliseconds').map(c=>c[1])).toEqual([ 2000, 3000 ]);
+    written.mockRestore();
+    removeWidget('logged');
+    removeWidget('logger');
   });
 
   test('a timer a routine watches carries on from the value it was last told', async () => {

--- a/tests/client/timer-tick.test.js
+++ b/tests/client/timer-tick.test.js
@@ -240,6 +240,21 @@ describe('Timer ticking', () => {
     removeWidget('routine');
   });
 
+  test('a timer a routine watches carries on from the value it was last told', async () => {
+    const timer = createTimer({ id: 'carried', millisecondsChangeRoutine: [] });
+    timer.applyDelta({ paused: false });
+    // three seconds of updates from the client that was writing it
+    for(let milliseconds = 1000; milliseconds <= 3000; milliseconds += 1000) {
+      await jest.advanceTimersByTimeAsync(1000);
+      timer.applyDelta({ milliseconds });
+    }
+
+    // ... and then it stops, so this client takes the writing over
+    await jest.advanceTimersByTimeAsync(4200);
+    expect(timer.get('milliseconds')).toBe(4000);
+    removeWidget('carried');
+  });
+
   test('a timer a routine watches never shows a time it will not reach', async () => {
     isPrimary = false;
     const timer = createTimer({ id: 'shown', millisecondsChangeRoutine: [] });

--- a/tests/client/timer-tick.test.js
+++ b/tests/client/timer-tick.test.js
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 
-import { widgets, addWidget } from '../../client/js/serverstate.js';
+import { batchEnd, batchStart, widgets, addWidget } from '../../client/js/serverstate.js';
+import { StateManaged } from '../../client/js/statemanaged.js';
 import { Widget } from '../../client/js/widgets/widget.js';
 import { setText, timeToMS } from '../../client/js/domhelpers.js';
 
@@ -10,22 +11,26 @@ import { removeWidget } from './client-util.js';
 // so expose the identifiers it references before importing it.
 let Timer;
 let isPrimary = true;
+let deltaCauses = [];
 beforeAll(async () => {
   globalThis.Widget = Widget;
   globalThis.widgets = widgets;
+  globalThis.StateManaged = StateManaged;
   globalThis.setText = setText;
   globalThis.timeToMS = timeToMS;
   globalThis.getSVG = url => url;
   globalThis.isPrimarySession = () => isPrimary;
-  globalThis.setDeltaCause = () => {};
+  globalThis.setDeltaCause = cause => deltaCauses.push(cause);
   globalThis.getMaxZ = () => 0;
   globalThis.updateMaxZ = () => {};
   globalThis.playerName = 'jestPlayer';
+  globalThis.jeRoutineLogging = false;
   ({ Timer } = await import('../../client/js/widgets/timer.js'));
 });
 
 beforeEach(() => {
   isPrimary = true;
+  deltaCauses = [];
   jest.useFakeTimers();
 });
 
@@ -104,11 +109,11 @@ describe('Timer ticking', () => {
   });
 
   test('updates that arrive late do not push the value behind the clock', async () => {
-    isPrimary = false;
-    const timer = createTimer({ id: 'late', paused: false });
+    const timer = createTimer({ id: 'late' });
     const started = Date.now();
+    // another client in the room started it and owns the ticking, 30ms late with every update
+    timer.applyDelta({ paused: false });
 
-    // the client that owns the ticking is 30ms late with every update
     await jest.advanceTimersByTimeAsync(1030);
     timer.applyDelta({ milliseconds: 1000 });
     for(const milliseconds of [ 2000, 3000 ]) {
@@ -126,7 +131,8 @@ describe('Timer ticking', () => {
     let timer;
     beforeEach(async () => {
       isPrimary = false;
-      timer = createTimer({ id: 'watched', paused: false });
+      timer = createTimer({ id: 'watched' });
+      timer.applyDelta({ paused: false });
       // three seconds of updates from the client that owns the ticking
       for(let milliseconds = 1000; milliseconds <= 3000; milliseconds += 1000) {
         await jest.advanceTimersByTimeAsync(1000);
@@ -153,13 +159,115 @@ describe('Timer ticking', () => {
       written.mockRestore();
     });
 
-    test('it takes over once the updates stop coming in', async () => {
-      await jest.advanceTimersByTimeAsync(4000);
-      expect(timer.get('milliseconds')).toBe(7000);
+    test('it leaves the first turn at a stalled writer to the primary session', async () => {
+      const written = jest.spyOn(timer, 'set');
+      await jest.advanceTimersByTimeAsync(5000);
+      expect(written).not.toHaveBeenCalled();
+      written.mockRestore();
+    });
+
+    test('it takes over once even the primary session stops writing', async () => {
+      await jest.advanceTimersByTimeAsync(8000);
+      expect(timer.get('milliseconds')).toBe(11000);
 
       await jest.advanceTimersByTimeAsync(1000);
-      expect(timer.get('milliseconds')).toBe(8000);
+      expect(timer.get('milliseconds')).toBe(12000);
     });
+
+    test('the primary session takes over after one grace period', async () => {
+      isPrimary = true;
+      await jest.advanceTimersByTimeAsync(4000);
+      expect(timer.get('milliseconds')).toBe(7000);
+    });
+  });
+
+  describe('the client that started it', () => {
+    test('writes the timer even when it is not the primary session', async () => {
+      isPrimary = false;
+      const timer = createTimer({ id: 'starter' });
+      await timer.setPaused('start');
+
+      await jest.advanceTimersByTimeAsync(3000);
+      expect(timer.get('milliseconds')).toBe(3000);
+      removeWidget('starter');
+    });
+
+    test('claims the writing for a start that a routine only sends when it ends', async () => {
+      isPrimary = false;
+      const timer = createTimer({ id: 'batched' });
+
+      // a routine collects its changes and sends them in one delta once it has run
+      batchStart();
+      await timer.setPaused('start');
+      batchEnd();
+
+      await jest.advanceTimersByTimeAsync(2000);
+      expect(timer.get('milliseconds')).toBe(2000);
+      removeWidget('batched');
+    });
+
+    test('hands the writing back once somebody else restarts the timer', async () => {
+      isPrimary = false;
+      const timer = createTimer({ id: 'handed' });
+      await timer.setPaused('start');
+      await jest.advanceTimersByTimeAsync(2000);
+      expect(timer.get('milliseconds')).toBe(2000);
+
+      // another client resets and restarts it in one routine, so its delta carries the start only -
+      // the claim still moves to that client
+      timer.applyDelta({ paused: false, milliseconds: 0 });
+
+      const written = jest.spyOn(timer, 'set');
+      await jest.advanceTimersByTimeAsync(3000);
+      expect(written).not.toHaveBeenCalled();
+      written.mockRestore();
+      removeWidget('handed');
+    });
+  });
+
+  test('a timer a routine watches passes on every value instead of jumping', async () => {
+    const timer = createTimer({ id: 'routine', paused: false, millisecondsChangeRoutine: [] });
+    await jest.advanceTimersByTimeAsync(1000);
+    const written = jest.spyOn(timer, 'set');
+
+    // the browser stopped running the interval for half a minute
+    jest.setSystemTime(Date.now() + 30000);
+    await jest.advanceTimersByTimeAsync(3000);
+
+    expect(written.mock.calls.filter(c=>c[0] == 'milliseconds').map(c=>c[1])).toEqual([ 2000, 3000, 4000 ]);
+    expect(timer.get('milliseconds')).toBe(4000);
+    written.mockRestore();
+    removeWidget('routine');
+  });
+
+  test('a timer a routine watches never shows a time it will not reach', async () => {
+    isPrimary = false;
+    const timer = createTimer({ id: 'shown', millisecondsChangeRoutine: [] });
+    timer.applyDelta({ paused: false });
+    await jest.advanceTimersByTimeAsync(1000);
+    timer.applyDelta({ milliseconds: 1000 });
+
+    // the client that writes it is throttled, so the value stays where it is until it gets there
+    await jest.advanceTimersByTimeAsync(2000);
+    expect(timer.domElement.textContent).toBe('0:01');
+    removeWidget('shown');
+  });
+
+  test('a tick that another client got to first leaves no cause behind', async () => {
+    const timer = createTimer({ id: 'overlap', paused: false });
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(deltaCauses).toEqual([ 'timer ticked' ]);
+
+    // during the moment two clients write, the other one wrote this value already
+    timer.applyDelta({ milliseconds: 2000 });
+    deltaCauses = [];
+    const written = jest.spyOn(timer, 'set');
+    await timer.writeTick(2000);
+
+    expect(written).not.toHaveBeenCalled();
+    expect(deltaCauses).toEqual([]);
+    written.mockRestore();
+    removeWidget('overlap');
   });
 
   describe('the value it displays', () => {

--- a/tests/client/timer-tick.test.js
+++ b/tests/client/timer-tick.test.js
@@ -108,6 +108,22 @@ describe('Timer ticking', () => {
     expect(preview.interval).toBe(undefined);
   });
 
+  test('a preview the editor dropped writes nothing even if it kept ticking', async () => {
+    isPrimary = false;
+    // the drag image builds its widgets the way the sidebar does and drops them again without
+    // taking them through applyRemove
+    const preview = new Timer('drag-preview-1');
+    widgets.set('drag-preview-1', preview);
+    preview.applyInitialDelta({ type: 'timer', paused: false });
+    const written = jest.spyOn(preview, 'set');
+    widgets.delete('drag-preview-1');
+
+    await jest.advanceTimersByTimeAsync(20000);
+    expect(written).not.toHaveBeenCalled();
+    written.mockRestore();
+    preview.stopTimer();
+  });
+
   test('updates that arrive late do not push the value behind the clock', async () => {
     const timer = createTimer({ id: 'late' });
     const started = Date.now();

--- a/tests/client/timer-tick.test.js
+++ b/tests/client/timer-tick.test.js
@@ -1,0 +1,155 @@
+import { jest } from '@jest/globals';
+
+import { widgets, addWidget } from '../../client/js/serverstate.js';
+import { Widget } from '../../client/js/widgets/widget.js';
+import { setText, timeToMS } from '../../client/js/domhelpers.js';
+
+import { removeWidget } from './client-util.js';
+
+// timer.js relies on the concatenated global scope of the shipped bundle rather than on imports,
+// so expose the identifiers it references before importing it.
+let Timer;
+let isPrimary = true;
+beforeAll(async () => {
+  globalThis.Widget = Widget;
+  globalThis.widgets = widgets;
+  globalThis.setText = setText;
+  globalThis.timeToMS = timeToMS;
+  globalThis.getSVG = url => url;
+  globalThis.isPrimarySession = () => isPrimary;
+  globalThis.setDeltaCause = () => {};
+  globalThis.getMaxZ = () => 0;
+  globalThis.updateMaxZ = () => {};
+  globalThis.playerName = 'jestPlayer';
+  ({ Timer } = await import('../../client/js/widgets/timer.js'));
+});
+
+beforeEach(() => {
+  isPrimary = true;
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+function createTimer(definition) {
+  const timer = new Timer(definition.id);
+  addWidget({ type: 'timer', ...definition }, timer);
+  return timer;
+}
+
+describe('Timer ticking', () => {
+  test('a running timer advances by one interval per interval', async () => {
+    const timer = createTimer({ id: 'running', paused: false });
+    await jest.advanceTimersByTimeAsync(3000);
+    expect(timer.get('milliseconds')).toBe(3000);
+    removeWidget('running');
+  });
+
+  test('a paused timer does not advance and starts on unpausing', async () => {
+    const timer = createTimer({ id: 'paused' });
+    await jest.advanceTimersByTimeAsync(3000);
+    expect(timer.get('milliseconds')).toBe(0);
+
+    await timer.setPaused('start');
+    await jest.advanceTimersByTimeAsync(2000);
+    expect(timer.get('milliseconds')).toBe(2000);
+    removeWidget('paused');
+  });
+
+  test('a countdown counts down in its own precision', async () => {
+    const timer = createTimer({ id: 'countdown', paused: false, countdown: true, precision: 500, milliseconds: 5000 });
+    await jest.advanceTimersByTimeAsync(2000);
+    expect(timer.get('milliseconds')).toBe(3000);
+    removeWidget('countdown');
+  });
+
+  test('a tab that was frozen catches up with the time that really passed', async () => {
+    const timer = createTimer({ id: 'frozen', paused: false });
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(timer.get('milliseconds')).toBe(1000);
+
+    // the browser stopped running the interval for half a minute
+    jest.setSystemTime(Date.now() + 30000);
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(timer.get('milliseconds')).toBe(32000);
+    removeWidget('frozen');
+  });
+
+  test('time a routine adds while the timer runs is kept', async () => {
+    const timer = createTimer({ id: 'incremented', paused: false });
+    await jest.advanceTimersByTimeAsync(2000);
+    await timer.setMilliseconds(60000, 'inc');
+    expect(timer.get('milliseconds')).toBe(62000);
+
+    await jest.advanceTimersByTimeAsync(2000);
+    expect(timer.get('milliseconds')).toBe(64000);
+    removeWidget('incremented');
+  });
+
+  test('a removed timer stops ticking', async () => {
+    const timer = createTimer({ id: 'removed', paused: false });
+    await jest.advanceTimersByTimeAsync(1000);
+    removeWidget('removed');
+    await jest.advanceTimersByTimeAsync(3000);
+    expect(timer.get('milliseconds')).toBe(1000);
+  });
+
+  test('a widget preview outside the room never ticks', async () => {
+    const preview = new Timer('preview');
+    preview.isReadonlyCopy = true;
+    preview.startTimer();
+    expect(preview.interval).toBe(undefined);
+  });
+
+  test('updates that arrive late do not push the value behind the clock', async () => {
+    isPrimary = false;
+    const timer = createTimer({ id: 'late', paused: false });
+    const started = Date.now();
+
+    // the client that owns the ticking is 30ms late with every update
+    await jest.advanceTimersByTimeAsync(1030);
+    timer.applyDelta({ milliseconds: 1000 });
+    for(const milliseconds of [ 2000, 3000 ]) {
+      await jest.advanceTimersByTimeAsync(1000);
+      timer.applyDelta({ milliseconds });
+    }
+
+    // ... and then stops, so this client has to finish the count itself
+    await jest.advanceTimersByTimeAsync(4970);
+    expect(timer.get('milliseconds')).toBe(Date.now() - started);
+    removeWidget('late');
+  });
+
+  describe('with another client ticking', () => {
+    let timer;
+    beforeEach(async () => {
+      isPrimary = false;
+      timer = createTimer({ id: 'watched', paused: false });
+      // three seconds of updates from the client that owns the ticking
+      for(let milliseconds = 1000; milliseconds <= 3000; milliseconds += 1000) {
+        await jest.advanceTimersByTimeAsync(1000);
+        timer.applyDelta({ milliseconds });
+      }
+    });
+
+    afterEach(() => removeWidget('watched'));
+
+    test('a client that is not the primary session leaves the value alone', async () => {
+      const written = jest.spyOn(timer, 'set');
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(written).not.toHaveBeenCalled();
+      expect(timer.get('milliseconds')).toBe(3000);
+      written.mockRestore();
+    });
+
+    test('it takes over once the updates stop coming in', async () => {
+      await jest.advanceTimersByTimeAsync(4000);
+      expect(timer.get('milliseconds')).toBe(7000);
+
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(timer.get('milliseconds')).toBe(8000);
+    });
+  });
+});


### PR DESCRIPTION
<!-- todo-human-input:start -->
## ⏳ To Do — waiting on a human maintainer

- **Should a timer a routine follows catch up on the intervals a backgrounded tab skipped?** The clock faces in the *Appearance* variant of the timer tutorial stand still while their window is minimized, because a timer with a `millisecondsChangeRoutine` is given every value it passes through and so counts only the ticks its browser delivered — unchanged by this PR, and the same on `main` ([measurements and the options](https://github.com/ArnoldSmith86/virtualtabletop/pull/3139#issuecomment-5416974468)). Leave it as it is, replay the skipped intervals when the tab wakes up, or put it under a property the game sets?
<!-- todo-human-input:end -->

A running timer widget is counted up by one of the clients in the room, which sends every new `milliseconds` value to the others. That client was picked once — whoever started the timer, or the first player in the room — and each tick simply added one interval to the previous value. Both halves of that made timers lose time or stop altogether:

- **The timer stopped when that client left the room** (#1655). Nobody took over, so it stood still while still showing itself as running, until somebody paused and restarted it.
- **A background tab made the timer run slow.** Browsers throttle `setInterval` in tabs that are not visible (down to once a minute) and suspend them completely on a sleeping device. Every interval that was skipped was a second the timer never counted, and it never caught up.
- **Two connections of the same player counted twice.** The check that started the ticking on load counted *players*, not connections, so a second tab or a second device under the same name could end up with two clients ticking and the timer running at double speed.

## What changed

- **The ticking belongs to the client that started the timer** — the one whose player pressed the button or ran the `TIMER` operation — so the timer's `millisecondsChangeRoutine` keeps running with that player's name, seats and inputs. Everybody else only writes once the value has stood still for a whole interval plus three seconds: the primary session (the oldest connection in the room) first, the rest of the room after a second such period. So a timer whose writer has left, and one that was already running when the room was loaded, is taken over by exactly one client, and even a stalled primary session gets replaced.
- **A timer nobody watches is derived from the wall clock** instead of being added to the previous value: a tick works out how many whole intervals have passed since the value it last measured from. A tab that was throttled or asleep therefore lands on the time that really passed on its next tick instead of falling behind.
- **A timer something watches passes on every value it takes.** If the timer has a `millisecondsChangeRoutine` or a `changeRoutine`, or another widget listens for updates, it advances by exactly one interval per tick as it always did — a countdown that acts on `milliseconds == 100` is still given that value when a throttled tab wakes up or another client takes the writing over. The intervals its browser skipped are time it did not count, as before; it just no longer stops for good. A client that takes such a timer over carries on from the value the previous one last wrote.
- **Time a routine adds while the timer runs is kept.** Any update a client did not write itself — `TIMER` with `inc`/`set`, another client's tick — becomes the new base the following ticks are measured from. An update that says exactly what the client would have written itself leaves the base alone, so the part of the interval that has not elapsed yet is not lost on every update.
- **A client that is not writing still shows the time.** The value is derived from the wall clock, so every client knows it without being told. While a stalled writer is given its grace period, the others keep their own display moving instead of standing still and then jumping. A timer something watches is excluded, because it does not catch up — its display would run ahead of the value it is going to take.
- **An hour or more gets an hours field.** The display was `m:ss` with an unbounded minute count, so an hour read as `60:00` and a tab that slept for three hours as `193:07`. From an hour on the value now reads `1:00:00` / `3:13:07`; below an hour nothing changes. The Start / End / Current time fields of the widget editor format and accept the same `h:mm:ss` form.
- **A tick that writes nothing leaves nothing behind.** Consecutive ticks share one undo entry, labelled `timer ticked`. A tick that finds the value already written — for the moment two clients write, the other one got there first — no longer leaves that cause on the delta for the player's next action to inherit and be merged into the timer's undo entry.
- **A widget preview outside the room no longer starts a timer.** The property editor and the widget sidebar render copies of a widget that are not part of the room; for a running timer such a copy used to start ticking and try to write to the room state under an id the room does not have. The sidebar's drag image now marks its previews as the read-only copies they are and takes them down through `applyRemove` when the drag is over, which also releases the styles, listeners and parent bookkeeping every other widget type left behind. A timer additionally refuses to write a tick for a widget the room does not hold.
- **A frozen tab hands the timer on instead of pushing a tick of its own.** The client that started a timer keeps writing it for as long as it runs, but it now gives that claim up once it has both stopped writing long enough to be taken over and been overtaken since. Without that, a tab coming back from being frozen wrote again straight away, which on a timer a routine follows put an extra interval on the clock and ran the routine an extra time. A one-off change from somebody else — a routine adding a minute — leaves the writing where it is.
- **An hours field is understood wherever a game writes a time, not just where one is shown.** `timeToMS`, the parser behind `start`, `end` and `TIMER`'s `value` / `seconds`, only knew `m:ss`, so the form the widget and the property editor display meant something else entirely in the JSON editor: `"start": "1:00:00"` reset a timer to 1 ms, an `"end"` of `"1:00:00"` never turned the alert on, and `TIMER seconds: "1:00:00"` set 0 — all three silently. It now takes an optional hours field. Nothing that parsed before changes, and a string with two colons could not mean anything until now.

No widget property or routine parameter is added, renamed or removed, so there is nothing to add to the validator or to `jeCommands` — the timer section of the property editor keeps exactly the fields it had, its time fields just render and accept an hours field as well.

## User-visible effects

- A running timer keeps running when the player who started it closes the tab; the room picks it up after about four seconds.
- Coming back to a tab whose plain display timer was throttled or asleep now shows the time that really passed — the value can jump forward by the time the tab was away, instead of being permanently behind.
- A timer that drives a routine still counts one tick per interval and skips no value, so games that act on an exact `milliseconds` value keep working unchanged.
- Time still does not pass while nobody is in the room; the timer continues from where it was when the first client comes back, as before.
- In edit mode the undo protocol no longer fills with one entry per tick: consecutive ticks share an entry, labelled `timer ticked`.
- A timer past an hour reads `1:00:00` instead of `60:00` ([before/after](https://agent.virtualtabletop.io/reports/pr/1540126994505666660/timer-hours-format.png)), which matters more now that a tab coming back from the background catches up instead of losing the time.

## Verified

- New jest fixture `tests/client/timer-tick.test.js` (28 tests) covering the interval, pausing and resuming, counting down, a frozen tab catching up, time added by a routine, a removed timer, a widget preview, following another client, keeping the display moving while waiting for it, taking the writing over in the right order, the starter keeping the writing even when it is not the primary session (including a start a routine only sends when it ends, and a restart that hands the writing on), a watched timer passing on every value it takes and carrying on from the value it was last told, a no-op tick leaving no delta cause behind, a dropped drag preview writing nothing, a `globalUpdateRoutine` in the room putting every timer on the value-by-value path, and a frozen starter dropping its claim after a takeover while keeping it when somebody else only adds time. `tests/client/primary-session.test.js` covers picking the session that takes over.
- `npm test`: 1383 tests pass. TestCafe `multiclient.js` passes locally; `editor.js` passed on the previous commit. (`routines.js` has one failure, `moving the mouse while a DELAY is running does not drag the clicked widget`, which reproduces identically with `main`'s `timer.js` in place, so it is not from this change. No fixture renders a timer — `render-fixtures.js` leaves it out on purpose.)
- Manually in Chromium with three clients in one room: the client that pressed start does all the writing and the other two send nothing, whether or not it is the oldest connection; when it closes its tab the oldest of the rest takes over after the grace period and the others stay quiet; when it freezes without disconnecting for nine seconds, the primary session's turn passes and the third client takes over; a timer with a `millisecondsChangeRoutine` was watched value by value through a takeover and produced `1000, 2000, …, 8000` with nothing skipped, the routine running under the starting player's name until the takeover. A four-timer tutorial room with precisions of 1000, 5000 and 500 ms was walked end to end and all of them keep step with each other. Pause, resume and reset behave as before; the undo protocol still collapses consecutive ticks into one entry and a player action after them keeps its own. The hours format was checked in the browser at the widget's default size and in the editor: `59:59` renders as before, `1:00:00` / `3:13:07` / `-3:13:07` render with hours, and the editor's Current time field round-trips `3:13:07`.
- The hours parsing was walked in a room in Chromium: with `"start": "1:00:00"` and `"end": "1:00:05"`, a `TIMER reset` puts the timer at `1:00:00` (it used to be 1 ms), `TIMER set seconds: "1:00:00"` does the same (it used to be 0), and the alert turns on five seconds later (it never did). Typing `2:30:15` into the editor's Current time field writes 9 015 000 ms and reads back as `2:30:15`.
- The drag previews were checked in edit mode in Chromium by dragging a saved widget that holds a running timer: before the fix the preview kept a one-second interval running for the rest of the session and threw once a second; now no interval is started at all, and dropping the widget still places it and it ticks in the room.

## Try it

A demo room is in this PR's test room [pr-test-ai](https://test.virtualtabletop.io/PR-3139/pr-test-ai), where it shows up in the game shelf once the test server has finished starting. It is written as a tutorial - **Types - Timer**, variant **Multi-client**, one room - with four examples: a plain count-up, a countdown from 2:00 with the alert, a `TIMER inc` button that adds a minute while the clock runs, and a timer whose `millisecondsChangeRoutine` counts its own ticks beside it, so you can watch the routine run once per interval however many people are watching and see that it skips no value. A `+ 1 hour` button next to the `+ 1 minute` one pushes a timer past the hour so the `1:00:00` display can be tried out. Things worth trying are written on the board: start it in one tab and close that tab, leave a tab in the background for a while, leave the room entirely and come back. The file itself is at [Timer check.vtt](https://agent.virtualtabletop.io/reports/pr/1540126994505666660/Timer%20check.vtt). It lives on the test server only - it is not part of this PR and nothing under `library/` is touched. It can be added to `library/tutorials/` on request.

## The timer tutorial, amended

`library/tutorials/Types - Timer/0.json` (variant **Basics**) told the reader that "one important limitation of the timer is that it is controlled by the player that started the timer. If that person leaves the room or the player's internet connection is disrupted while the timer is running, the timer will stop." The first half stays true - the player who starts a timer is still the one whose client counts it - but the second half stops being true with this PR.

The amended variant was published as a draft on this PR's test server and **accepted there by a maintainer (lawdawg96)**, who has since confirmed the amendment on this pull request, so it is part of this diff. Only `0.json` of that tutorial changes; variants `1.json` and `2.json`, its `assets/` and every other tutorial are untouched, and its `_meta.info` keeps the file's own fields unchanged apart from `lastUpdate` - the library image stays the existing square SVG `assets/1382176810_3946`. Five passages changed:

- the overview now says the timer belongs to the room, that another player carries it on when the one who started it closes their tab, and that a tab left in the background shows the time that really passed;
- the last example, the one already driving a `changeRoutine` every 500 ms, gains a sentence saying that a timer a routine follows is given every step it takes and so carries on where it was instead of catching up;
- the first example's "Add Widget button on the left side of the screen" becomes the `+` button in the top toolbar (there is no add control on the left any more);
- the first example mentions that an hour or more reads `1:00:00`;
- the overview's sentence about what the JSON editor accepts names all three forms a time can take now that `timeToMS` understands an hours field: "timers take milliseconds, minutes:seconds or hours:minutes:seconds for start and end as well as for TIMER's value and seconds parameters".

`node validator/validate_gamefile_node.js` exits 0 with no output for all three variants, and the room was walked end to end in the browser: all four timers start and pause from their own controls, the countdown reaches `0:00`, the 5000 ms example updates every five seconds, and the 500 ms one keeps step with the others while recolouring the holder below it. The hours sentence renders in the same six lines as the sentence it replaces, at the same line breaks, so the overview still fills the band exactly as before. [Types - Timer 0.vtt](https://agent.virtualtabletop.io/reports/pr/1540126994505666660/tutorials/Types%20-%20Timer%200.vtt) on the test server is packed straight from the committed file, so that room shows exactly what the repository holds.

Closes #1655.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3139/pr-test (or any other room on that server)




