### PR TITLE
Show what each operation did last on its routine editor card

### DIFF
--- a/client/css/editor/controls/events.css
+++ b/client/css/editor/controls/events.css
@@ -73,7 +73,22 @@
   font-size: 11px;
   font-style: italic;
   white-space: nowrap;
-  color: var(--textHelpColor);
+  color: var(--textColor);
+  opacity: var(--routineChromeOpacity);
+}
+
+/* why every card below is blank: shown until the first routine has been recorded (see
+   routinedebug.js), and gone the moment there is something to see */
+.events-editor-debug-hint {
+  color: var(--textColor);
+  opacity: var(--routineChromeOpacity);
+  font-size: 11px;
+  font-style: italic;
+  margin: 0 2px 2px;
+}
+
+.events-editor-debug-hint:empty {
+  display: none;
 }
 
 body.edit.darkMode .events-editor-property {

--- a/client/css/editor/controls/events.css
+++ b/client/css/editor/controls/events.css
@@ -65,6 +65,17 @@
   flex: 1;
 }
 
+/* whether the last interaction went through this routine at all (see routinedebug.js): the same
+   dimmed note the results on the operation cards are written in, so it reads as an observation
+   about the routine rather than as part of its name */
+.events-editor-runs {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-style: italic;
+  white-space: nowrap;
+  color: var(--textHelpColor);
+}
+
 body.edit.darkMode .events-editor-property {
   color: var(--textHighlightColor7);
 }

