### PR TITLE
Say in the deck wizard that an existing deck can be customized after adding it

### DIFF
--- a/client/css/editor/deckeditor.css
+++ b/client/css/editor/deckeditor.css
@@ -808,6 +808,15 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   display: block;
 }
 
+/* A finished deck can look like something that is taken as it is, so the group offering them says up front
+   that it is only the starting point of a deck of this game. */
+.deckEditorNewDeckGroupNote {
+  margin-bottom: 10px;
+  font-size: 12px;
+  line-height: 1.35;
+  opacity: 0.85;
+}
+
 .deckEditorNewDeckModes {
   display: flex;
   flex-direction: column;

--- a/client/css/editor/deckeditor.css
+++ b/client/css/editor/deckeditor.css
@@ -808,13 +808,13 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   display: block;
 }
 
-/* A finished deck can look like something that is taken as it is, so the group offering them says up front
-   that it is only the starting point of a deck of this game. */
+/* Introduces the options of a group with what picking one of them does. Kept no louder than the
+   descriptions of the options it stands above. */
 .deckEditorNewDeckGroupNote {
-  margin-bottom: 10px;
+  margin-bottom: 8px;
   font-size: 12px;
   line-height: 1.35;
-  opacity: 0.85;
+  opacity: 0.7;
 }
 
 .deckEditorNewDeckModes {

--- a/client/editor.html
+++ b/client/editor.html
@@ -251,9 +251,9 @@
           </div>
         </div>
         <div class="deckEditorNewDeckGroup" id="deckEditorNewDeckGroupExisting">
-          <button class="deckEditorNewDeckGroupHeader">Use an existing deck<span>Take a deck that is already finished, from the library or another game &mdash; and customize it afterwards</span></button>
+          <button class="deckEditorNewDeckGroupHeader">Use an existing deck<span>Take a deck that is already finished, from the library or another game &mdash; customize it afterwards</span></button>
           <div class="deckEditorNewDeckGroupBody">
-            <div class="deckEditorNewDeckGroupNote">It becomes a deck of <b>this</b> game and opens right here in the deck editor, where you can change its deck id, add and remove card types, and edit the faces, texts and images on the cards. Adding a deck from the library or from another game leaves that deck untouched.</div>
+            <div class="deckEditorNewDeckGroupNote">The deck you pick is added to this game and opens here in the deck editor, where you can still change everything about it. The original in the library, or in the other game, stays as it is.</div>
             <div class="deckEditorNewDeckModes">
               <label><input type="radio" name="deckEditorNewDeckMode" value="library"><b>Public library</b><span>Browse the ready-made decks shared in the public library</span></label>
               <label><input type="radio" name="deckEditorNewDeckMode" value="traditional"><b>Traditional deck</b><span>Standard, Spanish, German, Swiss, tarot, hanafuda, mahjong or dominoes</span></label>

--- a/client/editor.html
+++ b/client/editor.html
@@ -253,7 +253,7 @@
         <div class="deckEditorNewDeckGroup" id="deckEditorNewDeckGroupExisting">
           <button class="deckEditorNewDeckGroupHeader">Use an existing deck<span>Take a deck that is already finished, from the library or another game &mdash; and customize it afterwards</span></button>
           <div class="deckEditorNewDeckGroupBody">
-            <div class="deckEditorNewDeckGroupNote">Whichever one you pick becomes a deck of <b>this</b> game: it opens right here in the deck editor, where you can rename it, add and remove card types, and change the faces, texts and images on the cards. The deck it was copied from stays untouched.</div>
+            <div class="deckEditorNewDeckGroupNote">It becomes a deck of <b>this</b> game and opens right here in the deck editor, where you can change its deck id, add and remove card types, and edit the faces, texts and images on the cards. Adding a deck from the library or from another game leaves that deck untouched.</div>
             <div class="deckEditorNewDeckModes">
               <label><input type="radio" name="deckEditorNewDeckMode" value="library"><b>Public library</b><span>Browse the ready-made decks shared in the public library</span></label>
               <label><input type="radio" name="deckEditorNewDeckMode" value="traditional"><b>Traditional deck</b><span>Standard, Spanish, German, Swiss, tarot, hanafuda, mahjong or dominoes</span></label>

--- a/client/editor.html
+++ b/client/editor.html
@@ -251,7 +251,7 @@
           </div>
         </div>
         <div class="deckEditorNewDeckGroup" id="deckEditorNewDeckGroupExisting">
-          <button class="deckEditorNewDeckGroupHeader">Use an existing deck<span>Take a deck that is already finished, from the library or another game &mdash; customize it afterwards</span></button>
+          <button class="deckEditorNewDeckGroupHeader">Use an existing deck<span>Take a deck that is already finished, from the library or another game - customize it afterwards</span></button>
           <div class="deckEditorNewDeckGroupBody">
             <div class="deckEditorNewDeckGroupNote">The deck you pick is added to this game and opens here in the deck editor, where you can still change everything about it. The original in the library, or in the other game, stays as it is.</div>
             <div class="deckEditorNewDeckModes">

--- a/client/editor.html
+++ b/client/editor.html
@@ -251,8 +251,9 @@
           </div>
         </div>
         <div class="deckEditorNewDeckGroup" id="deckEditorNewDeckGroupExisting">
-          <button class="deckEditorNewDeckGroupHeader">Use an existing deck<span>Take a deck that is already finished, from the library or another game</span></button>
+          <button class="deckEditorNewDeckGroupHeader">Use an existing deck<span>Take a deck that is already finished, from the library or another game &mdash; and customize it afterwards</span></button>
           <div class="deckEditorNewDeckGroupBody">
+            <div class="deckEditorNewDeckGroupNote">Whichever one you pick becomes a deck of <b>this</b> game: it opens right here in the deck editor, where you can rename it, add and remove card types, and change the faces, texts and images on the cards. The deck it was copied from stays untouched.</div>
             <div class="deckEditorNewDeckModes">
               <label><input type="radio" name="deckEditorNewDeckMode" value="library"><b>Public library</b><span>Browse the ready-made decks shared in the public library</span></label>
               <label><input type="radio" name="deckEditorNewDeckMode" value="traditional"><b>Traditional deck</b><span>Standard, Spanish, German, Swiss, tarot, hanafuda, mahjong or dominoes</span></label>


### PR DESCRIPTION
## What this does

The "Use an existing deck" section of the deck editor's **Add a new deck** dialog now says that a deck taken from the library, from a traditional set or from a Tabletop Simulator file is only a starting point: it becomes a deck of the current game and can be customized in the deck editor right afterwards.

## Why

The section only described where the cards come from ("Take a deck that is already finished, from the library or another game"), which reads like the deck arrives finished and untouchable — so it looks like the choice between "use something ready-made" and "be able to design it yourself". It is not: whichever deck is picked is added to the game and the deck editor opens on it, where card types, faces, texts and images can all be edited just like in a deck built from scratch.

## The change

- The section header line reads "Take a deck that is already finished, from the library or another game — customize it afterwards", so the point is already visible while the section is collapsed.
- A two-sentence note above the three options spells out what happens after adding: the deck is added to this game, opens in the deck editor and can still be changed completely, while the original in the library or in the other game stays as it is. It is styled like the descriptions of the options it stands above (`font-size: 12px`, `opacity: 0.7`) so it does not out-rank them.

Screenshots (from a local run):

- section open, 1280×800: https://agent.virtualtabletop.io/reports/pr/1540341544882675843/newdeck-existing-laptop.png
- collapsed headers, 1280×800: https://agent.virtualtabletop.io/reports/pr/1540341544882675843/newdeck-collapsed-laptop.png
- section open, 390×844: https://agent.virtualtabletop.io/reports/pr/1540341544882675843/newdeck-existing-phonePT.png

## Testing

- `npm test` — 1347 passed
- `npx testcafe chromium:headless tests/testcafe/editor.js --test-grep "Deck editor"` — 24 passed
- Measured the dialog in a browser at 390×844, 844×390, 820×1180, 1280×800 and 1920×1080: the note is 2 lines (32px) on a laptop and 5 lines (81px) on a phone, down from 3 and 7 lines.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3144/pr-test (or any other room on that server)
