### PR TITLE
Don't crash the client when a widget is given a parent that does not exist

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -241,7 +241,6 @@ i.htmlattr{ color: var(--textHighlightColor2); }
 i.htmlvalue{ color: var(--textHighlightColor5); }
 i.csskey  { color: var(--textHighlightColor5); }
 i.cssvalue{ color: var(--textHighlightColor7); }
-i.error   { color: var(--textHighlightColor3); font-weight: bold; }
 
 /**** End color formatting ****/
 
@@ -259,6 +258,15 @@ i.error   { color: var(--textHighlightColor3); font-weight: bold; }
   text-overflow: ellipsis;
 }
 /*** End compute operations CSS ***/
+
+/* the messages below the context breadcrumb are their own paragraphs - inline they
+   run into the breadcrumb, which the pane does not break by itself */
+#jeCommands .error {
+  display: block;
+  margin-top: 8px;
+  color: var(--textHighlightColor3);
+  font-weight: bold;
+}
 
 #jeCommands {
   position: absolute;

--- a/client/css/layout.css
+++ b/client/css/layout.css
@@ -920,13 +920,23 @@ body.hitTest .widget:not(.line) {
 }
 
 .widget.limbo {
-  opacity: 0.5;
-  border: 5px dashed darkred;
+  opacity: 0.7;
+  border: 2px dashed darkred;
 }