--- a/client/css/editor/controls/routine.css
+++ b/client/css/editor/controls/routine.css
@@ -495,3 +495,79 @@ body.edit.darkMode .routine-editor-parameter-missing {
 .routine-editor-fields .routine-editor-func-name {
   color: var(--routineVariableColor);
 }
+
+/* What an operation did the last time it ran, under its sentence (see routinedebug.js). It is
+   there to be glanced at while a routine is written, not read like the sentence above it: one
+   size down, in the dimmed text the controls of a card are drawn in, and separated from the
+   sentence by a perforation in the page color rather than by a box of its own. Only what came
+   out and what went wrong carry a color, so the eye finds them without the strip competing with
+   the sentence above it. */
+.routine-editor-debug {
+  margin-top: 3px;
+  padding-top: 2px;
+  border-top: 1px dashed var(--backgroundColor);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+/* a card of a routine that has not run has nothing to say, and says it by not being there */
+.routine-editor-debug:empty {
+  display: none;
+}
+
+/* one run per line: a loop that went round twenty times reads as twenty statements under each
+   other, which is what makes them comparable at a glance */
+.routine-editor-debug-run {
+  display: block;
+  word-break: break-word;
+}
+
+/* everything but the values: the text color turned down the same way the controls of a card are,
+   which is what keeps it readable on the card (see --routineChromeOpacity) while staying clearly
+   behind the sentence */
+.routine-editor-debug-count,
+.routine-editor-debug-definition,
+.routine-editor-debug-arrow,
+.routine-editor-debug-idle,
+.routine-editor-debug-more {
+  color: var(--textColor);
+  opacity: var(--routineChromeOpacity);
+}
+
+/* how many of the runs below it read the same, in front of the line the way a multiplier is */
+.routine-editor-debug-count {
+  font-weight: bold;
+}
+
+/* What came out, in the color a value has everywhere else in the editor - and on the same
+   background the chips of the sentence sit on, because that is what those colors are tuned
+   against and what makes a result read as a value rather than as another word. */
+.routine-editor-debug-result {
+  background: var(--backgroundColor);
+  border-radius: 3px;
+  padding: 0 4px;
+  color: var(--routineVariableColor);
+}
+
+/* what the engine had to complain about, on a line of its own: a problem is not a footnote to
+   the result */
+.routine-editor-debug-problem {
+  display: block;
+  color: var(--routineProblemColor);
+}
+
+/* an operation that ran without a result, was skipped, or was never reached: a statement about
+   nothing having happened, so it is the one part of the strip written in italics */
+.routine-editor-debug-idle {
+  font-style: italic;
+}
+
+.routine-editor-debug-more {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.routine-editor-debug-more:hover {
+  color: var(--VTTblue);
+  opacity: 1;
+}

--- a/client/css/editor/controls/routine.css
+++ b/client/css/editor/controls/routine.css
@@ -504,8 +504,9 @@ body.edit.darkMode .routine-editor-parameter-missing {
    the sentence above it. */
 .routine-editor-debug {
   margin-top: 3px;
+  margin-bottom: 2px;
   padding-top: 2px;
-  border-top: 1px dashed var(--backgroundColor);
+  border-top: 1px dashed var(--routineDebugSeparatorColor);
   font-size: 11px;
   line-height: 1.5;
 }
@@ -547,6 +548,10 @@ body.edit.darkMode .routine-editor-parameter-missing {
   border-radius: 3px;
   padding: 0 4px;
   color: var(--routineVariableColor);
+  /* a result long enough to wrap is one value either way, so it keeps one box around it instead
+     of being cut into two half-pills */
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 /* what the engine had to complain about, on a line of its own: a problem is not a footnote to
@@ -562,9 +567,19 @@ body.edit.darkMode .routine-editor-parameter-missing {
   font-style: italic;
 }
 
+/* the runs a card does not show, opened the way everything else in the editor is opened: a
+   chevron, with enough padding around it to be hit rather than aimed at */
 .routine-editor-debug-more {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: -4px;
+  padding: 2px 4px;
   cursor: pointer;
-  text-decoration: underline;
+}
+
+.routine-editor-debug-more .material-symbols {
+  font-size: 14px;
 }
 
 .routine-editor-debug-more:hover {

--- a/client/css/editor/layout.css
+++ b/client/css/editor/layout.css
@@ -44,6 +44,11 @@ body {
      the 4.5:1 the rest of this file budgets for. Dark mode is fine as it is. */
   --routineBlankColor: #d32f2f;
 
+  /* What an operation ran into, on the card it ran on rather than on a chip: red as dark as it
+     has to be to clear 4.5:1 against --backgroundHighlightColor1, which the reds tuned against
+     the page and the chips both miss there. */
+  --routineProblemColor: #a50e0e;
+
   /* The card of the routine editor that was worked on last: a clear step lighter
      than the other cards (--backgroundHighlightColor1) so it is spotted without
      reading, while the chrome on it (see --routineChromeOpacity) still clears
@@ -96,6 +101,7 @@ body.edit.darkMode {
   --routinePropertyColor: #ff8fb1;
   --routineNumberColor: #40e0d0;
   --routineBlankColor: red;
+  --routineProblemColor: #ffb4ab;
   --routineActiveCardColor: #626262;
 
   color-scheme: dark;

--- a/client/css/editor/layout.css
+++ b/client/css/editor/layout.css
@@ -49,6 +49,12 @@ body {
      the page and the chips both miss there. */
   --routineProblemColor: #a50e0e;
 
+  /* The perforation between the sentence of an operation and what it did last. It sits on two
+     different card backgrounds (--backgroundHighlightColor1 and the lighter
+     --routineActiveCardColor), so it is written as a wash of the text color rather than as a
+     fixed color that vanishes on one of them. */
+  --routineDebugSeparatorColor: rgba(0, 0, 0, 0.25);
+
   /* The card of the routine editor that was worked on last: a clear step lighter
      than the other cards (--backgroundHighlightColor1) so it is spotted without
      reading, while the chrome on it (see --routineChromeOpacity) still clears
@@ -102,6 +108,7 @@ body.edit.darkMode {
   --routineNumberColor: #40e0d0;
   --routineBlankColor: red;
   --routineProblemColor: #ffb4ab;
+  --routineDebugSeparatorColor: rgba(255, 255, 255, 0.3);
   --routineActiveCardColor: #626262;
 
   color-scheme: dark;

--- a/client/css/editor/sidebarModules.css
+++ b/client/css/editor/sidebarModules.css
@@ -26,6 +26,36 @@
   display: inline-flex;
 }
 
+/* The header of the Debug module: what the log shows (the filter and the Clear button) on one
+   line, what is recorded (the two checkboxes) on the next - four controls that do not fit one line
+   in a panel this narrow. Each checkbox stays glued to its own label rather than the phrase
+   breaking across the wrap. */
+.editorModule .buttonBar.debugHeader {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 12px;
+  padding-right: 8px;
+}
+
+.editorModule .buttonBar.debugHeader #jeLogFilter {
+  flex: 1 1 120px;
+}
+
+.editorModule .buttonBar.debugHeader .debugHeaderSettings {
+  flex: 1 1 100%;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 12px;
+}
+
+.editorModule .buttonBar.debugHeader label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 /* The row with the primary action. Laid out as a flex row so a status text placed before the button - the
    explanation of why it is disabled - sits next to it instead of somewhere further up the panel. It wraps
    because that explanation is a sentence: in a narrow panel it was squeezed into a 40px wide column of

--- a/client/js/editor/controls/events.js
+++ b/client/js/editor/controls/events.js
@@ -430,6 +430,14 @@ class EventsEditor {
       name.textContent = routineTargets[target].describe(property);
       headerDOM.append(name);
 
+      // whether the last interaction went through this routine at all - worth seeing without
+      // opening every card in the list (see routinedebug.js)
+      const runs = document.createElement('span');
+      runs.className = 'events-editor-runs';
+      runs.dataset.debugRoutine = `${this.widgetID}/${key}`;
+      routineDebugRenderRoutine(runs);
+      headerDOM.append(runs);
+
       infoButton(headerDOM, `<pre>${escapeHTML(event.description)}</pre>`);
 
       // the sentences below lean on their colors, so the key to them is where a

--- a/client/js/editor/controls/events.js
+++ b/client/js/editor/controls/events.js
@@ -395,6 +395,14 @@ class EventsEditor {
 
     const entries = this.routineEntries();
     const targets = routineTargetsOf(this.widget);
+
+    // why the cards of the routines below are blank when nothing has run yet (see routinedebug.js)
+    if(entries.length) {
+      const debugHint = div(this.domElement, 'events-editor-debug-hint');
+      debugHint.dataset.debugHint = '1';
+      routineDebugRenderHint(debugHint);
+    }
+
     // the same routine in both places of a deck: each card says so, because on
     // its own neither would explain why the routine appears twice
     const inBothPlaces = entries.filter(entry=>entries.filter(other=>other.property == entry.property).length > 1).map(entry=>entry.property);
@@ -430,14 +438,6 @@ class EventsEditor {
       name.textContent = routineTargets[target].describe(property);
       headerDOM.append(name);
 
-      // whether the last interaction went through this routine at all - worth seeing without
-      // opening every card in the list (see routinedebug.js)
-      const runs = document.createElement('span');
-      runs.className = 'events-editor-runs';
-      runs.dataset.debugRoutine = `${this.widgetID}/${key}`;
-      routineDebugRenderRoutine(runs);
-      headerDOM.append(runs);
-
       infoButton(headerDOM, `<pre>${escapeHTML(event.description)}</pre>`);
 
       // the sentences below lean on their colors, so the key to them is where a
@@ -470,6 +470,15 @@ class EventsEditor {
         }
       });
       headerDOM.append(removeButton);
+
+      // whether the last interaction went through this routine at all - worth seeing without
+      // opening every card in the list (see routinedebug.js). Behind the controls rather than
+      // behind the name, which is what a narrow panel has to shorten first.
+      const runs = document.createElement('span');
+      runs.className = 'events-editor-runs';
+      runs.dataset.debugRoutine = `${this.widgetID}/${key}`;
+      routineDebugRenderRoutine(runs);
+      headerDOM.append(runs);
 
       focusable(headerDOM, _=>{
         this.expandedEvents[key] = !expanded;

--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -272,6 +272,17 @@ const routineColorLegendHTML = `
     <dt class="routine-editor-parameter-missing">number or text</dt>
     <dd>a blank the operation still needs - the word says what belongs there</dd>
   </dl>
+  <p>Under the sentence, dimmed, is what the operation did the last time it ran (switch it off in the Debug module):</p>
+  <dl class="routine-legend">
+    <dt class="routine-editor-debug-definition">'hand' to 'discard'</dt>
+    <dd>the values it worked with, once the variables in the sentence were filled in</dd>
+    <dt class="routine-editor-debug-result">2</dt>
+    <dd>what came out of it</dd>
+    <dt class="routine-editor-debug-problem">crate does not exist</dt>
+    <dd>what it ran into - the operation did not do what its sentence says</dd>
+    <dt class="routine-editor-debug-idle">ran</dt>
+    <dd>it did its work and there is no value to show for it. <i>not run</i> means the routine ran but never reached this operation, <i>skipped</i> that the operation itself is switched off.</dd>
+  </dl>
 `;
 
 // A chip has padding on both sides, which puts a space between it and the comma

--- a/client/js/editor/controls/routine.js
+++ b/client/js/editor/controls/routine.js
@@ -2071,6 +2071,7 @@ class RoutineEditor {
         this.routineChanged();
       };
       editor.routineEditor = this;
+      editor.routineIndex = index;
 
       variables = [ ...new Set([ ...variables, ...editor.getDefinedVariables() ]) ];
       collections = [ ...new Set([ ...collections, ...editor.getDefinedCollections() ]) ];
@@ -2974,6 +2975,7 @@ class RoutineOperationEditor {
     this.renderSentenceView(div(body, 'routine-editor-sentence'));
 
     this.renderParameterWarnings(body);
+    this.renderDebug(body);
 
     // the controls of the card, in two rows next to the sentence: what changes
     // the operation itself (its JSON, deleting it) on top, what moves it around
@@ -3008,6 +3010,26 @@ class RoutineOperationEditor {
       });
     }
     return dom;
+  }
+
+  // What this operation did the last time it ran, on a strip below its sentence (see
+  // routinedebug.js). It stays empty - and with that invisible - until the routine has run, so a
+  // card that is only being written reads exactly as it did before.
+  renderDebug(dom) {
+    const key = this.debugKey();
+    if(!key)
+      return;
+    const debugDOM = div(dom, 'routine-editor-debug');
+    debugDOM.dataset.debugKey = key;
+    routineDebugRender(debugDOM);
+  }
+
+  // where this card sits in the game, which is how the runs of its operation are filed
+  debugKey() {
+    const editor = this.routineEditor;
+    if(!editor || !editor.widgetID || !editor.routineKey || typeof this.routineIndex != 'number')
+      return null;
+    return `${editor.widgetID}/${editor.routineKey}/${this.routineIndex}`;
   }
 
   // the popup a chip edits its parameter in, and the hand-over to the full popup

--- a/client/js/editor/controls/routinedebug.js
+++ b/client/js/editor/controls/routinedebug.js
@@ -11,7 +11,7 @@
 // Runs that read the same are counted instead of kept twice, so a loop that does the same thing a
 // hundred times is one line saying so rather than a hundred. Everything is dropped when the next
 // user interaction runs a routine, so what a card shows always belongs to one interaction - the
-// same rule the Debug module's log follows.
+// same rule the Debug module's log follows, down to the "auto clear" setting that turns it off.
 
 const ROUTINE_DEBUG_MAX_RUNS = 40;      // runs kept per operation; further ones are only counted
 const ROUTINE_DEBUG_COLLAPSED_RUNS = 3; // runs a card shows until it is asked for all of them
@@ -21,9 +21,13 @@ const routineDebugOmitted = new Map();     // operation key -> runs that no long
 const routineDebugRoutineRuns = new Map(); // routine path -> how often the routine itself ran
 const routineDebugExpanded = new Set();    // operation keys that were asked to show every run
 
-// the routines and operations currently running, innermost first. Both are kept in step by the
-// logging calls of evaluateRoutine, which come in matched pairs for the whole routine.
-const routineDebugRoutineStack = [];
+// The routines and operations currently running, outermost first. Both are kept in step by the
+// logging calls of evaluateRoutine, which come in matched pairs - except when an operation throws,
+// which reports the end of nothing at all. So a routine that starts drops the frames its own
+// nesting depth says cannot be running any more, and a routine that ends drops the operations of
+// its own that were left behind: a routine that dies half way cannot wedge the cards on stale
+// results until the page is reloaded.
+const routineDebugRoutineStack = [];    // { path, operationDepth }
 const routineDebugOperationStack = [];
 
 let routineDebugResetOnNextRun = true;
@@ -42,18 +46,25 @@ function routineDebugClear() {
   routineDebugResetOnNextRun = false;
 }
 
-function routineDebugRoutineStart(path) {
+// depth is how many routines evaluateRoutine is already inside, so anything below that on the
+// stacks belongs to a routine that never came back
+function routineDebugRoutineStart(path, depth) {
+  if(routineDebugRoutineStack.length > depth) {
+    routineDebugOperationStack.length = routineDebugRoutineStack[depth].operationDepth;
+    routineDebugRoutineStack.length = depth;
+  }
   if(!routineDebugRoutineStack.length && routineDebugResetOnNextRun)
     routineDebugClear();
-  routineDebugRoutineStack.unshift(path || null);
+  routineDebugRoutineStack.push({ path: path || null, operationDepth: routineDebugOperationStack.length });
   if(path)
     routineDebugRoutineRuns.set(path, (routineDebugRoutineRuns.get(path) || 0) + 1);
 }
 
 function routineDebugRoutineEnd() {
-  if(!routineDebugRoutineStack.length)
+  const routine = routineDebugRoutineStack.pop();
+  if(!routine)
     return;
-  routineDebugRoutineStack.shift();
+  routineDebugOperationStack.length = routine.operationDepth;
   if(!routineDebugRoutineStack.length)
     routineDebugRefresh();
 }
@@ -61,12 +72,13 @@ function routineDebugRoutineEnd() {
 // index is missing for the pseudo operations the log wraps a loop body in - those stand for no
 // card, so they only keep the stack in step
 function routineDebugOperationStart(index) {
-  const path = routineDebugRoutineStack[0];
-  routineDebugOperationStack.unshift(path && typeof index == 'number' ? { key: `${path}/${index}` } : null);
+  const routine = routineDebugRoutineStack[routineDebugRoutineStack.length-1];
+  const path = routine && routine.path;
+  routineDebugOperationStack.push(path && typeof index == 'number' ? { key: `${path}/${index}` } : null);
 }
 
 function routineDebugOperationSummary(definition, result) {
-  const running = routineDebugOperationStack[0];
+  const running = routineDebugOperationStack[routineDebugOperationStack.length-1];
   if(running) {
     running.definition = definition;
     running.result = result;
@@ -74,7 +86,7 @@ function routineDebugOperationSummary(definition, result) {
 }
 
 function routineDebugOperationEnd(problems, skipped) {
-  const running = routineDebugOperationStack.shift();
+  const running = routineDebugOperationStack.pop();
   if(!running)
     return;
   routineDebugAddRun(running.key, {
@@ -137,7 +149,7 @@ function routineDebugRunsHTML(key) {
   if(expanded && omitted)
     html += `<span class="routine-editor-debug-idle">${omitted} further ${omitted == 1 ? 'run' : 'runs'} were not kept</span>`;
   if(runs.length > ROUTINE_DEBUG_COLLAPSED_RUNS)
-    html += `<span class="routine-editor-debug-more" data-debug-toggle="${escapeHTML(key)}">${expanded ? 'show less' : `+ ${hidden} more ${hidden == 1 ? 'run' : 'runs'}`}</span>`;
+    html += `<span class="routine-editor-debug-more">${expanded ? 'show less' : `+ ${hidden} more ${hidden == 1 ? 'run' : 'runs'}`}</span>`;
   return html;
 }
 
@@ -164,7 +176,7 @@ function routineDebugRunHTML(run) {
 function routineDebugRender(dom) {
   const key = dom.dataset.debugKey;
   dom.innerHTML = routineDebugRunsHTML(key);
-  for(const toggle of $a('[data-debug-toggle]', dom)) {
+  for(const toggle of $a('.routine-editor-debug-more', dom)) {
     focusable(toggle, _=>{
       if(routineDebugExpanded.has(key))
         routineDebugExpanded.delete(key);

--- a/client/js/editor/controls/routinedebug.js
+++ b/client/js/editor/controls/routinedebug.js
@@ -34,6 +34,9 @@ const routineDebugRoutineStack = [];    // { path, operationDepth }
 const routineDebugOperationStack = [];
 
 let routineDebugResetOnNextRun = true;
+// whether any routine has run since the recording started, which is what tells a card that has
+// nothing to show from one that could not have anything to show yet
+let routineDebugRecorded = false;
 let routineDebugRefreshPending = false;
 
 // A new user interaction starts with a clean slate, but only once it actually runs something:
@@ -55,6 +58,7 @@ function routineDebugClear() {
   routineDebugOmitted.clear();
   routineDebugRoutineRuns.clear();
   routineDebugResetOnNextRun = false;
+  routineDebugRecorded = false;
 }
 
 // depth is how many routines evaluateRoutine is already inside, so anything below that on the
@@ -67,6 +71,7 @@ function routineDebugRoutineStart(path, depth) {
   if(!routineDebugRoutineStack.length && routineDebugResetOnNextRun)
     routineDebugClear();
   routineDebugRoutineStack.push({ path: path || null, operationDepth: routineDebugOperationStack.length });
+  routineDebugRecorded = true;
   if(path)
     routineDebugRoutineRuns.set(path, (routineDebugRoutineRuns.get(path) || 0) + 1);
 }
@@ -136,6 +141,20 @@ function routineDebugRoutineOf(key) {
   return key.replace(/\/[^/]*$/, '');
 }
 
+// whether a routine this operation sits inside ran at all, however deeply nested it is. The
+// nearest one counts rather than only its own block: an operation in a branch that was not taken
+// sits in a block that never started, and saying nothing there would read as "never ran" while the
+// operation after an aborted CALL - the same situation - says so.
+function routineDebugRanAbove(key) {
+  let path = routineDebugRoutineOf(key);
+  while(path.indexOf('/') != -1) {
+    if(routineDebugRoutineRuns.get(path))
+      return true;
+    path = routineDebugRoutineOf(path);
+  }
+  return false;
+}
+
 // The results of one operation, as the markup of the strip below its sentence. Everything the
 // cards show goes through here, so a card rendered now and a card updated after a routine ran
 // look the same.
@@ -144,24 +163,56 @@ function routineDebugRunsHTML(key) {
   if(!runs.length) {
     // a routine that ran without reaching this operation says so - within a routine that did run,
     // the operations it stepped over are half of what there is to see
-    return routineDebugRoutineRuns.get(routineDebugRoutineOf(key))
+    return routineDebugRanAbove(key)
       ? '<span class="routine-editor-debug-idle">not run</span>'
       : '';
   }
 
+  const omitted = routineDebugOmitted.get(key) || 0;
+  if(routineDebugIsSequence(runs))
+    return routineDebugSequenceHTML(runs, omitted);
+
   const expanded = routineDebugExpanded.has(key);
   const shown = expanded ? runs : runs.slice(0, ROUTINE_DEBUG_COLLAPSED_RUNS);
-  const omitted = routineDebugOmitted.get(key) || 0;
   const hidden = runs.slice(shown.length).reduce((sum, run)=>sum + run.count, 0) + omitted;
 
   let html = shown.map(run=>routineDebugRunHTML(run)).join('');
-  // a loop long enough to fill the card is cut off rather than kept in full, and says so instead
-  // of letting the last line it shows read as the last round there was
   if(expanded && omitted)
-    html += `<span class="routine-editor-debug-idle">${omitted} further ${omitted == 1 ? 'run' : 'runs'} were not kept</span>`;
+    html += routineDebugOmittedHTML(omitted);
   if(runs.length > ROUTINE_DEBUG_COLLAPSED_RUNS)
-    html += `<span class="routine-editor-debug-more">${expanded ? 'show less' : `+ ${hidden} more ${hidden == 1 ? 'run' : 'runs'}`}</span>`;
+    html += routineDebugMoreHTML(expanded, hidden);
   return html;
+}
+
+// A loop that repeats one operation writes the same sentence on every round with only the result
+// differing, and then the sequence of results is the whole of what there is to read. Those runs are
+// written as one line - the sentence once, the results after it - so a five-round loop reads as
+// "1 3 6 10 15" instead of five lines the eye has to compare across their full width. Rounds that
+// differ in anything else keep a line each, because then the lines are what says what happened.
+function routineDebugIsSequence(runs) {
+  return runs.length > 1 && Boolean(runs[0].definition)
+    && runs.every(run=>!run.skipped && !run.problems.length && run.result !== '' && run.definition === runs[0].definition);
+}
+
+function routineDebugSequenceHTML(runs, omitted) {
+  const results = runs.map(run=>
+    (run.count > 1 ? `<span class="routine-editor-debug-count">${run.count}&times;</span>` : '')
+    + `<span class="routine-editor-debug-result">${escapeHTML(run.result)}</span>`).join(' ');
+  return `<span class="routine-editor-debug-run"><span class="routine-editor-debug-definition">${escapeHTML(runs[0].definition)}</span> <span class="routine-editor-debug-arrow">&rarr;</span> ${results}</span>`
+    + routineDebugOmittedHTML(omitted);
+}
+
+// a loop long enough to fill the card is cut off rather than kept in full, and says so instead of
+// letting the last line it shows read as the last round there was
+function routineDebugOmittedHTML(omitted) {
+  return omitted ? `<span class="routine-editor-debug-idle">${omitted} further ${omitted == 1 ? 'run' : 'runs'} were not kept</span>` : '';
+}
+
+// what asks a card for the runs it does not show, written the way the rest of the editor opens
+// something: the chevron of a collapsed section, with room around it to be hit
+function routineDebugMoreHTML(expanded, hidden) {
+  const label = expanded ? 'show less' : `+ ${hidden} more ${hidden == 1 ? 'run' : 'runs'}`;
+  return `<span class="routine-editor-debug-more"><span class="material-symbols">${expanded ? 'expand_more' : 'chevron_right'}</span>${label}</span>`;
 }
 
 function routineDebugRunHTML(run) {
@@ -198,6 +249,15 @@ function routineDebugRender(dom) {
   }
 }
 
+// Why every card of the widget is empty, above its list of routines. The results are only
+// collected once edit mode has been loaded, so the first thing anybody tries - press a button and
+// then open the editor to see what it did - has nothing to show and looks exactly like a routine
+// that never ran. Saying so is the difference between "run it again" and "this is broken".
+function routineDebugRenderHint(dom) {
+  const waiting = getJEroutineDebug() && !routineDebugRecorded;
+  dom.textContent = waiting ? 'Nothing recorded yet - what the operations do is collected from now on. Run a routine to see it on its cards.' : '';
+}
+
 // how often a whole routine ran, for the list of routines: which of them an interaction went
 // through is worth seeing without opening every one of them
 function routineDebugRenderRoutine(dom) {
@@ -224,4 +284,6 @@ function routineDebugRefreshNow() {
     routineDebugRender(dom);
   for(const dom of $a('[data-debug-routine]'))
     routineDebugRenderRoutine(dom);
+  for(const dom of $a('[data-debug-hint]'))
+    routineDebugRenderHint(dom);
 }

--- a/client/js/editor/controls/routinedebug.js
+++ b/client/js/editor/controls/routinedebug.js
@@ -26,7 +26,10 @@ const routineDebugExpanded = new Set();    // operation keys that were asked to 
 // which reports the end of nothing at all. So a routine that starts drops the frames its own
 // nesting depth says cannot be running any more, and a routine that ends drops the operations of
 // its own that were left behind: a routine that dies half way cannot wedge the cards on stale
-// results until the page is reloaded.
+// results until the page is reloaded. Two routines that interleave across an await - a delta from
+// another player running a changeRoutine while a local routine waits for an INPUT - file their
+// operations under whichever of them started last; that is a wrong line on a card, never a wrong
+// stack.
 const routineDebugRoutineStack = [];    // { path, operationDepth }
 const routineDebugOperationStack = [];
 

--- a/client/js/editor/controls/routinedebug.js
+++ b/client/js/editor/controls/routinedebug.js
@@ -22,14 +22,14 @@ const routineDebugRoutineRuns = new Map(); // routine path -> how often the rout
 const routineDebugExpanded = new Set();    // operation keys that were asked to show every run
 
 // The routines and operations currently running, outermost first. Both are kept in step by the
-// logging calls of evaluateRoutine, which come in matched pairs - except when an operation throws,
-// which reports the end of nothing at all. So a routine that starts drops the frames its own
-// nesting depth says cannot be running any more, and a routine that ends drops the operations of
-// its own that were left behind: a routine that dies half way cannot wedge the cards on stale
-// results until the page is reloaded. Two routines that interleave across an await - a delta from
-// another player running a changeRoutine while a local routine waits for an INPUT - file their
-// operations under whichever of them started last; that is a wrong line on a card, never a wrong
-// stack.
+// logging calls of evaluateRoutine, which come in matched pairs - a routine that dies half way is
+// closed off by jeLoggingRoutineAbort, which makes the calls the operations that threw never made.
+// A routine that ends still drops the operations of its own that were left behind, and a routine
+// that starts drops anything the logging no longer counts as running, so nothing can wedge the
+// cards on stale results until the page is reloaded. Two routines that interleave across an await
+// - a delta from another player running a changeRoutine while a local routine waits for an INPUT -
+// file their operations under whichever of them started last; that is a wrong line on a card,
+// never a wrong stack.
 const routineDebugRoutineStack = [];    // { path, operationDepth }
 const routineDebugOperationStack = [];
 
@@ -53,6 +53,9 @@ function routineDebugSetEnabled(enabled) {
   routineDebugRefreshNow();
 }
 
+// Everything the cards show goes, but not which of them were asked to show every run they have:
+// that is how the reader left the editor, not something the last interaction produced, so a card
+// whose operation runs again comes back open.
 function routineDebugClear() {
   routineDebugRuns.clear();
   routineDebugOmitted.clear();
@@ -61,12 +64,15 @@ function routineDebugClear() {
   routineDebugRecorded = false;
 }
 
-// depth is how many routines evaluateRoutine is already inside, so anything below that on the
-// stacks belongs to a routine that never came back
-function routineDebugRoutineStart(path, depth) {
-  if(routineDebugRoutineStack.length > depth) {
-    routineDebugOperationStack.length = routineDebugRoutineStack[depth].operationDepth;
-    routineDebugRoutineStack.length = depth;
+// frame is the nesting the logging opened this routine at (jeLoggingRoutineStart), which is the
+// one thing that counts the same routines this stack does - anything above it belongs to a routine
+// that never came back. Not evaluateRoutine's own depth: a routine the engine starts as a side
+// effect of an operation begins at depth 0 with the routine that set it off still running, and
+// keying on that would throw away the frame of the routine the player actually clicked.
+function routineDebugRoutineStart(path, frame) {
+  if(routineDebugRoutineStack.length > frame) {
+    routineDebugOperationStack.length = routineDebugRoutineStack[frame].operationDepth;
+    routineDebugRoutineStack.length = frame;
   }
   if(!routineDebugRoutineStack.length && routineDebugResetOnNextRun)
     routineDebugClear();
@@ -141,16 +147,25 @@ function routineDebugRoutineOf(key) {
   return key.replace(/\/[^/]*$/, '');
 }
 
+// the routine a nested block sits in: a block is addressed as "<routine>/<index>/<blockName>", so
+// dropping those two segments is its parent. Only that shape is walked out of, never a bare
+// "<widget>/<property>" - a widget whose id contains a slash would otherwise be read as a path
+// into another widget's routines.
+function routineDebugRoutineAround(path) {
+  const nested = path.match(/^(.*)\/\d+\/[^/]+$/);
+  return nested && nested[1];
+}
+
 // whether a routine this operation sits inside ran at all, however deeply nested it is. The
 // nearest one counts rather than only its own block: an operation in a branch that was not taken
 // sits in a block that never started, and saying nothing there would read as "never ran" while the
 // operation after an aborted CALL - the same situation - says so.
 function routineDebugRanAbove(key) {
   let path = routineDebugRoutineOf(key);
-  while(path.indexOf('/') != -1) {
+  while(path) {
     if(routineDebugRoutineRuns.get(path))
       return true;
-    path = routineDebugRoutineOf(path);
+    path = routineDebugRoutineAround(path);
   }
   return false;
 }

--- a/client/js/editor/controls/routinedebug.js
+++ b/client/js/editor/controls/routinedebug.js
@@ -1,0 +1,204 @@
+// What every operation of a routine did the last time it ran, shown on the card of the operation
+// itself: the values it worked with once the variables were filled in, what came out, and what
+// went wrong. A routine is followed where it is written instead of in a log next to it.
+//
+// A run is filed under the place of the operation in the game, in the same terms the routine
+// editor addresses its cards with - the widget, the property the routine is written in, and the
+// path of block and index into the nested routines ("card1/clickRoutine/2/thenRoutine/0"). So an
+// operation inside a loopRoutine collects every one of its runs on the one card that stands for
+// it, however often the loop went round.
+//
+// Runs that read the same are counted instead of kept twice, so a loop that does the same thing a
+// hundred times is one line saying so rather than a hundred. Everything is dropped when the next
+// user interaction runs a routine, so what a card shows always belongs to one interaction - the
+// same rule the Debug module's log follows.
+
+const ROUTINE_DEBUG_MAX_RUNS = 40;      // runs kept per operation; further ones are only counted
+const ROUTINE_DEBUG_COLLAPSED_RUNS = 3; // runs a card shows until it is asked for all of them
+
+const routineDebugRuns = new Map();        // operation key -> [ { text, definition, result, problems, skipped, count } ]
+const routineDebugOmitted = new Map();     // operation key -> runs that no longer fit
+const routineDebugRoutineRuns = new Map(); // routine path -> how often the routine itself ran
+const routineDebugExpanded = new Set();    // operation keys that were asked to show every run
+
+// the routines and operations currently running, innermost first. Both are kept in step by the
+// logging calls of evaluateRoutine, which come in matched pairs for the whole routine.
+const routineDebugRoutineStack = [];
+const routineDebugOperationStack = [];
+
+let routineDebugResetOnNextRun = true;
+let routineDebugRefreshPending = false;
+
+// A new user interaction starts with a clean slate, but only once it actually runs something:
+// clicking around in the editor must not empty the cards of the routine that was just watched.
+function routineDebugResetAfterInteraction() {
+  routineDebugResetOnNextRun = true;
+}
+
+function routineDebugClear() {
+  routineDebugRuns.clear();
+  routineDebugOmitted.clear();
+  routineDebugRoutineRuns.clear();
+  routineDebugResetOnNextRun = false;
+}
+
+function routineDebugRoutineStart(path) {
+  if(!routineDebugRoutineStack.length && routineDebugResetOnNextRun)
+    routineDebugClear();
+  routineDebugRoutineStack.unshift(path || null);
+  if(path)
+    routineDebugRoutineRuns.set(path, (routineDebugRoutineRuns.get(path) || 0) + 1);
+}
+
+function routineDebugRoutineEnd() {
+  if(!routineDebugRoutineStack.length)
+    return;
+  routineDebugRoutineStack.shift();
+  if(!routineDebugRoutineStack.length)
+    routineDebugRefresh();
+}
+
+// index is missing for the pseudo operations the log wraps a loop body in - those stand for no
+// card, so they only keep the stack in step
+function routineDebugOperationStart(index) {
+  const path = routineDebugRoutineStack[0];
+  routineDebugOperationStack.unshift(path && typeof index == 'number' ? { key: `${path}/${index}` } : null);
+}
+
+function routineDebugOperationSummary(definition, result) {
+  const running = routineDebugOperationStack[0];
+  if(running) {
+    running.definition = definition;
+    running.result = result;
+  }
+}
+
+function routineDebugOperationEnd(problems, skipped) {
+  const running = routineDebugOperationStack.shift();
+  if(!running)
+    return;
+  routineDebugAddRun(running.key, {
+    definition: running.definition || '',
+    result: running.result === undefined || running.result === null ? '' : String(running.result),
+    problems: (problems || []).map(String),
+    skipped: Boolean(skipped)
+  });
+}
+
+// what makes two runs read the same, and with that what is counted rather than listed twice
+function routineDebugRunText(run) {
+  return [ run.skipped, run.definition, run.result, ...run.problems ].join('\u0000');
+}
+
+function routineDebugAddRun(key, run) {
+  let runs = routineDebugRuns.get(key);
+  if(!runs)
+    routineDebugRuns.set(key, runs = []);
+  run.text = routineDebugRunText(run);
+  const previous = runs[runs.length-1];
+  if(previous && previous.text === run.text) {
+    ++previous.count;
+    return;
+  }
+  if(runs.length >= ROUTINE_DEBUG_MAX_RUNS) {
+    routineDebugOmitted.set(key, (routineDebugOmitted.get(key) || 0) + 1);
+    return;
+  }
+  run.count = 1;
+  runs.push(run);
+}
+
+// the routine an operation belongs to: its key without the index of the operation itself
+function routineDebugRoutineOf(key) {
+  return key.replace(/\/[^/]*$/, '');
+}
+
+// The results of one operation, as the markup of the strip below its sentence. Everything the
+// cards show goes through here, so a card rendered now and a card updated after a routine ran
+// look the same.
+function routineDebugRunsHTML(key) {
+  const runs = routineDebugRuns.get(key) || [];
+  if(!runs.length) {
+    // a routine that ran without reaching this operation says so - within a routine that did run,
+    // the operations it stepped over are half of what there is to see
+    return routineDebugRoutineRuns.get(routineDebugRoutineOf(key))
+      ? '<span class="routine-editor-debug-idle">not run</span>'
+      : '';
+  }
+
+  const expanded = routineDebugExpanded.has(key);
+  const shown = expanded ? runs : runs.slice(0, ROUTINE_DEBUG_COLLAPSED_RUNS);
+  const omitted = routineDebugOmitted.get(key) || 0;
+  const hidden = runs.slice(shown.length).reduce((sum, run)=>sum + run.count, 0) + omitted;
+
+  let html = shown.map(run=>routineDebugRunHTML(run)).join('');
+  // a loop long enough to fill the card is cut off rather than kept in full, and says so instead
+  // of letting the last line it shows read as the last round there was
+  if(expanded && omitted)
+    html += `<span class="routine-editor-debug-idle">${omitted} further ${omitted == 1 ? 'run' : 'runs'} were not kept</span>`;
+  if(runs.length > ROUTINE_DEBUG_COLLAPSED_RUNS)
+    html += `<span class="routine-editor-debug-more" data-debug-toggle="${escapeHTML(key)}">${expanded ? 'show less' : `+ ${hidden} more ${hidden == 1 ? 'run' : 'runs'}`}</span>`;
+  return html;
+}
+
+function routineDebugRunHTML(run) {
+  const parts = [];
+  if(run.count > 1)
+    parts.push(`<span class="routine-editor-debug-count">${run.count}&times;</span>`);
+  if(run.skipped)
+    parts.push('<span class="routine-editor-debug-idle">skipped</span>');
+  if(run.definition)
+    parts.push(`<span class="routine-editor-debug-definition">${escapeHTML(run.definition)}</span>`);
+  if(run.result !== '')
+    parts.push('<span class="routine-editor-debug-arrow">&rarr;</span>', `<span class="routine-editor-debug-result">${escapeHTML(run.result)}</span>`);
+  // an operation the engine has nothing to say about still says that it ran, because an empty
+  // line would read as "not run"
+  if(!run.skipped && !run.definition && run.result === '' && !run.problems.length)
+    parts.push('<span class="routine-editor-debug-idle">ran</span>');
+  const problems = run.problems.map(problem=>`<span class="routine-editor-debug-problem">${escapeHTML(problem)}</span>`).join('');
+  return `<span class="routine-editor-debug-run">${parts.join(' ')}${problems}</span>`;
+}
+
+// The strip of one card, filled in place: rewriting the card itself whenever a routine ends would
+// close the popup somebody is editing a parameter in.
+function routineDebugRender(dom) {
+  const key = dom.dataset.debugKey;
+  dom.innerHTML = routineDebugRunsHTML(key);
+  for(const toggle of $a('[data-debug-toggle]', dom)) {
+    focusable(toggle, _=>{
+      if(routineDebugExpanded.has(key))
+        routineDebugExpanded.delete(key);
+      else
+        routineDebugExpanded.add(key);
+      routineDebugRender(dom);
+    });
+  }
+}
+
+// how often a whole routine ran, for the list of routines: which of them an interaction went
+// through is worth seeing without opening every one of them
+function routineDebugRenderRoutine(dom) {
+  const runs = routineDebugRoutineRuns.get(dom.dataset.debugRoutine) || 0;
+  dom.textContent = runs ? (runs > 1 ? `ran ${runs}×` : 'ran') : '';
+  dom.title = runs ? `This routine ran ${runs} ${runs == 1 ? 'time' : 'times'} during the last interaction.` : '';
+}
+
+// Every strip on screen follows the routine that just ran. Deferred by a tick because one
+// interaction can run dozens of routines (every property change runs the changeRoutines of the
+// widget), and they all end up showing the same thing.
+function routineDebugRefresh() {
+  if(routineDebugRefreshPending)
+    return;
+  routineDebugRefreshPending = true;
+  setTimeout(_=>{
+    routineDebugRefreshPending = false;
+    routineDebugRefreshNow();
+  }, 0);
+}
+
+function routineDebugRefreshNow() {
+  for(const dom of $a('.routine-editor-debug[data-debug-key]'))
+    routineDebugRender(dom);
+  for(const dom of $a('[data-debug-routine]'))
+    routineDebugRenderRoutine(dom);
+}

--- a/client/js/editor/controls/routinedebug.js
+++ b/client/js/editor/controls/routinedebug.js
@@ -39,6 +39,14 @@ function routineDebugResetAfterInteraction() {
   routineDebugResetOnNextRun = true;
 }
 
+// Switching the results off takes what is on the cards with them: a strip left standing after the
+// switch was flipped would read as what the routine that runs next did.
+function routineDebugSetEnabled(enabled) {
+  if(!enabled)
+    routineDebugClear();
+  routineDebugRefreshNow();
+}
+
 function routineDebugClear() {
   routineDebugRuns.clear();
   routineDebugOmitted.clear();

--- a/client/js/editor/sidebar/json.js
+++ b/client/js/editor/sidebar/json.js
@@ -91,6 +91,14 @@ class DebugModule extends SidebarModule {
     jeLoggingFilterLog($('#jeLogFilter').value);
   }
 
+  // What every operation did last, shown on its card in the routine editor. It is collected for the
+  // rest of the session once edit mode has been loaded, so switching it off has to stop the
+  // collecting as well as empty the cards.
+  button_routineCardResults() {
+    setJEroutineDebug($('#routineCardResults').checked);
+    routineDebugSetEnabled($('#routineCardResults').checked);
+  }
+
   button_validationProblem(problem) {
     if(!jeEnabled)
       return;
@@ -130,11 +138,13 @@ class DebugModule extends SidebarModule {
       <input type=text id=jeLogFilter placeholder="Filter log...">
       <input type=checkbox id=autoClearLog checked><label for=autoClearLog> Clear after each interaction</label>
       <button icon=backspace id=clearLogButton disabled>Clear</button>
+      <input type=checkbox id=routineCardResults ${getJEroutineDebug() ? 'checked' : ''}><label for=routineCardResults> Results on routine cards</label>
     `);
     target.append($('#jeLog'));
 
     on('#jeLogFilter', 'input', e=>this.button_filter());
     on('#autoClearLog', 'change', e=>this.button_clearCheckbox());
+    on('#routineCardResults', 'change', e=>this.button_routineCardResults());
     on('#clearLogButton', 'click', e=>this.button_clearButton());
 
     setJEroutineLogging(jeRoutineLogging = true);

--- a/client/js/editor/sidebar/json.js
+++ b/client/js/editor/sidebar/json.js
@@ -134,11 +134,16 @@ class DebugModule extends SidebarModule {
   }
 
   renderModule(target) {
-    div(target, 'buttonBar', `
+    // What the log shows on the first line, what the recorder does on the second: four controls
+    // that no longer fit one line in a narrow panel, so the row wraps - with each checkbox and its
+    // label kept together, because a label that breaks mid-phrase ends up next to the wrong box.
+    div(target, 'buttonBar debugHeader', `
       <input type=text id=jeLogFilter placeholder="Filter log...">
-      <input type=checkbox id=autoClearLog checked><label for=autoClearLog> Clear after each interaction</label>
       <button icon=backspace id=clearLogButton disabled>Clear</button>
-      <input type=checkbox id=routineCardResults ${getJEroutineDebug() ? 'checked' : ''}><label for=routineCardResults> Results on routine cards</label>
+      <span class=debugHeaderSettings>
+        <label title="Empty the log whenever you do something in the room, so it always shows what one interaction did."><input type=checkbox id=autoClearLog checked> Clear after each interaction</label>
+        <label title="Also collect what every operation of a routine does, and show it in the routine editor under the sentence of the operation that did it."><input type=checkbox id=routineCardResults ${getJEroutineDebug() ? 'checked' : ''}> Show results on the routine editor's cards</label>
+      </span>
     `);
     target.append($('#jeLog'));
 

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3100,6 +3100,10 @@ let jeHTMLStack = [];
 let jeLoggingHTMLEnabled = false;
 let jeLoggingCardsEnabled = false;
 let jeLoggingOutermostRoutine = null;
+// operations of the routine that is running which have not reported an end yet, and the same for
+// the routines it is nested in - what jeLoggingRoutineAbort has to close when a routine dies
+let jeLoggingOpenOperations = 0;
+let jeLoggingOpenOperationStack = [];
 
 // Empty the log. Operations of a routine that is currently running have the log so far saved on
 // jeHTMLStack, so that has to be emptied too - otherwise jeLoggingRoutineOperationEnd prepends it
@@ -3108,6 +3112,17 @@ function jeLoggingClear() {
   jeLoggingHTML = '';
   for(const entry of jeHTMLStack)
     entry[0] = '';
+}
+
+// A new user interaction starts the log - and the results on the routine editor's cards - over, so
+// that what they show always belongs to one interaction. Nothing is emptied here: the flag is only
+// read once a routine actually runs, so clicking around without running anything leaves the last
+// interaction standing to be read. Called once per interaction, which for a widget hotkey is the
+// key event rather than the routines it sets off (client/js/mousehandling.js).
+export function jeRoutineNewInteraction() {
+  jeRoutineResetOnNextLog = jeRoutineAutoReset;
+  if(jeRoutineAutoReset)
+    routineDebugResetAfterInteraction();
 }
 
 function jeLoggingJSON(obj) {
@@ -3136,7 +3151,23 @@ export function jeLoggingRoutineStart(widget, property, initialVariables, initia
         <div class="jeLogNested ${jeLoggingDepth ? '' : 'active'}">
     `;
   }
+  jeLoggingOpenOperationStack.push(jeLoggingOpenOperations);
+  jeLoggingOpenOperations = 0;
   ++jeLoggingDepth;
+}
+
+// An operation that throws never reports its end, and neither does the routine it was in - the
+// matched calls above simply stop coming. Everything that routine still holds is closed off here,
+// back to the depth it started at, so one routine that dies half way cannot leave the log unrendered
+// and the switches unread for the rest of the session. Every operation that was still running gets
+// the problem written on it, so the cards read as the chain that died rather than going quiet.
+export function jeLoggingRoutineAbort(depth, problem) {
+  const problems = problem ? [ problem ] : [];
+  while(jeLoggingDepth > depth) {
+    while(jeLoggingOpenOperations)
+      jeLoggingRoutineOperationEnd(problems, {}, {}, false);
+    jeLoggingRoutineEnd({}, {});
+  }
 }
 
 export function jeLoggingRoutineEnd(variables, collections) {
@@ -3146,6 +3177,7 @@ export function jeLoggingRoutineEnd(variables, collections) {
     routineDebugRoutineEnd();
   if( jeLoggingHTMLEnabled && (jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine', 'Moves'].indexOf( jeHTMLStack[0][3] ) == -1) ) jeLoggingHTML += '</div></div>';
   --jeLoggingDepth;
+  jeLoggingOpenOperations = jeLoggingOpenOperationStack.pop() || 0;
   if(!jeLoggingDepth) {
     if(jeLoggingHTMLEnabled)
       jeLoggingRenderLog(jeLoggingHTML + '</div></div>');
@@ -3214,6 +3246,7 @@ function jeLoggingRoutineNotLogged(widget, property) {
 }
 
 export function jeLoggingRoutineOperationStart(original, applied, index) {
+  ++jeLoggingOpenOperations;
   if(jeLoggingCardsEnabled)
     routineDebugOperationStart(index);
   if(!jeLoggingHTMLEnabled)
@@ -3233,6 +3266,8 @@ export function jeLoggingRoutineOperationStart(original, applied, index) {
 }
 
 export function jeLoggingRoutineOperationEnd(problems, variables, collections, skipped) {
+  if(jeLoggingOpenOperations)
+    --jeLoggingOpenOperations;
   if(jeLoggingCardsEnabled)
     routineDebugOperationEnd(problems, skipped);
   if(!jeLoggingHTMLEnabled) {
@@ -4063,9 +4098,7 @@ function jeInitEventListeners() {
 
   window.addEventListener('mousedown', _=>jeMouseButtonIsDown = jeEnabled);
   window.addEventListener('mouseup', async function(e) {
-    jeRoutineResetOnNextLog = jeRoutineAutoReset;
-    if(jeRoutineAutoReset)
-      routineDebugResetAfterInteraction();
+    jeRoutineNewInteraction();
     if(!jeEnabled)
       return;
     jeMouseButtonIsDown = false;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3112,12 +3112,12 @@ function jeLoggingJSON(obj) {
   return html(JSON.stringify(obj, null, '  ').split('\n').slice(1, -1).join('\n'));
 }
 
-export function jeLoggingRoutineStart(widget, property, initialVariables, initialCollections, byReference, path) {
+export function jeLoggingRoutineStart(widget, property, initialVariables, initialCollections, byReference, path, depth) {
   if(!jeLoggingDepth) {
     jeLoggingHTMLEnabled = jeRoutineLogging;
     jeLoggingOutermostRoutine = { widget, property };
   }
-  routineDebugRoutineStart(path);
+  routineDebugRoutineStart(path, depth || 0);
   if( jeLoggingHTMLEnabled && (jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine', 'Moves'].indexOf( jeHTMLStack[0][3] ) == -1) ) {
     if(jeRoutineResetOnNextLog) {
       jeLoggingHTML = '';
@@ -4056,7 +4056,8 @@ function jeInitEventListeners() {
   window.addEventListener('mousedown', _=>jeMouseButtonIsDown = jeEnabled);
   window.addEventListener('mouseup', async function(e) {
     jeRoutineResetOnNextLog = jeRoutineAutoReset;
-    routineDebugResetAfterInteraction();
+    if(jeRoutineAutoReset)
+      routineDebugResetAfterInteraction();
     if(!jeEnabled)
       return;
     jeMouseButtonIsDown = false;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3093,10 +3093,12 @@ let jeLoggingHTML = '';
 let jeLoggingDepth = 0;
 let jeHTMLStack = [];
 // The log below is built while the Debug module is open, but a routine is recorded for the
-// routine editor's cards whenever the editor is loaded (see jeRoutineDebug in main.js). Which of
-// the two applies is decided when the outermost routine starts, so opening or closing the module
-// while a routine waits - for an INPUT, say - can never leave the log half built.
+// routine editor's cards whenever the editor is loaded and the cards are switched on (see
+// jeRoutineDebug in main.js). Which of the two applies is decided when the outermost routine
+// starts, so opening or closing the module - or flipping that switch - while a routine waits for
+// an INPUT can never leave the log or the stacks of the recorder half built.
 let jeLoggingHTMLEnabled = false;
+let jeLoggingCardsEnabled = false;
 let jeLoggingOutermostRoutine = null;
 
 // Empty the log. Operations of a routine that is currently running have the log so far saved on
@@ -3115,9 +3117,11 @@ function jeLoggingJSON(obj) {
 export function jeLoggingRoutineStart(widget, property, initialVariables, initialCollections, byReference, path, depth) {
   if(!jeLoggingDepth) {
     jeLoggingHTMLEnabled = jeRoutineLogging;
+    jeLoggingCardsEnabled = getJEroutineDebug();
     jeLoggingOutermostRoutine = { widget, property };
   }
-  routineDebugRoutineStart(path, depth || 0);
+  if(jeLoggingCardsEnabled)
+    routineDebugRoutineStart(path, depth || 0);
   if( jeLoggingHTMLEnabled && (jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine', 'Moves'].indexOf( jeHTMLStack[0][3] ) == -1) ) {
     if(jeRoutineResetOnNextLog) {
       jeLoggingHTML = '';
@@ -3138,7 +3142,8 @@ export function jeLoggingRoutineStart(widget, property, initialVariables, initia
 export function jeLoggingRoutineEnd(variables, collections) {
   if(!jeLoggingDepth)
     return; // defensive: unmatched End, should not happen since #2672
-  routineDebugRoutineEnd();
+  if(jeLoggingCardsEnabled)
+    routineDebugRoutineEnd();
   if( jeLoggingHTMLEnabled && (jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine', 'Moves'].indexOf( jeHTMLStack[0][3] ) == -1) ) jeLoggingHTML += '</div></div>';
   --jeLoggingDepth;
   if(!jeLoggingDepth) {
@@ -3209,7 +3214,8 @@ function jeLoggingRoutineNotLogged(widget, property) {
 }
 
 export function jeLoggingRoutineOperationStart(original, applied, index) {
-  routineDebugOperationStart(index);
+  if(jeLoggingCardsEnabled)
+    routineDebugOperationStart(index);
   if(!jeLoggingHTMLEnabled)
     return;
   let fcn;
@@ -3227,7 +3233,8 @@ export function jeLoggingRoutineOperationStart(original, applied, index) {
 }
 
 export function jeLoggingRoutineOperationEnd(problems, variables, collections, skipped) {
-  routineDebugOperationEnd(problems, skipped);
+  if(jeLoggingCardsEnabled)
+    routineDebugOperationEnd(problems, skipped);
   if(!jeLoggingHTMLEnabled) {
     jeRoutineResult = '';
     return;
@@ -3303,7 +3310,8 @@ export function jeLoggingRoutineOperationEnd(problems, variables, collections, s
 }
 
 export function jeLoggingRoutineOperationSummary(definition, result) {
-  routineDebugOperationSummary(definition, result);
+  if(jeLoggingCardsEnabled)
+    routineDebugOperationSummary(definition, result);
   if(!jeLoggingHTMLEnabled)
     return;
   jeRoutineResult = `<span class="jeLogSummary">${html(definition)}</span>

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3092,6 +3092,12 @@ let jeRoutineResult = '';
 let jeLoggingHTML = '';
 let jeLoggingDepth = 0;
 let jeHTMLStack = [];
+// The log below is built while the Debug module is open, but a routine is recorded for the
+// routine editor's cards whenever the editor is loaded (see jeRoutineDebug in main.js). Which of
+// the two applies is decided when the outermost routine starts, so opening or closing the module
+// while a routine waits - for an INPUT, say - can never leave the log half built.
+let jeLoggingHTMLEnabled = false;
+let jeLoggingOutermostRoutine = null;
 
 // Empty the log. Operations of a routine that is currently running have the log so far saved on
 // jeHTMLStack, so that has to be emptied too - otherwise jeLoggingRoutineOperationEnd prepends it
@@ -3106,8 +3112,13 @@ function jeLoggingJSON(obj) {
   return html(JSON.stringify(obj, null, '  ').split('\n').slice(1, -1).join('\n'));
 }
 
-export function jeLoggingRoutineStart(widget, property, initialVariables, initialCollections, byReference) {
-  if( jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine', 'Moves'].indexOf( jeHTMLStack[0][3] ) == -1 ) {
+export function jeLoggingRoutineStart(widget, property, initialVariables, initialCollections, byReference, path) {
+  if(!jeLoggingDepth) {
+    jeLoggingHTMLEnabled = jeRoutineLogging;
+    jeLoggingOutermostRoutine = { widget, property };
+  }
+  routineDebugRoutineStart(path);
+  if( jeLoggingHTMLEnabled && (jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine', 'Moves'].indexOf( jeHTMLStack[0][3] ) == -1) ) {
     if(jeRoutineResetOnNextLog) {
       jeLoggingHTML = '';
       jeRoutineResetOnNextLog = false;
@@ -3127,10 +3138,15 @@ export function jeLoggingRoutineStart(widget, property, initialVariables, initia
 export function jeLoggingRoutineEnd(variables, collections) {
   if(!jeLoggingDepth)
     return; // defensive: unmatched End, should not happen since #2672
-  if( jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine', 'Moves'].indexOf( jeHTMLStack[0][3] ) == -1 ) jeLoggingHTML += '</div></div>';
+  routineDebugRoutineEnd();
+  if( jeLoggingHTMLEnabled && (jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine', 'Moves'].indexOf( jeHTMLStack[0][3] ) == -1) ) jeLoggingHTML += '</div></div>';
   --jeLoggingDepth;
-  if(!jeLoggingDepth)
-    jeLoggingRenderLog(jeLoggingHTML + '</div></div>');
+  if(!jeLoggingDepth) {
+    if(jeLoggingHTMLEnabled)
+      jeLoggingRenderLog(jeLoggingHTML + '</div></div>');
+    else if(jeRoutineLogging)
+      jeLoggingRoutineNotLogged(jeLoggingOutermostRoutine.widget, jeLoggingOutermostRoutine.property); // logging was enabled while this routine was running
+  }
 }
 
 // Put the log into the panel. Everything that depends on the rendered DOM (the expander click
@@ -3174,7 +3190,7 @@ function jeLoggingRenderLog(logHTML) {
 // Called instead of jeLoggingRoutineEnd when logging was switched on while the routine was already
 // running (e.g. the Debug module was opened while the routine waited for an INPUT). That routine
 // cannot be logged retroactively, so leave a note explaining the gap instead of showing nothing.
-export function jeLoggingRoutineNotLogged(widget, property) {
+function jeLoggingRoutineNotLogged(widget, property) {
   if(jeLoggingDepth || jeHTMLStack.length || !$('#jeLog'))
     return;
   if(jeRoutineResetOnNextLog) {
@@ -3192,7 +3208,10 @@ export function jeLoggingRoutineNotLogged(widget, property) {
   jeLoggingRenderLog(jeLoggingHTML);
 }
 
-export function jeLoggingRoutineOperationStart(original, applied) {
+export function jeLoggingRoutineOperationStart(original, applied, index) {
+  routineDebugOperationStart(index);
+  if(!jeLoggingHTMLEnabled)
+    return;
   let fcn;
   if (typeof applied == 'string')
     if (applied.substring(0,3) == 'var')
@@ -3208,6 +3227,11 @@ export function jeLoggingRoutineOperationStart(original, applied) {
 }
 
 export function jeLoggingRoutineOperationEnd(problems, variables, collections, skipped) {
+  routineDebugOperationEnd(problems, skipped);
+  if(!jeLoggingHTMLEnabled) {
+    jeRoutineResult = '';
+    return;
+  }
   const collDisplay = {};
   for(const name in collections)
     collDisplay[name] = collections[name].map(w=>`${html(w.get('id'))} (${html(w.get('type')||'basic')})`);
@@ -3279,6 +3303,9 @@ export function jeLoggingRoutineOperationEnd(problems, variables, collections, s
 }
 
 export function jeLoggingRoutineOperationSummary(definition, result) {
+  routineDebugOperationSummary(definition, result);
+  if(!jeLoggingHTMLEnabled)
+    return;
   jeRoutineResult = `<span class="jeLogSummary">${html(definition)}</span>
      ${result ? '=&gt;' : ''} <span class="jeLogResult">${html(result || '')}</span>`;
 }
@@ -4029,6 +4056,7 @@ function jeInitEventListeners() {
   window.addEventListener('mousedown', _=>jeMouseButtonIsDown = jeEnabled);
   window.addEventListener('mouseup', async function(e) {
     jeRoutineResetOnNextLog = jeRoutineAutoReset;
+    routineDebugResetAfterInteraction();
     if(!jeEnabled)
       return;
     jeMouseButtonIsDown = false;

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3129,14 +3129,20 @@ function jeLoggingJSON(obj) {
   return html(JSON.stringify(obj, null, '  ').split('\n').slice(1, -1).join('\n'));
 }
 
-export function jeLoggingRoutineStart(widget, property, initialVariables, initialCollections, byReference, path, depth) {
+// Returns the frame this routine opens: the nesting the log and the recorder are at when it
+// starts, and with that the token that closes it again if it dies (jeLoggingRoutineAbort). The
+// depth evaluateRoutine counts is not that - the routines the engine starts as a side effect of an
+// operation (the enterRoutine of a MOVE, the changeRoutine of a property change, the clickRoutine
+// a CLICK runs) all begin at depth 0 while the routine that set them off is still running.
+export function jeLoggingRoutineStart(widget, property, initialVariables, initialCollections, byReference, path) {
+  const frame = jeLoggingDepth;
   if(!jeLoggingDepth) {
     jeLoggingHTMLEnabled = jeRoutineLogging;
     jeLoggingCardsEnabled = getJEroutineDebug();
     jeLoggingOutermostRoutine = { widget, property };
   }
   if(jeLoggingCardsEnabled)
-    routineDebugRoutineStart(path, depth || 0);
+    routineDebugRoutineStart(path, frame);
   if( jeLoggingHTMLEnabled && (jeHTMLStack.length == 0 || ['CALL', 'CLICK', 'IF', 'loopRoutine', 'Moves'].indexOf( jeHTMLStack[0][3] ) == -1) ) {
     if(jeRoutineResetOnNextLog) {
       jeLoggingHTML = '';
@@ -3154,16 +3160,19 @@ export function jeLoggingRoutineStart(widget, property, initialVariables, initia
   jeLoggingOpenOperationStack.push(jeLoggingOpenOperations);
   jeLoggingOpenOperations = 0;
   ++jeLoggingDepth;
+  return frame;
 }
 
 // An operation that throws never reports its end, and neither does the routine it was in - the
 // matched calls above simply stop coming. Everything that routine still holds is closed off here,
-// back to the depth it started at, so one routine that dies half way cannot leave the log unrendered
-// and the switches unread for the rest of the session. Every operation that was still running gets
-// the problem written on it, so the cards read as the chain that died rather than going quiet.
-export function jeLoggingRoutineAbort(depth, problem) {
+// back to the frame jeLoggingRoutineStart handed out for it, so one routine that dies half way
+// cannot leave the log unrendered and the switches unread for the rest of the session - while the
+// routine that set it off, which is still running, keeps everything it holds. Every operation that
+// was still running gets the problem written on it, so the cards read as the chain that died
+// rather than going quiet.
+export function jeLoggingRoutineAbort(frame, problem) {
   const problems = problem ? [ problem ] : [];
-  while(jeLoggingDepth > depth) {
+  while(jeLoggingDepth > frame) {
     while(jeLoggingOpenOperations)
       jeLoggingRoutineOperationEnd(problems, {}, {}, false);
     jeLoggingRoutineEnd({}, {});

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -12,6 +12,10 @@ export let jeEnabled = null;
 let zoom = 1;
 let offset = [ 0, 0 ];
 let jeRoutineLogging = false;
+// Whether every operation of a routine records what it did, so the routine editor can show it on
+// the card of the operation itself. Unlike the Debug module's log this stays on once the editor
+// has been loaded: a routine is run by playing the game, which happens with the editor closed.
+let jeRoutineDebug = false;
 
 let urlProperties = {};
 
@@ -825,6 +829,7 @@ async function loadEditMode() {
     const editmode = await import('./edit.js');
     $('body').classList.remove('loadingEditMode');
     Object.assign(window, editmode);
+    jeRoutineDebug = true;
     initializeEditMode(currentMetaData);
   }
 }

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -16,6 +16,7 @@ let jeRoutineLogging = false;
 // the card of the operation itself. Unlike the Debug module's log this stays on once the editor
 // has been loaded: a routine is run by playing the game, which happens with the editor closed.
 let jeRoutineDebug = false;
+const ROUTINE_DEBUG_SETTING = 'vtt-routine-card-results';
 
 let urlProperties = {};
 
@@ -809,7 +810,7 @@ async function loadEditMode() {
     edit = false;
     Object.assign(window, {
       $, $a, $c, div, progressButton, loadImage, on, onMessage, showOverlay, sleep, rand, shuffleArray,
-      setJEenabled, setJEroutineLogging, setZoomAndOffset, resetZoomAndPan, toggleEditMode, getEdit,
+      setJEenabled, setJEroutineLogging, setJEroutineDebug, getJEroutineDebug, setZoomAndOffset, resetZoomAndPan, toggleEditMode, getEdit,
       toServer, batchStart, batchEnd, setDeltaCause, sendPropertyUpdate, getUndoProtocol, setUndoProtocol, sendRawDelta, getDelta,
       addWidgetLocal, updateWidgetId, removeWidgetLocal,
       loadZipLibrary, waitForZipLibrary, zipBlob,
@@ -829,7 +830,7 @@ async function loadEditMode() {
     const editmode = await import('./edit.js');
     $('body').classList.remove('loadingEditMode');
     Object.assign(window, editmode);
-    jeRoutineDebug = true;
+    jeRoutineDebug = localStorage.getItem(ROUTINE_DEBUG_SETTING) != 'false';
     initializeEditMode(currentMetaData);
   }
 }
@@ -1033,6 +1034,18 @@ function setJEenabled(v) {
 
 function setJEroutineLogging(v) {
   jeRoutineLogging = v;
+}
+
+// Whether the routine editor collects what each operation did. Kept for the browser rather than
+// for the session, because somebody who does not want the results on the cards does not want them
+// again tomorrow either.
+function setJEroutineDebug(v) {
+  jeRoutineDebug = v;
+  localStorage.setItem(ROUTINE_DEBUG_SETTING, v);
+}
+
+function getJEroutineDebug() {
+  return jeRoutineDebug;
 }
 
 window.onresize = function(event) {

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -269,6 +269,12 @@ async function keyHandler(e) {
   if(isLoading || overlayActive || $('body').classList.contains('edit') || e.target.tagName == 'INPUT' || e.target.tagName == 'TEXTAREA')
     return;
 
+  // one interaction, however many widgets share the key - the routines below never pass through the
+  // mouse handling that otherwise tells the Debug module that a new interaction has begun. Both
+  // flags are off until edit mode has been loaded, which is what puts the function there.
+  if(jeRoutineLogging || jeRoutineDebug)
+    jeRoutineNewInteraction();
+
   batchStart();
   for(const widget of widgetFilter(w=>w.get('hotkey')===e.key&&w.isVisible()).sort((a,b)=>String(a.get('id')).localeCompare(b.get('id'))))
     await widget.click();

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -423,6 +423,15 @@ export class Card extends Widget {
     return super.getDefaultValue(property);
   }
 
+  // a card runs the routines its deck defines for all of its cards, and that is where the routine
+  // editor shows them: on the deck, in its card defaults
+  routineDebugPath(property) {
+    const cardDefaults = this.deck && this.deck.get('cardDefaults');
+    if(cardDefaults && this.state[property] === undefined && cardDefaults[property] === this.get(property))
+      return `${this.deck.get('id')}/cardDefaults.${property}`;
+    return super.routineDebugPath(property);
+  }
+
   getFaceCount() {
     const faceTemplates = this.deck.get('faceTemplates');
     if(Array.isArray(faceTemplates))

--- a/client/js/widgets/card.js
+++ b/client/js/widgets/card.js
@@ -423,13 +423,15 @@ export class Card extends Widget {
     return super.getDefaultValue(property);
   }
 
-  // a card runs the routines its deck defines for all of its cards, and that is where the routine
-  // editor shows them: on the deck, in its card defaults
+  // A card runs the routines its deck defines for all of its cards, and that is where the routine
+  // editor shows them: on the deck, in its card defaults. A routine that comes from a card type or
+  // a face template instead has no card in the editor at all, so there is nowhere to file what it
+  // did - saying nothing beats writing it under a routine that never ran.
   routineDebugPath(property) {
-    const cardDefaults = this.deck && this.deck.get('cardDefaults');
-    if(cardDefaults && this.state[property] === undefined && cardDefaults[property] === this.get(property))
-      return `${this.deck.get('id')}/cardDefaults.${property}`;
-    return super.routineDebugPath(property);
+    if(this.state[property] !== undefined || !this.deck)
+      return super.routineDebugPath(property);
+    const cardDefaults = this.deck.get('cardDefaults');
+    return cardDefaults && cardDefaults[property] === this.get(property) ? `${this.deck.get('id')}/cardDefaults.${property}` : null;
   }
 
   getFaceCount() {

--- a/client/js/widgets/deck.js
+++ b/client/js/widgets/deck.js
@@ -1,4 +1,4 @@
-class Deck extends Widget {
+export class Deck extends Widget {
   constructor(id) {
     super(id);
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1197,6 +1197,16 @@ export class Widget extends StateManaged {
       return unescape(dollarMatch ? variables[stringMatch] : stringMatch);
     }
 
+    // What a line worked with rather than what it says, for the log and for the results on the
+    // routine editor's cards: every ${name} of a plain variable replaced by the value it holds at
+    // that moment, so "total = ${total} + ${value}" is written down as "total = 1 + 2". Only names
+    // are filled in - anything more involved, and anything that is not a value a reader can read
+    // in passing, is left as it stands.
+    const substituteVariables = string=>string.replace(/\${([^}]+)}/g, (written, name)=>{
+      const value = variables[name];
+      return value === undefined || (value !== null && typeof value == 'object') ? written : JSON.stringify(value);
+    });
+
     const evaluateVariables = string=>{
       const identifierWithSpace = '(?:[a-zA-Z0-9 _-]|\\\\u[0-9a-fA-F]{4})+';
       const identifier          = identifierWithSpace.replace(/ /, '');
@@ -1402,13 +1412,16 @@ export class Widget extends StateManaged {
 
           const variable = match[1] !== undefined ? variables[unescape(match[2])] : unescape(match[2]);
           const index = match[3] !== undefined ? variables[unescape(match[4])] : unescape(match[4]);
+          // read before the assignment below: a line that changes a variable it also reads would
+          // otherwise be written down with the value it produced on both sides
+          const definition = routineLogging ? substituteVariables(a.substr(4)) : '';
           if(index !== undefined && (typeof variables[variable] != 'object' || variables[variable] === null))
             problems.push(`The variable ${variable} is not an object, so indexing it doesn't work.`);
           else if(index !== undefined)
             variables[variable][index] = await getValue(variables[variable][index]);
           else
             variables[variable] = await getValue(variables[variable]);
-          if(routineLogging) jeLoggingRoutineOperationSummary(a.substr(4), JSON.stringify(variables[variable]));
+          if(routineLogging) jeLoggingRoutineOperationSummary(definition, JSON.stringify(variables[variable]));
         } else {
           const comment = a.match(new RegExp('^(?://(.*))?\x24'));
           if (comment) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1184,7 +1184,21 @@ export class Widget extends StateManaged {
     return isValid;
   }
 
+  // Whatever the routine below leaves on the recorders - the Debug module's log and the results the
+  // routine editor shows on its cards - is taken off again even when an operation throws: the
+  // matched jeLogging calls simply stop coming then, and the depth they count would stay standing
+  // for good, so the log would never be rendered and the switches never read again.
   async evaluateRoutine(property, initialVariables, initialCollections, depth, byReference, debugPath) {
+    try {
+      return await this.evaluateRoutineOperations(property, initialVariables, initialCollections, depth, byReference, debugPath);
+    } catch(problem) {
+      if(jeRoutineLogging || jeRoutineDebug)
+        jeLoggingRoutineAbort(depth || 0, problem && problem.message || String(problem));
+      throw problem;
+    }
+  }
+
+  async evaluateRoutineOperations(property, initialVariables, initialCollections, depth, byReference, debugPath) {
     function unescape(str) {
       if(typeof str != 'string')
         return str;
@@ -1334,10 +1348,11 @@ export class Widget extends StateManaged {
 
     const routine = this.get(property) !== null ? this.get(property) : property;
 
-    // indexed rather than iterated: a game file can put something that is not an array here, and a
-    // routine reading nonsense has always run to its end instead of taking the client down with it
-    for(let operationIndex = 0; operationIndex < routine.length; ++operationIndex) {
-      const original = routine[operationIndex];
+    // counted alongside rather than indexed into: which operation of the routine this is says where
+    // its card in the routine editor is, and a routine is not always something to index into
+    let operationIndex = -1;
+    for(const original of routine) {
+      ++operationIndex;
       var problems = [];
       let a = JSON.parse(JSON.stringify(original));
       if(typeof a == 'object')

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1295,7 +1295,7 @@ export class Widget extends StateManaged {
     // in, and for a nested block the path its parent operation passed down
     const routinePath = typeof property == 'string' ? this.routineDebugPath(property) : debugPath;
     if(routineLogging)
-      jeLoggingRoutineStart(this, property, initialVariables, initialCollections, byReference, routinePath);
+      jeLoggingRoutineStart(this, property, initialVariables, initialCollections, byReference, routinePath, depth || 0);
 
     let variables = initialVariables;
     let collections = initialCollections;
@@ -1324,7 +1324,10 @@ export class Widget extends StateManaged {
 
     const routine = this.get(property) !== null ? this.get(property) : property;
 
-    for(const [ operationIndex, original ] of routine.entries()) {
+    // indexed rather than iterated: a game file can put something that is not an array here, and a
+    // routine reading nonsense has always run to its end instead of taking the client down with it
+    for(let operationIndex = 0; operationIndex < routine.length; ++operationIndex) {
+      const original = routine[operationIndex];
       var problems = [];
       let a = JSON.parse(JSON.stringify(original));
       if(typeof a == 'object')
@@ -1496,9 +1499,9 @@ export class Widget extends StateManaged {
             if(routineLogging) {
               const theWidget = a.widget != this.get('id') ? `in ${a.widget}` : '';
               if (a.return) {
-                let returnCollection = result.collection.map(w=>w.get('id')).join(',');
-                if(!result.collection.length || result.collection.length >= 5)
-                  returnCollection = `(${result.collection.length} widgets)`;
+                const returnCollection = result.collection.length && result.collection.length < 5
+                  ? result.collection.map(w=>w.get('id')).join(',')
+                  : `(${result.collection.length} widgets)`;
                 jeLoggingRoutineOperationSummary(
                   `${a.routine} ${theWidget} and return variable '${a.variable}' and collection '${a.collection}'`,
                   `${JSON.stringify(variables[a.variable])}; ${returnCollection}`)
@@ -2292,9 +2295,8 @@ export class Widget extends StateManaged {
             await sortWidgets(collections[a.collection], a.sortBy);
 
           if(routineLogging) {
-            let selectedWidgets = collections[a.collection].map(w=>w.get('id')).join(',');
-            if(!collections[a.collection].length || collections[a.collection].length >= 5)
-              selectedWidgets = `(${collections[a.collection].length} widgets)`;
+            const selected = collections[a.collection];
+            const selectedWidgets = selected.length && selected.length < 5 ? selected.map(w=>w.get('id')).join(',') : `(${selected.length} widgets)`;
             jeLoggingRoutineOperationSummary(`${a.type == 'all' ? '' : a.type} widgets with '${a.property}' ${a.relation} ${JSON.stringify(a.value)} from '${a.source}'`, `${a.mode} ${JSON.stringify(a.collection)} = ${selectedWidgets}`);
           }
         }
@@ -2649,7 +2651,7 @@ export class Widget extends StateManaged {
 
       if(routineLogging) jeLoggingRoutineOperationEnd(problems, variables, collections, false);
 
-      if(!routineLogging && problems.length)
+      if(!jeRoutineLogging && problems.length)
         console.log(problems);
 
       if(abortRoutine)

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1184,7 +1184,7 @@ export class Widget extends StateManaged {
     return isValid;
   }
 
-  async evaluateRoutine(property, initialVariables, initialCollections, depth, byReference) {
+  async evaluateRoutine(property, initialVariables, initialCollections, depth, byReference, debugPath) {
     function unescape(str) {
       if(typeof str != 'string')
         return str;
@@ -1285,14 +1285,17 @@ export class Widget extends StateManaged {
     if(tracingEnabled && typeof property == 'string')
       sendTraceEvent('evaluateRoutine', { id: this.get('id'), property });
 
-    // Capture the routine logging state once, at the start of the routine. Toggling the Debug
-    // panel while the routine is suspended (e.g. waiting for an INPUT modal) would otherwise
-    // mismatch the jeLogging start/end calls and crash the client. (#2672) A routine that was
-    // already running when logging got enabled can not be logged retroactively - it adds a note
-    // to the log instead (see jeLoggingRoutineNotLogged at the end of this function).
-    const routineLogging = jeRoutineLogging;
+    // Capture once, at the start of the routine, whether what it does is recorded - for the
+    // Debug module's log, for the results the routine editor shows on its cards, or for both.
+    // Toggling the Debug panel while the routine is suspended (e.g. waiting for an INPUT modal)
+    // would otherwise mismatch the jeLogging start/end calls and crash the client. (#2672)
+    const routineLogging = jeRoutineLogging || jeRoutineDebug;
+    // where the operations of this routine live, so the routine editor can file what each of them
+    // did under the card that stands for it: the widget and property a named routine is written
+    // in, and for a nested block the path its parent operation passed down
+    const routinePath = typeof property == 'string' ? this.routineDebugPath(property) : debugPath;
     if(routineLogging)
-      jeLoggingRoutineStart(this, property, initialVariables, initialCollections, byReference);
+      jeLoggingRoutineStart(this, property, initialVariables, initialCollections, byReference, routinePath);
 
     let variables = initialVariables;
     let collections = initialCollections;
@@ -1321,7 +1324,7 @@ export class Widget extends StateManaged {
 
     const routine = this.get(property) !== null ? this.get(property) : property;
 
-    for(const original of routine) {
+    for(const [ operationIndex, original ] of routine.entries()) {
       var problems = [];
       let a = JSON.parse(JSON.stringify(original));
       if(typeof a == 'object')
@@ -1336,7 +1339,7 @@ export class Widget extends StateManaged {
         property: typeof property == 'string' ? property : 'literal'
       };
 
-      if(routineLogging) jeLoggingRoutineOperationStart(original, a)
+      if(routineLogging) jeLoggingRoutineOperationStart(original, a, operationIndex)
 
       if(a.skip) {
         if(routineLogging) jeLoggingRoutineOperationEnd(problems, variables, collections, true);
@@ -1726,7 +1729,7 @@ export class Widget extends StateManaged {
           }
           if(routineLogging)
             jeLoggingRoutineOperationStart( "loopRoutine", "loopRoutine" );
-          await this.evaluateRoutine(a.loopRoutine, variables, collections, (depth || 0) + 1, true);
+          await this.evaluateRoutine(a.loopRoutine, variables, collections, (depth || 0) + 1, true, routinePath && `${routinePath}/${operationIndex}/loopRoutine`);
           if(routineLogging)
             jeLoggingRoutineOperationEnd([], variables, collections, false);
           for(const add in addVariables) {
@@ -1860,10 +1863,10 @@ export class Widget extends StateManaged {
             condition = await compute(a.relation, null, a.operand1, a.operand2);
           const branch = condition ? 'thenRoutine' : 'elseRoutine';
           if(Array.isArray(a[branch]))
-            await this.evaluateRoutine(a[branch], variables, collections, (depth || 0) + 1, true);
+            await this.evaluateRoutine(a[branch], variables, collections, (depth || 0) + 1, true, routinePath && `${routinePath}/${operationIndex}/${branch}`);
           if(routineLogging) {
             if (a.condition === undefined)
-              jeLoggingRoutineOperationSummary(`'${original.operand1}' ${a.relation} '${original.operand2}'`, `${JSON.stringify(condition)}`)
+              jeLoggingRoutineOperationSummary(`${JSON.stringify(a.operand1)} ${a.relation} ${JSON.stringify(a.operand2)}`, `${JSON.stringify(condition)}`)
             else
               jeLoggingRoutineOperationSummary(`'${original.condition}'`, `${JSON.stringify(condition)}`)
           }
@@ -2656,8 +2659,6 @@ export class Widget extends StateManaged {
 
     if(routineLogging)
       jeLoggingRoutineEnd(variables, collections);
-    else if(jeRoutineLogging)
-      jeLoggingRoutineNotLogged(this, property); // logging was enabled while this routine was running
 
     batchEnd();
 
@@ -2672,6 +2673,13 @@ export class Widget extends StateManaged {
     }
 
     return { variable: variables.result === undefined ? null : variables.result, collection: collections.result || [] };
+  }
+
+  // Where the routine a property runs is written down, in the terms the routine editor addresses
+  // its cards with, so it can show every operation what it did the last time it ran. A widget
+  // that runs a routine it does not own itself says where it comes from instead (see Card).
+  routineDebugPath(property) {
+    return `${this.get('id')}/${property}`;
   }
 
   get(property) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -1186,19 +1186,22 @@ export class Widget extends StateManaged {
 
   // Whatever the routine below leaves on the recorders - the Debug module's log and the results the
   // routine editor shows on its cards - is taken off again even when an operation throws: the
-  // matched jeLogging calls simply stop coming then, and the depth they count would stay standing
-  // for good, so the log would never be rendered and the switches never read again.
+  // matched jeLogging calls simply stop coming then, and the nesting they count would stay standing
+  // for good, so the log would never be rendered and the switches never read again. Only this
+  // routine is unwound, back to the frame the recorders handed out when it started - the routine
+  // that set it off, if there is one, is still running and keeps what it holds.
   async evaluateRoutine(property, initialVariables, initialCollections, depth, byReference, debugPath) {
+    const logging = {}; // .frame is filled in below, once the recorders know about this routine
     try {
-      return await this.evaluateRoutineOperations(property, initialVariables, initialCollections, depth, byReference, debugPath);
+      return await this.evaluateRoutineOperations(property, initialVariables, initialCollections, depth, byReference, debugPath, logging);
     } catch(problem) {
-      if(jeRoutineLogging || jeRoutineDebug)
-        jeLoggingRoutineAbort(depth || 0, problem && problem.message || String(problem));
+      if(logging.frame !== undefined)
+        jeLoggingRoutineAbort(logging.frame, problem && problem.message || String(problem));
       throw problem;
     }
   }
 
-  async evaluateRoutineOperations(property, initialVariables, initialCollections, depth, byReference, debugPath) {
+  async evaluateRoutineOperations(property, initialVariables, initialCollections, depth, byReference, debugPath, logging) {
     function unescape(str) {
       if(typeof str != 'string')
         return str;
@@ -1319,7 +1322,7 @@ export class Widget extends StateManaged {
     // in, and for a nested block the path its parent operation passed down
     const routinePath = typeof property == 'string' ? this.routineDebugPath(property) : debugPath;
     if(routineLogging)
-      jeLoggingRoutineStart(this, property, initialVariables, initialCollections, byReference, routinePath, depth || 0);
+      logging.frame = jeLoggingRoutineStart(this, property, initialVariables, initialCollections, byReference, routinePath);
 
     let variables = initialVariables;
     let collections = initialCollections;

--- a/server/minify.mjs
+++ b/server/minify.mjs
@@ -231,6 +231,7 @@ const EDITOR_JS = [
   'client/js/editor/deckeditor.js',
 
   'client/js/editor/controls/routine.js',
+  'client/js/editor/controls/routinedebug.js',
   'client/js/editor/controls/popup.js',
   'client/js/editor/controls/events.js',
 

--- a/tests/client/engine/controlflow.test.js
+++ b/tests/client/engine/controlflow.test.js
@@ -139,3 +139,23 @@ forEachLegacy(({ name, legacy }) => {
     });
   });
 });
+
+// A game file can put anything into a property a routine is read from. Reading a string as a
+// routine has always run to the end of it rather than taking the client down with it, and neither
+// case may throw: an exception escapes before the delta batch the routine opened is closed again,
+// after which the client stops sending its state at all.
+describe('a routine property that holds no routine', () => {
+  test('a string runs to its end instead of throwing', async () => {
+    const result = await runRoutine(routineState({
+      trigger: { type: 'button', clickRoutine: 'var broken = 1' }
+    }), 'clickRoutine');
+    expect(result.variable).toBe(null);
+  });
+
+  test('an object runs no operation instead of throwing', async () => {
+    const result = await runRoutine(routineState({
+      trigger: { type: 'button', clickRoutine: { func: 'SET', property: 'broken', value: 1 } }
+    }), 'clickRoutine');
+    expect(result.state.trigger.broken).toBe(undefined);
+  });
+});

--- a/tests/client/engine/controlflow.test.js
+++ b/tests/client/engine/controlflow.test.js
@@ -140,22 +140,15 @@ forEachLegacy(({ name, legacy }) => {
   });
 });
 
-// A game file can put anything into a property a routine is read from. Reading a string as a
-// routine has always run to the end of it rather than taking the client down with it, and neither
-// case may throw: an exception escapes before the delta batch the routine opened is closed again,
-// after which the client stops sending its state at all.
-describe('a routine property that holds no routine', () => {
-  test('a string runs to its end instead of throwing', async () => {
+// A game file can put anything into a property a routine is read from. A string is read one
+// character at a time rather than as a line of its own, which is nonsense that runs to its end
+// instead of taking the client down with it - and every one of those characters is an operation
+// the routine editor addresses by its place in the routine.
+describe('a routine property that holds a string', () => {
+  test('it runs to its end instead of throwing', async () => {
     const result = await runRoutine(routineState({
       trigger: { type: 'button', clickRoutine: 'var broken = 1' }
     }), 'clickRoutine');
     expect(result.variable).toBe(null);
-  });
-
-  test('an object runs no operation instead of throwing', async () => {
-    const result = await runRoutine(routineState({
-      trigger: { type: 'button', clickRoutine: { func: 'SET', property: 'broken', value: 1 } }
-    }), 'clickRoutine');
-    expect(result.state.trigger.broken).toBe(undefined);
   });
 });

--- a/tests/client/engine/harness.js
+++ b/tests/client/engine/harness.js
@@ -56,6 +56,22 @@ globalThis.DOMMatrix = globalThis.DOMMatrix || HarnessDOMMatrix;
 // anyway. Behaviour that lives in a subclass belongs in a TestCafe fixture.
 const widgetClasses = { widget: Widget, label: Label };
 
+// Cards and decks are bundle scripts rather than modules: they reach Widget and the widget map as
+// globals, so they can only be loaded once those are in place - which a static import would not
+// wait for. A test that needs them says so with 'await loadDeckWidgets()' before it builds a state.
+let deckWidgetsLoading = null;
+export function loadDeckWidgets() {
+  if(!deckWidgetsLoading)
+    deckWidgetsLoading = (async _=>{
+      globalThis.Widget = Widget;
+      const { Card } = await import('../../../client/js/widgets/card.js');
+      const { Deck } = await import('../../../client/js/widgets/deck.js');
+      globalThis.Deck = Deck; // a card checks what it was dropped on against it
+      Object.assign(widgetClasses, { card: Card, deck: Deck });
+    })();
+  return deckWidgetsLoading;
+}
+
 export function setLegacyModes(modes) {
   for(const [ name, value ] of Object.entries(fullLegacyCombination(modes)))
     legacyMode(name, value);

--- a/tests/client/engine/harness.js
+++ b/tests/client/engine/harness.js
@@ -24,8 +24,10 @@ globalThis.dropTargets = dropTargets;
 globalThis.getMaxZ = getMaxZ;
 globalThis.resetMaxZ = resetMaxZ;
 globalThis.updateMaxZ = updateMaxZ;
-// same for the routine logger the JSON editor installs
+// same for the routine logger the JSON editor installs and the per-operation results the routine
+// editor collects
 globalThis.jeRoutineLogging = false;
+globalThis.jeRoutineDebug = false;
 
 // jsdom has no CSS layout and no DOMMatrix/DOMPoint, which the geometry helpers use to turn a
 // widget's transform into coordinates. Operations that move widgets go through them, so the

--- a/tests/client/engine/routinedebug.test.js
+++ b/tests/client/engine/routinedebug.test.js
@@ -2,42 +2,39 @@
  * @jest-environment jsdom
  */
 // Every operation tells the routine editor where it sits, so the editor can show on the card of an
-// operation what that operation did (client/js/editor/controls/routinedebug.js). What is recorded
-// is the log the Debug module already collects - these cases pin down the addresses that go with
-// it, because a wrong one silently shows a run on the wrong card.
+// operation what that operation did (client/js/editor/controls/routinedebug.js). The cases here run
+// a real routine into the real recorder - the one the browser uses, loaded out of its file by
+// tests/client/logging-harness.js - and read the cards back, because a wrong address silently
+// shows a run on the wrong card and a model of the recorder's stack cannot go wrong the way the
+// stack does.
 import { loadDeckWidgets, runRoutine, routineState } from './harness.js';
+import { loadLogging, stripOf } from '../logging-harness.js';
 
-// the calls evaluateRoutine makes into the editor bundle, in the order it makes them. Outside the
-// browser those functions are globals of the bundle that is not there, so the test is the bundle.
-let calls = [];
+// Outside the browser the jeLogging functions evaluateRoutine calls are globals of a bundle that is
+// not there, so the test is the bundle.
+let logging;
 
-function installLoggingStubs() {
-  calls = [];
+function installLogging() {
+  logging = loadLogging();
   globalThis.jeRoutineDebug = true;
-  globalThis.jeLoggingRoutineStart = (widget, property, variables, collections, byReference, path)=>calls.push({ type: 'routine', path });
-  globalThis.jeLoggingRoutineEnd = _=>calls.push({ type: 'routineEnd' });
-  globalThis.jeLoggingRoutineOperationStart = (original, applied, index)=>calls.push({ type: 'operation', index });
-  globalThis.jeLoggingRoutineOperationEnd = (problems, variables, collections, skipped)=>calls.push({ type: 'operationEnd', problems: [ ...problems ], skipped: Boolean(skipped) });
-  globalThis.jeLoggingRoutineOperationSummary = (definition, result)=>calls.push({ type: 'summary', definition, result });
+  globalThis.jeRoutineLogging = false;
+  for(const name of [ 'jeLoggingRoutineStart', 'jeLoggingRoutineEnd', 'jeLoggingRoutineAbort',
+                      'jeLoggingRoutineOperationStart', 'jeLoggingRoutineOperationEnd', 'jeLoggingRoutineOperationSummary' ])
+    globalThis[name] = logging[name];
 }
 
-// what the routine editor would look up for each operation that ran: the path of the routine it
-// is in plus its index, which is exactly how the cards are addressed
-function operationKeys() {
-  const paths = [];
-  const keys = [];
-  for(const call of calls) {
-    if(call.type == 'routine')
-      paths.unshift(call.path);
-    else if(call.type == 'routineEnd')
-      paths.shift();
-    else if(call.type == 'operation' && paths[0] && typeof call.index == 'number')
-      keys.push(`${paths[0]}/${call.index}`);
-  }
-  return keys;
+// which cards collected a run, and how many runs each of them holds - a loop that goes round three
+// times files all three on the one card that stands for its operation
+function recorded() {
+  const cards = {};
+  for(const [ key, runs ] of logging.runs)
+    cards[key] = runs.reduce((count, run)=>count + run.count, 0);
+  return cards;
 }
 
-beforeEach(installLoggingStubs);
+const card = key => stripOf(logging, key);
+
+beforeEach(installLogging);
 afterEach(function() {
   globalThis.jeRoutineDebug = false;
 });
@@ -47,7 +44,7 @@ describe('where a running operation says it sits', () => {
     await runRoutine(routineState({
       trigger: { type: 'button', clickRoutine: [ 'var a = 1', 'var b = 2' ] }
     }), 'clickRoutine');
-    expect(operationKeys()).toEqual([ 'trigger/clickRoutine/0', 'trigger/clickRoutine/1' ]);
+    expect(recorded()).toEqual({ 'trigger/clickRoutine/0': 1, 'trigger/clickRoutine/1': 1 });
   });
 
   test('the branch of an IF is a routine of its own, under the index of the IF', async () => {
@@ -57,11 +54,14 @@ describe('where a running operation says it sits', () => {
         { func: 'IF', operand1: 1, relation: '==', operand2: 1, thenRoutine: [ 'var taken = 1' ], elseRoutine: [ 'var missed = 1' ] }
       ] }
     }), 'clickRoutine');
-    expect(operationKeys()).toEqual([
-      'trigger/clickRoutine/0',
-      'trigger/clickRoutine/1',
-      'trigger/clickRoutine/1/thenRoutine/0'
-    ]);
+    expect(recorded()).toEqual({
+      'trigger/clickRoutine/0': 1,
+      'trigger/clickRoutine/1': 1,
+      'trigger/clickRoutine/1/thenRoutine/0': 1
+    });
+    // the branch that was not taken never started, so its card says the routine around it ran
+    // without it rather than staying empty
+    expect(card('trigger/clickRoutine/1/elseRoutine/0')).toBe('not run');
   });
 
   test('every round of a loop files its operations under the same card', async () => {
@@ -70,12 +70,11 @@ describe('where a running operation says it sits', () => {
         { func: 'FOREACH', range: [ 1, 3 ], loopRoutine: [ 'var seen = ${value}' ] }
       ] }
     }), 'clickRoutine');
-    expect(operationKeys()).toEqual([
-      'trigger/clickRoutine/0',
-      'trigger/clickRoutine/0/loopRoutine/0',
-      'trigger/clickRoutine/0/loopRoutine/0',
-      'trigger/clickRoutine/0/loopRoutine/0'
-    ]);
+    expect(recorded()).toEqual({
+      'trigger/clickRoutine/0': 1,
+      'trigger/clickRoutine/0/loopRoutine/0': 3
+    });
+    expect(card('trigger/clickRoutine/0/loopRoutine/0')).toContain('seen = 3');
   });
 
   test('a called routine is addressed on the widget that owns it', async () => {
@@ -83,28 +82,28 @@ describe('where a running operation says it sits', () => {
       trigger: { type: 'button', clickRoutine: [ { func: 'CALL', widget: 'helper', routine: 'helperRoutine' } ] },
       helper: { type: 'button', helperRoutine: [ 'var called = 1' ] }
     }), 'clickRoutine');
-    expect(operationKeys()).toEqual([ 'trigger/clickRoutine/0', 'helper/helperRoutine/0' ]);
+    expect(recorded()).toEqual({ 'trigger/clickRoutine/0': 1, 'helper/helperRoutine/0': 1 });
   });
 
   test('a skipped operation is recorded as one that ran and did nothing', async () => {
     await runRoutine(routineState({
       trigger: { type: 'button', clickRoutine: [ { func: 'FLIP', skip: true } ] }
     }), 'clickRoutine');
-    expect(calls.filter(c=>c.type == 'operationEnd')).toEqual([ { type: 'operationEnd', problems: [], skipped: true } ]);
+    expect(card('trigger/clickRoutine/0')).toBe('skipped');
   });
 
   test('an IF says which values it compared, not which variables it read', async () => {
     await runRoutine(routineState({
       trigger: { type: 'button', clickRoutine: [ 'var wanted = 3', { func: 'IF', operand1: '${wanted}', relation: '<', operand2: 5 } ] }
     }), 'clickRoutine');
-    expect(calls).toContainEqual({ type: 'summary', definition: '3 < 5', result: 'true' });
+    expect(card('trigger/clickRoutine/1')).toBe('3 < 5 → true');
   });
 
   test('a var line is recorded with the values it read, not with the names it wrote', async () => {
     await runRoutine(routineState({
       trigger: { type: 'button', clickRoutine: [ 'var total = 4', 'var value = 3', 'var total = ${total} + ${value}' ] }
     }), 'clickRoutine');
-    expect(calls).toContainEqual({ type: 'summary', definition: 'total = 4 + 3', result: '7' });
+    expect(card('trigger/clickRoutine/2')).toBe('total = 4 + 3 → 7');
   });
 
   test('nothing is recorded while neither the editor nor the Debug module is there', async () => {
@@ -112,7 +111,63 @@ describe('where a running operation says it sits', () => {
     await runRoutine(routineState({
       trigger: { type: 'button', clickRoutine: [ 'var a = 1' ] }
     }), 'clickRoutine');
-    expect(calls).toEqual([]);
+    expect(recorded()).toEqual({});
+  });
+});
+
+// An operation can set a routine off that the engine starts from scratch - a MOVE that lands in a
+// holder with an enterRoutine, a property change with a changeRoutine, a CLICK. Those start at
+// depth 0 while the routine that triggered them is still running, so anything that reads that depth
+// as "nothing else is running" throws away the cards of the routine the player actually clicked.
+describe('a routine another routine sets off', () => {
+  test('an enterRoutine is filed on the holder without emptying the routine that moved into it', async () => {
+    await runRoutine(routineState({
+      trigger: { type: 'button', clickRoutine: [ { func: 'MOVE', from: 'source', to: 'target' }, 'var afterwards = 1' ] },
+      source: { type: 'widget' },
+      target: { type: 'widget', enterRoutine: [ 'var entered = 1' ] },
+      token: { type: 'widget', parent: 'source' }
+    }), 'clickRoutine');
+    expect(recorded()).toEqual({
+      'trigger/clickRoutine/0': 1,
+      'trigger/clickRoutine/1': 1,
+      'target/enterRoutine/0': 1
+    });
+    expect(card('trigger/clickRoutine/1')).toBe('afterwards = 1 → 1');
+  });
+
+  test('a changeRoutine of a widget a SET wrote to is filed on that widget', async () => {
+    await runRoutine(routineState({
+      trigger: { type: 'button', clickRoutine: [
+        { func: 'SELECT', type: 'all', property: 'id', value: 'watched' },
+        { func: 'SET', property: 'value', value: 7 },
+        'var afterwards = 1'
+      ] },
+      watched: { type: 'widget', changeRoutine: [ 'var changed = 1' ] }
+    }), 'clickRoutine');
+    expect(recorded()).toEqual({
+      'trigger/clickRoutine/0': 1,
+      'trigger/clickRoutine/1': 1,
+      'trigger/clickRoutine/2': 1,
+      'watched/changeRoutine/0': 1
+    });
+  });
+
+  test('the clickRoutine a CLICK runs is filed on the widget it clicked', async () => {
+    await runRoutine(routineState({
+      trigger: { type: 'button', clickRoutine: [
+        { func: 'SELECT', type: 'all', property: 'id', value: 'other' },
+        { func: 'CLICK' },
+        'var afterwards = 1'
+      ] },
+      other: { type: 'button', clickRoutine: [ 'var clicked = 1' ] }
+    }), 'clickRoutine');
+    expect(recorded()).toEqual({
+      'trigger/clickRoutine/0': 1,
+      'trigger/clickRoutine/1': 1,
+      'trigger/clickRoutine/2': 1,
+      'other/clickRoutine/0': 1
+    });
+    expect(card('trigger/clickRoutine/2')).toBe('afterwards = 1 → 1');
   });
 });
 
@@ -130,23 +185,22 @@ describe('a card runs a routine of its deck', () => {
 
   test('a routine the deck defines for its cards is addressed in the card defaults of the deck', async () => {
     await runOnCard(deckState({ cardDefaults: { clickRoutine: [ 'var fromDeck = 1' ] } }));
-    expect(operationKeys()).toEqual([ 'deck1/cardDefaults.clickRoutine/0' ]);
+    expect(recorded()).toEqual({ 'deck1/cardDefaults.clickRoutine/0': 1 });
   });
 
   test('a block nested in such a routine is addressed there too', async () => {
     await runOnCard(deckState({ cardDefaults: { clickRoutine: [
       { func: 'FOREACH', range: [ 1, 2 ], loopRoutine: [ 'var seen = ${value}' ] }
     ] } }));
-    expect(operationKeys()).toEqual([
-      'deck1/cardDefaults.clickRoutine/0',
-      'deck1/cardDefaults.clickRoutine/0/loopRoutine/0',
-      'deck1/cardDefaults.clickRoutine/0/loopRoutine/0'
-    ]);
+    expect(recorded()).toEqual({
+      'deck1/cardDefaults.clickRoutine/0': 1,
+      'deck1/cardDefaults.clickRoutine/0/loopRoutine/0': 2
+    });
   });
 
   test('a routine the card has itself is addressed on the card', async () => {
     await runOnCard(deckState({ cardDefaults: { clickRoutine: [ 'var fromDeck = 1' ] } }, { clickRoutine: [ 'var own = 1' ] }));
-    expect(operationKeys()).toEqual([ 'card1/clickRoutine/0' ]);
+    expect(recorded()).toEqual({ 'card1/clickRoutine/0': 1 });
   });
 
   // A card type and a face template are the two other places a deck can put a routine, and the
@@ -157,47 +211,48 @@ describe('a card runs a routine of its deck', () => {
       cardDefaults: { clickRoutine: [ 'var fromDeck = 1' ] },
       cardTypes: { a: { clickRoutine: [ 'var fromType = 1' ] } }
     }));
-    expect(operationKeys()).toEqual([]);
+    expect(recorded()).toEqual({});
   });
 
   test('a routine of a face template is not addressed either', async () => {
     await runOnCard(deckState({
       faceTemplates: [ { properties: { clickRoutine: [ 'var fromFace = 1' ] } } ]
     }));
-    expect(operationKeys()).toEqual([]);
+    expect(recorded()).toEqual({});
   });
 });
 
 // An operation that throws never reports its end, and neither does the routine it was in. What
 // those calls would have taken off the log and the recorder is unwound in one go instead - without
