### PR TITLE
Fix the History module crashing after a toolbar undo and make that undo redoable

### DIFF
--- a/client/css/editor/sidebarModules.css
+++ b/client/css/editor/sidebarModules.css
@@ -877,13 +877,20 @@
 
 /* undo */
 
+/* every row is a control: a comfortable target, and a hanging indent so the second line of a
+   wrapped row sits under its text instead of where the text of the next row starts */
 .undo.editorModule > .undoEntry {
-  padding: 2px;
-  color: var(--textDimColor1);
+  padding: 6px 4px 6px 1.8em;
+  text-indent: -1.4em;
+  color: var(--textHelpColor);
   cursor: pointer;
 }
 
-.undo.editorModule > .active.undoEntry {
+.undo.editorModule > .undoEntry:hover {
+  background: var(--backgroundHighlightColor2);
+}
+
+.undo.editorModule > .active.undoEntry, .undo.editorModule > .active.undoEntry:hover {
   color: var(--textColor);
   background: var(--backgroundHighlightColor1);
   cursor: unset;

--- a/client/js/editor/layout.js
+++ b/client/js/editor/layout.js
@@ -86,10 +86,12 @@ function initializeEditor(currentMetaData) {
 }
 
 // restoring an earlier state replaces the undo protocol, which invalidates what the
-// modules have rendered from it
+// modules have rendered from it and what the toolbar buttons made of its length
 function undoProtocolChanged() {
   for(const module of sidebarModules)
     module.onUndoProtocolChanged();
+  for(const button of toolbarButtons)
+    button.onUndoProtocolChanged();
 }
 
 function metaReceived(data) {

--- a/client/js/editor/layout.js
+++ b/client/js/editor/layout.js
@@ -85,6 +85,13 @@ function initializeEditor(currentMetaData) {
   openEditor();
 }
 
+// restoring an earlier state replaces the undo protocol, which invalidates what the
+// history module has rendered from it
+function undoProtocolChanged() {
+  for(const module of sidebarModules)
+    module.onUndoProtocolChanged();
+}
+
 function metaReceived(data) {
   for(const module of sidebarModules)
     module.onMetaReceived(data);

--- a/client/js/editor/layout.js
+++ b/client/js/editor/layout.js
@@ -86,7 +86,7 @@ function initializeEditor(currentMetaData) {
 }
 
 // restoring an earlier state replaces the undo protocol, which invalidates what the
-// history module has rendered from it
+// modules have rendered from it
 function undoProtocolChanged() {
   for(const module of sidebarModules)
     module.onUndoProtocolChanged();

--- a/client/js/editor/selection.js
+++ b/client/js/editor/selection.js
@@ -331,6 +331,8 @@ export function editorReceiveDelta(delta) {
 
   for(const module of sidebarModules)
     module.onDeltaReceived(delta);
+  for(const button of toolbarButtons)
+    button.onDeltaReceived(delta);
   selectionBarDeltaReceived(delta);
   deckEditorReceiveDelta(delta);
 }

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -2093,7 +2093,7 @@ class PropertiesModule extends SidebarModule {
           continue;
         const button = document.createElement('button');
         button.setAttribute('icon', icon);
-        button.disabled = selectedWidgets.length < (toolbarButton.minimumSelection || 1);
+        button.disabled = toolbarButton.isDisabled();
         // explain a disabled distribute button (needs 3+ widgets) rather than
         // just leaving it gray with no hint why
         button.title = (toolbarButton.tooltip || '') + (button.disabled && toolbarButton.minimumSelection > 1 ?

--- a/client/js/editor/sidebar/undo.js
+++ b/client/js/editor/sidebar/undo.js
@@ -2,25 +2,19 @@ class UndoModule extends SidebarModule {
   constructor() {
     super('undo', 'History', 'Undo changes from editing or playing.');
     this.lastRenderedIndex = -2;
+    this.lastRenderedEntry = null;
     this.latestEntryDOM = null;
   }
 
   onClose() {
     this.lastRenderedIndex = -2;
+    this.lastRenderedEntry = null;
     this.latestEntryDOM = null;
   }
 
   onDeltaReceivedWhileActive(delta) {
-    if(!this.inUndoMode) {
-      if(this.resetOnNextDelta) {
-        for(const entry of $a('.undoEntry', this.moduleDOM))
-          entry.remove();
-        this.lastRenderedIndex = -1;
-        this.resetOnNextDelta = false;
-        this.latestEntryDOM = null;
-      }
+    if(!this.inUndoMode)
       this.renderModule(this.moduleDOM);
-    }
   }
 
   onEntryClick(index, dom) {
@@ -32,10 +26,26 @@ class UndoModule extends SidebarModule {
     this.setActiveIndex(index, dom);
     this.inUndoMode = false;
 
+    // the rows above the clicked one stay in the DOM and this.protocol keeps their
+    // entries, so they can be clicked to return to that state - until the next
+    // change arrives and renderModule drops the now unreachable timeline
     setUndoProtocol(this.protocol.slice(0, index+1));
-    this.resetOnNextDelta = true;
 
     setSelection([...selectedWidgets].filter(w=>widgets.has(w.id)));
+  }
+
+  onUndoProtocolChanged() {
+    if(this.moduleDOM)
+      this.renderModule(this.moduleDOM);
+  }
+
+  removeEntries() {
+    for(const entry of $a('.undoEntry', this.moduleDOM))
+      entry.remove();
+    this.lastRenderedIndex = -1;
+    this.lastRenderedEntry = null;
+    this.latestEntryDOM = null;
+    this.activeDOM = null;
   }
 
   renderModule(target) {
@@ -47,6 +57,12 @@ class UndoModule extends SidebarModule {
     }
 
     this.protocol = [...getUndoProtocol()];
+
+    // returning to an earlier state cuts the protocol short, so the rows rendered so
+    // far can describe entries that are gone by now - start over instead of writing
+    // to a row that has no entry behind it anymore
+    if(this.lastRenderedIndex >= 0 && this.protocol[this.lastRenderedIndex] !== this.lastRenderedEntry)
+      this.removeEntries();
 
     if(this.latestEntryDOM) {
       const d = this.protocol[this.lastRenderedIndex].delta;
@@ -67,6 +83,7 @@ class UndoModule extends SidebarModule {
     }
 
     this.lastRenderedIndex = this.protocol.length - 1;
+    this.lastRenderedEntry = this.protocol[this.lastRenderedIndex] || null;
   }
 
   setActiveIndex(index, dom) {

--- a/client/js/editor/sidebar/undo.js
+++ b/client/js/editor/sidebar/undo.js
@@ -1,6 +1,6 @@
 class UndoModule extends SidebarModule {
   constructor() {
-    super('undo', 'History', 'Undo changes from editing or playing.');
+    super('undo', 'History', 'See and return to earlier states of this room.');
     this.lastRenderedIndex = -2;
     this.renderedEntries = [];
     this.latestEntryDOM = null;
@@ -54,7 +54,7 @@ class UndoModule extends SidebarModule {
   renderModule(target) {
     if(this.lastRenderedIndex == -2) {
       this.addHeader('History');
-      const hintDiv = hint('This lists all the changes that were done to this room until you loaded the page.<br><br>You can click on any row to return the room to the state after the described action.<br><br>You can afterwards return to a future state by clicking that one but as soon as you make new changes after returning to a state in the past, you can no longer restore anything from the now parallel timeline.');
+      const hintDiv = hint('This lists all the changes that were done to this room until you loaded the page.<br><br>You can click on any row to return the room to the state after the described action.<br><br>You can afterwards return to a future state by clicking that one but as soon as you make new changes after returning to a state in the past, you can no longer restore anything from the now parallel timeline.<br><br>The Undo button in the toolbar works differently: it removes the change from this list for good, together with everything that happened after it, so those rows disappear and their states cannot be returned to.');
       this.moduleDOM.append(hintDiv);
       this.lastRenderedIndex = -1;
     }
@@ -74,14 +74,14 @@ class UndoModule extends SidebarModule {
 
     if(this.latestEntryDOM) {
       const d = this.protocol[this.lastRenderedIndex].delta;
-      this.latestEntryDOM.innerText = `${this.lastRenderedIndex+1} - ${d.c || 'unknown'} (${Object.keys(d.s).length} widget${Object.keys(d.s).length == 1 ? '' : 's'} changed)`;
+      this.latestEntryDOM.innerText = `${this.lastRenderedIndex+1} - ${d.c || 'change with no description'} (${Object.keys(d.s).length} widget${Object.keys(d.s).length == 1 ? '' : 's'} changed)`;
     }
 
     for(let i=this.lastRenderedIndex+1; i<this.protocol.length; ++i) {
       const div = document.createElement('div');
       const affectedWidgets = Object.keys(this.protocol[i].delta.s);
-      div.innerText = `${i+1} - ${this.protocol[i].delta.c || 'unknown'} (${affectedWidgets.length} widget${affectedWidgets.length == 1 ? '' : 's'} changed)`;
-      div.onclick = _=>this.onEntryClick(i, div);
+      div.innerText = `${i+1} - ${this.protocol[i].delta.c || 'change with no description'} (${affectedWidgets.length} widget${affectedWidgets.length == 1 ? '' : 's'} changed)`;
+      focusable(div, _=>this.onEntryClick(i, div));
       div.className = 'undoEntry';
       this.moduleDOM.insertBefore(div, $('.undoEntry', this.moduleDOM));
       this.latestEntryDOM = div;

--- a/client/js/editor/sidebar/undo.js
+++ b/client/js/editor/sidebar/undo.js
@@ -2,13 +2,13 @@ class UndoModule extends SidebarModule {
   constructor() {
     super('undo', 'History', 'Undo changes from editing or playing.');
     this.lastRenderedIndex = -2;
-    this.lastRenderedEntry = null;
+    this.renderedEntries = [];
     this.latestEntryDOM = null;
   }
 
   onClose() {
     this.lastRenderedIndex = -2;
-    this.lastRenderedEntry = null;
+    this.renderedEntries = [];
     this.latestEntryDOM = null;
   }
 
@@ -24,28 +24,31 @@ class UndoModule extends SidebarModule {
     for(let i=this.activeIndex+1; i<=index; ++i)
       sendRawDelta(this.protocol[i].delta);
     this.setActiveIndex(index, dom);
-    this.inUndoMode = false;
 
     // the rows above the clicked one stay in the DOM and this.protocol keeps their
     // entries, so they can be clicked to return to that state - until the next
     // change arrives and renderModule drops the now unreachable timeline
     setUndoProtocol(this.protocol.slice(0, index+1));
+    undoProtocolChanged();
+    this.inUndoMode = false;
 
     setSelection([...selectedWidgets].filter(w=>widgets.has(w.id)));
   }
 
-  onUndoProtocolChanged() {
-    if(this.moduleDOM)
+  onUndoProtocolChangedWhileActive() {
+    if(!this.inUndoMode)
       this.renderModule(this.moduleDOM);
   }
 
-  removeEntries() {
-    for(const entry of $a('.undoEntry', this.moduleDOM))
-      entry.remove();
-    this.lastRenderedIndex = -1;
-    this.lastRenderedEntry = null;
-    this.latestEntryDOM = null;
-    this.activeDOM = null;
+  // the newest row is the first one in the DOM, so the row of the last rendered entry
+  // is what a shortened protocol drops
+  removeLatestEntry() {
+    if(this.activeDOM === this.latestEntryDOM)
+      this.activeDOM = null;
+    this.latestEntryDOM.remove();
+    this.renderedEntries.pop();
+    this.lastRenderedIndex = this.renderedEntries.length - 1;
+    this.latestEntryDOM = $('.undoEntry', this.moduleDOM);
   }
 
   renderModule(target) {
@@ -58,11 +61,16 @@ class UndoModule extends SidebarModule {
 
     this.protocol = [...getUndoProtocol()];
 
-    // returning to an earlier state cuts the protocol short, so the rows rendered so
-    // far can describe entries that are gone by now - start over instead of writing
-    // to a row that has no entry behind it anymore
-    if(this.lastRenderedIndex >= 0 && this.protocol[this.lastRenderedIndex] !== this.lastRenderedEntry)
-      this.removeEntries();
+    // returning to an earlier state cuts the protocol short, so the rows rendered so far
+    // can describe entries that are gone by now - drop those rows instead of writing to a
+    // row that has no entry behind it anymore
+    while(this.lastRenderedIndex >= 0 && this.protocol[this.lastRenderedIndex] !== this.renderedEntries[this.lastRenderedIndex])
+      this.removeLatestEntry();
+
+    // the row of the entry that was dropped can have been the active one, in which case the
+    // room is now in the state the row below it describes
+    if(!this.activeDOM && this.latestEntryDOM)
+      this.setActiveIndex(this.lastRenderedIndex, this.latestEntryDOM);
 
     if(this.latestEntryDOM) {
       const d = this.protocol[this.lastRenderedIndex].delta;
@@ -77,13 +85,13 @@ class UndoModule extends SidebarModule {
       div.className = 'undoEntry';
       this.moduleDOM.insertBefore(div, $('.undoEntry', this.moduleDOM));
       this.latestEntryDOM = div;
+      this.renderedEntries[i] = this.protocol[i];
 
       if(i == this.protocol.length-1)
         this.setActiveIndex(i, div);
     }
 
     this.lastRenderedIndex = this.protocol.length - 1;
-    this.lastRenderedEntry = this.protocol[this.lastRenderedIndex] || null;
   }
 
   setActiveIndex(index, dom) {

--- a/client/js/editor/sidebar/undo.js
+++ b/client/js/editor/sidebar/undo.js
@@ -18,6 +18,20 @@ class UndoModule extends SidebarModule {
       this.renderModule(this.moduleDOM);
   }
 
+  // changes made while edit mode is closed never reach the modules, so the list is out of date
+  // by the time it is on screen again
+  onEditorOpen() {
+    if(this.moduleDOM)
+      this.renderModule(this.moduleDOM);
+  }
+
+  // a complete room state - loading another game, or a reconnect - appends an entry to the
+  // protocol the same way a change does
+  onStateReceivedWhileActive(state) {
+    if(!this.inUndoMode)
+      this.renderModule(this.moduleDOM);
+  }
+
   onUndoProtocolChangedWhileActive() {
     if(!this.inUndoMode)
       this.renderModule(this.moduleDOM);

--- a/client/js/editor/sidebar/undo.js
+++ b/client/js/editor/sidebar/undo.js
@@ -1,15 +1,16 @@
+// Set when this module is constructed so the toolbar's undo button can take its step back through
+// the list this module shows instead of cutting the protocol short behind its back.
+let undoModule = null;
+
 class UndoModule extends SidebarModule {
   constructor() {
     super('undo', 'History', 'See and return to earlier states of this room.');
-    this.lastRenderedIndex = -2;
-    this.renderedEntries = [];
-    this.latestEntryDOM = null;
+    undoModule = this;
+    this.clearRows();
   }
 
   onClose() {
-    this.lastRenderedIndex = -2;
-    this.renderedEntries = [];
-    this.latestEntryDOM = null;
+    this.clearRows();
   }
 
   onDeltaReceivedWhileActive(delta) {
@@ -17,88 +18,95 @@ class UndoModule extends SidebarModule {
       this.renderModule(this.moduleDOM);
   }
 
-  onEntryClick(index, dom) {
+  onUndoProtocolChangedWhileActive() {
+    if(!this.inUndoMode)
+      this.renderModule(this.moduleDOM);
+  }
+
+  // one per row of the list, oldest first: the protocol entry the row describes, the delta that
+  // entry held when the row was rendered - a change can merge into an entry in place, which leaves
+  // the entry itself the same object - and the row.
+  clearRows() {
+    this.rows = [];
+    this.activeIndex = -1;
+    this.hintRendered = false;
+  }
+
+  // the entries between the active row and the clicked one are undone or replayed, and the
+  // protocol is cut short at the clicked entry so a new change continues from there. The rows
+  // above it stay in the list, so their states can be returned to until a new change lands where
+  // they were and makes them unreachable.
+  onEntryClick(index) {
     this.inUndoMode = true;
     for(let i=this.activeIndex; i>index; --i)
-      sendRawDelta({s:this.protocol[i].undoDelta});
+      sendRawDelta({s:this.rows[i].entry.undoDelta});
     for(let i=this.activeIndex+1; i<=index; ++i)
-      sendRawDelta(this.protocol[i].delta);
-    this.setActiveIndex(index, dom);
+      sendRawDelta(this.rows[i].entry.delta);
+    this.setActiveIndex(index);
 
-    // the rows above the clicked one stay in the DOM and this.protocol keeps their
-    // entries, so they can be clicked to return to that state - until the next
-    // change arrives and renderModule drops the now unreachable timeline
-    setUndoProtocol(this.protocol.slice(0, index+1));
+    setUndoProtocol(this.rows.slice(0, index+1).map(row=>row.entry));
     undoProtocolChanged();
     this.inUndoMode = false;
 
     setSelection([...selectedWidgets].filter(w=>widgets.has(w.id)));
   }
 
-  onUndoProtocolChangedWhileActive() {
-    if(!this.inUndoMode)
-      this.renderModule(this.moduleDOM);
-  }
-
-  // the newest row is the first one in the DOM, so the row of the last rendered entry
-  // is what a shortened protocol drops
-  removeLatestEntry() {
-    if(this.activeDOM === this.latestEntryDOM)
-      this.activeDOM = null;
-    this.latestEntryDOM.remove();
-    this.renderedEntries.pop();
-    this.lastRenderedIndex = this.renderedEntries.length - 1;
-    this.latestEntryDOM = $('.undoEntry', this.moduleDOM);
+  removeLatestRow() {
+    this.rows.pop().dom.remove();
   }
 
   renderModule(target) {
-    if(this.lastRenderedIndex == -2) {
+    if(!this.hintRendered) {
       this.addHeader('History');
-      const hintDiv = hint('This lists all the changes that were done to this room until you loaded the page.<br><br>You can click on any row to return the room to the state after the described action.<br><br>You can afterwards return to a future state by clicking that one but as soon as you make new changes after returning to a state in the past, you can no longer restore anything from the now parallel timeline.<br><br>The Undo button in the toolbar works differently: it removes the change from this list for good, together with everything that happened after it, so those rows disappear and their states cannot be returned to.');
+      const hintDiv = hint('This lists all the changes that were done to this room until you loaded the page.<br><br>You can click on any row to return the room to the state after the described action.<br><br>You can afterwards return to a future state by clicking that one but as soon as you make new changes after returning to a state in the past, you can no longer restore anything from the now parallel timeline.<br><br>The Undo button in the toolbar takes the same step as clicking the row below the active one, so what it undoes can be restored here as well.');
       this.moduleDOM.append(hintDiv);
-      this.lastRenderedIndex = -1;
+      this.hintRendered = true;
     }
 
-    this.protocol = [...getUndoProtocol()];
+    const protocol = getUndoProtocol();
 
-    // returning to an earlier state cuts the protocol short, so the rows rendered so far
-    // can describe entries that are gone by now - drop those rows instead of writing to a
-    // row that has no entry behind it anymore
-    while(this.lastRenderedIndex >= 0 && this.protocol[this.lastRenderedIndex] !== this.renderedEntries[this.lastRenderedIndex])
-      this.removeLatestEntry();
+    // how much of the list the protocol still confirms - it only ever changes at its end: a new
+    // entry, a return to an earlier state cutting it short, or a change merging into the last entry
+    let confirmed = Math.min(protocol.length, this.rows.length);
+    while(confirmed && (this.rows[confirmed-1].entry !== protocol[confirmed-1] || this.rows[confirmed-1].delta !== protocol[confirmed-1].delta.s))
+      --confirmed;
 
-    // the row of the entry that was dropped can have been the active one, in which case the
-    // room is now in the state the row below it describes
-    if(!this.activeDOM && this.latestEntryDOM)
-      this.setActiveIndex(this.lastRenderedIndex, this.latestEntryDOM);
+    // the rows past the end of the protocol describe the states an undo stepped over: they stay
+    // clickable so the step can be taken back, and go once a new change lands where they were
+    if(confirmed < protocol.length)
+      while(this.rows.length > confirmed)
+        this.removeLatestRow();
 
-    if(this.latestEntryDOM) {
-      const d = this.protocol[this.lastRenderedIndex].delta;
-      this.latestEntryDOM.innerText = `${this.lastRenderedIndex+1} - ${d.c || 'change with no description'} (${Object.keys(d.s).length} widget${Object.keys(d.s).length == 1 ? '' : 's'} changed)`;
+    for(let i=this.rows.length; i<protocol.length; ++i) {
+      const dom = document.createElement('div');
+      const affectedWidgets = Object.keys(protocol[i].delta.s);
+      dom.innerText = `${i+1} - ${protocol[i].delta.c || 'change with no description'} (${affectedWidgets.length} widget${affectedWidgets.length == 1 ? '' : 's'} changed)`;
+      dom.className = 'undoEntry';
+      focusable(dom, _=>this.onEntryClick(i));
+      this.moduleDOM.insertBefore(dom, $('.undoEntry', this.moduleDOM));
+      this.rows[i] = { entry: protocol[i], delta: protocol[i].delta.s, dom };
     }
 
-    for(let i=this.lastRenderedIndex+1; i<this.protocol.length; ++i) {
-      const div = document.createElement('div');
-      const affectedWidgets = Object.keys(this.protocol[i].delta.s);
-      div.innerText = `${i+1} - ${this.protocol[i].delta.c || 'change with no description'} (${affectedWidgets.length} widget${affectedWidgets.length == 1 ? '' : 's'} changed)`;
-      focusable(div, _=>this.onEntryClick(i, div));
-      div.className = 'undoEntry';
-      this.moduleDOM.insertBefore(div, $('.undoEntry', this.moduleDOM));
-      this.latestEntryDOM = div;
-      this.renderedEntries[i] = this.protocol[i];
-
-      if(i == this.protocol.length-1)
-        this.setActiveIndex(i, div);
-    }
-
-    this.lastRenderedIndex = this.protocol.length - 1;
+    // the room is in the state the last entry of the protocol describes, whatever is still listed
+    // above it
+    this.setActiveIndex(protocol.length-1);
   }
 
-  setActiveIndex(index, dom) {
-    if(this.activeDOM)
-      this.activeDOM.classList.remove('active');
-    this.activeDOM = dom;
-    this.activeDOM.classList.add('active');
+  setActiveIndex(index) {
+    if(this.rows[this.activeIndex])
+      this.rows[this.activeIndex].dom.classList.remove('active');
     this.activeIndex = index;
+    if(this.rows[index])
+      this.rows[index].dom.classList.add('active');
+  }
+
+  // the toolbar's undo button takes the same step as a click on the row below the active one, so
+  // that what it undoes stays reachable - as long as the list is showing the protocol it shortens
+  undoOneStep() {
+    if(!this.moduleDOM || this.activeIndex < 1 || this.activeIndex != getUndoProtocol().length-1)
+      return false;
+
+    this.onEntryClick(this.activeIndex-1);
+    return true;
   }
 }

--- a/client/js/editor/sidebarModule.js
+++ b/client/js/editor/sidebarModule.js
@@ -174,6 +174,9 @@ class SidebarModule {
   onStateReceivedWhileActive(state) {
   }
 
+  onUndoProtocolChanged() {
+  }
+
   openInTarget(target) {
     // the content width is only for the panel that opened itself - once a module is opened or closed
     // by hand, the panel goes back to the width the user has (or hasn't) set (see renderSidebar)

--- a/client/js/editor/sidebarModule.js
+++ b/client/js/editor/sidebarModule.js
@@ -175,6 +175,11 @@ class SidebarModule {
   }
 
   onUndoProtocolChanged() {
+    if(this.moduleDOM)
+      this.onUndoProtocolChangedWhileActive();
+  }
+
+  onUndoProtocolChangedWhileActive() {
   }
 
   openInTarget(target) {

--- a/client/js/editor/toolbar/undo.js
+++ b/client/js/editor/toolbar/undo.js
@@ -4,6 +4,12 @@ class UndoButton extends ToolbarButton {
   }
 
   click() {
+    // the History module steps back through the list it shows, which keeps what was undone
+    // reachable in it - with the module closed there is no list to keep it in, so the protocol
+    // is simply cut short
+    if(undoModule && undoModule.undoOneStep())
+      return;
+
     const protocol = [...getUndoProtocol()];
 
     if(protocol.length > 1) {

--- a/client/js/editor/toolbar/undo.js
+++ b/client/js/editor/toolbar/undo.js
@@ -13,8 +13,17 @@ class UndoButton extends ToolbarButton {
     const protocol = [...getUndoProtocol()];
 
     if(protocol.length > 1) {
+      // between the undo delta and the shortened protocol the entry being undone is still the
+      // last one of the protocol, so a render in between would give that undo a row of its own
+      if(undoModule)
+        undoModule.inUndoMode = true;
+
       sendRawDelta({s:protocol[protocol.length-1].undoDelta});
       setUndoProtocol(protocol.slice(0, protocol.length-1));
+
+      if(undoModule)
+        undoModule.inUndoMode = false;
+
       setSelection([...selectedWidgets].filter(w=>widgets.has(w.id)));
       undoProtocolChanged();
     }

--- a/client/js/editor/toolbar/undo.js
+++ b/client/js/editor/toolbar/undo.js
@@ -13,4 +13,22 @@ class UndoButton extends ToolbarButton {
       undoProtocolChanged();
     }
   }
+
+  onDeltaReceived(delta) {
+    this.updateEnabled();
+  }
+
+  onEditorOpen() {
+    this.updateEnabled();
+  }
+
+  onUndoProtocolChanged() {
+    this.updateEnabled();
+  }
+
+  // the first protocol entry is the room as it was loaded, so there is nothing left to
+  // undo while it is the only one - clicking would be a silent no-op
+  isDisabled() {
+    return getUndoProtocol().length <= 1;
+  }
 }

--- a/client/js/editor/toolbar/undo.js
+++ b/client/js/editor/toolbar/undo.js
@@ -10,6 +10,7 @@ class UndoButton extends ToolbarButton {
       sendRawDelta({s:protocol[protocol.length-1].undoDelta});
       setUndoProtocol(protocol.slice(0, protocol.length-1));
       setSelection([...selectedWidgets].filter(w=>widgets.has(w.id)));
+      undoProtocolChanged();
     }
   }
 }

--- a/client/js/editor/toolbarButton.js
+++ b/client/js/editor/toolbarButton.js
@@ -16,6 +16,9 @@ class ToolbarButton {
     batchEnd();
   }
 
+  onDeltaReceived(delta) {
+  }
+
   onEditorClose() {
   }
 
@@ -34,6 +37,20 @@ class ToolbarButton {
     this.setMinimumSelection(this.minimumSelection);
   }
 
+  onUndoProtocolChanged() {
+  }
+
+  // a button is unavailable while doing what it does is impossible - by default that means
+  // too little selected, buttons that depend on something else override this
+  isDisabled() {
+    return selectedWidgets.length < this.minimumSelection;
+  }
+
+  updateEnabled() {
+    if(this.domElement && $('button', this.domElement))
+      $('button', this.domElement).disabled = this.isDisabled();
+  }
+
   render(target) {
     this.domElement = div(target, 'editorToolbarButton', `
       <button icon=${this.icon}><span>${this.tooltip}${this.hotkey ? '<br><br>Hotkey: '+this.hotkey : ''}</span>
@@ -45,8 +62,7 @@ class ToolbarButton {
 
   setMinimumSelection(count) {
     this.minimumSelection = count;
-    if(this.domElement && $('button', this.domElement))
-      $('button', this.domElement).disabled = selectedWidgets.length < count;
+    this.updateEnabled();
   }
 }
 

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -150,6 +150,7 @@ test('Undoing from the toolbar keeps the History module in sync', async t => {
   await setName(t);
 
   const historyRows = Selector('.undoEntry');
+  const undoButton = Selector('#editorToolbar [icon=undo]');
   const widgetCount = ClientFunction(() => widgets.size);
   await t
     .click('#editButton')
@@ -179,6 +180,12 @@ test('Undoing from the toolbar keeps the History module in sync', async t => {
     .click('#editorToolbar [icon=undo]')
     .expect(historyRows.count).eql(rowsBefore)
     .expect(widgetCount()).eql(1);
+
+  // the first entry is the room as it was loaded, so the button turns off once it is the
+  // only one left and clicking it would do nothing
+  for(let rows = await historyRows.count; rows > 1; --rows)
+    await t.expect(undoButton.hasAttribute('disabled')).notOk().click(undoButton);
+  await t.expect(undoButton.hasAttribute('disabled')).ok();
   await setEditorState(null);
 });
 

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -138,8 +138,8 @@ test('A module is closed again through its sidebar button', async t => {
 
 // The toolbar's undo button cuts the undo protocol short behind the History module's back, so the
 // rows the module has rendered describe entries that are no longer in the protocol. It has to drop
-// them instead of writing to a row that has no entry behind it - the second undo in a row lands on
-// exactly that row.
+// them instead of writing to a row that has no entry behind it - the next change of any kind, and
+// a second undo in a row, both land on exactly that row.
 test('Undoing from the toolbar keeps the History module in sync', async t => {
   await t.resizeWindow(1280, 800);
   await setRoomState({
@@ -168,9 +168,67 @@ test('Undoing from the toolbar keeps the History module in sync', async t => {
     .click('#editorToolbar [icon=undo]')
     .expect(historyRows.count).eql(rowsBefore+1)
     .expect(widgetCount()).eql(4)
+    // the sequence the crash reports arrived from: one undo, and then a change of any kind
+    .click('#editorToolbar > div > [icon=add]')
+    .click('#add-holder')
+    .expect(historyRows.count).eql(rowsBefore+2)
+    .expect(widgetCount()).eql(5)
+    .click('#editorToolbar [icon=undo]')
+    .expect(historyRows.count).eql(rowsBefore+1)
+    .expect(widgetCount()).eql(4)
     .click('#editorToolbar [icon=undo]')
     .expect(historyRows.count).eql(rowsBefore)
     .expect(widgetCount()).eql(1);
+  await setEditorState(null);
+});
+
+// A row click cuts the protocol short as well, but keeps the rows above it in the DOM so the user
+// can return to that future state - so those rows have to survive until the next change makes them
+// unreachable, and go when it arrives.
+test('Clicking a History row returns to that state and keeps the newer rows until a new change', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    widget: { id: 'widget', type: 'basic', x: 200, y: 200 }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState({ modules: { History: 'editorModuleTopLeft' } });
+  await setName(t);
+
+  const historyRows = Selector('.undoEntry');
+  const widgetCount = ClientFunction(() => widgets.size);
+  await t
+    .click('#editButton')
+    .expect(Selector('#editorModuleTopLeft.undo').exists).ok();
+
+  const rowsBefore = await historyRows.count;
+  await t
+    .click('#editorToolbar > div > [icon=add]')
+    .click('#add-line')
+    .click('#editorToolbar > div > [icon=add]')
+    .click('#add-holder')
+    .expect(historyRows.count).eql(rowsBefore+2)
+    .expect(widgetCount()).eql(5)
+    // the newest row is the first one in the panel, so the second one is the line
+    .click(historyRows.nth(1))
+    .expect(widgetCount()).eql(4)
+    .expect(historyRows.count).eql(rowsBefore+2)
+    .expect(historyRows.nth(1).hasClass('active')).ok()
+    // the row of the holder is still there and returns the room to that future state
+    .click(historyRows.nth(0))
+    .expect(widgetCount()).eql(5)
+    .expect(historyRows.nth(0).hasClass('active')).ok()
+    // going back once more and then adding a widget makes that state unreachable, so its row is
+    // replaced by the one of the new change
+    .click(historyRows.nth(1))
+    .expect(widgetCount()).eql(4)
+    .click('#editorToolbar > div > [icon=add]')
+    .click('#add-holder')
+    .expect(historyRows.count).eql(rowsBefore+2)
+    .expect(widgetCount()).eql(5)
+    .expect(historyRows.nth(0).hasClass('active')).ok()
+    .click('#editorToolbar [icon=undo]')
+    .expect(historyRows.count).eql(rowsBefore+1)
+    .expect(widgetCount()).eql(4);
   await setEditorState(null);
 });
 

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -256,6 +256,61 @@ test('Clicking a History row returns to that state and keeps the newer rows unti
   await setEditorState(null);
 });
 
+// The panel only hears about a change while edit mode is open, and a complete room state does
+// not reach it at all - both leave the list describing an older protocol than the room is in. The
+// undo button steps back through that list, so it has to be caught up before it is used again.
+test('The History module catches up on changes it did not see', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    widget: { id: 'widget', type: 'basic', x: 200, y: 200 }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState({ modules: { History: 'editorModuleTopLeft' } });
+  await setName(t);
+
+  const historyRows = Selector('.undoEntry');
+  const undoButton = Selector('#editorToolbar [icon=undo]');
+  const widgetX = ClientFunction(() => widgets.get('widget').get('x'));
+  const moveWidget = ClientFunction(() => widgets.get('widget').set('x', 400));
+  await t
+    .click('#editButton')
+    .expect(Selector('#editorModuleTopLeft.undo').exists).ok();
+
+  const rowsBefore = await historyRows.count;
+  await t
+    .click('#editorToolbar > div > [icon=add]')
+    .click('#add-holder')
+    .expect(historyRows.count).eql(rowsBefore+1)
+    // leave edit mode, change something while playing and come back: the change is listed and is
+    // the state the room is in, so undoing it takes the widget back instead of adding a row of
+    // its own for the undo
+    .click('#editorToolbar [icon=close]')
+    .expect(Selector('body').hasClass('edit')).notOk();
+  await moveWidget();
+  await t
+    .click('#editButton')
+    .expect(historyRows.count).eql(rowsBefore+2)
+    .expect(historyRows.nth(0).hasClass('active')).ok()
+    .click(undoButton)
+    .expect(historyRows.count).eql(rowsBefore+2)
+    .expect(historyRows.nth(1).hasClass('active')).ok()
+    .expect(widgetX()).eql(200);
+
+  // a complete room state is an entry of the protocol as well, so the list takes it the same way -
+  // it replaces the row of the state the undo above stepped over, which it just made unreachable
+  await setRoomState({
+    other: { id: 'other', type: 'basic', x: 100, y: 100 }
+  });
+  await t
+    .expect(historyRows.count).eql(rowsBefore+2)
+    .expect(historyRows.nth(0).hasClass('active')).ok()
+    .expect(historyRows.nth(0).innerText).contains('complete room state')
+    .click(undoButton)
+    .expect(historyRows.count).eql(rowsBefore+2)
+    .expect(historyRows.nth(1).hasClass('active')).ok();
+  await setEditorState(null);
+});
+
 test('Pan in edit mode while holding Space', async t => {
   await t.resizeWindow(1280, 800);
   await setRoomState({

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -137,9 +137,10 @@ test('A module is closed again through its sidebar button', async t => {
 });
 
 // The toolbar's undo button cuts the undo protocol short behind the History module's back, so the
-// rows the module has rendered describe entries that are no longer in the protocol. It has to drop
-// them instead of writing to a row that has no entry behind it - the next change of any kind, and
-// a second undo in a row, both land on exactly that row.
+// rows the module has rendered describe entries that are no longer in the protocol. They stay in
+// the list as the states the undo stepped over, which is what makes a toolbar undo redoable, and
+// the module must not write to a row that has no entry behind it - the next change of any kind,
+// and a second undo in a row, both land on exactly that row.
 test('Undoing from the toolbar keeps the History module in sync', async t => {
   await t.resizeWindow(1280, 800);
   await setRoomState({
@@ -152,6 +153,7 @@ test('Undoing from the toolbar keeps the History module in sync', async t => {
   const historyRows = Selector('.undoEntry');
   const undoButton = Selector('#editorToolbar [icon=undo]');
   const widgetCount = ClientFunction(() => widgets.size);
+  const protocolLength = ClientFunction(() => getUndoProtocol().length);
   await t
     .click('#editButton')
     .expect(Selector('#editorModuleTopLeft.undo').exists).ok();
@@ -165,27 +167,41 @@ test('Undoing from the toolbar keeps the History module in sync', async t => {
     .click('#add-holder')
     .expect(historyRows.count).eql(rowsBefore+2)
     .expect(widgetCount()).eql(5) // the widget of the room state, the line with its two stops, the holder
-    // each undo drops the row of the entry it removes instead of adding one for itself
-    .click('#editorToolbar [icon=undo]')
-    .expect(historyRows.count).eql(rowsBefore+1)
+    // an undo steps back through the list instead of dropping what it undid: the row stays and the
+    // one below it becomes the active one
+    .click(undoButton)
+    .expect(historyRows.count).eql(rowsBefore+2)
+    .expect(historyRows.nth(1).hasClass('active')).ok()
     .expect(widgetCount()).eql(4)
-    // the sequence the crash reports arrived from: one undo, and then a change of any kind
+    // so clicking the row again takes the undo back
+    .click(historyRows.nth(0))
+    .expect(historyRows.nth(0).hasClass('active')).ok()
+    .expect(widgetCount()).eql(5)
+    // the sequence the crash reports arrived from: one undo, and then a change of any kind - which
+    // is what makes the state the undo stepped over unreachable, so its row is replaced
+    .click(undoButton)
     .click('#editorToolbar > div > [icon=add]')
     .click('#add-holder')
     .expect(historyRows.count).eql(rowsBefore+2)
+    .expect(historyRows.nth(0).hasClass('active')).ok()
     .expect(widgetCount()).eql(5)
-    .click('#editorToolbar [icon=undo]')
-    .expect(historyRows.count).eql(rowsBefore+1)
-    .expect(widgetCount()).eql(4)
-    .click('#editorToolbar [icon=undo]')
-    .expect(historyRows.count).eql(rowsBefore)
+    // and the other one: two undos in a row
+    .click(undoButton)
+    .click(undoButton)
+    .expect(historyRows.count).eql(rowsBefore+2)
+    .expect(historyRows.nth(2).hasClass('active')).ok()
     .expect(widgetCount()).eql(1);
 
   // the first entry is the room as it was loaded, so the button turns off once it is the
   // only one left and clicking it would do nothing
-  for(let rows = await historyRows.count; rows > 1; --rows)
+  for(let entries = await protocolLength(); entries > 1; --entries)
     await t.expect(undoButton.hasAttribute('disabled')).notOk().click(undoButton);
-  await t.expect(undoButton.hasAttribute('disabled')).ok();
+  await t
+    .expect(undoButton.hasAttribute('disabled')).ok()
+    // everything the button undid is still listed, so the newest row brings all of it back
+    .click(historyRows.nth(0))
+    .expect(widgetCount()).eql(5)
+    .expect(undoButton.hasAttribute('disabled')).notOk();
   await setEditorState(null);
 });
 
@@ -234,7 +250,8 @@ test('Clicking a History row returns to that state and keeps the newer rows unti
     .expect(widgetCount()).eql(5)
     .expect(historyRows.nth(0).hasClass('active')).ok()
     .click('#editorToolbar [icon=undo]')
-    .expect(historyRows.count).eql(rowsBefore+1)
+    .expect(historyRows.count).eql(rowsBefore+2)
+    .expect(historyRows.nth(1).hasClass('active')).ok()
     .expect(widgetCount()).eql(4);
   await setEditorState(null);
 });

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -136,6 +136,44 @@ test('A module is closed again through its sidebar button', async t => {
   await setEditorState(null);
 });
 
+// The toolbar's undo button cuts the undo protocol short behind the History module's back, so the
+// rows the module has rendered describe entries that are no longer in the protocol. It has to drop
+// them instead of writing to a row that has no entry behind it - the second undo in a row lands on
+// exactly that row.
+test('Undoing from the toolbar keeps the History module in sync', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    widget: { id: 'widget', type: 'basic', x: 200, y: 200 }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState({ modules: { History: 'editorModuleTopLeft' } });
+  await setName(t);
+
+  const historyRows = Selector('.undoEntry');
+  const widgetCount = ClientFunction(() => widgets.size);
+  await t
+    .click('#editButton')
+    .expect(Selector('#editorModuleTopLeft.undo').exists).ok();
+
+  // the room states the client loaded with - one per state message it has seen so far
+  const rowsBefore = await historyRows.count;
+  await t
+    .click('#editorToolbar > div > [icon=add]')
+    .click('#add-line')
+    .click('#editorToolbar > div > [icon=add]')
+    .click('#add-holder')
+    .expect(historyRows.count).eql(rowsBefore+2)
+    .expect(widgetCount()).eql(5) // the widget of the room state, the line with its two stops, the holder
+    // each undo drops the row of the entry it removes instead of adding one for itself
+    .click('#editorToolbar [icon=undo]')
+    .expect(historyRows.count).eql(rowsBefore+1)
+    .expect(widgetCount()).eql(4)
+    .click('#editorToolbar [icon=undo]')
+    .expect(historyRows.count).eql(rowsBefore)
+    .expect(widgetCount()).eql(1);
+  await setEditorState(null);
+});
+
 test('Pan in edit mode while holding Space', async t => {
   await t.resizeWindow(1280, 800);
   await setRoomState({


### PR DESCRIPTION
## What this changes

Pressing the editor toolbar's **Undo** button (or its `z` hotkey) twice in a row while the **History** sidebar module is open threw a client error and stopped undoing. This makes the History module notice that the undo protocol was replaced and re-render its rows, so repeated undos keep working — and, since the panel is the only redo this app has, a toolbar undo now takes the same step as clicking the row below the active one, so it can be taken back by clicking that row again.

## The bug

`UndoButton.click()` (`client/js/editor/toolbar/undo.js`) does two things: it sends the undo delta, and it then replaces the undo protocol with a shortened copy.

The History module (`client/js/editor/sidebar/undo.js`) renders its rows incrementally and remembers `lastRenderedIndex`, the index of the newest row it has drawn. Sending the undo delta re-enters the module through `onDeltaReceivedWhileActive()` **before** the protocol is shortened, so the module renders one extra row for that delta and bumps `lastRenderedIndex` — and the truncation right afterwards leaves that index pointing past the end of the protocol.

Its own `resetOnNextDelta` flag covered exactly this for a click on one of its rows, but the toolbar button never set it. So:

* **first undo** — the panel gains a phantom `… - unknown` row and keeps the row of the entry that was just undone;
* **second undo** — `renderModule()` reaches `this.protocol[this.lastRenderedIndex].delta` for an index that no longer exists and throws, so nothing is undone at all:

```
can't access property "delta", this.protocol[this.lastRenderedIndex] is undefined
  renderModule
  onDeltaReceivedWhileActive
  onDeltaReceived
  editorReceiveDelta
  receiveDelta
  sendRawDelta
  click            (the toolbar's undo button)
  onClick
  onKeyDown
```

## Reproduction

Reproduced on a local checkout of `main` (`044a8bb4`) with Chromium, and confirmed fixed on this branch:

1. Open any room and put something in it, so the room has a few undo-protocol entries.
2. Enter edit mode and open the **History** module from the sidebar.
3. Click the toolbar's **Undo** button. → a `N - unknown (… changed)` row appears on top of the list instead of the undone row disappearing.
4. Click **Undo** again. → `TypeError: Cannot read properties of undefined (reading 'delta')` in the console (Firefox words it as `can't access property "delta", …`), and the room does not change. Every further undo throws the same way.

The second crash report arrived from the shorter variant: a *single* undo, and then a change of any kind - moving a widget, a routine running, another player acting - lands on that same phantom row. After the first throw the panel freezes and keeps its rows while the protocol grows behind it.

With the History module closed, the same clicks work — which is why this only hits people who keep that panel open.

## The fix

* The module keeps one record per row - the protocol entry it describes, the delta that entry held when the row was rendered, and the row itself - and works out on every render how much of its list the protocol still confirms. The protocol only ever changes at its end, so that walk costs one comparison in the normal case. Rows past the end of the protocol are the states an undo stepped over: they stay in the list and stay clickable. Rows the protocol *contradicts* are dropped from the newest one down, which is what removes the parallel timeline once a new change lands where those states were. The `resetOnNextDelta` flag is gone; so is rebuilding the whole list, which grows with every delta since page load.
* The rendered delta is part of the comparison because a change can merge into the last protocol entry *in place* (`addDeltaEntryToUndoProtocol()` merges deltas that share a cause), leaving the entry the same object while the state it describes is no longer the one the rows above it were recorded against. Without that check those rows would survive a change they cannot be replayed onto.
* Replacing the protocol is announced through a new `onUndoProtocolChanged()` sidebar-module hook from both places that replace it, so the panel re-renders immediately rather than staying stale until the next change arrives. The History module skips the render for its own steps, and the hook follows the guarded `onX`/`onXWhileActive` dispatcher convention of the other broadcasts in `SidebarModule`.
* `UndoButton.click()` takes its step through the module (`undoModule.undoOneStep()`, the singleton pattern `deckEditorToolbarButton` already uses) rather than shortening the protocol behind its back, so the button and a click on the row below the active one are literally the same operation. With the History module closed there is no list to keep the step in, so the button falls back to shortening the protocol the way it always did; the same happens if the panel is not showing the protocol it is about to shorten.

* The panel is caught up on the changes it cannot hear about: `receiveDelta()` only notifies the editor while edit mode is open, and a complete room state (loading another game, a reconnect) was never delivered to this module at all, so its list could describe an older protocol than the room was in - and the undo button, which steps back through that list, then fell back to shortening the protocol and listed its own undo delta as a change. It now re-renders on `onEditorOpen()` and on `onStateReceivedWhileActive()`, and the fallback in the button runs behind the module's own guard so it can never render a protocol it is halfway through shortening.

Clicking a row in the History panel is unchanged: the rows above the clicked one stay in the list and remain clickable to return to that state, until the next change makes that timeline unreachable.

## The panel it makes load-bearing

Once the History list is the only honest account of what Undo did, its existing readability problems start to matter, so the same branch fixes them:

* The rows that are still clickable - the states ahead of the one the room was returned to - were drawn in `--textDimColor1`, the colour the editor uses for borders and dashes, measuring 1.61:1 on the panel background. They use `--textHelpColor` now (5.74:1), while the active row and everything below it stay in the normal text colour.
* Rows get a hover band, a comfortable height, a hanging indent so a wrapped row no longer runs into the next one, and a keyboard: `tabIndex`, `role="button"` and Enter/Space through the editor's `focusable()` helper. They are the only way to move forward again, and they were mouse-only.
* The hint now says that the toolbar Undo takes the same step as clicking the row below the active one, so what it undoes can be restored from the panel. A row whose delta carries no description reads `change with no description` rather than `unknown`.
* The toolbar's **Undo** button was drawn fully enabled while the protocol held nothing but the state the room was loaded with, where clicking it does nothing at all. `undoProtocolChanged()` now reaches the toolbar buttons as well as the sidebar modules - the way every other broadcast in `layout.js` does - and the button greys itself out, the same feedback the Delete button next to it already gives. `ToolbarButton` grew an `isDisabled()` predicate for that, so the selection-driven default and the undo button's own rule go through one place.

## Making a toolbar undo redoable

Asked in the project's Discord, since it is a behaviour question rather than part of the crash:

> Should pressing the toolbar's Undo button stay final, or should it be redoable from the History panel the way clicking a row is?

@ArnoldSmith86 answered:

> Make the toolbar undo redoable, like clicking the row below the active…

That is what the button does now. Before, it took the entry out of the protocol and the step was gone for good — on `main` the phantom row the bug left behind made it *look* reversible, but clicking that row replayed an undo delta as if it were a change and the panel and the room disagreed from there on. The rows it undoes now stay in the list, dimmed and clickable, exactly like the ones a row click leaves behind, and a new change replaces them.

## Test plan

- [x] TestCafe regression test `Undoing from the toolbar keeps the History module in sync` in `tests/testcafe/editor.js` - adds two widgets with the History module open, then walks both crashing sequences: an undo followed by a change of any kind, and two undos in a row, checking after each step that the rows track the protocol. It also takes a toolbar undo back by clicking its row, watches a new change replace the row an undo stepped over, and undoes to the floor and back up again. It fails on `main` and passes here.
- [x] TestCafe regression test `Clicking a History row returns to that state and keeps the newer rows until a new change` - covers the other path the check now carries: return to an earlier state through a row, return to the future state its row still offers, then make a change and watch the unreachable row be replaced by the one of the new change.
- [x] The toolbar test also undoes down to the last protocol entry and checks that the Undo button is enabled the whole way and disabled at the floor.
- [x] Drove the panel in Chromium at 1280x800, 390x844 and in dark mode through toolbar undo, repeated undo, row click, keyboard activation and row-click-then-undo, with no console errors.
- [x] Checked the case that makes the kept rows tricky: undo, then a change whose cause matches the last protocol entry, which `addDeltaEntryToUndoProtocol()` merges into that entry in place. The rows the undo stepped over are dropped, as they must be.
- [x] `npm test` - 1347 passed
- [x] TestCafe regression test `The History module catches up on changes it did not see` - leaves edit mode with the panel open, changes a widget while playing, comes back and undoes; then sends a complete room state into the open panel and undoes again. Both check that the change is listed and that the undo takes it back instead of adding a row of its own.
- [x] `npx testcafe chromium:headless tests/testcafe/editor.js` - 71 passed

## A room to try it in

The workflow this adds — undo from the toolbar, then pick the undone state back up from the History list — is not exercised by anything in the library, so the branch comes with a demo room built to tutorial quality: **Xtras - History**. Following the standing rule for test rooms it is deliberately **not** part of the diff: it lives on this PR's test server, in the [pr-test-ai room](https://test.virtualtabletop.io/PR-3143/pr-test-ai), and can be moved into `library/tutorials/` on request. The save file is [Xtras - History.vtt](https://agent.virtualtabletop.io/reports/pr/1540315285150507009/Xtras%20-%20History.vtt).

Three tokens, three outlines and a button, with the walkthrough written on the board: drag the tokens to fill the list, press **Undo** twice and watch the rows stay behind dimmed, click the top row to take both undos back, then undo once more and change something else instead to see the unreachable row replaced. The room follows `docs/tutorials.md` — band layout, semantic ids, `layer: -3` captions, 60/25/22px typography, `_meta.info` copied field for field from `Properties - dragLimit` (the newest tutorial) with only `name`, `image` and `lastUpdate` differing (`variant` is empty, as `docs/tutorials.md` asks for a single-topic tutorial), and a square 530×530 SVG library image in the style of the other `Xtras -` badges. `node validator/validate_gamefile_node.js` passes on it, and it was walked end to end in Chromium, from the game list to the last step, with no console errors.

| the three changes | two toolbar undos, rows kept | the top row takes both back |
|---|---|---|
| ![three changes](https://agent.virtualtabletop.io/reports/pr/1540315285150507009/pr3143-room/03-three-changes.png) | ![two undos](https://agent.virtualtabletop.io/reports/pr/1540315285150507009/pr3143-room/04-after-two-undos.png) | ![redone](https://agent.virtualtabletop.io/reports/pr/1540315285150507009/pr3143-room/05-redone-by-row-click.png) |

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3143/pr-test (or any other room on that server)