+/* the marker sits above the widget instead of in its content flow: it has to stay
+   readable on a 24px token and must not run into whatever the widget draws itself */
 .widget.limbo::before {
   content: 'Invalid Parent';
-  font-size: 16px;
-  color: darkred;
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  padding: 0 4px;
+  border-radius: 2px;
+  background: darkred;
+  color: white;
+  font: bold 11px/1.4 sans-serif;
+  white-space: nowrap;
+  pointer-events: none;
 }
 
 body:not(.edit) .widget.limbo {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -2052,12 +2052,12 @@ async function jeApplyChangesMulti() {
     batchStart();
     setDeltaCause(`${getPlayerDetails().playerName} edited properties on multiple widgets in editor`);
     jeDeltaIsOurs = true;
-    const widgets = jeMultiSelectedWidgets();
-    const widgetIDs = widgets.map(w=>w.get('id'));
+    const selection = jeMultiSelectedWidgets();
+    const widgetIDs = selection.map(w=>w.get('id'));
     for(const key in currentState) {
       if(key != 'widgets') {
-        for(const w of widgets) {
-          if(typeof currentState[key] != 'object' || currentState[key] === null || Object.keys(currentState[key]).filter(k=>!widgetIDs.includes(k)).length)
+        for(const w of selection) {
+          if(!jeMultiValueIsPerWidget(currentState[key], widgetIDs))
             await setValueIfNeeded(w, key, currentState[key]);
           else if(currentState[key][w.get('id')] !== undefined)
             await setValueIfNeeded(w, key, currentState[key][w.get('id')]);
@@ -2389,6 +2389,17 @@ function jeMultiSelectedWidgets() {
     }));
   }
   return selected;
+}
+
+// In the multi-selection editor a property is either one value that goes to all
+// selected widgets or an object that maps each selected widget id to its own.
+function jeMultiValueIsPerWidget(value, widgetIDs) {
+  return typeof value == 'object' && value !== null && !Object.keys(value).filter(k=>!widgetIDs.includes(k)).length;
+}
+
+function jeMultiParentValues(state) {
+  const widgetIDs = jeMultiSelectedWidgets().map(w=>w.get('id'));
+  return jeMultiValueIsPerWidget(state.parent, widgetIDs) ? Object.values(state.parent) : [ state.parent ];
 }
 
 function jeSelectedIDs() {
@@ -2965,10 +2976,14 @@ function jeGetContext() {
     try {
       jeStateNow = JSON.parse(v);
 
-      if(!Array.isArray(jeStateNow.widgets))
+      if(!Array.isArray(jeStateNow.widgets)) {
         jeJSONerror = 'Key widgets is not an array.';
-      else
-        jeJSONerror = null;
+      } else {
+        // the same check the single widget mode does above - a parent no widget
+        // in the room has would leave the whole selection in limbo
+        const missingParent = jeMultiParentValues(jeStateNow).find(parent=>parent !== undefined && parent !== null && !widgets.has(parent));
+        jeJSONerror = missingParent === undefined ? null : `Parent ${missingParent} does not exist.`;
+      }
     } catch(e) {
       jeStateNow = null;
       jeJSONerror = e;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -2397,17 +2397,44 @@ function jeMultiValueIsPerWidget(value, widgetIDs) {
   return typeof value == 'object' && value !== null && !Object.keys(value).filter(k=>!widgetIDs.includes(k)).length;
 }
 
-// Pairs every parent in the multi-selection state with the widget it belongs to,
-// or with null where one value goes to the whole selection. Gathering the ids of
-// the selection means running its search terms, so the shared case is answered
-// without doing that.
-function jeMultiParentEntries(state) {
-  if(typeof state.parent != 'object' || state.parent === null)
-    return [ [ null, state.parent ] ];
+// Pairs every value the multi-selection state gives for a property with the widget
+// it belongs to, or with null where one value goes to the whole selection. Gathering
+// the ids of the selection means running its search terms, so the shared case is
+// answered without doing that.
+function jeMultiPropertyEntries(state, property) {
+  const value = state[property];
+  if(typeof value != 'object' || value === null)
+    return [ [ null, value ] ];
   const widgetIDs = jeMultiSelectedWidgets().map(w=>w.get('id'));
-  if(!jeMultiValueIsPerWidget(state.parent, widgetIDs))
-    return [ [ null, state.parent ] ];
-  return Object.entries(state.parent);
+  if(!jeMultiValueIsPerWidget(value, widgetIDs))
+    return [ [ null, value ] ];
+  return Object.entries(value);
+}
+
+// The properties of a multi-selection whose value has to name a widget in the room,
+// with the message for the first one that does not.
+function jeMultiWidgetReferenceError(state) {
+  for(const [ property, label ] of [ [ 'parent', 'Parent' ], [ 'deck', 'Deck' ] ]) {
+    if(state[property] === undefined)
+      continue;
+    // deck names a widget on a card - on anything else it is an ordinary property
+    // that happens to be called deck
+    if(property == 'deck' && !jeMultiSelectedWidgets().some(w=>w.get('type') == 'card'))
+      continue;
+    const missing = jeMultiPropertyEntries(state, property).find(([ , value ])=>value !== undefined && value !== null && !widgets.has(value));
+    if(!missing)
+      continue;
+    const [ widgetID, value ] = missing;
+    if(typeof value != 'object')
+      return `${label} ${value} does not exist${widgetID === null ? '' : ` (widget "${widgetID}")`}.`;
+    // an object arrives here either as a value that is no ID at all, or as a
+    // per-widget object whose keys do not match the selection - which makes the whole
+    // object the one value the selection shares
+    return widgetID === null
+      ? `${label} has to be a widget ID, or an object with one entry per selected widget.`
+      : `${label} has to be a widget ID (widget "${widgetID}").`;
+  }
+  return null;
 }
 
 function jeSelectedIDs() {
@@ -2955,7 +2982,7 @@ function jeGetContext() {
   }
 
   // make sure the context actually exists in the widget
-  if(!jeJSONerror) {
+  if(!jeJSONisUnparsed()) {
     let pointer = jeStateNow;
     for(let i=1; i<keys.length; ++i) {
       if(pointer[keys[i]] === undefined) {
@@ -2969,7 +2996,7 @@ function jeGetContext() {
   // insert the operation type as a virtual key so commands can check which operation they're in
   try {
     for(let i=1; i<keys.length-1; ++i) {
-      if(String(keys[i]).match(/Routine$/) && typeof keys[i+1] == 'number' && !jeJSONerror) {
+      if(String(keys[i]).match(/Routine$/) && typeof keys[i+1] == 'number' && !jeJSONisUnparsed()) {
         const operation = jeGetValue(keys.slice(1, i+2), true);
         const func = typeof operation == 'string' && operation.match(/^var/) ? 'var expression' : operation.func;
         keys.splice(i+2, 0, '(' + (func || String(keys.slice(0, i+2))) + ')');
@@ -2987,17 +3014,12 @@ function jeGetContext() {
       if(!Array.isArray(jeStateNow.widgets)) {
         jeJSONerror = 'Key widgets is not an array.';
       } else {
-        // the same check the single widget mode does above - a parent no widget
-        // in the room has would leave the whole selection in limbo. While the
-        // widgets array itself is being edited, the parent values still describe
+        // the same checks the single widget mode does above - a parent no widget in
+        // the room has would leave the whole selection in limbo, a deck no widget in
+        // the room has leaves the card without faces and drops it on the next load.
+        // While the widgets array itself is being edited, the values still describe
         // the previous selection, so there is nothing to check yet.
-        const missing = keys[1] == 'widgets' ? undefined : jeMultiParentEntries(jeStateNow).find(([ , parent ])=>parent !== undefined && parent !== null && !widgets.has(parent));
-        if(missing === undefined)
-          jeJSONerror = null;
-        else if(typeof missing[1] == 'object')
-          jeJSONerror = 'Parent has to be a widget ID, or an object with one entry per selected widget.';
-        else
-          jeJSONerror = `Parent ${missing[1]} does not exist${missing[0] === null ? '' : ` (widget "${missing[0]}")`}.`;
+        jeJSONerror = keys[1] == 'widgets' ? null : jeMultiWidgetReferenceError(jeStateNow);
       }
     } catch(e) {
       jeStateNow = null;
@@ -3030,7 +3052,7 @@ function jeGetValue(context, all) {
 }
 
 function jeInsert(context, key, value) {
-  if(!jeJSONerror) {
+  if(!jeJSONisUnparsed()) {
     let pointer = jeGetValue(context);
     pointer[key] = '###SELECT ME###';
     jeSetAndSelect(value);
@@ -3787,10 +3809,11 @@ function jeMatchCommandName(name, filter) {
   return filterWords.every(fw => words.some(w => w.startsWith(fw)));
 }
 
-// A parse error leaves nothing to show commands for. A state that parsed and was
-// only rejected for what it says - a parent that does not exist, an ID already in
-// use - still has a valid object behind it, and the commands that would fix it are
-// exactly the ones the user needs while the message is on screen.
+// A parse error leaves nothing to work with. A state that parsed and was only
+// rejected for what it says - a parent that does not exist, an ID already in use -
+// still has a valid object behind it, so the context can be resolved against it and
+// the commands that would fix it stay available and keep inserting. Only handing the
+// state to the room waits for the message to go away.
 function jeJSONisUnparsed() {
   return jeJSONerror instanceof Error;
 }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -2397,13 +2397,17 @@ function jeMultiValueIsPerWidget(value, widgetIDs) {
   return typeof value == 'object' && value !== null && !Object.keys(value).filter(k=>!widgetIDs.includes(k)).length;
 }
 
-// gathering the ids of the selection means running its search terms, so a
-// parent that is one value for all of them is answered without doing that
-function jeMultiParentValues(state) {
+// Pairs every parent in the multi-selection state with the widget it belongs to,
+// or with null where one value goes to the whole selection. Gathering the ids of
+// the selection means running its search terms, so the shared case is answered
+// without doing that.
+function jeMultiParentEntries(state) {
   if(typeof state.parent != 'object' || state.parent === null)
-    return [ state.parent ];
+    return [ [ null, state.parent ] ];
   const widgetIDs = jeMultiSelectedWidgets().map(w=>w.get('id'));
-  return jeMultiValueIsPerWidget(state.parent, widgetIDs) ? Object.values(state.parent) : [ state.parent ];
+  if(!jeMultiValueIsPerWidget(state.parent, widgetIDs))
+    return [ [ null, state.parent ] ];
+  return Object.entries(state.parent);
 }
 
 function jeSelectedIDs() {
@@ -2987,8 +2991,13 @@ function jeGetContext() {
         // in the room has would leave the whole selection in limbo. While the
         // widgets array itself is being edited, the parent values still describe
         // the previous selection, so there is nothing to check yet.
-        const missingParent = keys[1] == 'widgets' ? undefined : jeMultiParentValues(jeStateNow).find(parent=>parent !== undefined && parent !== null && !widgets.has(parent));
-        jeJSONerror = missingParent === undefined ? null : `Parent ${missingParent} does not exist.`;
+        const missing = keys[1] == 'widgets' ? undefined : jeMultiParentEntries(jeStateNow).find(([ , parent ])=>parent !== undefined && parent !== null && !widgets.has(parent));
+        if(missing === undefined)
+          jeJSONerror = null;
+        else if(typeof missing[1] == 'object')
+          jeJSONerror = 'Parent has to be a widget ID, or an object with one entry per selected widget.';
+        else
+          jeJSONerror = `Parent ${missing[1]} does not exist${missing[0] === null ? '' : ` (widget "${missing[0]}")`}.`;
       }
     } catch(e) {
       jeStateNow = null;
@@ -3778,6 +3787,14 @@ function jeMatchCommandName(name, filter) {
   return filterWords.every(fw => words.some(w => w.startsWith(fw)));
 }
 
+// A parse error leaves nothing to show commands for. A state that parsed and was
+// only rejected for what it says - a parent that does not exist, an ID already in
+// use - still has a valid object behind it, and the commands that would fix it are
+// exactly the ones the user needs while the message is on screen.
+function jeJSONisUnparsed() {
+  return jeJSONerror instanceof Error;
+}
+
 function jeShowCommands() {
 
   // First set up top buttons
@@ -3814,7 +3831,7 @@ function jeShowCommands() {
   for(const command of jeCommands) {
     delete command.currentKey;
     const contextMatch = context.match(new RegExp(command.context));
-    if(contextMatch && contextMatch[0]!= "" && (!command.context || command.onEmpty || jeStateNow && !jeJSONerror) && (!command.show || command.show())) {
+    if(contextMatch && contextMatch[0]!= "" && (!command.context || command.onEmpty || jeStateNow && !jeJSONisUnparsed()) && (!command.show || command.show())) {
       const title = command.isTypeSpecific || command.isTypeSpecific === undefined ? contextMatch[0] : 'widget';
       if(activeCommands[title] === undefined)
         activeCommands[title] = [];
@@ -3827,7 +3844,7 @@ function jeShowCommands() {
     commandText += `<div id="var_results"></div>\n`;
   }
 
-  if(!jeJSONerror) {
+  if(!jeJSONisUnparsed()) {
     const usedKeys = { a: 1, c: 1, x: 1, v: 1, w: 1, n: 1, t: 1, q: 1, j: 1, z: 1 };
 
     const sortByName = function(a, b) {
@@ -3994,11 +4011,11 @@ function jeShowCommands() {
   commandText += `\n\n${html(context)}\n`;
   if(jeJSONerror) {
     if(jeMode == 'widget')
-      commandText += `\nCtrl-Space: go to error\n`;
-    commandText += `\n<i class=error>${html(String(jeJSONerror))}</i>\n`;
+      commandText += `\n<div>Ctrl-Space: go to error</div>\n`;
+    commandText += `\n<div class=error>${html(String(jeJSONerror))}</div>\n`;
   }
   if(jeCommandError)
-    commandText += `\n<i class=error>Last command failed: ${html(String(jeCommandError))}</i>\n`;
+    commandText += `\n<div class=error>Last command failed: ${html(String(jeCommandError))}</div>\n`;
   if(jeSecondaryWidget)
     commandText += `\n\n<pre>${html(jeSecondaryWidget)}</pre>\n`;
   commandText += `</div>`;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -2414,25 +2414,37 @@ function jeMultiPropertyEntries(state, property) {
 // The properties of a multi-selection whose value has to name a widget in the room,
 // with the message for the first one that does not.
 function jeMultiWidgetReferenceError(state) {
+  // gathering the selection means running its search terms, so a state without either
+  // property is answered without doing that
+  let cardIDs = null;
+  const goesToACard = widgetID => {
+    if(cardIDs === null)
+      cardIDs = new Set(jeMultiSelectedWidgets().filter(w=>w.get('type') == 'card').map(w=>w.get('id')));
+    return widgetID === null ? cardIDs.size > 0 : cardIDs.has(widgetID);
+  };
   for(const [ property, label ] of [ [ 'parent', 'Parent' ], [ 'deck', 'Deck' ] ]) {
     if(state[property] === undefined)
       continue;
-    // deck names a widget on a card - on anything else it is an ordinary property
-    // that happens to be called deck
-    if(property == 'deck' && !jeMultiSelectedWidgets().some(w=>w.get('type') == 'card'))
-      continue;
-    const missing = jeMultiPropertyEntries(state, property).find(([ , value ])=>value !== undefined && value !== null && !widgets.has(value));
-    if(!missing)
-      continue;
-    const [ widgetID, value ] = missing;
-    if(typeof value != 'object')
-      return `${label} ${value} does not exist${widgetID === null ? '' : ` (widget "${widgetID}")`}.`;
-    // an object arrives here either as a value that is no ID at all, or as a
-    // per-widget object whose keys do not match the selection - which makes the whole
-    // object the one value the selection shares
-    return widgetID === null
-      ? `${label} has to be a widget ID, or an object with one entry per selected widget.`
-      : `${label} has to be a widget ID (widget "${widgetID}").`;
+    for(const [ widgetID, value ] of jeMultiPropertyEntries(state, property)) {
+      // deck names a deck on a card - on anything else it is an ordinary property
+      // that happens to be called deck
+      if(property == 'deck' && !goesToACard(widgetID))
+        continue;
+      if(value === undefined || value === null)
+        continue;
+      const forWidget = widgetID === null ? '' : ` (widget "${widgetID}")`;
+      // an object arrives here either as a value that is no ID at all, or as a
+      // per-widget object whose keys do not match the selection - which makes the
+      // whole object the one value the selection shares
+      if(typeof value == 'object')
+        return widgetID === null
+          ? `${label} has to be a widget ID, or an object with one entry per selected widget.`
+          : `${label} has to be a widget ID${forWidget}.`;
+      if(!widgets.has(value))
+        return `${label} ${value} does not exist${forWidget}.`;
+      if(property == 'deck' && !widgets.get(value).get('cardTypes'))
+        return `Given widget ${value} is not a deck or doesn't define cardTypes${forWidget}.`;
+    }
   }
   return null;
 }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -2002,6 +2002,11 @@ function jeAddWidgetPropertyCommand(object, widgetBase, property) {
 }
 
 async function jeApplyChanges() {
+  // while the state is only semantically wrong the commands keep editing the text, but the
+  // room is never handed a state it cannot load - including by the commands that apply their
+  // own change instead of going through the gated call in clickButton
+  if(jeJSONerror)
+    return;
   if(jeMode == 'multi')
     return await jeApplyChangesMulti();
 
@@ -2430,13 +2435,15 @@ function jeMultiWidgetReferenceError(state) {
       // that happens to be called deck
       if(property == 'deck' && !goesToACard(widgetID))
         continue;
-      if(value === undefined || value === null)
+      // null is applied by deleting the property: a widget without a parent belongs to the
+      // room, while a card without a deck is dropped on the next load like a missing one
+      if(value === undefined || (value === null && property != 'deck'))
         continue;
       const forWidget = widgetID === null ? '' : ` (widget "${widgetID}")`;
       // an object arrives here either as a value that is no ID at all, or as a
       // per-widget object whose keys do not match the selection - which makes the
       // whole object the one value the selection shares
-      if(typeof value == 'object')
+      if(value !== null && typeof value == 'object')
         return widgetID === null
           ? `${label} has to be a widget ID, or an object with one entry per selected widget.`
           : `${label} has to be a widget ID${forWidget}.`;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -2397,7 +2397,11 @@ function jeMultiValueIsPerWidget(value, widgetIDs) {
   return typeof value == 'object' && value !== null && !Object.keys(value).filter(k=>!widgetIDs.includes(k)).length;
 }
 
+// gathering the ids of the selection means running its search terms, so a
+// parent that is one value for all of them is answered without doing that
 function jeMultiParentValues(state) {
+  if(typeof state.parent != 'object' || state.parent === null)
+    return [ state.parent ];
   const widgetIDs = jeMultiSelectedWidgets().map(w=>w.get('id'));
   return jeMultiValueIsPerWidget(state.parent, widgetIDs) ? Object.values(state.parent) : [ state.parent ];
 }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -2980,8 +2980,10 @@ function jeGetContext() {
         jeJSONerror = 'Key widgets is not an array.';
       } else {
         // the same check the single widget mode does above - a parent no widget
-        // in the room has would leave the whole selection in limbo
-        const missingParent = jeMultiParentValues(jeStateNow).find(parent=>parent !== undefined && parent !== null && !widgets.has(parent));
+        // in the room has would leave the whole selection in limbo. While the
+        // widgets array itself is being edited, the parent values still describe
+        // the previous selection, so there is nothing to check yet.
+        const missingParent = keys[1] == 'widgets' ? undefined : jeMultiParentValues(jeStateNow).find(parent=>parent !== undefined && parent !== null && !widgets.has(parent));
         jeJSONerror = missingParent === undefined ? null : `Parent ${missingParent} does not exist.`;
       }
     } catch(e) {

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -55,8 +55,8 @@ function generateUniqueWidgetID(type, derivedIDs) {
   return id;
 }
 
-export function addWidget(widget, instance) {
-  if(widget.parent && !widgets.has(widget.parent)) {
+export function addWidget(widget, instance, allowMissingParent) {
+  if(widget.parent && !widgets.has(widget.parent) && !allowMissingParent) {
     if(!deferredChildren[widget.parent])
       deferredChildren[widget.parent] = [];
     deferredChildren[widget.parent].push(widget);
@@ -129,8 +129,11 @@ export function addWidget(widget, instance) {
       addWidget(c);
   delete deferredCards[widget.id];
 
+  // a parent chain that closes into a cycle is entered through one of its
+  // widgets, which is already here again when the chain leads back to it
   for(const c of deferredChildren[widget.id] || [])
-    addWidget(c);
+    if(!widgets.has(c.id))
+      addWidget(c);
   delete deferredChildren[widget.id];
 }
 
@@ -516,17 +519,23 @@ function receiveStateFromServer(args) {
     }
   }
 
+  // Whatever still waits for a parent here waits for a widget the state does not
+  // contain. Those widgets go onto the surface in limbo instead of being dropped:
+  // edit mode outlines them as "Invalid Parent", so they can be found and given a
+  // real parent rather than silently disappearing from the room.
+  for(const parentID of Object.keys(deferredChildren)) {
+    for(const widget of deferredChildren[parentID] || []) {
+      console.error(`Widget "${widget.id}" is in limbo because its parent "${parentID}" does not exist!`);
+      addWidget(widget, undefined, true);
+    }
+  }
+  deferredChildren = {};
+
   if(Object.keys(deferredCards).length) {
     for(const [ deckID, widgets ] of Object.entries(deferredCards))
       for(const widget of widgets)
         console.error(`Could not add card "${widget.id}" because its deck "${deckID}" does not exist!`);
     deferredCards = {};
-  }
-  if(Object.keys(deferredChildren).length) {
-    for(const [ deckID, widgets ] of Object.entries(deferredChildren))
-      for(const widget of widgets)
-        console.error(`Could not add widget "${widget.id}" because its parent "${deckID}" does not exist!`);
-    deferredChildren = {};
   }
 
   // before resetZoomAndPan, which clamps the pan against the board size and the scale

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -503,6 +503,10 @@ function receiveStateFromServer(args) {
   for(const widget of widgetFilter(w=>w.domElement.parentElement === topSurface))
     widget.applyRemoveRecursive();
   widgets.clear();
+  // whatever an earlier delta deferred waits for a room that does not exist anymore:
+  // keeping it would add a second copy of a widget this state contains
+  deferredChildren = {};
+  deferredCards = {};
   dropTargets.clear();
   maxZ = {};
   StateManaged.globalUpdateListeners = {};

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -129,8 +129,8 @@ export function addWidget(widget, instance, allowMissingParent) {
       addWidget(c);
   delete deferredCards[widget.id];
 
-  // a parent chain that closes into a cycle is entered through one of its
-  // widgets, which is already here again when the chain leads back to it
+  // a widget that was deferred more than once (its parent changed while it was
+  // waiting) is only added by the first of those parents that shows up
   for(const c of deferredChildren[widget.id] || [])
     if(!widgets.has(c.id))
       addWidget(c);
@@ -520,15 +520,30 @@ function receiveStateFromServer(args) {
   }
 
   // Whatever still waits for a parent here waits for a widget the state does not
-  // contain. Those widgets go onto the surface in limbo instead of being dropped:
-  // edit mode outlines them as "Invalid Parent", so they can be found and given a
-  // real parent rather than silently disappearing from the room.
+  // contain, or for one that is itself still waiting. Only the former go onto the
+  // surface in limbo instead of being dropped - edit mode outlines them as "Invalid
+  // Parent", so they can be found and given a real parent rather than silently
+  // disappearing from the room. Their own descendants follow through the regular
+  // deferred handling once they are there, so the hierarchy below an orphan survives
+  // no matter in which order the widgets appear in the state.
+  const deferredIDs = new Set();
+  for(const children of Object.values(deferredChildren))
+    for(const widget of children)
+      deferredIDs.add(widget.id);
   for(const parentID of Object.keys(deferredChildren)) {
-    for(const widget of deferredChildren[parentID] || []) {
+    if(deferredIDs.has(parentID))
+      continue;
+    for(const widget of deferredChildren[parentID]) {
       console.error(`Widget "${widget.id}" is in limbo because its parent "${parentID}" does not exist!`);
       addWidget(widget, undefined, true);
     }
+    delete deferredChildren[parentID];
   }
+
+  // a parent chain that closes into a cycle has no widget that could be added first
+  for(const [ parentID, children ] of Object.entries(deferredChildren))
+    for(const widget of children)
+      console.error(`Could not add widget "${widget.id}" because its parent "${parentID}" could not be added!`);
   deferredChildren = {};
 
   if(Object.keys(deferredCards).length) {

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -533,7 +533,7 @@ function receiveStateFromServer(args) {
   for(const parentID of Object.keys(deferredChildren)) {
     if(deferredIDs.has(parentID))
       continue;
-    for(const widget of deferredChildren[parentID]) {
+    for(const widget of deferredChildren[parentID] || []) {
       console.error(`Widget "${widget.id}" is in limbo because its parent "${parentID}" does not exist!`);
       addWidget(widget, undefined, true);
     }

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -45,13 +45,15 @@ export class Card extends Widget {
         this.domElement.innerHTML = '';
         this.deck.removeCard(this);
       }
-      if(delta.deck) {
-        this.deck = widgets.get(delta.deck);
+      // a deck that does not exist in the room leaves the card without faces instead
+      // of throwing halfway through updating the DOM
+      this.deck = delta.deck && widgets.get(delta.deck) || null;
+      if(this.deck) {
         this.deck.addCard(this);
         const faceTemplates = this.deck.get('faceTemplates');
         this.createFaces(Array.isArray(faceTemplates) ? faceTemplates : []);
-      } else {
-        this.deck = null;
+      } else if(delta.deck) {
+        console.error(`Card ${this.get('id')} has no faces because its deck ${delta.deck} does not exist!`);
       }
       for(const child of childNodes)
         if(!child.className.match(/cardFace/))
@@ -424,7 +426,7 @@ export class Card extends Widget {
   }
 
   getFaceCount() {
-    const faceTemplates = this.deck.get('faceTemplates');
+    const faceTemplates = this.deck && this.deck.get('faceTemplates');
     if(Array.isArray(faceTemplates))
       return faceTemplates.length;
     else

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -45,15 +45,17 @@ export class Card extends Widget {
         this.domElement.innerHTML = '';
         this.deck.removeCard(this);
       }
-      // a deck that does not exist in the room leaves the card without faces instead
-      // of throwing halfway through updating the DOM
-      this.deck = delta.deck && widgets.get(delta.deck) || null;
+      // a deck that is not in the room, or an id that names a widget which is no deck,
+      // leaves the card without faces instead of throwing halfway through updating the
+      // DOM - the same widgets a state load refuses to build a card for
+      const referenced = delta.deck && widgets.get(delta.deck) || null;
+      this.deck = referenced instanceof Deck ? referenced : null;
       if(this.deck) {
         this.deck.addCard(this);
         const faceTemplates = this.deck.get('faceTemplates');
         this.createFaces(Array.isArray(faceTemplates) ? faceTemplates : []);
       } else if(delta.deck) {
-        console.error(`Card ${this.get('id')} has no faces because its deck ${delta.deck} does not exist!`);
+        console.error(`Card ${this.get('id')} has no faces because ${referenced ? `widget ${delta.deck} is not a deck` : `its deck ${delta.deck} does not exist`}!`);
       }
       for(const child of childNodes)
         if(!child.className.match(/cardFace/))

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -3244,13 +3244,16 @@ export class Widget extends StateManaged {
       if(this.isBeingRemoved && !this.isBeingRenamed)
         for(const line of linesWithStop(this.id))
           await line.removeStop(this.id);
-      if(oldValue) {
+      // a parent id no widget in the room has leaves this one in limbo (the
+      // editor marks it "Invalid Parent") - there is nothing to hand the widget
+      // over to or take it from, so that half of the move is simply skipped
+      if(oldValue && widgets.has(oldValue)) {
         const oldParent = widgets.get(oldValue);
         await oldParent.onChildRemove(this);
         if(this.get('type') != 'holder' && Array.isArray(oldParent.get('leaveRoutine')))
           await oldParent.evaluateRoutine('leaveRoutine', {}, { child: [ this ] });
       }
-      if(newValue) {
+      if(newValue && widgets.has(newValue)) {
         const newParent = widgets.get(newValue);
         await newParent.onChildAdd(this, oldValue);
         if(Array.isArray(newParent.get('enterRoutine')))

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -3247,17 +3247,20 @@ export class Widget extends StateManaged {
       // a parent id no widget in the room has leaves this one in limbo (the
       // editor marks it "Invalid Parent") - there is nothing to hand the widget
       // over to or take it from, so that half of the move is simply skipped
-      if(oldValue && widgets.has(oldValue)) {
-        const oldParent = widgets.get(oldValue);
+      const oldParent = oldValue && widgets.has(oldValue) ? widgets.get(oldValue) : null;
+      if(oldParent) {
         await oldParent.onChildRemove(this);
         if(this.get('type') != 'holder' && Array.isArray(oldParent.get('leaveRoutine')))
           await oldParent.evaluateRoutine('leaveRoutine', {}, { child: [ this ] });
       }
       if(newValue && widgets.has(newValue)) {
+        // a widget in limbo sits on the surface, so it arrives with global
+        // coordinates and there is no widget it can name as the one it came from
+        const oldParentID = oldParent ? oldValue : null;
         const newParent = widgets.get(newValue);
-        await newParent.onChildAdd(this, oldValue);
+        await newParent.onChildAdd(this, oldParentID);
         if(Array.isArray(newParent.get('enterRoutine')))
-          await newParent.evaluateRoutine('enterRoutine', { oldParentID: oldValue === undefined ? null : oldValue }, { child: [ this ] });
+          await newParent.evaluateRoutine('enterRoutine', { oldParentID }, { child: [ this ] });
       }
       if(!this.disablePileUpdateAfterParentChange)
         await this.updatePiles();

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -3346,7 +3346,7 @@ export class Widget extends StateManaged {
 
     this.applyInitialDelta(state);
     target.appendChild(this.domElement);
-    if(this instanceof Card)
+    if(this instanceof Card && this.deck)
       this.deck.removeCard(this);
     return this;
   }

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -5430,10 +5430,12 @@ test('Editing the widgets array of a selection with different parents works', as
 // contains one has to arrive somewhere the creator can find and fix it.
 test('A widget whose parent does not exist is loaded into limbo', async t => {
   await t.resizeWindow(1280, 800);
+  // the child comes before its parent so the load has to follow the chain instead of
+  // relying on the order the widgets happen to be stored in
   await setRoomState({
     box: { id: 'box', type: 'basic', x: 100, y: 100, width: 600, height: 400 },
-    orphan: { id: 'orphan', type: 'basic', parent: 'ghost', x: 700, y: 300, width: 100, height: 100 },
-    child: { id: 'child', type: 'basic', parent: 'orphan', x: 10, y: 10, width: 50, height: 50 }
+    child: { id: 'child', type: 'basic', parent: 'orphan', x: 10, y: 10, width: 50, height: 50 },
+    orphan: { id: 'orphan', type: 'basic', parent: 'ghost', x: 700, y: 300, width: 100, height: 100 }
   });
   await ClientFunction(prepareClient)();
   await setName(t);

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -5540,6 +5540,30 @@ test('A multi-widget selection is not given a deck that does not exist', async t
     .expect(widgetProperty('two', 'deck')).eql('deck')
     .expect(ClientFunction(() => window.jsonEditErrors)()).eql([]);
 
+  // deleting the deck leaves the card without one, which the next load drops just the same
+  await t
+    .typeText('#jeText', JSON.stringify(Object.assign({}, selection, { deck: null }), null, '  '), { replace: true, paste: true })
+    .pressKey('end')
+    .expect(jsonError()).eql('Deck null does not exist.')
+    .expect(widgetProperty('one', 'deck')).eql('deck')
+    .expect(widgetProperty('two', 'deck')).eql('deck');
+
+  // a command that applies its own change instead of leaving that to the editor does not
+  // get to hand the state over either
+  await t
+    .typeText('#jeText', JSON.stringify(Object.assign({}, selection, { deck: 'nope', icon: { name: 'star' } }), null, '  '), { replace: true, paste: true })
+    .pressKey('end')
+    .expect(jsonError()).eql('Deck nope does not exist.');
+  await putCursorBehind('"star"');
+  await t
+    .click('#je_iconToString')
+    .expect(jsonEditorText()).contains('"icon": "star"')
+    .expect(jsonError()).eql('Deck nope does not exist.')
+    .expect(widgetProperty('one', 'deck')).eql('deck')
+    .expect(widgetProperty('two', 'deck')).eql('deck')
+    .expect(widgetProperty('one', 'icon')).notOk()
+    .expect(ClientFunction(() => window.jsonEditErrors)()).eql([]);
+
   // a routine reaches the same property without going through the editor, so the card
   // has to survive it there too - without faces until it names a deck again
   await ClientFunction(() => widgets.get('one').set('deck', 'nope'))();

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -5528,6 +5528,7 @@ test('The context commands still insert while a semantic error is shown', async 
 
   await t
     .click('#editButton')
+    .expect(Selector('#editorModuleTopLeft.data_object').exists).ok()
     .click('#w_one')
     .expect(jsonText()).contains('"id": "one"');
 

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -5414,3 +5414,31 @@ test('Editing the widgets array of a selection with different parents works', as
     .expect(parentOf('one')).eql('container');
   await setEditorState(null);
 });
+
+// A parent that names no widget is refused by the editor, but a state that already
+// contains one has to arrive somewhere the creator can find and fix it.
+test('A widget whose parent does not exist is loaded into limbo', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    box: { id: 'box', type: 'basic', x: 100, y: 100, width: 600, height: 400 },
+    orphan: { id: 'orphan', type: 'basic', parent: 'ghost', x: 700, y: 300, width: 100, height: 100 },
+    child: { id: 'child', type: 'basic', parent: 'orphan', x: 10, y: 10, width: 50, height: 50 }
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  await t
+    .click('#editButton')
+    .expect(Selector('#w_orphan').hasClass('limbo')).ok()
+    // a widget below one in limbo comes along and keeps its own parent
+    .expect(Selector('#w_child').exists).ok()
+    .expect(Selector('#w_child').hasClass('limbo')).notOk()
+    .expect(parentOf('child')).eql('orphan');
+
+  // giving it a real parent takes it out of limbo where it stands
+  await ClientFunction(() => widgets.get('orphan').set('parent', 'box'))();
+  await t
+    .expect(Selector('#w_orphan').hasClass('limbo')).notOk()
+    .expect(parentOf('orphan')).eql('box')
+    .expect(ClientFunction(() => widgets.get('orphan').get('x'))()).eql(600);
+});

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -5334,6 +5334,8 @@ test('A multi-widget selection is not given a parent that does not exist', async
   await ClientFunction(() => {
     window.jsonEditErrors = [];
     window.addEventListener('error', event => window.jsonEditErrors.push(String(event.error || event.message)));
+    // set() is not awaited anywhere in the editor, so a throw inside it arrives as a rejected promise
+    window.addEventListener('unhandledrejection', event => window.jsonEditErrors.push(String(event.reason)));
   })();
 
   await t

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -5301,25 +5301,21 @@ test('Send feedback', async t => {
 // a selection of several of them is no different: writing it through would ask a
 // parent that does not exist to take the widgets in, and the next edit would ask
 // the same of the one they came from.
-const jsonText = ClientFunction(() => document.querySelector('#jeText').textContent);
 const jsonError = ClientFunction(() => {
   const error = document.querySelector('#jeCommands .error');
   return error ? error.textContent.trim() : '';
 });
-const parentOf = ClientFunction(id => widgets.get(id).get('parent'));
-const deckOf = ClientFunction(id => widgets.get(id).get('deck'));
 const faceCountOf = ClientFunction(id => document.querySelectorAll(`#w_${id} .cardFace`).length);
-const layerOf = ClientFunction(id => widgets.get(id).get('layer'));
-// the band that selects both widgets at once, in offsets of the surface it is drawn on
-const selectionBand = ClientFunction(() => {
+// the board coordinates of a band around the given widgets, wherever their holder put them
+const bandAround = ClientFunction(ids => {
   const surface = document.querySelector('#topSurface').getBoundingClientRect();
-  const one = document.querySelector('#w_one').getBoundingClientRect();
-  const two = document.querySelector('#w_two').getBoundingClientRect();
+  const scale = surface.width/1600;
+  const boxes = ids.map(id => document.querySelector(`#w_${id}`).getBoundingClientRect());
   return {
-    offsetX: Math.round(one.left - surface.left) - 10,
-    offsetY: Math.round(one.top - surface.top) - 10,
-    dx: Math.round(two.right - one.left) + 20,
-    dy: Math.round(two.bottom - one.top) + 20
+    x1: (Math.min(...boxes.map(b=>b.left)) - surface.left)/scale - 10,
+    y1: (Math.min(...boxes.map(b=>b.top)) - surface.top)/scale - 10,
+    x2: (Math.max(...boxes.map(b=>b.right)) - surface.left)/scale + 10,
+    y2: (Math.max(...boxes.map(b=>b.bottom)) - surface.top)/scale + 10
   };
 });
 
@@ -5345,18 +5341,18 @@ test('A multi-widget selection is not given a parent that does not exist', async
     .click('#editButton')
     .expect(Selector('#editorModuleTopLeft.data_object').exists).ok();
 
-  const band = await selectionBand();
+  const band = await bandAround([ 'one', 'two' ]);
+  await bandSelect(t, band.x1, band.y1, band.x2, band.y2);
   await t
-    .drag('#topSurface', band.dx, band.dy, { offsetX: band.offsetX, offsetY: band.offsetY })
-    .expect(jsonText()).contains('"widgets"');
+    .expect(jsonEditorText()).contains('"widgets"');
 
-  const selection = JSON.parse(await jsonText());
+  const selection = JSON.parse(await jsonEditorText());
   await t
     .typeText('#jeText', JSON.stringify(Object.assign({}, selection, { parent: 'nope' }), null, '  '), { replace: true, paste: true })
     .pressKey('end')
     .expect(jsonError()).eql('Parent nope does not exist.')
-    .expect(parentOf('one')).eql('holder')
-    .expect(parentOf('two')).eql('holder')
+    .expect(widgetProperty('one', 'parent')).eql('holder')
+    .expect(widgetProperty('two', 'parent')).eql('holder')
     .expect(ClientFunction(() => window.jsonEditErrors)()).eql([])
     // with one parent per widget the message names the widget it belongs to
     .typeText('#jeText', JSON.stringify(Object.assign({}, selection, { parent: { one: 'nope', two: 'holder' } }), null, '  '), { replace: true, paste: true })
@@ -5377,8 +5373,8 @@ test('A multi-widget selection is not given a parent that does not exist', async
     .typeText('#jeText', JSON.stringify(Object.assign({}, selection, { parent: 'target' }), null, '  '), { replace: true, paste: true })
     .pressKey('end')
     .expect(jsonError()).eql('')
-    .expect(parentOf('one')).eql('target')
-    .expect(parentOf('two')).eql('target');
+    .expect(widgetProperty('one', 'parent')).eql('target')
+    .expect(widgetProperty('two', 'parent')).eql('target');
   await setEditorState(null);
 });
 
@@ -5418,10 +5414,10 @@ test('Editing the widgets array of a selection with different parents works', as
     .click('#editButton')
     .expect(Selector('#editorModuleTopLeft.data_object').exists).ok();
 
-  const band = await selectionBand();
+  const band = await bandAround([ 'one', 'two' ]);
+  await bandSelect(t, band.x1, band.y1, band.x2, band.y2);
   await t
-    .drag('#topSurface', band.dx, band.dy, { offsetX: band.offsetX, offsetY: band.offsetY })
-    .expect(jsonText()).contains('"parent": {')
+    .expect(jsonEditorText()).contains('"parent": {')
     .click('#jeText');
 
   await t.expect(caretAfter('"one')).ok();
@@ -5429,7 +5425,7 @@ test('Editing the widgets array of a selection with different parents works', as
     .pressKey('x')
     .expect(jsonError()).eql('')
     .expect(ClientFunction(() => JSON.parse(document.querySelector('#jeText').textContent))()).contains({ parent: null })
-    .expect(parentOf('one')).eql('container');
+    .expect(widgetProperty('one', 'parent')).eql('container');
   await setEditorState(null);
 });
 
@@ -5453,14 +5449,51 @@ test('A widget whose parent does not exist is loaded into limbo', async t => {
     // a widget below one in limbo comes along and keeps its own parent
     .expect(Selector('#w_child').exists).ok()
     .expect(Selector('#w_child').hasClass('limbo')).notOk()
-    .expect(parentOf('child')).eql('orphan');
+    .expect(widgetProperty('child', 'parent')).eql('orphan');
 
   // giving it a real parent takes it out of limbo where it stands
   await ClientFunction(() => widgets.get('orphan').set('parent', 'box'))();
   await t
     .expect(Selector('#w_orphan').hasClass('limbo')).notOk()
-    .expect(parentOf('orphan')).eql('box')
+    .expect(widgetProperty('orphan', 'parent')).eql('box')
     .expect(ClientFunction(() => widgets.get('orphan').get('x'))()).eql(600);
+});
+
+// A widget a delta could not add waits for its parent for as long as the room stands.
+// The state that arrives on a reconnect or a load describes another room, in which it
+// may well be there - so what is left waiting has to go with the room it waited in.
+const widgetNodeCount = ClientFunction(id => document.querySelectorAll(`[id="w_${id}"]`).length);
+test('A widget a delta left waiting is not added a second time by a state', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    box: { id: 'box', type: 'basic', x: 100, y: 100, width: 600, height: 400 }
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  await t
+    .click('#editButton')
+    .expect(Selector('#editorSidebar').exists).ok();
+
+  // the delta another client sends after deleting the parent this one still has
+  await ClientFunction(() => sendRawDelta({ s: { orphan: { id: 'orphan', type: 'basic', parent: 'ghost', x: 700, y: 300, width: 100, height: 100 } } }))();
+  await t.expect(widgetNodeCount('orphan')).eql(0);
+
+  await setRoomState({
+    box: { id: 'box', type: 'basic', x: 100, y: 100, width: 600, height: 400 },
+    orphan: { id: 'orphan', type: 'basic', parent: 'ghost', x: 700, y: 300, width: 100, height: 100 }
+  });
+  await t
+    .expect(Selector('#w_orphan').hasClass('limbo')).ok()
+    .expect(widgetNodeCount('orphan')).eql(1);
+
+  // and a state that healed the room leaves nothing of it behind
+  await setRoomState({
+    box: { id: 'box', type: 'basic', x: 100, y: 100, width: 600, height: 400 }
+  });
+  await t
+    .expect(widgetNodeCount('orphan')).eql(0)
+    .expect(Selector('#w_box').exists).ok();
 });
 
 // A deck that names no widget throws while the card builds its DOM, and unlike a bad
@@ -5486,23 +5519,37 @@ test('A multi-widget selection is not given a deck that does not exist', async t
     .click('#editButton')
     .expect(Selector('#editorModuleTopLeft.data_object').exists).ok();
 
-  const band = await selectionBand();
+  const band = await bandAround([ 'one', 'two' ]);
+  await bandSelect(t, band.x1, band.y1, band.x2, band.y2);
   await t
-    .drag('#topSurface', band.dx, band.dy, { offsetX: band.offsetX, offsetY: band.offsetY })
-    .expect(jsonText()).contains('"widgets"');
+    .expect(jsonEditorText()).contains('"widgets"');
 
-  const selection = JSON.parse(await jsonText());
+  const selection = JSON.parse(await jsonEditorText());
   await t
     .typeText('#jeText', JSON.stringify(Object.assign({}, selection, { deck: 'nope' }), null, '  '), { replace: true, paste: true })
     .pressKey('end')
     .expect(jsonError()).eql('Deck nope does not exist.')
-    .expect(deckOf('one')).eql('deck')
-    .expect(deckOf('two')).eql('deck')
+    .expect(widgetProperty('one', 'deck')).eql('deck')
+    .expect(widgetProperty('two', 'deck')).eql('deck')
+    .expect(ClientFunction(() => window.jsonEditErrors)()).eql([])
+    // a widget that exists but is no deck cannot hold cards either
+    .typeText('#jeText', JSON.stringify(Object.assign({}, selection, { deck: 'holder' }), null, '  '), { replace: true, paste: true })
+    .pressKey('end')
+    .expect(jsonError()).eql(`Given widget holder is not a deck or doesn't define cardTypes.`)
+    .expect(widgetProperty('one', 'deck')).eql('deck')
+    .expect(widgetProperty('two', 'deck')).eql('deck')
     .expect(ClientFunction(() => window.jsonEditErrors)()).eql([]);
 
   // a routine reaches the same property without going through the editor, so the card
   // has to survive it there too - without faces until it names a deck again
   await ClientFunction(() => widgets.get('one').set('deck', 'nope'))();
+  await t
+    .expect(ClientFunction(() => window.jsonEditErrors)()).eql([])
+    .expect(Selector('#w_one').exists).ok()
+    .expect(faceCountOf('one')).eql(0);
+  // a widget that is no deck cannot give the card faces either, and says so instead
+  // of throwing where the deck it came from is already gone
+  await ClientFunction(() => widgets.get('one').set('deck', 'holder'))();
   await t
     .expect(ClientFunction(() => window.jsonEditErrors)()).eql([])
     .expect(Selector('#w_one').exists).ok()
@@ -5530,26 +5577,26 @@ test('The context commands still insert while a semantic error is shown', async 
     .click('#editButton')
     .expect(Selector('#editorModuleTopLeft.data_object').exists).ok()
     .click('#w_one')
-    .expect(jsonText()).contains('"id": "one"');
+    .expect(jsonEditorText()).contains('"id": "one"');
 
-  const state = JSON.parse(await jsonText());
+  const state = JSON.parse(await jsonEditorText());
   await t
     .typeText('#jeText', JSON.stringify(Object.assign({}, state, { parent: 'nope' }), null, '  '), { replace: true, paste: true })
     .pressKey('end')
     .expect(jsonError()).eql('Parent nope does not exist.')
     .expect(Selector('#widget_basic_layer').exists).ok()
     .click('#widget_basic_layer')
-    .expect(jsonText()).contains('"layer"')
+    .expect(jsonEditorText()).contains('"layer"')
     // the room only takes it once the parent names a widget again
-    .expect(parentOf('one')).eql('holder')
-    .expect(layerOf('one')).eql(1);
+    .expect(widgetProperty('one', 'parent')).eql('holder')
+    .expect(widgetProperty('one', 'layer')).eql(1);
 
-  const inserted = JSON.parse(await jsonText());
+  const inserted = JSON.parse(await jsonEditorText());
   inserted.layer = 2;
   await t
     .typeText('#jeText', JSON.stringify(Object.assign({}, inserted, { parent: 'holder' }), null, '  '), { replace: true, paste: true })
     .pressKey('end')
     .expect(jsonError()).eql('')
-    .expect(layerOf('one')).eql(2);
+    .expect(widgetProperty('one', 'layer')).eql(2);
   await setEditorState(null);
 });

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -5355,6 +5355,17 @@ test('A multi-widget selection is not given a parent that does not exist', async
     .expect(parentOf('one')).eql('holder')
     .expect(parentOf('two')).eql('holder')
     .expect(ClientFunction(() => window.jsonEditErrors)()).eql([])
+    // with one parent per widget the message names the widget it belongs to
+    .typeText('#jeText', JSON.stringify(Object.assign({}, selection, { parent: { one: 'nope', two: 'holder' } }), null, '  '), { replace: true, paste: true })
+    .pressKey('end')
+    .expect(jsonError()).eql('Parent nope does not exist (widget "one").')
+    // a key that names no selected widget makes the whole object the parent, which
+    // is not an id either - naming a value as the missing one would be a guess
+    .typeText('#jeText', JSON.stringify(Object.assign({}, selection, { parent: { one: 'holder', twoo: 'holder' } }), null, '  '), { replace: true, paste: true })
+    .pressKey('end')
+    .expect(jsonError()).eql('Parent has to be a widget ID, or an object with one entry per selected widget.')
+    // the commands that would fix it stay reachable while the message is up
+    .expect(Selector('#jeContextButtons button').withText('enter new parent ID').exists).ok()
     // a parent that does exist still goes to every widget of the selection
     .typeText('#jeText', JSON.stringify(Object.assign({}, selection, { parent: 'target' }), null, '  '), { replace: true, paste: true })
     .pressKey('end')

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -5361,3 +5361,54 @@ test('A multi-widget selection is not given a parent that does not exist', async
     .expect(parentOf('two')).eql('target');
   await setEditorState(null);
 });
+
+// The widgets array holds the search terms of the selection, so while it is
+// being edited the parent values still belong to the widgets selected before.
+const caretAfter = ClientFunction(needle => {
+  const root = document.querySelector('#jeText');
+  const index = root.textContent.indexOf(needle) + needle.length;
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let seen = 0, node;
+  while(node = walker.nextNode()) {
+    if(seen + node.length >= index) {
+      const range = document.createRange();
+      range.setStart(node, index - seen);
+      range.collapse(true);
+      getSelection().removeAllRanges();
+      getSelection().addRange(range);
+      return true;
+    }
+    seen += node.length;
+  }
+  return false;
+});
+
+test('Editing the widgets array of a selection with different parents works', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    container: { id: 'container', type: 'basic', x: 0, y: 0, width: 40, height: 40 },
+    one: { id: 'one', type: 'basic', parent: 'container', x: 200, y: 300, width: 100, height: 100 },
+    two: { id: 'two', type: 'basic', x: 500, y: 300, width: 100, height: 100 }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState({ modules: { JSON: 'editorModuleTopLeft' } });
+  await setName(t);
+
+  await t
+    .click('#editButton')
+    .expect(Selector('#editorModuleTopLeft.data_object').exists).ok();
+
+  const band = await selectionBand();
+  await t
+    .drag('#topSurface', band.dx, band.dy, { offsetX: band.offsetX, offsetY: band.offsetY })
+    .expect(jsonText()).contains('"parent": {')
+    .click('#jeText');
+
+  await t.expect(caretAfter('"one')).ok();
+  await t
+    .pressKey('x')
+    .expect(jsonError()).eql('')
+    .expect(ClientFunction(() => JSON.parse(document.querySelector('#jeText').textContent))()).contains({ parent: null })
+    .expect(parentOf('one')).eql('container');
+  await setEditorState(null);
+});

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -5307,6 +5307,9 @@ const jsonError = ClientFunction(() => {
   return error ? error.textContent.trim() : '';
 });
 const parentOf = ClientFunction(id => widgets.get(id).get('parent'));
+const deckOf = ClientFunction(id => widgets.get(id).get('deck'));
+const faceCountOf = ClientFunction(id => document.querySelectorAll(`#w_${id} .cardFace`).length);
+const layerOf = ClientFunction(id => widgets.get(id).get('layer'));
 // the band that selects both widgets at once, in offsets of the surface it is drawn on
 const selectionBand = ClientFunction(() => {
   const surface = document.querySelector('#topSurface').getBoundingClientRect();
@@ -5364,6 +5367,10 @@ test('A multi-widget selection is not given a parent that does not exist', async
     .typeText('#jeText', JSON.stringify(Object.assign({}, selection, { parent: { one: 'holder', twoo: 'holder' } }), null, '  '), { replace: true, paste: true })
     .pressKey('end')
     .expect(jsonError()).eql('Parent has to be a widget ID, or an object with one entry per selected widget.')
+    // one key per widget but a value that is not an id points at that widget
+    .typeText('#jeText', JSON.stringify(Object.assign({}, selection, { parent: { one: 'holder', two: { holder: true } } }), null, '  '), { replace: true, paste: true })
+    .pressKey('end')
+    .expect(jsonError()).eql('Parent has to be a widget ID (widget "two").')
     // the commands that would fix it stay reachable while the message is up
     .expect(Selector('#jeContextButtons button').withText('enter new parent ID').exists).ok()
     // a parent that does exist still goes to every widget of the selection
@@ -5454,4 +5461,94 @@ test('A widget whose parent does not exist is loaded into limbo', async t => {
     .expect(Selector('#w_orphan').hasClass('limbo')).notOk()
     .expect(parentOf('orphan')).eql('box')
     .expect(ClientFunction(() => widgets.get('orphan').get('x'))()).eql(600);
+});
+
+// A deck that names no widget throws while the card builds its DOM, and unlike a bad
+// parent it is written out before that happens - so the card is gone on the next load.
+test('A multi-widget selection is not given a deck that does not exist', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    deck: { id: 'deck', type: 'deck', parent: 'holder', cardTypes: { a: {} }, faceTemplates: [ { objects: [] } ] },
+    holder: { id: 'holder', type: 'holder', x: 100, y: 100, width: 600, height: 400 },
+    one: { id: 'one', type: 'card', deck: 'deck', cardType: 'a', parent: 'holder', x: 100, y: 200 },
+    two: { id: 'two', type: 'card', deck: 'deck', cardType: 'a', parent: 'holder', x: 350, y: 200 }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState({ modules: { JSON: 'editorModuleTopLeft' } });
+  await setName(t);
+  await ClientFunction(() => {
+    window.jsonEditErrors = [];
+    window.addEventListener('error', event => window.jsonEditErrors.push(String(event.error || event.message)));
+    window.addEventListener('unhandledrejection', event => window.jsonEditErrors.push(String(event.reason)));
+  })();
+
+  await t
+    .click('#editButton')
+    .expect(Selector('#editorModuleTopLeft.data_object').exists).ok();
+
+  const band = await selectionBand();
+  await t
+    .drag('#topSurface', band.dx, band.dy, { offsetX: band.offsetX, offsetY: band.offsetY })
+    .expect(jsonText()).contains('"widgets"');
+
+  const selection = JSON.parse(await jsonText());
+  await t
+    .typeText('#jeText', JSON.stringify(Object.assign({}, selection, { deck: 'nope' }), null, '  '), { replace: true, paste: true })
+    .pressKey('end')
+    .expect(jsonError()).eql('Deck nope does not exist.')
+    .expect(deckOf('one')).eql('deck')
+    .expect(deckOf('two')).eql('deck')
+    .expect(ClientFunction(() => window.jsonEditErrors)()).eql([]);
+
+  // a routine reaches the same property without going through the editor, so the card
+  // has to survive it there too - without faces until it names a deck again
+  await ClientFunction(() => widgets.get('one').set('deck', 'nope'))();
+  await t
+    .expect(ClientFunction(() => window.jsonEditErrors)()).eql([])
+    .expect(Selector('#w_one').exists).ok()
+    .expect(faceCountOf('one')).eql(0);
+  await ClientFunction(() => widgets.get('one').set('deck', 'deck'))();
+  await t
+    .expect(ClientFunction(() => window.jsonEditErrors)()).eql([])
+    .expect(faceCountOf('one')).eql(1);
+  await setEditorState(null);
+});
+
+// The message says the state cannot be handed to the room yet, not that the editor is
+// out of order - the commands that write the property the message asks for keep working.
+test('The context commands still insert while a semantic error is shown', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    holder: { id: 'holder', type: 'holder', x: 100, y: 100, width: 600, height: 400 },
+    one: { id: 'one', type: 'basic', parent: 'holder', x: 100, y: 200, width: 100, height: 100 }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState({ modules: { JSON: 'editorModuleTopLeft' } });
+  await setName(t);
+
+  await t
+    .click('#editButton')
+    .click('#w_one')
+    .expect(jsonText()).contains('"id": "one"');
+
+  const state = JSON.parse(await jsonText());
+  await t
+    .typeText('#jeText', JSON.stringify(Object.assign({}, state, { parent: 'nope' }), null, '  '), { replace: true, paste: true })
+    .pressKey('end')
+    .expect(jsonError()).eql('Parent nope does not exist.')
+    .expect(Selector('#widget_basic_layer').exists).ok()
+    .click('#widget_basic_layer')
+    .expect(jsonText()).contains('"layer"')
+    // the room only takes it once the parent names a widget again
+    .expect(parentOf('one')).eql('holder')
+    .expect(layerOf('one')).eql(1);
+
+  const inserted = JSON.parse(await jsonText());
+  inserted.layer = 2;
+  await t
+    .typeText('#jeText', JSON.stringify(Object.assign({}, inserted, { parent: 'holder' }), null, '  '), { replace: true, paste: true })
+    .pressKey('end')
+    .expect(jsonError()).eql('')
+    .expect(layerOf('one')).eql(2);
+  await setEditorState(null);
 });

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -5296,3 +5296,68 @@ test('Send feedback', async t => {
     .expect(Selector('#feedbackOverlay').visible).notOk()
     .expect(Selector('#statesButton').hasClass('active')).ok();
 });
+
+// A parent that names no widget in the room is refused for a single widget, and
+// a selection of several of them is no different: writing it through would ask a
+// parent that does not exist to take the widgets in, and the next edit would ask
+// the same of the one they came from.
+const jsonText = ClientFunction(() => document.querySelector('#jeText').textContent);
+const jsonError = ClientFunction(() => {
+  const error = document.querySelector('#jeCommands .error');
+  return error ? error.textContent.trim() : '';
+});
+const parentOf = ClientFunction(id => widgets.get(id).get('parent'));
+// the band that selects both widgets at once, in offsets of the surface it is drawn on
+const selectionBand = ClientFunction(() => {
+  const surface = document.querySelector('#topSurface').getBoundingClientRect();
+  const one = document.querySelector('#w_one').getBoundingClientRect();
+  const two = document.querySelector('#w_two').getBoundingClientRect();
+  return {
+    offsetX: Math.round(one.left - surface.left) - 10,
+    offsetY: Math.round(one.top - surface.top) - 10,
+    dx: Math.round(two.right - one.left) + 20,
+    dy: Math.round(two.bottom - one.top) + 20
+  };
+});
+
+test('A multi-widget selection is not given a parent that does not exist', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    holder: { id: 'holder', type: 'holder', x: 100, y: 100, width: 600, height: 400 },
+    target: { id: 'target', type: 'holder', x: 800, y: 100, width: 300, height: 300 },
+    one: { id: 'one', type: 'basic', parent: 'holder', x: 100, y: 200, width: 100, height: 100 },
+    two: { id: 'two', type: 'basic', parent: 'holder', x: 350, y: 200, width: 100, height: 100 }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState({ modules: { JSON: 'editorModuleTopLeft' } });
+  await setName(t);
+  await ClientFunction(() => {
+    window.jsonEditErrors = [];
+    window.addEventListener('error', event => window.jsonEditErrors.push(String(event.error || event.message)));
+  })();
+
+  await t
+    .click('#editButton')
+    .expect(Selector('#editorModuleTopLeft.data_object').exists).ok();
+
+  const band = await selectionBand();
+  await t
+    .drag('#topSurface', band.dx, band.dy, { offsetX: band.offsetX, offsetY: band.offsetY })
+    .expect(jsonText()).contains('"widgets"');
+
+  const selection = JSON.parse(await jsonText());
+  await t
+    .typeText('#jeText', JSON.stringify(Object.assign({}, selection, { parent: 'nope' }), null, '  '), { replace: true, paste: true })
+    .pressKey('end')
+    .expect(jsonError()).eql('Parent nope does not exist.')
+    .expect(parentOf('one')).eql('holder')
+    .expect(parentOf('two')).eql('holder')
+    .expect(ClientFunction(() => window.jsonEditErrors)()).eql([])
+    // a parent that does exist still goes to every widget of the selection
+    .typeText('#jeText', JSON.stringify(Object.assign({}, selection, { parent: 'target' }), null, '  '), { replace: true, paste: true })
+    .pressKey('end')
+    .expect(jsonError()).eql('')
+    .expect(parentOf('one')).eql('target')
+    .expect(parentOf('two')).eql('target');
+  await setEditorState(null);
+});


### PR DESCRIPTION
Giving a widget a `parent` that names no widget in the room crashed the client. `Widget.onPropertyChange()` looked the old and the new parent up in the widget map and called `onChildRemove()` / `onChildAdd()` on the result without checking that there is one:

```
TypeError: Cannot read properties of undefined (reading 'onChildAdd')
    at Widget.onPropertyChange
    at async Widget.set
    at async setValueIfNeeded
    at async jeApplyChangesMulti
```

The JSON editor's **multi-selection** mode is what let such a parent through: it validated only that the `widgets` key is an array, while the single-widget mode has always refused the parent with *"Parent X does not exist."* and applied nothing. So editing `"parent"` for several selected widgets at once was one typo away from a dead client — every keystroke while the id was incomplete threw. The same hole was open for `deck`, where the bad value was written out before the throw, so the card was gone on the next load.

## Reproduction (on `main`)

1. Open a room, enter edit mode and open the **JSON** sidebar module.
2. Put two plain widgets into a holder.
3. Draw a selection band around both of them, so the JSON editor shows the multi-selection JSON with a shared `"parent"`.
4. Change the value of `"parent"` to an id no widget in the room has.

The client throws `Cannot read properties of undefined (reading 'onChildAdd')` on the first keystroke. The delta still goes out, so the widgets end up in limbo, and from then on every further keystroke throws `Cannot read properties of undefined (reading 'onChildRemove')` for the parent they came from. Verified by driving a real browser against a local checkout of `main`; the new TestCafe test below fails on `main` with exactly that stack and passes with this branch.

The same steps with two cards and `"deck"` instead of `"parent"` throw `Cannot read properties of undefined (reading 'addCard')`, and leave the cards with a deck that does not exist — which drops them from the room on the next load.

## Changes

- **`client/js/widgets/widget.js`** — `onPropertyChange('parent', …)` skips the leave half when the old parent id names no widget, and the enter half when the new one does not. A widget coming out of limbo hangs below the surface, so it arrives with the coordinates of the room and names no widget it came from: `onChildAdd()` and the new parent's `enterRoutine` are given `null` instead of the dangling id, which is what makes the widget keep its place on the board. A widget without an existing parent is a state the client already supports: `applyDeltaToDOM()` puts it in limbo and edit mode outlines it as *"Invalid Parent"*. It can now be put there and taken out of there again without throwing, so a widget that ends up in limbo — for whatever reason — stays recoverable by giving it a real parent. `renderReadonlyCopyRaw()` no longer dereferences a card's `deck` unchecked either, the way `applyRemove()` already does not.
- **`client/js/widgets/card.js`** — a card whose `deck` names no widget, or names one that is not a deck, is left without faces instead of throwing in the middle of `applyDeltaToDOM()`, where it had already emptied its DOM and left the deck it came from. Those are the same two widgets a state load refuses to build a card for. That is the same shape of guard `widget.js` gets for `parent`, and it is what a routine's `SET` reaches without going through the editor.
- **`client/js/serverstate.js`** — a widget's recoverability now survives a reload. A widget whose parent is not in the state used to wait for it until the end of the load and then be thrown away with a `console.error`, so such a room lost the widget on every refresh with nothing to see. It goes onto the surface in limbo instead, exactly like a widget put there while the room is open, and whatever hangs below it comes along and keeps its own parent. What a *delta* deferred is dropped together with the widgets it belongs to when a state replaces the room: it waits for a room that does not exist anymore, and a state that contains the same widget would otherwise add it twice and leave the copy it overwrote on the board.
- **`client/js/jsonedit.js`** — the multi-selection editor runs the same *"Parent X does not exist."* and *"Deck X does not exist."* checks the single-widget editor runs, for a value given to the whole selection as well as for one given per widget. The "is this value per widget or shared by all of them" test both places need is now one helper instead of an inline expression. `deck` is checked for the values that go to a card and only for those, because on any other widget it is an ordinary property that happens to be called `deck`; a value that names a widget which is no deck is refused with the single-widget editor's *"Given widget X is not a deck or doesn't define cardTypes."*, and deleting the property on a card is refused too, because a card without a deck is dropped on the next load just like one whose deck is missing. The checks stay out of the way while the `widgets` array itself is being edited: that edit is a re-selection, which reloads the editor instead of writing any property, and the values in the text still belong to the widgets selected before it. When the value is given per widget the message names the widget it belongs to, and a value that is not a widget id at all says so instead of reading `Parent [object Object] does not exist.`
- **`client/js/jsonedit.js`**, the command pane — the pane no longer empties itself while a parent id is being typed: a parse error still leaves nothing to act on, but a state that parsed and was only rejected for its content keeps its context buttons. Everything that reads the caret's context now uses that same distinction, so the buttons the pane shows in that state actually insert what they say — `jeInsert()` and the check that trims the context to what the widget really has used to require no error at all, which would have left a pane full of buttons that swallow the click. Only handing the state to the room still waits for the message to go away, and that wait now lives in `jeApplyChanges()` itself: the commands that apply their own change - the color picker, the asset uploads, the symbol and audio pickers, every icon command - do not go through the gated call the pane makes for the insert commands, and would otherwise hand the room the whole state, dangling reference included.
- **`client/css/jsonedit.css`** — the message is a paragraph of its own below the context line rather than an inline `<i>` that ran into it.
- **`client/css/layout.css`** — the *Invalid Parent* marker is a badge above the widget instead of text inside it, where it ran into the widget's own content and turned to mush on two small widgets side by side.
- **`tests/testcafe/editor.js`** — a test that bands two widgets in a holder, gives the selection a parent that does not exist and expects the editor to say so for a shared parent, for a per-widget one, for a per-widget value that is no id and for a value that is no id at all, the widgets to keep their parent, the commands that fix it to stay up, and nothing to reach `window.onerror` or `unhandledrejection`; then gives them a parent that does exist and expects it to apply to both. A second test does the same with `deck` on two cards - a missing deck, a widget that is no deck and a deleted one - clicks a command that applies its own change while the message is up and expects the editor text to take it while both cards keep their deck, and then sets the bad deck the way a routine would and expects the card to stay in the room without faces and to get them back. A third bands two widgets with *different* parents and edits the `widgets` array, expecting the editor to re-sync to the narrowed selection without an error. A fourth loads a state whose widget names a parent that is not in it and expects that widget in limbo, its own child alongside it, and a real parent to take it out of limbo where it stands. A fifth clicks a context button while *"Parent X does not exist."* is up and expects the property to appear in the editor text and to reach the room once the parent names a widget again. A sixth sends a delta that adds a widget with a missing parent, then loads a state containing that same widget, and expects exactly one node for it — and none at all once a state without it arrives.

No widget property, routine operation or creator-facing default changes, so there is nothing to add to the validator or to the editor's insert buttons.

Related: #3027 makes the client survive a *cyclic* parent chain by falling back to the same limbo state; this fixes the case where the parent id simply names nothing.

## Verification

- `npm test` (jest): 1523 passed.
- `npx testcafe chromium:headless tests/testcafe/editor.js`: 95 passed on top of the current `main`, including the new limbo-on-load, deck, context-command and delta-deferred tests. `tests/testcafe/card.js`: 9 passed.
- Each new test was confirmed to fail with the client code of the previous commit and to pass with it.
- Driven in a real browser at 1280x800: a state with three dangling parents loads three widgets marked *Invalid Parent* instead of an empty board, and the refusals read `Parent nope does not exist.`, `Parent nope does not exist (widget "one").` and `Parent has to be a widget ID, or an object with one entry per selected widget.` — screenshots: [marker](https://agent.virtualtabletop.io/reports/pr/1540315064949805069/pr3141-ui/01-invalid-parent-badge.png), [shared](https://agent.virtualtabletop.io/reports/pr/1540315064949805069/pr3141-ui/02-shared-parent-error.png), [not an id](https://agent.virtualtabletop.io/reports/pr/1540315064949805069/pr3141-ui/03-parent-object-error.png), [per widget](https://agent.virtualtabletop.io/reports/pr/1540315064949805069/pr3141-ui/04-per-widget-parent-error.png).

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3141/pr-test (or any other room on that server)