-// it the depth they count stays standing, and with it the log is never rendered again.
+// it the nesting they count stays standing, and with it the log is never rendered again.
 describe('a routine that dies half way', () => {
-  test('says so once, with the depth it started at and what went wrong', async () => {
-    const aborts = [];
-    globalThis.jeLoggingRoutineAbort = (depth, problem)=>aborts.push({ depth, problem });
-    globalThis.jeRoutineLogging = false;
-    try {
-      await expect(runRoutine(routineState({
-        trigger: { type: 'button', clickRoutine: { notARoutine: true } }
-      }), 'clickRoutine')).rejects.toThrow();
-      expect(aborts).toEqual([ { depth: 0, problem: expect.any(String) } ]);
-    } finally {
-      delete globalThis.jeLoggingRoutineAbort;
-    }
+  const dying = _=>runRoutine(routineState({
+    trigger: { type: 'button', clickRoutine: { notARoutine: true } }
+  }), 'clickRoutine');
+
+  test('the routine that runs after it is recorded and rendered as usual', async () => {
+    await expect(dying()).rejects.toThrow();
+    await runRoutine(routineState({
+      trigger: { type: 'button', clickRoutine: [ 'var afterwards = 1' ] }
+    }), 'clickRoutine');
+    expect(recorded()).toEqual({ 'trigger/clickRoutine/0': 1 });
+  });
+
+  test('a block that dies inside a running routine takes only itself off', async () => {
+    await expect(runRoutine(routineState({
+      trigger: { type: 'button', clickRoutine: [
+        'var before = 1',
+        { func: 'FOREACH', range: [ 1, 2 ], loopRoutine: { notARoutine: true } }
+      ] }
+    }), 'clickRoutine')).rejects.toThrow();
+    // the operation the routine died in says what went wrong, on its own card
+    expect(card('trigger/clickRoutine/0')).toBe('before = 1 → 1');
+    expect(card('trigger/clickRoutine/1')).toContain('not iterable');
   });
 
   test('nothing is unwound while neither the editor nor the Debug module is there', async () => {
-    const aborts = [];
-    globalThis.jeLoggingRoutineAbort = (depth, problem)=>aborts.push({ depth, problem });
     globalThis.jeRoutineDebug = false;
-    globalThis.jeRoutineLogging = false;
-    try {
-      await expect(runRoutine(routineState({
-        trigger: { type: 'button', clickRoutine: { notARoutine: true } }
-      }), 'clickRoutine')).rejects.toThrow();
-      expect(aborts).toEqual([]);
-    } finally {
-      delete globalThis.jeLoggingRoutineAbort;
-    }
+    globalThis.jeLoggingRoutineAbort = _=>{ throw Error('the recorders are not there and were asked to unwind'); };
+    await expect(dying()).rejects.toThrow(/iterable/);
   });
 });

--- a/tests/client/engine/routinedebug.test.js
+++ b/tests/client/engine/routinedebug.test.js
@@ -149,11 +149,55 @@ describe('a card runs a routine of its deck', () => {
     expect(operationKeys()).toEqual([ 'card1/clickRoutine/0' ]);
   });
 
-  test('a card type that overrides the routine is not addressed in the card defaults', async () => {
+  // A card type and a face template are the two other places a deck can put a routine, and the
+  // routine editor has no card for either of them - so there is nowhere to show what they did, and
+  // nothing is filed rather than filing it under a routine that did not run.
+  test('a routine of a card type is not addressed in the card defaults, nor anywhere else', async () => {
     await runOnCard(deckState({
       cardDefaults: { clickRoutine: [ 'var fromDeck = 1' ] },
       cardTypes: { a: { clickRoutine: [ 'var fromType = 1' ] } }
     }));
-    expect(operationKeys()).toEqual([ 'card1/clickRoutine/0' ]);
+    expect(operationKeys()).toEqual([]);
+  });
+
+  test('a routine of a face template is not addressed either', async () => {
+    await runOnCard(deckState({
+      faceTemplates: [ { properties: { clickRoutine: [ 'var fromFace = 1' ] } } ]
+    }));
+    expect(operationKeys()).toEqual([]);
+  });
+});
+
+// An operation that throws never reports its end, and neither does the routine it was in. What
+// those calls would have taken off the log and the recorder is unwound in one go instead - without
+// it the depth they count stays standing, and with it the log is never rendered again.
+describe('a routine that dies half way', () => {
+  test('says so once, with the depth it started at and what went wrong', async () => {
+    const aborts = [];
+    globalThis.jeLoggingRoutineAbort = (depth, problem)=>aborts.push({ depth, problem });
+    globalThis.jeRoutineLogging = false;
+    try {
+      await expect(runRoutine(routineState({
+        trigger: { type: 'button', clickRoutine: { notARoutine: true } }
+      }), 'clickRoutine')).rejects.toThrow();
+      expect(aborts).toEqual([ { depth: 0, problem: expect.any(String) } ]);
+    } finally {
+      delete globalThis.jeLoggingRoutineAbort;
+    }
+  });
+
+  test('nothing is unwound while neither the editor nor the Debug module is there', async () => {
+    const aborts = [];
+    globalThis.jeLoggingRoutineAbort = (depth, problem)=>aborts.push({ depth, problem });
+    globalThis.jeRoutineDebug = false;
+    globalThis.jeRoutineLogging = false;
+    try {
+      await expect(runRoutine(routineState({
+        trigger: { type: 'button', clickRoutine: { notARoutine: true } }
+      }), 'clickRoutine')).rejects.toThrow();
+      expect(aborts).toEqual([]);
+    } finally {
+      delete globalThis.jeLoggingRoutineAbort;
+    }
   });
 });

--- a/tests/client/engine/routinedebug.test.js
+++ b/tests/client/engine/routinedebug.test.js
@@ -5,7 +5,7 @@
 // operation what that operation did (client/js/editor/controls/routinedebug.js). What is recorded
 // is the log the Debug module already collects - these cases pin down the addresses that go with
 // it, because a wrong one silently shows a run on the wrong card.
-import { runRoutine, routineState } from './harness.js';
+import { loadDeckWidgets, runRoutine, routineState } from './harness.js';
 
 // the calls evaluateRoutine makes into the editor bundle, in the order it makes them. Outside the
 // browser those functions are globals of the bundle that is not there, so the test is the bundle.
@@ -106,5 +106,47 @@ describe('where a running operation says it sits', () => {
       trigger: { type: 'button', clickRoutine: [ 'var a = 1' ] }
     }), 'clickRoutine');
     expect(calls).toEqual([]);
+  });
+});
+
+// A card mostly runs routines that are not written on the card: they belong to the deck, which
+// hands them to every card it made. The editor shows them there, so that is where their runs have
+// to be filed - the deck knows nothing about the card that ran them.
+describe('a card runs a routine of its deck', () => {
+  beforeAll(loadDeckWidgets);
+
+  const deckState = (deck, card)=>routineState({
+    deck1: Object.assign({ type: 'deck', cardTypes: { a: {} }, faceTemplates: [ { properties: {} } ] }, deck),
+    card1: Object.assign({ type: 'card', deck: 'deck1', cardType: 'a' }, card)
+  });
+  const runOnCard = state=>runRoutine(state, 'clickRoutine', { trigger: 'card1' });
+
+  test('a routine the deck defines for its cards is addressed in the card defaults of the deck', async () => {
+    await runOnCard(deckState({ cardDefaults: { clickRoutine: [ 'var fromDeck = 1' ] } }));
+    expect(operationKeys()).toEqual([ 'deck1/cardDefaults.clickRoutine/0' ]);
+  });
+
+  test('a block nested in such a routine is addressed there too', async () => {
+    await runOnCard(deckState({ cardDefaults: { clickRoutine: [
+      { func: 'FOREACH', range: [ 1, 2 ], loopRoutine: [ 'var seen = ${value}' ] }
+    ] } }));
+    expect(operationKeys()).toEqual([
+      'deck1/cardDefaults.clickRoutine/0',
+      'deck1/cardDefaults.clickRoutine/0/loopRoutine/0',
+      'deck1/cardDefaults.clickRoutine/0/loopRoutine/0'
+    ]);
+  });
+
+  test('a routine the card has itself is addressed on the card', async () => {
+    await runOnCard(deckState({ cardDefaults: { clickRoutine: [ 'var fromDeck = 1' ] } }, { clickRoutine: [ 'var own = 1' ] }));
+    expect(operationKeys()).toEqual([ 'card1/clickRoutine/0' ]);
+  });
+
+  test('a card type that overrides the routine is not addressed in the card defaults', async () => {
+    await runOnCard(deckState({
+      cardDefaults: { clickRoutine: [ 'var fromDeck = 1' ] },
+      cardTypes: { a: { clickRoutine: [ 'var fromType = 1' ] } }
+    }));
+    expect(operationKeys()).toEqual([ 'card1/clickRoutine/0' ]);
   });
 });

