### PR TITLE
Don't crash the game list when an uploaded file has no game metadata

### DIFF
--- a/client/css/overlays/states.css
+++ b/client/css/overlays/states.css
@@ -856,7 +856,7 @@ div:nth-of-type(2) > .list > .roomState .star {
   word-break: break-all;
 }
 
-.variant .variant-name:empty::before {
+.variant:not(:only-child) .variant-name:empty::before {
   content: attr(data-placeholder);
   color: gray;
   font-style: italic;

--- a/client/css/overlays/states.css
+++ b/client/css/overlays/states.css
@@ -856,6 +856,12 @@ div:nth-of-type(2) > .list > .roomState .star {
   word-break: break-all;
 }
 
+.variant .variant-name:empty::before {
+  content: attr(data-placeholder);
+  color: gray;
+  font-style: italic;
+}
+
 .variant .variant-name>div {
   line-height: 34px;
 }

--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -464,16 +464,25 @@ export function applyValuesToDOM(parent, obj) {
     toggleClass(hideDom, 'hidden', !hideDom.dataset.showfor.split('|').filter(field=>obj[field]).length);
 }
 
+// enableEditing writes the placeholder into the element as real text, so the field is empty as
+// long as that text is still there and the user has not typed in it - a value that only looks
+// like the placeholder, or contains it, is what the user typed and has to survive as it is
+function isUntouchedPlaceholder(dom, value) {
+  return dom.classList.contains('showsPlaceholder') && value == (dom.dataset.placeholder || '<empty>');
+}
+
 export function getValuesFromDOM(parent) {
   const obj = {};
   for(const dom of $a('[data-field]:not([data-target=href])', parent)) {
     images2emojis(dom);
     if(dom.dataset.target == 'checked')
       obj[dom.dataset.field] = dom.checked;
-    else if(dom.dataset.html && (dom.innerText.trim() || dom.innerHTML.match(/<img|<video/)) && dom.innerText != (dom.dataset.placeholder || '<empty>'))
+    else if(dom.dataset.html && (dom.innerText.trim() || dom.innerHTML.match(/<img|<video/)) && !isUntouchedPlaceholder(dom, dom.innerText.trim()))
       obj[dom.dataset.field] = unmapAssetURLs(DOMPurify.sanitize(dom.innerHTML, { USE_PROFILES: { html: true } }));
-    else
-      obj[dom.dataset.field] = dom[dom.dataset.target || 'innerText'].trim().replace(dom.dataset.placeholder || '<empty>', '');
+    else {
+      const value = dom[dom.dataset.target || 'innerText'].trim();
+      obj[dom.dataset.field] = isUntouchedPlaceholder(dom, value) ? '' : value;
+    }
     emojis2images(dom);
   }
   return obj;
@@ -491,6 +500,8 @@ export function enableEditing(parent, obj) {
     dom.classList.remove('hidden');
     if(!dom.innerText.trim() && !dom.innerHTML.match(/<img|<video/)) {
       dom.innerText = dom.dataset.placeholder || '<empty>';
+      dom.classList.add('showsPlaceholder');
+      dom.oninput = _=>dom.classList.remove('showsPlaceholder');
       dom.onclick = function(e) {
         if(dom.innerText == (dom.dataset.placeholder || '<empty>'))
           document.execCommand('selectAll', false, null);
@@ -510,6 +521,7 @@ export function disableEditing(parent, obj) {
   for(const dom of $a('[data-field]:not([data-target=href])', parent)) {
     if(dom.contentEditable != 'false' && !dom.classList.contains('uneditable')) {
       dom.contentEditable = false;
+      dom.classList.remove('showsPlaceholder');
       if(!obj[dom.dataset.field]) {
         dom[dom.dataset.target || 'innerText'] = '';
         if(!dom.dataset.forceshow)

--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -209,9 +209,12 @@ async function uploadStateFile(sourceFile, targetURL, metaCallback, progressCall
       if(filename.match(/^[^\/]+\.json$/)) {
         const content = parseJSONorNull(jsonFiles[filename]);
         if(content && content._meta) {
-          variants.push(content._meta.info || {});
+          // the info of a hand-written file can hold anything, while everything that reads a
+          // variant treats it as an object it can read properties from and write them to
+          const variantInfo = typeof content._meta.info == 'object' ? content._meta.info : null;
+          variants.push(variantInfo || {});
           if(!info)
-            info = content._meta.info || null;
+            info = variantInfo;
         }
       }
     }

--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -129,11 +129,14 @@ function addStateFile(f) {
   } while($(`.roomState[data-id="${id}"]`));
   stateDOM.dataset.id = id;
   stateDOM.className = 'uploading visible roomState noImage';
+  // the badge belongs to games that declare AI imagery, but the template shows it by default
+  $('.ai-badge', stateDOM).classList.add('hidden');
 
   let isSave = false;
   function metaCallback(name, similarName, image, variants, savePlayers, saveDate) {
     if(image) {
       stateDOM.classList.remove('noImage');
+      $('img', stateDOM).onerror = _=>stateDOM.classList.add('noImage');
       $('img', stateDOM).src = image;
     }
 
@@ -160,6 +163,15 @@ function addStateFile(f) {
   uploadStateFile(f, `addState/${roomID}/${id}/file/${f.name}`, metaCallback, progressCallback, doneCallback);
 }
 
+// the extensions the server removes from the name of an uploaded file (see Room.addState) - the
+// tile has to remove the same ones so its provisional name is the one the game ends up with
+const gameFileExtension = /\.(vtt|vttc|vtts|pcio|zip)$/i;
+
+// the file types readStatesFromBuffer can read, named the way a first-time user knows them
+function alertNotAGameFile(fileName) {
+  alert(`${fileName} does not contain a game. You can add VTT files (.vtt, .vttc, .vtts), playingcards.io files (.pcio) and Tabletop Simulator workshop files (.zip).`);
+}
+
 function parseJSONorNull(bytes) {
   try {
     return JSON.parse(fflate.strFromU8(bytes));
@@ -179,11 +191,11 @@ async function uploadStateFile(sourceFile, targetURL, metaCallback, progressCall
     entries = zipIndex(buffer);
     jsonFiles = await unzipBuffer(buffer, name=>name.match(/json$/));
   } catch(e) {
-    alert(`${sourceFile.name} is not a valid VTT, VTTC, VTTS or PCIO file.`);
+    alertNotAGameFile(sourceFile.name);
     return;
   }
 
-  const fileName = sourceFile.name.replace(/\.[^.]+$/, '');
+  const fileName = sourceFile.name.replace(gameFileExtension, '');
   let containsJSON = false;
   let info = null;
   const variants = [];
@@ -208,7 +220,7 @@ async function uploadStateFile(sourceFile, targetURL, metaCallback, progressCall
   }
 
   if(!containsJSON) {
-    alert(`${sourceFile.name} is not a valid VTT, VTTC, VTTS or PCIO file.`);
+    alertNotAGameFile(sourceFile.name);
     return;
   } else if(!info) {
     // without metadata the file name is all the tile can show until the server has read the file
@@ -263,8 +275,10 @@ async function uploadStateFile(sourceFile, targetURL, metaCallback, progressCall
 
   var req = new XMLHttpRequest();
   req.onload = function(e) {
-    if(e.target.status != 200)
-      alert(`${e.target.status}: ${e.target.response}`);
+    if(e.target.status != 200) {
+      console.error(`Uploading ${sourceFile.name} failed with status ${e.target.status}: ${e.target.response}`);
+      alert(`${sourceFile.name}: ${e.target.response || 'The server did not accept the file.'}`);
+    }
     loadCallback();
   };
   req.upload.onprogress = e=>progressCallback(e.loaded/e.total);
@@ -542,6 +556,10 @@ function fillStatesList(states, starred, activeState, returnServer, activePlayer
   for(const state of Object.values(states)) {
     state.starred = starred && starred[state.publicLibrary];
     state.stars = state.stars || 0;
+    // metadata written by hand or by another tool can hold anything, and everything that shows
+    // the image of a game here expects a string or nothing
+    if(typeof state.image != 'string')
+      state.image = '';
     for(const variant of state.variants)
       if(variant.plStateID)
         publicLibraryLinksFound[`${variant.plStateID} - ${variant.plVariantID}`] = true;
@@ -912,6 +930,11 @@ function fillStateDetails(states, state, dom) {
 
     const vEntry = domByTemplate('template-variantslist-entry', variant);
     vEntry.className = isLinkedVariant ? 'linked variant' : 'variant';
+
+    // a variant without a name of its own renders as a blank row, which gives the user nothing to
+    // tell several of them apart - the number is the one the play button loads
+    if(!variant.variant)
+      $('.variant-name', vEntry).dataset.placeholder = `Variant ${+variantID + 1}`;
 
     if(isLinkedVariant)
       for(const dom of $a('[data-field]', vEntry))

--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -136,8 +136,8 @@ function addStateFile(f) {
   function metaCallback(name, similarName, image, variants, savePlayers, saveDate) {
     if(image) {
       stateDOM.classList.remove('noImage');
-      $('img', stateDOM).onerror = _=>stateDOM.classList.add('noImage');
-      $('img', stateDOM).src = image;
+      $('img:not(.emoji)', stateDOM).onerror = _=>stateDOM.classList.add('noImage');
+      $('img:not(.emoji)', stateDOM).src = image;
     }
 
     isSave = !!savePlayers;
@@ -192,6 +192,7 @@ async function uploadStateFile(sourceFile, targetURL, metaCallback, progressCall
     jsonFiles = await unzipBuffer(buffer, name=>name.match(/json$/));
   } catch(e) {
     alertNotAGameFile(sourceFile.name);
+    loadCallback(true);
     return;
   }
 
@@ -211,7 +212,7 @@ async function uploadStateFile(sourceFile, targetURL, metaCallback, progressCall
         if(content && content._meta) {
           // the info of a hand-written file can hold anything, while everything that reads a
           // variant treats it as an object it can read properties from and write them to
-          const variantInfo = typeof content._meta.info == 'object' ? content._meta.info : null;
+          const variantInfo = typeof content._meta.info == 'object' && !Array.isArray(content._meta.info) ? content._meta.info : null;
           variants.push(variantInfo || {});
           if(!info)
             info = variantInfo;
@@ -224,6 +225,7 @@ async function uploadStateFile(sourceFile, targetURL, metaCallback, progressCall
 
   if(!containsJSON) {
     alertNotAGameFile(sourceFile.name);
+    loadCallback(true);
     return;
   } else if(!info) {
     // without metadata the file name is all the tile can show until the server has read the file
@@ -282,7 +284,7 @@ async function uploadStateFile(sourceFile, targetURL, metaCallback, progressCall
       console.error(`Uploading ${sourceFile.name} failed with status ${e.target.status}: ${e.target.response}`);
       alert(`${sourceFile.name}: ${e.target.response || 'The server did not accept the file.'}`);
     }
-    loadCallback();
+    loadCallback(e.target.status != 200);
   };
   req.upload.onprogress = e=>progressCallback(e.loaded/e.total);
 
@@ -560,12 +562,17 @@ function fillStatesList(states, starred, activeState, returnServer, activePlayer
     state.starred = starred && starred[state.publicLibrary];
     state.stars = state.stars || 0;
     // metadata written by hand or by another tool can hold anything, and everything that shows
-    // the image of a game here expects a string or nothing
+    // one of the images of a game here expects a string or nothing
     if(typeof state.image != 'string')
       state.image = '';
-    for(const variant of state.variants)
+    if(typeof state.similarImage != 'string')
+      state.similarImage = '';
+    for(const variant of state.variants) {
+      if(typeof variant.variantImage != 'string')
+        variant.variantImage = '';
       if(variant.plStateID)
         publicLibraryLinksFound[`${variant.plStateID} - ${variant.plVariantID}`] = true;
+    }
   }
 
   const categories = {
@@ -623,6 +630,7 @@ function fillStatesList(states, starred, activeState, returnServer, activePlayer
 
     if(state.image) {
       const mappedURL = mapAssetURLs(state.image);
+      $('img:not(.emoji)', entry).onerror = _=>entry.classList.add('noImage');
       if(loadedLibraryImages[mappedURL]) {
         $('img:not(.emoji)', entry).dataset.src = $('img:not(.emoji)', entry).src = mappedURL;
       } else {
@@ -935,7 +943,7 @@ function fillStateDetails(states, state, dom) {
     vEntry.className = isLinkedVariant ? 'linked variant' : 'variant';
 
     // a variant without a name of its own renders as a blank row, which gives the user nothing to
-    // tell several of them apart - the number is the one the play button loads
+    // tell several of them apart - the number is its position in the list
     if(!variant.variant)
       $('.variant-name', vEntry).dataset.placeholder = `Variant ${+variantID + 1}`;
 
@@ -1046,12 +1054,14 @@ function fillStateDetails(states, state, dom) {
 
       const variantDOM = [];
       const filenameSuffix = rand().toString(36).substring(3, 11);
+      let createOperation = null;
 
       function metaCallback(name, similarName, image, variants) {
-        variantOperationQueue.push({
+        createOperation = {
           operation: 'create',
           filenameSuffix
-        });
+        };
+        variantOperationQueue.push(createOperation);
         for(const variant of variants) {
           const vEntry = addVariant($a('#stateDetailsOverlay .variant').length, variant);
           vEntry.classList.add('uploading');
@@ -1063,7 +1073,17 @@ function fillStateDetails(states, state, dom) {
         for(const d of variantDOM)
           d.style.setProperty('--progress', percent);
       }
-      function doneCallback() {
+      function doneCallback(failed) {
+        // the rows and the operation were added before the server saw the file, so a rejected
+        // upload has to take them back: saving them would send more variants than the game has,
+        // which makes the server drop the whole edit
+        if(failed) {
+          for(const d of variantDOM)
+            removeFromDOM(d);
+          variantDOM.length = 0;
+          if(createOperation)
+            variantOperationQueue.splice(variantOperationQueue.indexOf(createOperation), 1);
+        }
         for(const d of variantDOM)
           d.classList.remove('uploading');
         if(!$('#stateDetailsOverlay .uploading.variant'))

--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -121,6 +121,7 @@ function selectVTTfile(callback) {
   });
 }
 
+// returns the upload, so a caller can wait for it to finish
 function addStateFile(f) {
   const stateDOM = domByTemplate('template-stateslist-entry');
   let id;
@@ -157,10 +158,12 @@ function addStateFile(f) {
   }
   function doneCallback() {
     uploadingStates[isSave ? 0 : 1] = uploadingStates[isSave ? 0 : 1].filter(s=>s!=stateDOM);
-    removeFromDOM(stateDOM);
+    // a file the client rejects before it is sent never reaches metaCallback, so its tile was
+    // never inserted into the list - remove() tolerates that, removeChild does not
+    stateDOM.remove();
   }
 
-  uploadStateFile(f, `addState/${roomID}/${id}/file/${f.name}`, metaCallback, progressCallback, doneCallback);
+  return uploadStateFile(f, `addState/${roomID}/${id}/file/${f.name}`, metaCallback, progressCallback, doneCallback);
 }
 
 // the extensions the server removes from the name of an uploaded file (see Room.addState) - the
@@ -936,6 +939,10 @@ function fillStateDetails(states, state, dom) {
     if(variant.plStateID)
       variant = states[variant.plStateID].variants[variant.plVariantID];
 
+    // an uploaded file reaches this with the metadata it was written with, which can hold anything
+    // where a string belongs - fillStatesList only normalizes what the server has already read
+    if(typeof variant.variantImage != 'string')
+      variant.variantImage = '';
     if(!variant.variantImage)
       variant.variantImage = state.image;
 
@@ -943,7 +950,8 @@ function fillStateDetails(states, state, dom) {
     vEntry.className = isLinkedVariant ? 'linked variant' : 'variant';
 
     // a variant without a name of its own renders as a blank row, which gives the user nothing to
-    // tell several of them apart - the number is its position in the list
+    // tell several of them apart - the number is its position in the list. The details list only
+    // shows it while the game has more than one variant, the name field uses it as its hint always
     if(!variant.variant)
       $('.variant-name', vEntry).dataset.placeholder = `Variant ${+variantID + 1}`;
 
@@ -1079,8 +1087,9 @@ function fillStateDetails(states, state, dom) {
         // which makes the server drop the whole edit
         if(failed) {
           for(const d of variantDOM)
-            removeFromDOM(d);
+            d.remove();
           variantDOM.length = 0;
+          updateEmptyVariantsHint();
           if(createOperation)
             variantOperationQueue.splice(variantOperationQueue.indexOf(createOperation), 1);
         }

--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -160,6 +160,14 @@ function addStateFile(f) {
   uploadStateFile(f, `addState/${roomID}/${id}/file/${f.name}`, metaCallback, progressCallback, doneCallback);
 }
 
+function parseJSONorNull(bytes) {
+  try {
+    return JSON.parse(fflate.strFromU8(bytes));
+  } catch(e) {
+    return null;
+  }
+}
+
 async function uploadStateFile(sourceFile, targetURL, metaCallback, progressCallback, loadCallback) {
   await waitForZipLibrary();
 
@@ -175,36 +183,44 @@ async function uploadStateFile(sourceFile, targetURL, metaCallback, progressCall
     return;
   }
 
-  let json = null;
+  const fileName = sourceFile.name.replace(/\.[^.]+$/, '');
+  let containsJSON = false;
+  let info = null;
+  const variants = [];
   const assets = {};
   for(const [ filename, entry ] of Object.entries(entries)) {
     if(jsonFiles[filename]) {
-      const content = JSON.parse(fflate.strFromU8(jsonFiles[filename]));
-      if(!json) {
-        json = content;
-        if(json._meta)
-          json._meta.info.variants = [];
+      containsJSON = true;
+      // the server reads a variant from every JSON file in the top level of the zip, so the
+      // JSON of a PCIO or TTS file and anything an asset happens to contain is not one - and
+      // a game file written by hand or by another tool can be missing its metadata entirely
+      if(filename.match(/^[^\/]+\.json$/)) {
+        const content = parseJSONorNull(jsonFiles[filename]);
+        if(content && content._meta) {
+          variants.push(content._meta.info || {});
+          if(!info)
+            info = content._meta.info || null;
+        }
       }
-      if(json._meta)
-        json._meta.info.variants.push(content._meta.info);
     }
     if(filename.match(/^\/?(user)?assets/) && entry.size)
       assets[entry.crc + '_' + entry.size] = filename;
   }
 
-  if(json === null) {
+  if(!containsJSON) {
     alert(`${sourceFile.name} is not a valid VTT, VTTC, VTTS or PCIO file.`);
     return;
-  } else if(Array.isArray(json)) {
-    metaCallback(sourceFile.name.replace(/\.[^.]+$/, ''), '', null, [{}], null, null);
+  } else if(!info) {
+    // without metadata the file name is all the tile can show until the server has read the file
+    metaCallback(fileName, '', null, [{}], null, null);
   } else {
     let imageURL = null;
 
-    if(json._meta.info.image) {
-      if(json._meta.info.image.match(/^http/)) {
-        imageURL = json._meta.info.image;
-      } else if(entries[json._meta.info.image.substr(1)]) {
-        const imageFile = json._meta.info.image.substr(1);
+    if(info.image) {
+      if(info.image.match(/^http/)) {
+        imageURL = info.image;
+      } else if(entries[info.image.substr(1)]) {
+        const imageFile = info.image.substr(1);
         const image = toBase64((await unzipBuffer(buffer, name=>name == imageFile))[imageFile]);
         for(const [ type, pattern ] of Object.entries({ jpeg: '^\\/9j\\/', png: '^iVBO', 'svg+xml': '^PHN2', gif: '^R0lG', webp: '^UklG' }))
           if(image.match(pattern))
@@ -212,7 +228,7 @@ async function uploadStateFile(sourceFile, targetURL, metaCallback, progressCall
       }
     }
 
-    metaCallback(json._meta.info.name, json._meta.info.similarName, imageURL, json._meta.info.variants, json._meta.info.savePlayers, json._meta.info.saveDate);
+    metaCallback(info.name || fileName, info.similarName, imageURL, variants, info.savePlayers, info.saveDate);
   }
 
   const result = await fetch('assetcheck', {

--- a/client/js/overlays/states.js
+++ b/client/js/overlays/states.js
@@ -212,11 +212,11 @@ async function uploadStateFile(sourceFile, targetURL, metaCallback, progressCall
     return;
   } else if(!info) {
     // without metadata the file name is all the tile can show until the server has read the file
-    metaCallback(fileName, '', null, [{}], null, null);
+    metaCallback(fileName, '', null, variants.length ? variants : [{}], null, null);
   } else {
     let imageURL = null;
 
-    if(info.image) {
+    if(typeof info.image == 'string') {
       if(info.image.match(/^http/)) {
         imageURL = info.image;
       } else if(entries[info.image.substr(1)]) {

--- a/client/room.html
+++ b/client/room.html
@@ -258,7 +258,7 @@
       </div>
       <div>
         <div icon="upload">
-          <p>Upload VTT or PCIO files you downloaded from the web.</p>
+          <p>Upload VTT or PCIO files you downloaded from the web, or a Tabletop Simulator workshop ZIP file.</p>
           <p>You can find compatible game files on <a href="https://boardgamegeek.com/geeklist/272690/games-implemented-playingcardsio">a boardgamegeek.com geeklist</a>,
           <a href="https://www.reddit.com/r/PlayingCardsIO/">the PlayingCardsIO subreddit</a>,
           <a href="https://www.notion.so/4d27ed5a430d422b99b3fa21b66714e6">its notion.so database</a> or

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -110,9 +110,9 @@ export default class Room {
         let name = type == 'file' && srcName || 'Unnamed';
 
         const variant = states[state][v];
-        // only an object holds metadata - assigning a string here would spread it into the
-        // game as one property per character
-        const variantInfo = variant._meta && typeof variant._meta.info == 'object' ? variant._meta.info : null;
+        // only an object holds metadata - assigning a string here would spread it into the game
+        // as one property per character, and an array as one property per element
+        const variantInfo = variant._meta && typeof variant._meta.info == 'object' && !Array.isArray(variant._meta.info) ? variant._meta.info : null;
         const meta = Object.assign({
           name: name.replace(/\.(vtt|vttc|vtts|pcio|zip)$/i, ''),
           image: '',
@@ -449,8 +449,12 @@ export default class Room {
         return;
     }
 
+    // a client whose optimistic variant rows got ahead of the game - an upload it added a row
+    // for and the server then rejected - sends input for variants that do not exist, and losing
+    // the rest of the edit over that is worse than ignoring it
     for(const variantID in variantInput)
-      Object.assign(variants[variantID], variantInput[variantID]);
+      if(variants[variantID])
+        Object.assign(variants[variantID], variantInput[variantID]);
 
     meta.variants = variants;
     Object.assign(this.state._meta.states[id], meta);

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -111,7 +111,7 @@ export default class Room {
 
         const variant = states[state][v];
         const meta = Object.assign({
-          name: name.replace(/\.pcio/, ''),
+          name: name.replace(/\.(vtt|vttc|vtts|pcio|zip)$/i, ''),
           image: '',
           rules: '',
           bgg: '',

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -110,6 +110,9 @@ export default class Room {
         let name = type == 'file' && srcName || 'Unnamed';
 
         const variant = states[state][v];
+        // only an object holds metadata - assigning a string here would spread it into the
+        // game as one property per character
+        const variantInfo = variant._meta && typeof variant._meta.info == 'object' ? variant._meta.info : null;
         const meta = Object.assign({
           name: name.replace(/\.(vtt|vttc|vtts|pcio|zip)$/i, ''),
           image: '',
@@ -123,7 +126,7 @@ export default class Room {
           variant: '',
           link: '',
           attribution: ''
-        }, (variant._meta || {}).info || {});
+        }, variantInfo || {});
 
         if(stateID.match(/^PL:/)) {
           this.writePublicLibraryToFilesystem(stateID, newVariantID, variant);

--- a/tests/client/editable-fields.test.js
+++ b/tests/client/editable-fields.test.js
@@ -1,0 +1,83 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// domhelpers.js belongs to the room bundle and uses the emoji helpers of client/js/symbols.js as
+// globals, so evaluate its source with stubs for them the way the other client tests do
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const source = fs.readFileSync(path.join(dir, '../../client/js/domhelpers.js'), 'utf8').replace(/^export /gm, '');
+const { enableEditing, disableEditing, getValuesFromDOM } = new Function('images2emojis', 'emojis2images', `
+  ${source};
+  return { enableEditing, disableEditing, getValuesFromDOM };
+`)(()=>{}, ()=>{});
+
+// jsdom implements neither innerText nor the input event of contentEditable, and the editing
+// helpers only ever read plain text from these fields
+Object.defineProperty(window.HTMLElement.prototype, 'innerText', {
+  configurable: true,
+  get() { return this.textContent; },
+  set(value) { this.textContent = value; }
+});
+
+const $ = (selector, parent=document) => parent.querySelector(selector);
+
+function variantRow(name, placeholder) {
+  document.body.innerHTML = `<div class="variant"><div class="variant-name" data-field="variant" data-placeholder="${placeholder}">${name}</div></div>`;
+  return $('.variant');
+}
+
+function type(row, text) {
+  const field = $('.variant-name', row);
+  field.innerText = text;
+  field.oninput();
+}
+
+describe('editing a field with a placeholder', () => {
+  test('reads an untouched placeholder as an empty value', () => {
+    const row = variantRow('', 'Variant 1');
+    enableEditing(row, { variant: '' });
+
+    expect($('.variant-name', row).innerText).toBe('Variant 1');
+    expect(getValuesFromDOM(row)).toEqual({ variant: '' });
+  });
+
+  // the placeholder of an unnamed variant is a name the user may well type themselves, so what
+  // they typed must not be mistaken for the placeholder or stripped out of a longer name
+  test('keeps a name the user typed even when it looks like the placeholder', () => {
+    const row = variantRow('', 'Variant 1');
+    enableEditing(row, { variant: '' });
+    type(row, 'Variant 1');
+
+    expect(getValuesFromDOM(row)).toEqual({ variant: 'Variant 1' });
+  });
+
+  test('keeps a name that contains the placeholder', () => {
+    const row = variantRow('', 'Variant 2');
+    enableEditing(row, { variant: '' });
+    type(row, 'Variant 2 - Advanced');
+
+    expect(getValuesFromDOM(row)).toEqual({ variant: 'Variant 2 - Advanced' });
+  });
+
+  test('keeps a name a variant already has', () => {
+    const row = variantRow('Advanced', 'Variant 1');
+    enableEditing(row, { variant: 'Advanced' });
+
+    expect(getValuesFromDOM(row)).toEqual({ variant: 'Advanced' });
+  });
+
+  // a row that was saved empty and is edited again shows the placeholder again, so the flag that
+  // marks it as placeholder text has to be gone once editing ends
+  test('shows the placeholder again after saving an empty field', () => {
+    const row = variantRow('', 'Variant 1');
+    enableEditing(row, { variant: '' });
+    const values = getValuesFromDOM(row);
+    disableEditing(row, values);
+
+    expect($('.variant-name', row).innerText).toBe('');
+
+    enableEditing(row, values);
+    expect($('.variant-name', row).innerText).toBe('Variant 1');
+    expect(getValuesFromDOM(row)).toEqual({ variant: '' });
+  });
+});

--- a/tests/client/state-upload.test.js
+++ b/tests/client/state-upload.test.js
@@ -88,6 +88,17 @@ describe('uploading a game file', () => {
     expect(overlay.uploaded.length).toBe(1);
   });
 
+  // Room.addState names a game after the file it came from and removes the extension itself, so
+  // a tile that removed a different set would rename itself once the server answers
+  test('removes the same file extensions from the fallback name as the server', async () => {
+    const overlay = loadStatesOverlay();
+    const noMeta = { '0.json': { _meta: { version: 8 } } };
+
+    expect((await upload(overlay, vttFile('My Game.VTT', noMeta)))[0][0]).toBe('My Game');
+    expect((await upload(overlay, vttFile('My Game v1.2.vtt', noMeta)))[0][0]).toBe('My Game v1.2');
+    expect((await upload(overlay, vttFile('My Game.data', noMeta)))[0][0]).toBe('My Game.data');
+  });
+
   test('keeps one variant per JSON file when none of them has metadata', async () => {
     const overlay = loadStatesOverlay();
     const meta = await upload(overlay, vttFile('Handwritten.vtt', {
@@ -135,7 +146,7 @@ describe('uploading a game file', () => {
     const meta = await upload(overlay, vttFile('Pictures.zip', { 'image.png': 'not a game' }));
 
     expect(meta).toEqual([]);
-    expect(overlay.alerts).toEqual([ 'Pictures.zip is not a valid VTT, VTTC, VTTS or PCIO file.' ]);
+    expect(overlay.alerts).toEqual([ 'Pictures.zip does not contain a game. You can add VTT files (.vtt, .vttc, .vtts), playingcards.io files (.pcio) and Tabletop Simulator workshop files (.zip).' ]);
     expect(overlay.uploaded.length).toBe(0);
   });
 });

--- a/tests/client/state-upload.test.js
+++ b/tests/client/state-upload.test.js
@@ -88,6 +88,30 @@ describe('uploading a game file', () => {
     expect(overlay.uploaded.length).toBe(1);
   });
 
+  test('keeps one variant per JSON file when none of them has metadata', async () => {
+    const overlay = loadStatesOverlay();
+    const meta = await upload(overlay, vttFile('Handwritten.vtt', {
+      '0.json': { _meta: { version: 8 }, w1: { id: 'w1' } },
+      '1.json': { _meta: { version: 8 }, w2: { id: 'w2' } }
+    }));
+
+    expect(meta).toEqual([ [ 'Handwritten', '', null, [ {}, {} ], null, null ] ]);
+    expect(overlay.uploaded.length).toBe(1);
+  });
+
+  // metadata written by hand or by another tool can hold anything, so nothing in it may be
+  // dereferenced as if its type was known
+  test('ignores an image that is not a string', async () => {
+    const overlay = loadStatesOverlay();
+    const meta = await upload(overlay, vttFile('Odd.vtt', {
+      '0.json': { _meta: { version: 8, info: { name: 'Odd Game', image: 3 } } }
+    }));
+
+    expect(meta).toEqual([ [ 'Odd Game', undefined, null, [ { name: 'Odd Game', image: 3 } ], undefined, undefined ] ]);
+    expect(overlay.alerts).toEqual([]);
+    expect(overlay.uploaded.length).toBe(1);
+  });
+
   test('falls back to the file name for PCIO and TTS files, whose JSON is not a variant', async () => {
     const overlay = loadStatesOverlay();
     expect(await upload(overlay, vttFile('game.pcio', { 'widgets.json': [ { id: 'w1' } ] })))

--- a/tests/client/state-upload.test.js
+++ b/tests/client/state-upload.test.js
@@ -9,7 +9,7 @@ import * as fflate from 'fflate';
 const dir = path.dirname(fileURLToPath(import.meta.url));
 const statesSource = fs.readFileSync(path.join(dir, '../../client/js/overlays/states.js'), 'utf8').replace(/^export /gm, '');
 
-function loadStatesOverlay() {
+function loadStatesOverlay(serverStatus=200) {
   document.body.innerHTML = `<select id="librarySort"><option value="name">name</option></select>`;
 
   const alerts = [];
@@ -22,7 +22,7 @@ function loadStatesOverlay() {
     setRequestHeader() {}
     send(body) {
       uploaded.push(body);
-      this.onload({ target: { status: 200 } });
+      this.onload({ target: { status: serverStatus, response: 'Unable to load and add the game.' } });
     }
   }
 
@@ -40,7 +40,7 @@ function loadStatesOverlay() {
     XHR
   );
 
-  return Object.assign(scope, { alerts, uploaded });
+  return Object.assign(scope, { alerts, uploaded, uploadFailed: [] });
 }
 
 function vttFile(name, files) {
@@ -54,7 +54,7 @@ function vttFile(name, files) {
 
 async function upload(overlay, file) {
   const meta = [];
-  await overlay.uploadStateFile(file, 'addState/room/id/file/name', (...args)=>meta.push(args), ()=>{}, ()=>{});
+  await overlay.uploadStateFile(file, 'addState/room/id/file/name', (...args)=>meta.push(args), ()=>{}, failed=>overlay.uploadFailed.push(failed));
   return meta;
 }
 
@@ -136,8 +136,14 @@ describe('uploading a game file', () => {
       '1.json': { _meta: { version: 8, info: { name: 'Second Variant' } } }
     }))).toEqual([ [ 'Second Variant', undefined, null, [ {}, { name: 'Second Variant' } ], undefined, undefined ] ]);
 
+    // an array is an object as far as typeof is concerned, and assigning one into a game
+    // spreads it in as one property per element
+    expect(await upload(overlay, vttFile('Odd.vtt', {
+      '0.json': { _meta: { version: 8, info: [ 'bad', 'metadata' ] } }
+    }))).toEqual([ [ 'Odd', '', null, [ {} ], null, null ] ]);
+
     expect(overlay.alerts).toEqual([]);
-    expect(overlay.uploaded.length).toBe(2);
+    expect(overlay.uploaded.length).toBe(3);
   });
 
   test('falls back to the file name for PCIO and TTS files, whose JSON is not a variant', async () => {
@@ -165,5 +171,19 @@ describe('uploading a game file', () => {
     expect(meta).toEqual([]);
     expect(overlay.alerts).toEqual([ 'Pictures.zip does not contain a game. You can add VTT files (.vtt, .vttc, .vtts), playingcards.io files (.pcio) and Tabletop Simulator workshop files (.zip).' ]);
     expect(overlay.uploaded.length).toBe(0);
+  });
+
+  // the "add variant" flow adds its rows before the server has seen the file, so it has to be
+  // told that the upload failed to be able to take them back
+  test('reports whether the upload succeeded to the done callback', async () => {
+    const overlay = loadStatesOverlay();
+    await upload(overlay, vttFile('Good.vtt', { '0.json': { _meta: { version: 8 } } }));
+    expect(overlay.uploadFailed).toEqual([ false ]);
+
+    const rejected = loadStatesOverlay(404);
+    await upload(rejected, vttFile('Broken.vtt', { '0.json': 'not json at all' }));
+    await upload(rejected, vttFile('Pictures.zip', { 'image.png': 'not a game' }));
+    await upload(rejected, { name: 'Notes.txt', arrayBuffer: async () => fflate.strToU8('not a zip').buffer });
+    expect(rejected.uploadFailed).toEqual([ true, true, true ]);
   });
 });

--- a/tests/client/state-upload.test.js
+++ b/tests/client/state-upload.test.js
@@ -1,0 +1,117 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import * as fflate from 'fflate';
+
+// states.js belongs to the room bundle, which server/minify.mjs concatenates - so it uses
+// the helpers of the other files as globals instead of importing them. Evaluate its source
+// with stubs for the ones the upload path needs, the way the other overlay tests do.
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const statesSource = fs.readFileSync(path.join(dir, '../../client/js/overlays/states.js'), 'utf8').replace(/^export /gm, '');
+
+function loadStatesOverlay() {
+  document.body.innerHTML = `<select id="librarySort"><option value="name">name</option></select>`;
+
+  const alerts = [];
+  const uploaded = [];
+  class XHR {
+    constructor() {
+      this.upload = {};
+    }
+    open() {}
+    setRequestHeader() {}
+    send(body) {
+      uploaded.push(body);
+      this.onload({ target: { status: 200 } });
+    }
+  }
+
+  const scope = new Function('$', '$a', 'onLoad', 'IntersectionObserver', 'fflate', 'alert', 'fetch', 'XMLHttpRequest', `
+    ${statesSource};
+    return { uploadStateFile };
+  `)(
+    (selector, parent=document) => parent.querySelector(selector),
+    (selector, parent=document) => [ ...parent.querySelectorAll(selector) ],
+    () => {},
+    class { observe() {} unobserve() {} },
+    fflate,
+    message => alerts.push(message),
+    async () => ({ json: async () => ({}) }),
+    XHR
+  );
+
+  return Object.assign(scope, { alerts, uploaded });
+}
+
+function vttFile(name, files) {
+  const entries = {};
+  for(const [ filename, content ] of Object.entries(files))
+    entries[filename] = fflate.strToU8(typeof content == 'string' ? content : JSON.stringify(content));
+  const zip = fflate.zipSync(entries);
+  // jsdom has no File.arrayBuffer(), and the upload only needs the name and the bytes
+  return { name, arrayBuffer: async () => zip.buffer };
+}
+
+async function upload(overlay, file) {
+  const meta = [];
+  await overlay.uploadStateFile(file, 'addState/room/id/file/name', (...args)=>meta.push(args), ()=>{}, ()=>{});
+  return meta;
+}
+
+describe('uploading a game file', () => {
+  test('reads name, image and variants from the metadata of the first variant', async () => {
+    const overlay = loadStatesOverlay();
+    const meta = await upload(overlay, vttFile('Some Game.vtt', {
+      '0.json': { _meta: { version: 8, info: { name: 'Some Game', image: 'https://example.com/i.png', savePlayers: 2, saveDate: 1234 } } },
+      '1.json': { _meta: { version: 8, info: { name: 'Some Game', variant: 'Advanced' } } }
+    }));
+
+    expect(meta.length).toBe(1);
+    expect(meta[0][0]).toBe('Some Game');
+    expect(meta[0][2]).toBe('https://example.com/i.png');
+    expect(meta[0][3].length).toBe(2);
+    expect(meta[0][4]).toBe(2);
+    expect(overlay.alerts).toEqual([]);
+    expect(overlay.uploaded.length).toBe(1);
+  });
+
+  // the server accepts a game file without metadata, so reading it must not throw before
+  // the file is even sent - the tile is named after the file until the server answers
+  test('falls back to the file name when the metadata is missing', async () => {
+    const overlay = loadStatesOverlay();
+    const meta = await upload(overlay, vttFile('Handwritten.vtt', {
+      '0.json': { _meta: { version: 8 }, w1: { id: 'w1' } }
+    }));
+
+    expect(meta).toEqual([ [ 'Handwritten', '', null, [ {} ], null, null ] ]);
+    expect(overlay.alerts).toEqual([]);
+    expect(overlay.uploaded.length).toBe(1);
+  });
+
+  test('falls back to the file name for PCIO and TTS files, whose JSON is not a variant', async () => {
+    const overlay = loadStatesOverlay();
+    expect(await upload(overlay, vttFile('game.pcio', { 'widgets.json': [ { id: 'w1' } ] })))
+      .toEqual([ [ 'game', '', null, [ {} ], null, null ] ]);
+    expect(await upload(overlay, vttFile('mod.zip', { 'WorkshopUpload': '', 'Mods/Workshop/1.json': { SaveName: 'Mod' } })))
+      .toEqual([ [ 'mod', '', null, [ {} ], null, null ] ]);
+    expect(overlay.alerts).toEqual([]);
+    expect(overlay.uploaded.length).toBe(2);
+  });
+
+  test('uploads a file with unreadable JSON and lets the server report the problem', async () => {
+    const overlay = loadStatesOverlay();
+    const meta = await upload(overlay, vttFile('Broken.vtt', { '0.json': 'not json at all' }));
+
+    expect(meta).toEqual([ [ 'Broken', '', null, [ {} ], null, null ] ]);
+    expect(overlay.uploaded.length).toBe(1);
+  });
+
+  test('rejects a file without any JSON in it', async () => {
+    const overlay = loadStatesOverlay();
+    const meta = await upload(overlay, vttFile('Pictures.zip', { 'image.png': 'not a game' }));
+
+    expect(meta).toEqual([]);
+    expect(overlay.alerts).toEqual([ 'Pictures.zip is not a valid VTT, VTTC, VTTS or PCIO file.' ]);
+    expect(overlay.uploaded.length).toBe(0);
+  });
+});

--- a/tests/client/state-upload.test.js
+++ b/tests/client/state-upload.test.js
@@ -26,9 +26,9 @@ function loadStatesOverlay(serverStatus=200) {
     }
   }
 
-  const scope = new Function('$', '$a', 'onLoad', 'IntersectionObserver', 'fflate', 'alert', 'fetch', 'XMLHttpRequest', `
+  const scope = new Function('$', '$a', 'onLoad', 'IntersectionObserver', 'fflate', 'alert', 'fetch', 'XMLHttpRequest', 'domByTemplate', 'removeFromDOM', 'rand', 'roomID', `
     ${statesSource};
-    return { uploadStateFile };
+    return { uploadStateFile, addStateFile };
   `)(
     (selector, parent=document) => parent.querySelector(selector),
     (selector, parent=document) => [ ...parent.querySelectorAll(selector) ],
@@ -37,7 +37,15 @@ function loadStatesOverlay(serverStatus=200) {
     fflate,
     message => alerts.push(message),
     async () => ({ json: async () => ({}) }),
-    XHR
+    XHR,
+    () => {
+      const dom = document.createElement('div');
+      dom.innerHTML = '<img><h3></h3><i></i><span class="ai-badge"></span>';
+      return dom;
+    },
+    node => node.parentNode.removeChild(node),
+    () => Math.random(),
+    'room'
   );
 
   return Object.assign(scope, { alerts, uploaded, uploadFailed: [] });
@@ -185,5 +193,18 @@ describe('uploading a game file', () => {
     await upload(rejected, vttFile('Pictures.zip', { 'image.png': 'not a game' }));
     await upload(rejected, { name: 'Notes.txt', arrayBuffer: async () => fflate.strToU8('not a zip').buffer });
     expect(rejected.uploadFailed).toEqual([ true, true, true ]);
+  });
+
+  // the tile is only put into the game list by metaCallback, which a file that is rejected before
+  // it is sent never reaches - so the done callback of the game shelf has to cope with a tile that
+  // has no parent instead of taking the whole client down with it
+  test('drops the tile of a rejected file without throwing', async () => {
+    const overlay = loadStatesOverlay();
+
+    await overlay.addStateFile({ name: 'Notes.txt', arrayBuffer: async () => fflate.strToU8('not a zip').buffer });
+    await overlay.addStateFile(vttFile('Pictures.zip', { 'image.png': 'not a game' }));
+
+    expect(overlay.alerts.length).toBe(2);
+    expect(overlay.uploaded.length).toBe(0);
   });
 });

--- a/tests/client/state-upload.test.js
+++ b/tests/client/state-upload.test.js
@@ -123,6 +123,23 @@ describe('uploading a game file', () => {
     expect(overlay.uploaded.length).toBe(1);
   });
 
+  // addVariant writes variantImage into every variant it renders, so a variant that is not an
+  // object would throw there - in the "add variant from file" flow before the file is even sent
+  test('ignores metadata that is not an object', async () => {
+    const overlay = loadStatesOverlay();
+    expect(await upload(overlay, vttFile('Odd.vtt', {
+      '0.json': { _meta: { version: 8, info: 'bad metadata' } }
+    }))).toEqual([ [ 'Odd', '', null, [ {} ], null, null ] ]);
+
+    expect(await upload(overlay, vttFile('Odd.vtt', {
+      '0.json': { _meta: { version: 8, info: 'bad metadata' } },
+      '1.json': { _meta: { version: 8, info: { name: 'Second Variant' } } }
+    }))).toEqual([ [ 'Second Variant', undefined, null, [ {}, { name: 'Second Variant' } ], undefined, undefined ] ]);
+
+    expect(overlay.alerts).toEqual([]);
+    expect(overlay.uploaded.length).toBe(2);
+  });
+
   test('falls back to the file name for PCIO and TTS files, whose JSON is not a variant', async () => {
     const overlay = loadStatesOverlay();
     expect(await upload(overlay, vttFile('game.pcio', { 'widgets.json': [ { id: 'w1' } ] })))

--- a/tests/server/room.test.js
+++ b/tests/server/room.test.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import * as fflate from 'fflate';
 
 import Room from '../../server/room.mjs';
 import { VERSION } from '../../server/fileupdater.mjs';
@@ -35,6 +36,14 @@ function roomLoadingStates(states) {
 function writeVariantFiles(stateID, count) {
   for(let i=0; i<count; ++i)
     fs.writeFileSync(path.join(directory, `${stateID}-${i}.json`), `{"variant":${i}}`);
+}
+
+// a zip of the given files, the way an uploaded game file reaches addState
+function gameFile(files) {
+  const entries = {};
+  for(const [ filename, content ] of Object.entries(files))
+    entries[filename] = fflate.strToU8(typeof content == 'string' ? content : JSON.stringify(content));
+  return Buffer.from(fflate.zipSync(entries));
 }
 
 beforeEach(function() {
@@ -141,5 +150,51 @@ describe('server/room.mjs', function() {
     expect(states.empty).toBeUndefined();
     expect(states.filled).toBeDefined();
     expect(states['PL:games/Empty']).toBeDefined();
+  });
+
+  // the tile the client shows while the file is uploading is named after the file the same way,
+  // so a game that is named after its file here must not rename itself once this answers
+  test('addState names a game after its file without the extension', async function() {
+    const room = roomWithStates({});
+    const noMeta = { '0.json': { _meta: { version: 8 } } };
+
+    await room.addState('a', 'file', gameFile(noMeta), 'My Game.vtt');
+    await room.addState('b', 'file', gameFile(noMeta), 'My Game.VTTS');
+    await room.addState('c', 'file', gameFile(noMeta), 'My Game v1.2.vtt');
+    await room.addState('d', 'file', gameFile(noMeta), 'My Game.data');
+
+    expect(Object.values(room.state._meta.states).map(state=>state.name)).toEqual([ 'My Game', 'My Game', 'My Game v1.2', 'My Game.data' ]);
+  });
+
+  // metadata written by hand or by another tool can hold anything, and assigning something that
+  // is not an object into the game spreads it in one property per character or element
+  test('addState reads the metadata of a variant only when it is an object', async function() {
+    const room = roomWithStates({});
+
+    await room.addState('a', 'file', gameFile({ '0.json': { _meta: { version: 8, info: 'bad metadata' } } }), 'Odd.vtt');
+    await room.addState('b', 'file', gameFile({ '0.json': { _meta: { version: 8, info: [ 'bad', 'metadata' ] } } }), 'Odd.vtt');
+    await room.addState('c', 'file', gameFile({ '0.json': { _meta: { version: 8, info: { name: 'Good', variant: 'Advanced' } } } }), 'Odd.vtt');
+
+    expect(room.state._meta.states.a.name).toEqual('Odd');
+    expect(Object.keys(room.state._meta.states.a)).not.toContain('0');
+    expect(room.state._meta.states.a.variants).toEqual([ { players: '', language: '', variant: '', variantImage: undefined } ]);
+
+    expect(room.state._meta.states.b.name).toEqual('Odd');
+    expect(Object.keys(room.state._meta.states.b)).not.toContain('0');
+
+    expect(room.state._meta.states.c.name).toEqual('Good');
+    expect(room.state._meta.states.c.variants[0].variant).toEqual('Advanced');
+  });
+
+  // a client whose optimistic variant rows got ahead of the game sends input for a variant that
+  // does not exist - dropping the rest of the edit over that loses everything the user typed
+  test('editState ignores input for a variant that does not exist', function() {
+    const room = roomWithStates({});
+    room.state._meta.states.a = { name: 'Game', variants: [ { variant: '' } ] };
+
+    room.editState(player, 'a', { name: 'Renamed' }, [ { variant: 'Basic' }, { variant: 'Ghost' } ], []);
+
+    expect(room.state._meta.states.a.name).toEqual('Renamed');
+    expect(room.state._meta.states.a.variants).toEqual([ { variant: 'Basic' } ]);
   });
 });


### PR DESCRIPTION
Uploading a game file into the game list could kill the client with `TypeError: Cannot set properties of undefined (setting 'variants')`, which left the new tile stuck at "uploading" and the file never sent — with no error message anywhere.

Before sending the file, the game list reads its metadata to show the name, the preview image and the variants on the tile. That code took the **first** JSON file anywhere in the zip and assumed it is a game variant with a complete `_meta.info`. Several perfectly uploadable files break that assumption:

- a game file written by hand or by another tool, whose `_meta` has no `info` (the reported crash — the server is happy with it, `room.mjs` reads `(variant._meta || {}).info || {}`),
- a Tabletop Simulator workshop zip, whose JSON lives in a subfolder and has no `_meta` at all (`TypeError: Cannot read properties of undefined (reading 'info')`, same function, one line further down),
- anything else in the zip that ends in `.json` — an asset keeps its own name — and any JSON that does not parse,
- an `info.image` that is not a string, which threw while the tile was being built.

The scan now mirrors what the server does in `readVariantsFromBuffer()`: only a top-level `*.json` that carries `_meta` counts as a variant, and nothing in the metadata is dereferenced as if its type was known. When none of the variants has an `info`, the tile is named after the file until the server answers — still one row per variant — and the upload proceeds, so an unusable file is now rejected by the server with its usual message instead of taking the page down first.

## Reproduction on main

Reproduced locally on `main` (Chromium, driven with Playwright), which throws exactly the reported error:

1. Create a zip containing a single `0.json` with `{"_meta":{"version":8},"w1":{"id":"w1","type":"basic"}}` and name it `whatever.vtt`.
2. Open a room, open the game list (the "games" toolbar button) and drop the file on it (picking it via the upload button in "Add game" does the same).
3. The tile appears, stays at "uploading" forever and nothing is sent. The console shows `TypeError: Cannot set properties of undefined (setting 'variants')`.

Dropping a TTS workshop zip on the same overlay reproduces the sibling crash in the same function.

With this change both files upload: the first is added as a game named after the file, the second goes through the TTS importer.

## Tests

`tests/client/state-upload.test.js` covers the metadata scan: a normal two-variant save (name, image, variant count), a file whose `_meta` has no `info`, a metadata-less file with two variants, a non-string image, PCIO and TTS files, an unreadable JSON file and a zip with no JSON in it at all. Five of the seven fail on `main`.

`npm test` passes, as does `tests/testcafe/publiclibrary-1.js`, which exercises the same overlay.


## Follow-up from the UI/UX review

The upload path now also holds up on screen, not just in the console:

- **A variant with no name of its own gets a number.** A metadata-less file with `0.json`, `1.json` and `2.json` used to land as three blank rows with nothing but a PLAY button on each. Every unnamed variant now shows `Variant 1`, `Variant 2`, … as a placeholder in the details list and as the placeholder of the name field in edit mode (where it used to read `<empty>` three times). It is a placeholder, not content: saving without touching it stores an empty variant name as before. This also covers the pre-existing case of a normal game whose `variant` is an empty string.
- **The tile no longer renames itself.** The provisional name stripped every extension while `Room.addState()` only stripped `.pcio`, so `My Handwritten Game` flipped to `My Handwritten Game.vtt` the moment the server answered. Both sides now strip the same anchored list (`.vtt`, `.vttc`, `.vtts`, `.pcio`, `.zip`).
- **An image that is not a string never reaches an `<img>`.** The type check used to protect only the preview during the upload, so the finished tile rendered `<img src="3">` and a broken-image glyph. The game list normalizes a non-string `image` to none, which covers the tile, the prev/next card on the details page and the details header. A preview image that fails to load falls back to the image-less tile too.
- **A file in flight no longer claims to use AI imagery.** The tile is built from the same template as a finished game, which shows the "AI generated imagery" badge by default; only the list render hid it.
- **The messages a rejected file produces are readable.** The client-side rejection names the file types in words and includes the Tabletop Simulator workshop zip this PR unblocks, the server's failure message no longer leads with a raw `404:` (the status goes to the console), and the "Add game" overlay mentions that a workshop zip can be uploaded.
- **Metadata that is not an object is treated as no metadata.** A file whose `_meta.info` is a string put that string into the variants array, and `addVariant()` assigns `variantImage` to every variant it renders - in **Game details → Edit → Add variant → Upload files** that threw before the file was sent and took the whole client down with the "Something went wrong in your browser" screen. Both the game list and `Room.addState()` now read `info` only when it is an object; the server used to spread such a value into the game as one property per character.

Screenshots of the result: [shelf after uploading metadata-less files](https://agent.virtualtabletop.io/reports/pr/1540608745157955634/ui-recheck/01-shelf.png), [three numbered variants](https://agent.virtualtabletop.io/reports/pr/1540608745157955634/ui-recheck/02-details-3variants.png), [the same rows in edit mode](https://agent.virtualtabletop.io/reports/pr/1540608745157955634/ui-recheck/06-details-edit.png), [a tile in flight without the AI badge](https://agent.virtualtabletop.io/reports/pr/1540608745157955634/ui-recheck/05-uploading-tile.png).

`npm test` passes (1367 tests), as do `tests/testcafe/boardsize.js` and `tests/testcafe/publiclibrary-1.js`, which drive the game shelf and the variants list.

## Follow-up from the code reviews

- **A variant name that looks like its placeholder survives.** The placeholder is written into the field as real text while editing, and reading it back stripped that text wherever it occurred — so typing `Variant 2 - Advanced` into row 2 saved `" - Advanced"`, and `Variant 1` into row 1 saved nothing. The field is now marked while the placeholder text is untouched and unmarked on the first keystroke, so only a field nobody typed in is read as empty. The same test replaces the `<empty game description>` comparison in the rich-text branch.
- **Every image of a game is normalized, not just the main one.** `variantImage` and `similarImage` from hand-written metadata reached an `<img src>` unchecked and rendered a broken-image glyph in the variants list and the "similar to" card.
- **An array is not metadata.** `typeof [] == 'object'`, so `"info": ["a","b"]` passed the guard from the previous round and was spread into the game one property per element. Both the game list and `Room.addState()` reject it now.
- **A rejected upload takes its optimistic rows back.** In **Game details → Edit → Add variant → Upload files** the variant rows and the queued `create` operation are added before the server has seen the file. When the server rejected it, they stayed — and the next Save sent one variant more than the game has, which threw server-side and silently discarded the whole edit. The upload now reports failure to its caller, which removes the rows and the queued operation again; `editState()` additionally ignores input for a variant that does not exist instead of losing the rest of the edit. The two client-side rejections report failure as well, so the details overlay no longer stays stuck in its uploading state.

`tests/server/room.test.js` now drives `Room.addState()` against real game files (the name it derives from the file, and metadata that is not an object), and `tests/client/editable-fields.test.js` covers the placeholder round trip. `npm test` passes (1381 tests), as does `tests/testcafe/publiclibrary-1.js`.

Screenshots: [renaming two unnamed variants](https://agent.virtualtabletop.io/reports/pr/1540608745157955634/ui-recheck/11-variants-typed.png), [both names after saving and reloading](https://agent.virtualtabletop.io/reports/pr/1540608745157955634/ui-recheck/12-variants-saved.png), [no leftover row after a rejected upload](https://agent.virtualtabletop.io/reports/pr/1540608745157955634/ui-recheck/14-rejected-upload.png), [non-string images on the details page](https://agent.virtualtabletop.io/reports/pr/1540608745157955634/ui-recheck/13-odd-images-details.png).

## Follow-up from the fourth code review

- **A file the shelf rejects no longer takes the client down.** The tile of an uploading file is only put into the game list once its metadata has been read, so a file that is rejected before it is sent - a plain text file, a zip without any JSON - reached the done callback with a tile that has no parent. Removing it through `removeChild` threw, and since the shelf does not await the upload that surfaced as an unhandled rejection and the "Something went wrong in your browser" screen. Both done callbacks use `remove()` now, which tolerates a detached node.
- **The `Variant N` placeholder is limited to games that have more than one variant.** On the details page of a game with a single variant it labelled nothing, and roughly 70 % of the library is in that state. The name field still pre-fills with it in edit mode, where it is the hint of an empty field.
- **A variant image that is not a string is normalized where the optimistic rows are built.** In **Game details → Edit → Add variant → Upload files** the rows come straight from the uploaded file, so a `"variantImage": 3` rendered `<img src="3">` and was persisted through the save.

`tests/client/state-upload.test.js` now drives `addStateFile()` itself against a non-zip file and a zip without JSON, which fails on the unfixed code with `Cannot read properties of null (reading 'removeChild')`. The branch is rebased on current `main`; the conflicts in `server/room.mjs` (the empty-variants block from #3150 above the guarded variant loop) and `tests/server/room.test.js` (the new tests reuse main's `roomWithStates()` helper) are resolved.

`npm test` passes (1670 tests), as does `tests/testcafe/publiclibrary-1.js`.

Screenshots: [the shelf after two rejected files and two real ones](https://agent.virtualtabletop.io/reports/pr/1540608745157955634/ui-recheck/20-shelf-after-rejected.png), a single variant in [view](https://agent.virtualtabletop.io/reports/pr/1540608745157955634/ui-recheck/21-details-single-variant.png) and [edit](https://agent.virtualtabletop.io/reports/pr/1540608745157955634/ui-recheck/22-edit-single-variant.png) mode, three variants in [view](https://agent.virtualtabletop.io/reports/pr/1540608745157955634/ui-recheck/23-details-three-variants.png) and [edit](https://agent.virtualtabletop.io/reports/pr/1540608745157955634/ui-recheck/24-edit-three-variants.png) mode, [an odd variant image that no longer reaches the row](https://agent.virtualtabletop.io/reports/pr/1540608745157955634/ui-recheck/26-addvariant-odd-image.png).

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3145/pr-test (or any other room on that server)