--- a/tests/client/engine/routinedebug.test.js
+++ b/tests/client/engine/routinedebug.test.js
@@ -100,6 +100,13 @@ describe('where a running operation says it sits', () => {
     expect(calls).toContainEqual({ type: 'summary', definition: '3 < 5', result: 'true' });
   });
 
+  test('a var line is recorded with the values it read, not with the names it wrote', async () => {
+    await runRoutine(routineState({
+      trigger: { type: 'button', clickRoutine: [ 'var total = 4', 'var value = 3', 'var total = ${total} + ${value}' ] }
+    }), 'clickRoutine');
+    expect(calls).toContainEqual({ type: 'summary', definition: 'total = 4 + 3', result: '7' });
+  });
+
   test('nothing is recorded while neither the editor nor the Debug module is there', async () => {
     globalThis.jeRoutineDebug = false;
     await runRoutine(routineState({

--- a/tests/client/engine/routinedebug.test.js
+++ b/tests/client/engine/routinedebug.test.js
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment jsdom
+ */
+// Every operation tells the routine editor where it sits, so the editor can show on the card of an
+// operation what that operation did (client/js/editor/controls/routinedebug.js). What is recorded
+// is the log the Debug module already collects - these cases pin down the addresses that go with
+// it, because a wrong one silently shows a run on the wrong card.
+import { runRoutine, routineState } from './harness.js';
+
+// the calls evaluateRoutine makes into the editor bundle, in the order it makes them. Outside the
+// browser those functions are globals of the bundle that is not there, so the test is the bundle.
+let calls = [];
+
+function installLoggingStubs() {
+  calls = [];
+  globalThis.jeRoutineDebug = true;
+  globalThis.jeLoggingRoutineStart = (widget, property, variables, collections, byReference, path)=>calls.push({ type: 'routine', path });
+  globalThis.jeLoggingRoutineEnd = _=>calls.push({ type: 'routineEnd' });
+  globalThis.jeLoggingRoutineOperationStart = (original, applied, index)=>calls.push({ type: 'operation', index });
+  globalThis.jeLoggingRoutineOperationEnd = (problems, variables, collections, skipped)=>calls.push({ type: 'operationEnd', problems: [ ...problems ], skipped: Boolean(skipped) });
+  globalThis.jeLoggingRoutineOperationSummary = (definition, result)=>calls.push({ type: 'summary', definition, result });
+}
+
+// what the routine editor would look up for each operation that ran: the path of the routine it
+// is in plus its index, which is exactly how the cards are addressed
+function operationKeys() {
+  const paths = [];
+  const keys = [];
+  for(const call of calls) {
+    if(call.type == 'routine')
+      paths.unshift(call.path);
+    else if(call.type == 'routineEnd')
+      paths.shift();
+    else if(call.type == 'operation' && paths[0] && typeof call.index == 'number')
+      keys.push(`${paths[0]}/${call.index}`);
+  }
+  return keys;
+}
+
+beforeEach(installLoggingStubs);
+afterEach(function() {
+  globalThis.jeRoutineDebug = false;
+});
+
+describe('where a running operation says it sits', () => {
+  test('a named routine is addressed by its widget and property', async () => {
+    await runRoutine(routineState({
+      trigger: { type: 'button', clickRoutine: [ 'var a = 1', 'var b = 2' ] }
+    }), 'clickRoutine');
+    expect(operationKeys()).toEqual([ 'trigger/clickRoutine/0', 'trigger/clickRoutine/1' ]);
+  });
+
+  test('the branch of an IF is a routine of its own, under the index of the IF', async () => {
+    await runRoutine(routineState({
+      trigger: { type: 'button', clickRoutine: [
+        'var a = 1',
+        { func: 'IF', operand1: 1, relation: '==', operand2: 1, thenRoutine: [ 'var taken = 1' ], elseRoutine: [ 'var missed = 1' ] }
+      ] }
+    }), 'clickRoutine');
+    expect(operationKeys()).toEqual([
+      'trigger/clickRoutine/0',
+      'trigger/clickRoutine/1',
+      'trigger/clickRoutine/1/thenRoutine/0'
+    ]);
+  });
+
+  test('every round of a loop files its operations under the same card', async () => {
+    await runRoutine(routineState({
+      trigger: { type: 'button', clickRoutine: [
+        { func: 'FOREACH', range: [ 1, 3 ], loopRoutine: [ 'var seen = ${value}' ] }
+      ] }
+    }), 'clickRoutine');
+    expect(operationKeys()).toEqual([
+      'trigger/clickRoutine/0',
+      'trigger/clickRoutine/0/loopRoutine/0',
+      'trigger/clickRoutine/0/loopRoutine/0',
+      'trigger/clickRoutine/0/loopRoutine/0'
+    ]);
+  });
+
+  test('a called routine is addressed on the widget that owns it', async () => {
+    await runRoutine(routineState({
+      trigger: { type: 'button', clickRoutine: [ { func: 'CALL', widget: 'helper', routine: 'helperRoutine' } ] },
+      helper: { type: 'button', helperRoutine: [ 'var called = 1' ] }
+    }), 'clickRoutine');
+    expect(operationKeys()).toEqual([ 'trigger/clickRoutine/0', 'helper/helperRoutine/0' ]);
+  });
+
+  test('a skipped operation is recorded as one that ran and did nothing', async () => {
+    await runRoutine(routineState({
+      trigger: { type: 'button', clickRoutine: [ { func: 'FLIP', skip: true } ] }
+    }), 'clickRoutine');
+    expect(calls.filter(c=>c.type == 'operationEnd')).toEqual([ { type: 'operationEnd', problems: [], skipped: true } ]);
+  });
+
+  test('an IF says which values it compared, not which variables it read', async () => {
+    await runRoutine(routineState({
+      trigger: { type: 'button', clickRoutine: [ 'var wanted = 3', { func: 'IF', operand1: '${wanted}', relation: '<', operand2: 5 } ] }
+    }), 'clickRoutine');
+    expect(calls).toContainEqual({ type: 'summary', definition: '3 < 5', result: 'true' });
+  });
+
+  test('nothing is recorded while neither the editor nor the Debug module is there', async () => {
+    globalThis.jeRoutineDebug = false;
+    await runRoutine(routineState({
+      trigger: { type: 'button', clickRoutine: [ 'var a = 1' ] }
+    }), 'clickRoutine');
+    expect(calls).toEqual([]);
+  });
+});

--- a/tests/client/logging-harness.js
+++ b/tests/client/logging-harness.js
@@ -1,0 +1,60 @@
+// The Debug module's log and the results the routine editor shows on its cards, wired to each
+// other the way the editor bundle wires them, so a test can drive the real recorder instead of a
+// model of it - a model of a stack cannot fail the way the stack does.
+//
+// jsonedit.js and routinedebug.js are plain scripts that the server concatenates into its bundles,
+// so evaluate just the parts under test out of their files and hand them the handful of names the
+// bundle would give them.
+import fs from 'fs';
+
+export const source = file => fs.readFileSync(file, 'utf8');
+
+export function sectionOf(file, marker) {
+  const text = source(file);
+  return text.slice(text.indexOf(`// START ${marker}`), text.indexOf(`// END ${marker}`)).replace(/^export /gm, '');
+}
+
+export function loadLogging() {
+  // the panel the log is written into, emptied rather than the whole body: a test that runs a real
+  // routine has its widgets in the same document
+  let log = document.getElementById('jeLog');
+  if(!log) {
+    log = document.createElement('div');
+    log.id = 'jeLog';
+    document.body.appendChild(log);
+  }
+  log.innerHTML = '';
+  const deps = {
+    $: selector => document.querySelector(selector),
+    $a: (selector, parent) => (parent || document).querySelectorAll(selector),
+    $c: (selector, parent) => (parent || document).querySelector(selector),
+    html: string => String(string).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+    escapeHTML: string => String(string).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+    focusable: () => {},
+    getDelta: () => ({ s: {} }),
+    cardsEnabled: true
+  };
+  return new Function('deps', `
+    const { $, $a, $c, html, escapeHTML, focusable, getDelta } = deps;
+    const getJEroutineDebug = _=>deps.cardsEnabled;
+    let jeRoutineLogging = false;
+    ${source('client/js/editor/controls/routinedebug.js')}
+    ${sectionOf('client/js/jsonedit.js', 'routine logging')}
+    return {
+      deps,
+      setLogging: value=>jeRoutineLogging = value,
+      runs: routineDebugRuns, routineRuns: routineDebugRoutineRuns,
+      jeLoggingRoutineStart, jeLoggingRoutineEnd, jeLoggingRoutineAbort,
+      jeLoggingRoutineOperationStart, jeLoggingRoutineOperationEnd, jeLoggingRoutineOperationSummary,
+      jeRoutineNewInteraction, routineDebugRender, routineDebugSetEnabled
+    };
+  `)(deps);
+}
+
+// What the card of one operation reads, rendered by the recorder itself.
+export function stripOf(logging, key) {
+  const dom = document.createElement('div');
+  dom.dataset.debugKey = key;
+  logging.routineDebugRender(dom);
+  return dom.textContent;
+}

--- a/tests/client/routine-math.test.js
+++ b/tests/client/routine-math.test.js
@@ -10,6 +10,7 @@ describe("Scenarios: Math expressions in routines", () => {
   const testName = "routine-math";
   beforeAll(() => {
     window.jeRoutineLogging = false;
+    window.jeRoutineDebug = false;
   });
 
   async function evaluate(expression) {

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -57,7 +57,8 @@ beforeAll(() => {
     'isWidgetPickerChangingSelection', 'closeEditorPopups', 'commonInfoTopic', 'parameterInfoLine', 'templateLead', 'leadLabel', 'infoButton',
     'structureInfoHTML',
     'routineDebugRoutineStart', 'routineDebugRoutineEnd', 'routineDebugOperationStart', 'routineDebugOperationSummary',
-    'routineDebugOperationEnd', 'routineDebugRefreshNow', 'routineDebugResetAfterInteraction', 'routineDebugClear'
+    'routineDebugOperationEnd', 'routineDebugRefreshNow', 'routineDebugResetAfterInteraction', 'routineDebugClear',
+    'routineDebugSetEnabled'
   ];
   // eval in test scope so the plain-script class declarations see the jsdom globals
   eval(code + '\n' + exposed.map(x => `globalThis['${x}'] = ${x};`).join('\n'));
@@ -3945,16 +3946,18 @@ describe('working out a value with var', () => {
 describe('what an operation did last time', () => {
   const buttonWidget = { state: { id: 'button1', type: 'button' } };
 
-  // one run of a routine: every operation in order, each with what it did
-  function runRoutine(path, operations) {
-    routineDebugRoutineStart(path);
+  // one run of a routine: every operation in order, each with what it did. depth is what
+  // evaluateRoutine passes for a nested block, and with it the recorder drops frames of routines
+  // that never reported their end.
+  function runRoutine(path, operations, depth = 0) {
+    routineDebugRoutineStart(path, depth);
     for (const [ index, operation ] of operations.entries()) {
       routineDebugOperationStart(index);
       if (operation.definition !== undefined)
         routineDebugOperationSummary(operation.definition, operation.result);
       if (operation.blocks)
         for (const [ block, blockOperations ] of Object.entries(operation.blocks))
-          runRoutine(`${path}/${index}/${block}`, blockOperations);
+          runRoutine(`${path}/${index}/${block}`, blockOperations, depth + 1);
       routineDebugOperationEnd(operation.problems || [], operation.skipped);
     }
     routineDebugRoutineEnd();
@@ -4029,6 +4032,33 @@ describe('what an operation did last time', () => {
     routineDebugResetAfterInteraction();
     runRoutine('button1/clickRoutine', [ { definition: 'second' } ]);
     expect(strips(editorFor([ { func: 'SHUFFLE' } ]))).toEqual([ 'second' ]);
+  });
+
+  test('a routine that never reported its end leaves nothing behind for the next interaction', () => {
+    // an operation that throws takes the end of its routine with it, so that routine stays on the
+    // stack of the recorder - where it used to keep the next interaction from starting clean
+    routineDebugRoutineStart('button1/clickRoutine', 0);
+    routineDebugOperationStart(0);
+    routineDebugOperationSummary('half way', '');
+    routineDebugOperationEnd([], false);
+
+    routineDebugResetAfterInteraction();
+    runRoutine('button1/clickRoutine', [ { definition: 'the deck' } ]);
+    expect(strips(editorFor([ { func: 'SHUFFLE' } ]))).toEqual([ 'the deck' ]);
+  });
+
+  test('switching the results off takes what is on the cards with it', () => {
+    const editor = editorFor([ { func: 'SHUFFLE' } ]);
+    document.body.append(editor.domElement);
+    try {
+      runRoutine('button1/clickRoutine', [ { definition: 'the deck' } ]);
+      routineDebugRefreshNow();
+      expect(strips(editor)).toEqual([ 'the deck' ]);
+      routineDebugSetEnabled(false);
+      expect(strips(editor)).toEqual([ '' ]);
+    } finally {
+      editor.domElement.remove();
+    }
   });
 
   test('the list of routines says which of them ran', () => {

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -36,6 +36,7 @@ beforeAll(() => {
     'client/js/editor/controls/widgetselection.js',
     'client/js/editor/controls/popup.js',
     'client/js/editor/controls/routine.js',
+    'client/js/editor/controls/routinedebug.js',
     'client/js/editor/controls/events.js'
   ];
   const code = files.map(f => fs.readFileSync(f, 'utf8')).join('\n');
@@ -54,7 +55,9 @@ beforeAll(() => {
     'renderWidgetSelectPopout', 'startWidgetPicker', 'stopWidgetPicker', 'isWidgetPickerActive',
     'handleWidgetPickerSelection', 'handleWidgetPickerClick', 'selectWidgetsInRoom', 'widgetPickerTarget', 'endWidgetPickerWithoutTarget',
     'isWidgetPickerChangingSelection', 'closeEditorPopups', 'commonInfoTopic', 'parameterInfoLine', 'templateLead', 'leadLabel', 'infoButton',
-    'structureInfoHTML'
+    'structureInfoHTML',
+    'routineDebugRoutineStart', 'routineDebugRoutineEnd', 'routineDebugOperationStart', 'routineDebugOperationSummary',
+    'routineDebugOperationEnd', 'routineDebugRefreshNow', 'routineDebugResetAfterInteraction', 'routineDebugClear'
   ];
   // eval in test scope so the plain-script class declarations see the jsdom globals
   eval(code + '\n' + exposed.map(x => `globalThis['${x}'] = ${x};`).join('\n'));
@@ -3932,5 +3935,108 @@ describe('working out a value with var', () => {
     expect(plain.querySelector('.popup-operation-func')).toBeNull();
     expect(plain.querySelector('.popup-operation-example').textContent).toBe('the value');
     popup.hide();
+  });
+});
+
+// What every operation did the last time it ran, on the card of the operation itself. The runs are
+// collected by the logging calls of evaluateRoutine (see tests/client/engine/routinedebug.test.js
+// for the addresses they carry) - here they are played back by hand, so a case says what a card
+// shows without a room having to run anything.
+describe('what an operation did last time', () => {
+  const buttonWidget = { state: { id: 'button1', type: 'button' } };
+
+  // one run of a routine: every operation in order, each with what it did
+  function runRoutine(path, operations) {
+    routineDebugRoutineStart(path);
+    for (const [ index, operation ] of operations.entries()) {
+      routineDebugOperationStart(index);
+      if (operation.definition !== undefined)
+        routineDebugOperationSummary(operation.definition, operation.result);
+      if (operation.blocks)
+        for (const [ block, blockOperations ] of Object.entries(operation.blocks))
+          runRoutine(`${path}/${index}/${block}`, blockOperations);
+      routineDebugOperationEnd(operation.problems || [], operation.skipped);
+    }
+    routineDebugRoutineEnd();
+  }
+
+  function editorFor(routine) {
+    return new RoutineEditor(buttonWidget, routine, [], [], { routineKey: 'clickRoutine' });
+  }
+
+  function strips(editor) {
+    return [...editor.domElement.querySelectorAll('.routine-editor-debug')].map(strip => strip.textContent);
+  }
+
+  beforeEach(() => routineDebugClear());
+
+  test('a card says what its operation worked with and what came out', () => {
+    runRoutine('button1/clickRoutine', [ { definition: "'hand' to 'discard'", result: '2' } ]);
+    expect(strips(editorFor([ { func: 'MOVE' } ]))[0]).toBe("'hand' to 'discard' → 2");
+  });
+
+  test('runs that read the same are counted instead of listed twice', () => {
+    runRoutine('button1/clickRoutine', [ { definition: 'the deck' } ]);
+    runRoutine('button1/clickRoutine', [ { definition: 'the deck' } ]);
+    runRoutine('button1/clickRoutine', [ { definition: 'the deck' } ]);
+    expect(strips(editorFor([ { func: 'SHUFFLE' } ]))[0]).toBe('3× the deck');
+  });
+
+  test('a loop shows the first of its rounds and offers the rest', () => {
+    runRoutine('button1/clickRoutine', [ { blocks: { loopRoutine: [] } } ]);
+    for (let i = 1; i <= 6; ++i)
+      runRoutine('button1/clickRoutine/0/loopRoutine', [ { definition: 'var seen =', result: String(i) } ]);
+
+    const editor = editorFor([ { func: 'FOREACH', loopRoutine: [ 'var seen = ${value}' ] } ]);
+    const strip = editor.domElement.querySelector('[data-debug-key="button1/clickRoutine/0/loopRoutine/0"]');
+    expect(strip.textContent).toBe('var seen = → 1var seen = → 2var seen = → 3+ 3 more runs');
+
+    strip.querySelector('.routine-editor-debug-more').click();
+    expect(strip.textContent).toContain('var seen = → 6');
+    expect(strip.textContent).toContain('show less');
+  });
+
+  test('what an operation ran into is on a line of its own', () => {
+    runRoutine('button1/clickRoutine', [ { definition: "from 'nowhere'", problems: [ 'Widget ID nowhere does not exist.' ] } ]);
+    const editor = editorFor([ { func: 'MOVE' } ]);
+    expect(editor.domElement.querySelector('.routine-editor-debug-problem').textContent).toBe('Widget ID nowhere does not exist.');
+  });
+
+  test('an operation a routine did not reach says so, one it never ran at all says nothing', () => {
+    runRoutine('button1/clickRoutine', [ { definition: 'cancelled' } ]); // the routine stopped after the first operation
+    const editor = editorFor([ { func: 'INPUT' }, { func: 'FLIP' } ]);
+    expect(strips(editor)).toEqual([ 'cancelled', 'not run' ]);
+
+    const untouched = new RoutineEditor(buttonWidget, [ { func: 'FLIP' } ], [], [], { routineKey: 'enterRoutine' });
+    expect(strips(untouched)).toEqual([ '' ]);
+  });
+
+  test('a card on screen follows the routine that runs after it was rendered', () => {
+    const editor = editorFor([ { func: 'SHUFFLE' } ]);
+    document.body.append(editor.domElement);
+    try {
+      expect(strips(editor)).toEqual([ '' ]);
+      runRoutine('button1/clickRoutine', [ { definition: 'the deck' } ]);
+      routineDebugRefreshNow();
+      expect(strips(editor)).toEqual([ 'the deck' ]);
+    } finally {
+      editor.domElement.remove();
+    }
+  });
+
+  test('the next interaction starts from nothing rather than adding to the last one', () => {
+    runRoutine('button1/clickRoutine', [ { definition: 'first' } ]);
+    routineDebugResetAfterInteraction();
+    runRoutine('button1/clickRoutine', [ { definition: 'second' } ]);
+    expect(strips(editorFor([ { func: 'SHUFFLE' } ]))).toEqual([ 'second' ]);
+  });
+
+  test('the list of routines says which of them ran', () => {
+    runRoutine('button1/clickRoutine', [ { definition: 'the deck' } ]);
+    runRoutine('button1/clickRoutine', [ { definition: 'the deck' } ]);
+    const widget = { state: { id: 'button1', type: 'button', clickRoutine: [ { func: 'SHUFFLE' } ], enterRoutine: [] } };
+    const eventsEditor = new EventsEditor(widget, () => {});
+    const runs = [...eventsEditor.domElement.querySelectorAll('.events-editor-runs')].map(r => r.textContent);
+    expect(runs).toEqual([ 'ran 2×', '' ]);
   });
 });

--- a/tests/client/routineeditor.test.js
+++ b/tests/client/routineeditor.test.js
@@ -20,6 +20,7 @@ beforeAll(() => {
   window.widgets = new Map();
   window.roomID = 'testroom'; // the tutorial links of info popups use it
   window.setSelection = () => {};
+  window.getJEroutineDebug = () => true; // the switch in the Debug module (main.js), which is on by default
   window.closePropertyInfoPopup = () => {}; // the sidebar's own info tips (propertyInputs.js)
   window.editorTypeNames = { basic: 'Widget', button: 'Button', canvas: 'Canvas', card: 'Card', holder: 'Holder', label: 'Label', seat: 'Seat', timer: 'Timer' };
   // the validator tables are part of the editor bundle; the property proposals read them
@@ -3985,18 +3986,31 @@ describe('what an operation did last time', () => {
     expect(strips(editorFor([ { func: 'SHUFFLE' } ]))[0]).toBe('3× the deck');
   });
 
-  test('a loop shows the first of its rounds and offers the rest', () => {
+  test('rounds that only differ in what came out are one line, the sentence first', () => {
     runRoutine('button1/clickRoutine', [ { blocks: { loopRoutine: [] } } ]);
     for (let i = 1; i <= 6; ++i)
       runRoutine('button1/clickRoutine/0/loopRoutine', [ { definition: 'var seen =', result: String(i) } ]);
 
     const editor = editorFor([ { func: 'FOREACH', loopRoutine: [ 'var seen = ${value}' ] } ]);
     const strip = editor.domElement.querySelector('[data-debug-key="button1/clickRoutine/0/loopRoutine/0"]');
-    expect(strip.textContent).toBe('var seen = → 1var seen = → 2var seen = → 3+ 3 more runs');
+    expect(strip.textContent).toBe('var seen = → 1 2 3 4 5 6');
+    expect(strip.querySelector('.routine-editor-debug-more')).toBeNull();
+  });
+
+  test('rounds that did different things keep a line each, and offer the ones they hide', () => {
+    runRoutine('button1/clickRoutine', [ { blocks: { loopRoutine: [] } } ]);
+    for (let i = 1; i <= 6; ++i)
+      runRoutine('button1/clickRoutine/0/loopRoutine', [ { definition: `from 'box${i}'`, result: '1' } ]);
+
+    const editor = editorFor([ { func: 'FOREACH', loopRoutine: [ { func: 'MOVE' } ] } ]);
+    const strip = editor.domElement.querySelector('[data-debug-key="button1/clickRoutine/0/loopRoutine/0"]');
+    const runs = [...strip.querySelectorAll('.routine-editor-debug-run')].map(run => run.textContent);
+    expect(runs).toEqual([ "from 'box1' → 1", "from 'box2' → 1", "from 'box3' → 1" ]);
+    expect(strip.querySelector('.routine-editor-debug-more').textContent).toContain('+ 3 more runs');
 
     strip.querySelector('.routine-editor-debug-more').click();
-    expect(strip.textContent).toContain('var seen = → 6');
-    expect(strip.textContent).toContain('show less');
+    expect(strip.textContent).toContain("from 'box6' → 1");
+    expect(strip.querySelector('.routine-editor-debug-more').textContent).toContain('show less');
   });
 
   test('what an operation ran into is on a line of its own', () => {
@@ -4012,6 +4026,27 @@ describe('what an operation did last time', () => {
 
     const untouched = new RoutineEditor(buttonWidget, [ { func: 'FLIP' } ], [], [], { routineKey: 'enterRoutine' });
     expect(strips(untouched)).toEqual([ '' ]);
+  });
+
+  test('an operation in a branch that was not taken says so like any other one that was not reached', () => {
+    runRoutine('button1/clickRoutine', [ { definition: '1 > 2 → false', blocks: { thenRoutine: [] } } ]);
+    const editor = editorFor([ { func: 'IF', thenRoutine: [ { func: 'FLIP' } ], elseRoutine: [ { func: 'SHUFFLE' } ] } ]);
+    const notTaken = editor.domElement.querySelector('[data-debug-key="button1/clickRoutine/0/elseRoutine/0"]');
+    expect(notTaken.textContent).toBe('not run');
+  });
+
+  test('the list of routines says why its cards are blank until something has run', () => {
+    const widget = { state: { id: 'button1', type: 'button', clickRoutine: [ { func: 'SHUFFLE' } ] } };
+    const eventsEditor = new EventsEditor(widget, () => {});
+    document.body.append(eventsEditor.domElement);
+    try {
+      expect(eventsEditor.domElement.querySelector('.events-editor-debug-hint').textContent).toContain('Nothing recorded yet');
+      runRoutine('button1/clickRoutine', [ { definition: 'the deck' } ]);
+      routineDebugRefreshNow();
+      expect(eventsEditor.domElement.querySelector('.events-editor-debug-hint').textContent).toBe('');
+    } finally {
+      eventsEditor.domElement.remove();
+    }
   });
 
   test('a card on screen follows the routine that runs after it was rendered', () => {

--- a/tests/client/routinelogging.test.js
+++ b/tests/client/routinelogging.test.js
@@ -1,51 +1,13 @@
 /**
  * @jest-environment jsdom
  */
-import fs from 'fs';
+import { loadLogging, source, stripOf } from './logging-harness.js';
 
 // What the Debug module's log and the results on the routine editor's cards are collected by: the
-// jeLogging calls of evaluateRoutine, which come in matched pairs and count a depth. The cases
-// here are about the lifecycle itself rather than about the markup - what happens when a routine
-// dies half way and the ends never come, and what starts one interaction apart from the last.
-//
-// jsonedit.js, mousehandling.js and routinedebug.js are plain scripts that the server concatenates
-// into its bundles, so evaluate just the parts under test out of their files and hand them the
-// handful of names the bundle would give them.
-const source = file => fs.readFileSync(file, 'utf8');
-
-function sectionOf(file, marker) {
-  const text = source(file);
-  return text.slice(text.indexOf(`// START ${marker}`), text.indexOf(`// END ${marker}`)).replace(/^export /gm, '');
-}
-
-// the recorder and the logging that drives it, wired to each other the way the editor bundle does
-function loadLogging() {
-  document.body.innerHTML = '<div id="jeLog"></div>';
-  const deps = {
-    $: selector => document.querySelector(selector),
-    $a: (selector, parent) => (parent || document).querySelectorAll(selector),
-    $c: (selector, parent) => (parent || document).querySelector(selector),
-    html: string => String(string).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
-    escapeHTML: string => String(string).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
-    focusable: () => {},
-    getDelta: () => ({ s: {} }),
-    cardsEnabled: true
-  };
-  return new Function('deps', `
-    const { $, $a, $c, html, escapeHTML, focusable, getDelta } = deps;
-    const getJEroutineDebug = _=>deps.cardsEnabled;
-    let jeRoutineLogging = false;
-    ${source('client/js/editor/controls/routinedebug.js')}
-    ${sectionOf('client/js/jsonedit.js', 'routine logging')}
-    return {
-      deps,
-      setLogging: value=>jeRoutineLogging = value,
-      jeLoggingRoutineStart, jeLoggingRoutineEnd, jeLoggingRoutineAbort,
-      jeLoggingRoutineOperationStart, jeLoggingRoutineOperationEnd, jeLoggingRoutineOperationSummary,
-      jeRoutineNewInteraction, routineDebugRender, routineDebugSetEnabled
-    };
-  `)(deps);
-}
+// jeLogging calls of evaluateRoutine, which come in matched pairs around a frame. The cases here
+// are about the lifecycle itself rather than about the markup - what happens when a routine dies
+// half way and the ends never come, what a routine that starts another one does to it, and what
+// starts one interaction apart from the last.
 
 // the widget hotkeys, which run their routines straight from the key event rather than through the
 // mouse handling every other interaction goes through
@@ -65,20 +27,15 @@ function loadKeyHandler(logging, widgets) {
   });
 }
 
+const widgetNamed = id => ({ get: _=>id });
+
 // one routine of one operation, the calls in the order evaluateRoutine makes them
 function runRoutine(logging, path, definition) {
-  logging.jeLoggingRoutineStart({ get: _=>'button1' }, 'clickRoutine', {}, {}, false, path, 0);
+  logging.jeLoggingRoutineStart(widgetNamed('button1'), 'clickRoutine', {}, {}, false, path);
   logging.jeLoggingRoutineOperationStart('SHUFFLE', { func: 'SHUFFLE' }, 0);
   logging.jeLoggingRoutineOperationSummary(definition, '');
   logging.jeLoggingRoutineOperationEnd([], {}, {}, false);
   logging.jeLoggingRoutineEnd({}, {});
-}
-
-function stripOf(logging, key) {
-  const dom = document.createElement('div');
-  dom.dataset.debugKey = key;
-  logging.routineDebugRender(dom);
-  return dom.textContent;
 }
 
 describe('a routine that dies half way', () => {
@@ -86,9 +43,9 @@ describe('a routine that dies half way', () => {
     const logging = loadLogging();
     logging.setLogging(true);
 
-    logging.jeLoggingRoutineStart({ get: _=>'button1' }, 'clickRoutine', {}, {}, false, 'button1/clickRoutine', 0);
+    const frame = logging.jeLoggingRoutineStart(widgetNamed('button1'), 'clickRoutine', {}, {}, false, 'button1/clickRoutine');
     logging.jeLoggingRoutineOperationStart('MOVE', { func: 'MOVE' }, 0);
-    logging.jeLoggingRoutineAbort(0, 'from is not a widget'); // the operation threw: no ends arrive
+    logging.jeLoggingRoutineAbort(frame, 'from is not a widget'); // the operation threw: no ends arrive
 
     expect(document.querySelector('#jeLog').innerHTML).toContain('from is not a widget');
 
@@ -99,9 +56,9 @@ describe('a routine that dies half way', () => {
   test('the operation it died in says what went wrong on its card', () => {
     const logging = loadLogging();
 
-    logging.jeLoggingRoutineStart({ get: _=>'button1' }, 'clickRoutine', {}, {}, false, 'button1/clickRoutine', 0);
+    const frame = logging.jeLoggingRoutineStart(widgetNamed('button1'), 'clickRoutine', {}, {}, false, 'button1/clickRoutine');
     logging.jeLoggingRoutineOperationStart('MOVE', { func: 'MOVE' }, 0);
-    logging.jeLoggingRoutineAbort(0, 'from is not a widget');
+    logging.jeLoggingRoutineAbort(frame, 'from is not a widget');
 
     expect(stripOf(logging, 'button1/clickRoutine/0')).toBe('from is not a widget');
   });
@@ -109,11 +66,11 @@ describe('a routine that dies half way', () => {
   test('only the block that died is unwound, not the routine that called it', () => {
     const logging = loadLogging();
 
-    logging.jeLoggingRoutineStart({ get: _=>'button1' }, 'clickRoutine', {}, {}, false, 'button1/clickRoutine', 0);
+    logging.jeLoggingRoutineStart(widgetNamed('button1'), 'clickRoutine', {}, {}, false, 'button1/clickRoutine');
     logging.jeLoggingRoutineOperationStart('IF', { func: 'IF' }, 0);
-    logging.jeLoggingRoutineStart({ get: _=>'button1' }, [], {}, {}, true, 'button1/clickRoutine/0/thenRoutine', 1);
+    const frame = logging.jeLoggingRoutineStart(widgetNamed('button1'), [], {}, {}, true, 'button1/clickRoutine/0/thenRoutine');
     logging.jeLoggingRoutineOperationStart('MOVE', { func: 'MOVE' }, 0);
-    logging.jeLoggingRoutineAbort(1, 'from is not a widget');
+    logging.jeLoggingRoutineAbort(frame, 'from is not a widget');
     // the caller is still running and reports its own end as usual
     logging.jeLoggingRoutineOperationEnd([], {}, {}, false);
     logging.jeLoggingRoutineEnd({}, {});
@@ -122,17 +79,69 @@ describe('a routine that dies half way', () => {
     expect(stripOf(logging, 'button1/clickRoutine/0')).toBe('ran');
   });
 
+  // The frame a routine reports as dead is the one it was handed when it started, never the depth
+  // evaluateRoutine counts: a routine the engine starts as a side effect of an operation begins at
+  // depth 0 while the routine that set it off is still running, so unwinding to depth 0 would end
+  // the routine the player clicked while it is still going.
+  test('a routine that dies while another one is running leaves the one that set it off standing', () => {
+    const logging = loadLogging();
+
+    logging.jeLoggingRoutineStart(widgetNamed('button1'), 'clickRoutine', {}, {}, false, 'button1/clickRoutine');
+    logging.jeLoggingRoutineOperationStart('MOVE', { func: 'MOVE' }, 0);
+    const frame = logging.jeLoggingRoutineStart(widgetNamed('holder1'), 'enterRoutine', {}, {}, false, 'holder1/enterRoutine');
+    logging.jeLoggingRoutineOperationStart('FLIP', { func: 'FLIP' }, 0);
+    logging.jeLoggingRoutineAbort(frame, 'card is not a widget');
+    // the MOVE swallowed nothing, so the routine that triggered the enterRoutine reports its ends
+    logging.jeLoggingRoutineOperationEnd([], {}, {}, false);
+    logging.jeLoggingRoutineOperationStart('SHUFFLE', { func: 'SHUFFLE' }, 1);
+    logging.jeLoggingRoutineOperationSummary('the deck', '');
+    logging.jeLoggingRoutineOperationEnd([], {}, {}, false);
+    logging.jeLoggingRoutineEnd({}, {});
+
+    expect(stripOf(logging, 'holder1/enterRoutine/0')).toBe('card is not a widget');
+    expect(stripOf(logging, 'button1/clickRoutine/0')).toBe('ran');
+    expect(stripOf(logging, 'button1/clickRoutine/1')).toBe('the deck');
+  });
+
   test('switching the results off afterwards is read by the routine that runs next', () => {
     const logging = loadLogging();
 
-    logging.jeLoggingRoutineStart({ get: _=>'button1' }, 'clickRoutine', {}, {}, false, 'button1/clickRoutine', 0);
+    const frame = logging.jeLoggingRoutineStart(widgetNamed('button1'), 'clickRoutine', {}, {}, false, 'button1/clickRoutine');
     logging.jeLoggingRoutineOperationStart('MOVE', { func: 'MOVE' }, 0);
-    logging.jeLoggingRoutineAbort(0, 'from is not a widget');
+    logging.jeLoggingRoutineAbort(frame, 'from is not a widget');
 
     logging.deps.cardsEnabled = false;
     logging.routineDebugSetEnabled(false);
     runRoutine(logging, 'button1/clickRoutine', 'the deck');
     expect(stripOf(logging, 'button1/clickRoutine/0')).toBe('');
+  });
+});
+
+// An operation can set another routine off - a MOVE that lands in a holder with an enterRoutine, a
+// property change with a changeRoutine, a CLICK. That routine is nested in the one that is running,
+// however the engine counts its depth, and taking the frames of the outer one off the stack for it
+// would make every operation after the trigger read "not run" under a header that says "ran".
+describe('an operation that sets another routine off', () => {
+  test('leaves the cards of the routine it runs in where they are', () => {
+    const logging = loadLogging();
+
+    logging.jeLoggingRoutineStart(widgetNamed('button1'), 'clickRoutine', {}, {}, false, 'button1/clickRoutine');
+    logging.jeLoggingRoutineOperationStart('MOVE', { func: 'MOVE' }, 0);
+    logging.jeLoggingRoutineStart(widgetNamed('holder1'), 'enterRoutine', {}, {}, false, 'holder1/enterRoutine');
+    logging.jeLoggingRoutineOperationStart('FLIP', { func: 'FLIP' }, 0);
+    logging.jeLoggingRoutineOperationSummary('the card', 'flipped');
+    logging.jeLoggingRoutineOperationEnd([], {}, {}, false);
+    logging.jeLoggingRoutineEnd({}, {});
+    logging.jeLoggingRoutineOperationSummary('the card into the holder', '');
+    logging.jeLoggingRoutineOperationEnd([], {}, {}, false);
+    logging.jeLoggingRoutineOperationStart('SHUFFLE', { func: 'SHUFFLE' }, 1);
+    logging.jeLoggingRoutineOperationSummary('the deck', '');
+    logging.jeLoggingRoutineOperationEnd([], {}, {}, false);
+    logging.jeLoggingRoutineEnd({}, {});
+
+    expect(stripOf(logging, 'button1/clickRoutine/0')).toBe('the card into the holder');
+    expect(stripOf(logging, 'button1/clickRoutine/1')).toBe('the deck');
+    expect(stripOf(logging, 'holder1/enterRoutine/0')).toBe('the card → flipped');
   });
 });
 

--- a/tests/client/routinelogging.test.js
+++ b/tests/client/routinelogging.test.js
@@ -1,0 +1,173 @@
+/**
+ * @jest-environment jsdom
+ */
+import fs from 'fs';
+
+// What the Debug module's log and the results on the routine editor's cards are collected by: the
+// jeLogging calls of evaluateRoutine, which come in matched pairs and count a depth. The cases
+// here are about the lifecycle itself rather than about the markup - what happens when a routine
+// dies half way and the ends never come, and what starts one interaction apart from the last.
+//
+// jsonedit.js, mousehandling.js and routinedebug.js are plain scripts that the server concatenates
+// into its bundles, so evaluate just the parts under test out of their files and hand them the
+// handful of names the bundle would give them.
+const source = file => fs.readFileSync(file, 'utf8');
+
+function sectionOf(file, marker) {
+  const text = source(file);
+  return text.slice(text.indexOf(`// START ${marker}`), text.indexOf(`// END ${marker}`)).replace(/^export /gm, '');
+}
+
+// the recorder and the logging that drives it, wired to each other the way the editor bundle does
+function loadLogging() {
+  document.body.innerHTML = '<div id="jeLog"></div>';
+  const deps = {
+    $: selector => document.querySelector(selector),
+    $a: (selector, parent) => (parent || document).querySelectorAll(selector),
+    $c: (selector, parent) => (parent || document).querySelector(selector),
+    html: string => String(string).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+    escapeHTML: string => String(string).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+    focusable: () => {},
+    getDelta: () => ({ s: {} }),
+    cardsEnabled: true
+  };
+  return new Function('deps', `
+    const { $, $a, $c, html, escapeHTML, focusable, getDelta } = deps;
+    const getJEroutineDebug = _=>deps.cardsEnabled;
+    let jeRoutineLogging = false;
+    ${source('client/js/editor/controls/routinedebug.js')}
+    ${sectionOf('client/js/jsonedit.js', 'routine logging')}
+    return {
+      deps,
+      setLogging: value=>jeRoutineLogging = value,
+      jeLoggingRoutineStart, jeLoggingRoutineEnd, jeLoggingRoutineAbort,
+      jeLoggingRoutineOperationStart, jeLoggingRoutineOperationEnd, jeLoggingRoutineOperationSummary,
+      jeRoutineNewInteraction, routineDebugRender, routineDebugSetEnabled
+    };
+  `)(deps);
+}
+
+// the widget hotkeys, which run their routines straight from the key event rather than through the
+// mouse handling every other interaction goes through
+function loadKeyHandler(logging, widgets) {
+  const code = source('client/js/mousehandling.js').match(/^async function keyHandler[\s\S]*?^}/m)[0];
+  return new Function('deps', `
+    const { $, widgetFilter, batchStart, batchEnd, jeRoutineNewInteraction } = deps;
+    const isLoading = false, overlayActive = false, jeRoutineLogging = false, jeRoutineDebug = true;
+    ${code}
+    return keyHandler;
+  `)({
+    $: selector => document.querySelector(selector),
+    widgetFilter: filter => widgets.filter(filter),
+    batchStart: () => {},
+    batchEnd: () => {},
+    jeRoutineNewInteraction: logging.jeRoutineNewInteraction
+  });
+}
+
+// one routine of one operation, the calls in the order evaluateRoutine makes them
+function runRoutine(logging, path, definition) {
+  logging.jeLoggingRoutineStart({ get: _=>'button1' }, 'clickRoutine', {}, {}, false, path, 0);
+  logging.jeLoggingRoutineOperationStart('SHUFFLE', { func: 'SHUFFLE' }, 0);
+  logging.jeLoggingRoutineOperationSummary(definition, '');
+  logging.jeLoggingRoutineOperationEnd([], {}, {}, false);
+  logging.jeLoggingRoutineEnd({}, {});
+}
+
+function stripOf(logging, key) {
+  const dom = document.createElement('div');
+  dom.dataset.debugKey = key;
+  logging.routineDebugRender(dom);
+  return dom.textContent;
+}
+
+describe('a routine that dies half way', () => {
+  test('the next routine is logged and rendered again rather than counted into the dead one', () => {
+    const logging = loadLogging();
+    logging.setLogging(true);
+
+    logging.jeLoggingRoutineStart({ get: _=>'button1' }, 'clickRoutine', {}, {}, false, 'button1/clickRoutine', 0);
+    logging.jeLoggingRoutineOperationStart('MOVE', { func: 'MOVE' }, 0);
+    logging.jeLoggingRoutineAbort(0, 'from is not a widget'); // the operation threw: no ends arrive
+
+    expect(document.querySelector('#jeLog').innerHTML).toContain('from is not a widget');
+
+    runRoutine(logging, 'button1/clickRoutine', 'the deck');
+    expect(document.querySelector('#jeLog').innerHTML).toContain('the deck');
+  });
+
+  test('the operation it died in says what went wrong on its card', () => {
+    const logging = loadLogging();
+
+    logging.jeLoggingRoutineStart({ get: _=>'button1' }, 'clickRoutine', {}, {}, false, 'button1/clickRoutine', 0);
+    logging.jeLoggingRoutineOperationStart('MOVE', { func: 'MOVE' }, 0);
+    logging.jeLoggingRoutineAbort(0, 'from is not a widget');
+
+    expect(stripOf(logging, 'button1/clickRoutine/0')).toBe('from is not a widget');
+  });
+
+  test('only the block that died is unwound, not the routine that called it', () => {
+    const logging = loadLogging();
+
+    logging.jeLoggingRoutineStart({ get: _=>'button1' }, 'clickRoutine', {}, {}, false, 'button1/clickRoutine', 0);
+    logging.jeLoggingRoutineOperationStart('IF', { func: 'IF' }, 0);
+    logging.jeLoggingRoutineStart({ get: _=>'button1' }, [], {}, {}, true, 'button1/clickRoutine/0/thenRoutine', 1);
+    logging.jeLoggingRoutineOperationStart('MOVE', { func: 'MOVE' }, 0);
+    logging.jeLoggingRoutineAbort(1, 'from is not a widget');
+    // the caller is still running and reports its own end as usual
+    logging.jeLoggingRoutineOperationEnd([], {}, {}, false);
+    logging.jeLoggingRoutineEnd({}, {});
+
+    expect(stripOf(logging, 'button1/clickRoutine/0/thenRoutine/0')).toBe('from is not a widget');
+    expect(stripOf(logging, 'button1/clickRoutine/0')).toBe('ran');
+  });
+
+  test('switching the results off afterwards is read by the routine that runs next', () => {
+    const logging = loadLogging();
+
+    logging.jeLoggingRoutineStart({ get: _=>'button1' }, 'clickRoutine', {}, {}, false, 'button1/clickRoutine', 0);
+    logging.jeLoggingRoutineOperationStart('MOVE', { func: 'MOVE' }, 0);
+    logging.jeLoggingRoutineAbort(0, 'from is not a widget');
+
+    logging.deps.cardsEnabled = false;
+    logging.routineDebugSetEnabled(false);
+    runRoutine(logging, 'button1/clickRoutine', 'the deck');
+    expect(stripOf(logging, 'button1/clickRoutine/0')).toBe('');
+  });
+});
+
+describe('what one interaction is', () => {
+  const widget = (id, hotkey, onClick) => ({
+    get: property => property == 'hotkey' ? hotkey : id,
+    isVisible: _=>true,
+    click: async _=>onClick(id)
+  });
+
+  test('every widget that shares a hotkey belongs to the same interaction', async () => {
+    const logging = loadLogging();
+    const clicked = [];
+    const keyHandler = loadKeyHandler(logging, [
+      widget('button1', 'x', id=>runRoutine(logging, `${id}/clickRoutine`, `${id} ran`) || clicked.push(id)),
+      widget('button2', 'x', id=>runRoutine(logging, `${id}/clickRoutine`, `${id} ran`) || clicked.push(id))
+    ]);
+
+    await keyHandler({ key: 'x', target: { tagName: 'DIV' } });
+    expect(clicked).toEqual([ 'button1', 'button2' ]);
+    expect(stripOf(logging, 'button1/clickRoutine/0')).toBe('button1 ran');
+    expect(stripOf(logging, 'button2/clickRoutine/0')).toBe('button2 ran');
+  });
+
+  test('the next hotkey starts from nothing rather than adding to the one before', async () => {
+    const logging = loadLogging();
+    const keyHandler = loadKeyHandler(logging, [
+      widget('button1', 'x', id=>runRoutine(logging, `${id}/clickRoutine`, 'first')),
+      widget('button2', 'y', id=>runRoutine(logging, `${id}/clickRoutine`, 'second'))
+    ]);
+
+    await keyHandler({ key: 'x', target: { tagName: 'DIV' } });
+    await keyHandler({ key: 'y', target: { tagName: 'DIV' } });
+
+    expect(stripOf(logging, 'button1/clickRoutine/0')).toBe('');
+    expect(stripOf(logging, 'button2/clickRoutine/0')).toBe('second');
+  });
+});

--- a/tests/client/widget-click.test.js
+++ b/tests/client/widget-click.test.js
@@ -44,6 +44,7 @@ describe("Scenarios: Clicking widgets", () => {
 
     testLabel = addLabel(`${testName}-test-label`);
     window.jeRoutineLogging = false;
+    window.jeRoutineDebug = false;
   });
   afterAll(() => {
     removeWidget(testWidget.get('id'));

--- a/tests/client/widget-count.test.js
+++ b/tests/client/widget-count.test.js
@@ -18,6 +18,7 @@ describe("Scenarios: Counting widgets", () => {
 
     testLabel = addLabel(`${testName}-test-label`);
     window.jeRoutineLogging = false;
+    window.jeRoutineDebug = false;
   });
   afterAll(() => {
     removeWidget(testWidget.get('id'));


### PR DESCRIPTION
To Do:

- [x] Need a way to turn this off. → **Show results on the routine editor's cards** in the Debug module, remembered per browser (see *Switching it off* below).
- [ ] Personally, I don't like the way it looks; needs some different formatting. → I would rather not guess: four concrete alternatives are up for a decision in a comment below, and I will build whichever you pick. (The layout has since had a full UI/UX pass — see the reply to the UI review — but that was about fixing what was broken, not about the shape you asked for.)
- [ ] A routine a card inherits from a **card type** or a **face template** has no card in the routine editor, so its runs have nowhere to go. Showing them means adding those routines to a card's Automations list — a new editing surface. The proposal, and the one question in it (editable and writing back to the deck, or read-only with the deck as the place to change it), is in a comment below; this PR lands without it and records nothing for those routines meanwhile.

------

Every operation of a routine now shows what it did the last time it ran, right under its sentence in the **Edit Widgets → Routines** editor: the values it actually worked with once the variables were filled in, what came out, and what the engine complained about. Until now that information only existed in the Debug module's log, next to the routine rather than on it, and it had to be read as nested JSON.

![a routine with its results](https://agent.virtualtabletop.io/reports/pr/1540842835283148841/routine-cards-if-not-run.png)

## What a card shows

- `definition → result` — the same summary the Debug log builds, in the dimmed text the card controls are drawn in, with the result on the value-coloured pill the sentence uses for its chips. Variables are filled in with the values the operation read, so a `var` line reads `total = 1 + 2 → 3` rather than `total = ${total} + ${value} → 3`.
- **Problems** on a line of their own, in red — a broken routine is usually easiest to find on the operation that ran into it.
- `skipped` for an operation with `skip`, `ran` for one the engine has nothing to say about, and `not run` for an operation a routine that *did* run never reached — an aborted `CALL`, a cancelled `INPUT`, or a branch of an `IF` that was not taken.
- An operation that runs many times keeps every run: **one line per run**, so a `FOREACH` body or a helper routine can be followed round by round. Consecutive runs that read the same are counted (`5×  the deck`) instead of repeated; runs that differ only in what came out are written as one line — the sentence once, the results after it; and a long list of different runs shows the first three and offers the rest.
- The list of routines says which of them an interaction went through at all (`ran`, `ran 3×`), so you don't have to open each one to find out. Until the first routine has been recorded it says so instead, because the recording only starts once edit mode has been loaded and blank cards otherwise read as a broken feature.
- The `palette` legend on every routine header explains the strip, the result pill, the red problem line and the words `ran` / `not run` / `skipped`.

![a loop with one line per round](https://agent.virtualtabletop.io/reports/pr/1540842835283148841/routine-cards-loop.png)

Everything is dropped when the next user interaction runs a routine, so what a card shows always belongs to one interaction — the same rule the Debug module's log follows, down to its *Clear after each interaction* setting, which now switches that off for the cards as well. A card of a routine that has not run is empty and invisible, so a routine that is only being written reads exactly as it did before.

## How it works

- `client/js/editor/controls/routinedebug.js` collects the runs. They are filed under the place of the operation in the game, in the same terms the routine editor addresses its cards with — `card1/clickRoutine/2/thenRoutine/0`. `evaluateRoutine` passes that path down into nested blocks, and a card runs the routines its deck defines for it, so `cardDefaults` routines are filed on the deck where the editor shows them.
- The recorder is fed by the `jeLogging…` calls `evaluateRoutine` already makes, so there is one description of what an operation did rather than two. Which of the two consumers a routine is recorded for is latched when the outermost routine starts, so opening or closing the Debug module while a routine waits for an `INPUT` still cannot leave the log half built (#2672).
- Recording starts once edit mode has been loaded in this browser session and stays on after it is closed — a routine is run by *playing*, which happens with the editor closed. Players who never open the editor pay nothing: both the flag and the module live in the editor bundle. Once it *has* been loaded, every routine of the session is summarised, which costs about 8 µs per operation (measured on a routine of 20 000 loop rounds × 3 operations: 1.9 s without the recorder, 2.4 s with it) — under a millisecond for the few dozen operations an interaction usually runs, and the switch below turns it off for a playtest that is heavy enough to feel it. Building the Debug module's log, which stringifies the variables, the collections and the whole delta per operation, still only happens while that module is open.
- Which routine a run belongs to is the frame `jeLoggingRoutineStart` hands back — the nesting the log and the recorder are actually at — never `evaluateRoutine`'s `depth` parameter. A routine the engine starts as a side effect of an operation (the `enterRoutine` of a `MOVE`, the `changeRoutine` of a property change, the `clickRoutine` a `CLICK` runs) begins at depth 0 while the routine that set it off is still running, so reading that depth as the nesting would drop the frame of the routine the player clicked.
- An operation that throws never reports its end and neither does the routine it was in, so `evaluateRoutine` unwinds what such a routine left on the log and on the recorder itself, back to that same frame, writing the problem on every operation that was still running. Without it one broken routine would keep the nesting above zero for the rest of the session — the log never rendered again and the switch below never read again — and unwinding by `depth` instead would end a routine that is still going.
- Runs are capped at 40 per operation; further ones are counted and the card says so.

## Switching it off

![the Debug module's settings](https://agent.virtualtabletop.io/reports/pr/1540842835283148841/debug-module-header-1280.png)

**Show results on the routine editor's cards**, next to the log's own settings in the Debug module, stops the recording and empties the cards that are on screen. The choice lives in `localStorage`, not just in the session, so it survives a reload; the flag edit mode sets when it loads starts from that setting, and a routine that is already running keeps the consumer it was started with.

## Behaviour changes worth noting

- The `IF` summary now reads the values that were compared instead of the operands as they are written (`3 < 5 → true` rather than `'${wanted}' < '5' → true`). The sentence right above the strip already shows the operands, so repeating them there said nothing.
- A `var` line is likewise summarised with the values it read rather than with the `${…}` it is written with (`total = 1 + 2` instead of `total = ${total} + ${value}`).

Both also change those lines in the Debug module's log. Worth a line on the wiki's Edit-Mode page.

## Demo room

A tutorial-quality demo room, **Operations - Debugging**, is on this PR's test server in the `pr-test-ai` room (https://test.virtualtabletop.io/PR-3151/pr-test-ai) — open edit mode once, close it again, then press any of its buttons and open the routine that ran. It is deliberately **not** part of this diff and touches nothing under `library/`; it can be added to `library/tutorials/` on request. It is a tutorial in two variants:

1. **Reading a run** — an `IF` that says which values it compared and whose un-taken branch says `not run`, a `FOREACH` with one line per round, a routine that runs into a problem, and a `MOVE` that sets the receiving holder's own `enterRoutine` going: the operations after it go on saying what they did, and what the holder did is on the holder.
2. **Routines elsewhere** — a `CALL` whose operations are shown on the widget that owns the routine, the same routine called three times (`ran 3×`), a `CALL` that does not return so that the operation below it says `not run`, and a deck whose `cardDefaults` routine every one of its cards runs — the addressing that would silently show nothing anywhere if it were wrong.

Both variants pass `node validator/validate_gamefile_node.js`, were walked end to end in a browser, share the square 530×530 SVG library image, and their `_meta.info` mirrors `library/tutorials/Properties - dragLimit/0.json` field for field. Download: [Operations - Debugging.vtt](https://agent.virtualtabletop.io/reports/pr/1540842835283148841/Operations%20-%20Debugging.vtt)

## Tests

- `tests/client/engine/routinedebug.test.js` — a real routine run into the real recorder (loaded out of its file by `tests/client/logging-harness.js` together with the real logging section of `jsonedit.js`), with the cards read back: the address every running operation reports (named routines, `IF` branches, every round of a `FOREACH`, a `CALL` into another widget, a routine a deck defines for all of its cards, and a card type or face template whose routine has no card and is therefore filed nowhere), a routine set off by an `enterRoutine`, by a `changeRoutine` and by a `CLICK` — each asserting the operations after the trigger are still filed on the routine that triggered it — a skipped operation, a `var` line recorded with the values it read, nothing recorded with neither the editor nor the Debug module there, and a routine that dies half way followed by one that runs normally.
- `tests/client/routineeditor.test.js` — what a card shows: the result, the counted runs, rounds collapsed to one line, rounds that differ and their expander, problems, `not run` (including in a branch that was not taken), the note that nothing has been recorded yet, the live update of a card already on screen, the per-interaction reset, the `ran n×` note in the list of routines, that a routine which never reported its end leaves nothing behind for the next interaction, and that switching the results off empties the cards.
- `tests/client/routinelogging.test.js` — the lifecycle itself, run against the real `jsonedit.js` logging section, the real recorder and the real `keyHandler`: after a routine dies the next one is logged and rendered again, the card of the operation it died in says what went wrong, only the block that died is unwound, the on/off switch is read again by the routine that runs next, widgets sharing a hotkey are one interaction, and the next hotkey starts from nothing.
- `tests/client/engine/controlflow.test.js` — a routine property that holds a string runs to its end instead of throwing.
- `npm test` passes (43 suites / 1399 tests) and the TestCafe `routines.js` and `holderevents.js` fixtures were run locally; the full CI matrix — `editor.js` (which covers the #2672 Debug-while-INPUT case) and `compute-4.js` (which reads the Debug log) included — is green on this head.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3151/pr-test (or any other room on that server)


