### PR TITLE
Write background-color instead of the background shorthand from the editor's color pickers

### DIFF
--- a/client/css/editor/propertyInputs.css
+++ b/client/css/editor/propertyInputs.css
@@ -417,6 +417,16 @@
   font-size: 12px;
 }
 
+/* A color row shows whatever the declaration holds, which for a background
+   shorthand can be a full image url: it is cut off rather than wrapped so the
+   close button keeps its place on the row - the tooltip has the whole value. */
+.editorModule .colorPicker .propertyPickerValueText {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .editorModule .propertyPickerSection {
   margin-top: 8px;
 }

--- a/client/js/editor/propertyInputs.js
+++ b/client/js/editor/propertyInputs.js
@@ -1713,6 +1713,16 @@ function computedCssValue(element, key) {
   return value || null;
 }
 
+// The color inputs edit the background-color longhand, because the background
+// shorthand also resets background-image/-size/-repeat and would drop the image
+// a widget shows (and the scaling the room css gives it). A game that keeps its
+// color in the shorthand still has it read from there, and moved to the longhand
+// as soon as the color is changed.
+function legacyBackgroundColor(css, cssClass) {
+  const value = parsePropertyFromCSS(css, 'background', null, cssClass);
+  return value !== null && cssBackgroundIsPlainColor(value) ? value : null;
+}
+
 function cssValueOptions(module, widget, key, cssProperty='css', cssClass='default', extraOptions={}) {
   // a css string/object is per-widget, so a multi-selection reads/writes
   // through each selected widget's own options instead of merging blobs
@@ -1742,6 +1752,7 @@ function cssValueOptions(module, widget, key, cssProperty='css', cssClass='defau
   }
 
   let warned = false;
+  const legacyShorthand = key == 'background-color';
   // element the declaration actually renders on, used to preview the effective
   // default when nothing is explicitly set
   const effectiveElement = _=>{
@@ -1750,11 +1761,21 @@ function cssValueOptions(module, widget, key, cssProperty='css', cssClass='defau
     return widget.domElement;
   };
   return Object.assign({
-    getValue: _=>parsePropertyFromCSS(widget.get(cssProperty), key, null, cssClass),
+    getValue: _=>{
+      const value = parsePropertyFromCSS(widget.get(cssProperty), key, null, cssClass);
+      if(value === null && legacyShorthand)
+        return legacyBackgroundColor(widget.get(cssProperty), cssClass);
+      return value;
+    },
     getEffective: _=>{
       const raw = parsePropertyFromCSS(widget.get(cssProperty), key, null, cssClass);
       if(propertyInputValueSet(raw))
         return raw;
+      if(legacyShorthand) {
+        const legacy = legacyBackgroundColor(widget.get(cssProperty), cssClass);
+        if(propertyInputValueSet(legacy))
+          return legacy;
+      }
       return computedCssValue(effectiveElement(), key);
     },
     setValue: v=>{
@@ -1768,7 +1789,10 @@ function cssValueOptions(module, widget, key, cssProperty='css', cssClass='defau
         }
         return;
       }
-      module.inputValueUpdated(widget, cssProperty, mergePropertyFromCSS(css, key, v, cssClass));
+      let merged = mergePropertyFromCSS(css, key, v, cssClass);
+      if(legacyShorthand && legacyBackgroundColor(css, cssClass) !== null)
+        merged = mergePropertyFromCSS(merged, 'background', null, cssClass);
+      module.inputValueUpdated(widget, cssProperty, merged);
       if(widget.applyDeltaToDOM)
         widget.applyDeltaToDOM({ [cssProperty]: widget.get(cssProperty) });
     },

--- a/client/js/editor/propertyInputs.js
+++ b/client/js/editor/propertyInputs.js
@@ -1185,6 +1185,31 @@ function colorInputHexValue(value, host) {
   return resolved && resolved != 'transparent' ? cssColorHexValue(resolved) : null;
 }
 
+// The hex of an rgb()/rgba() the browser resolved a color to, without its
+// alpha, or null for anything else - a color space the browser keeps as it is
+// (oklch, color()) does not reduce to one.
+function opaqueHexFromRGBExpression(value) {
+  const parts = String(value === null || value === undefined ? '' : value).trim().match(/^rgba?\(([^()]*)\)$/i);
+  if(!parts)
+    return null;
+  const channels = parts[1].split(/[\s,/]+/).filter(part=>part !== '').slice(0, 3).map(Number);
+  if(channels.length < 3 || channels.some(channel=>!isFinite(channel)))
+    return null;
+  return '#' + channels.map(channel=>Math.max(0, Math.min(255, Math.round(channel))).toString(16).padStart(2, '0')).join('');
+}
+
+// The hex an <input type="color"> stands in with for a color it cannot show
+// exactly: the element has no alpha, so a semi-transparent color still opens
+// the dialog on the color it is made of instead of losing the dialog. null for
+// everything that is no single color (a gradient, an image shorthand).
+function colorInputOpaqueHexValue(value, host) {
+  const text = cssValueWithoutImportant(value);
+  if(!text)
+    return null;
+  const resolved = resolveCssColorExpression(host, text);
+  return resolved == 'transparent' ? '#000000' : opaqueHexFromRGBExpression(resolved);
+}
+
 class ColorInput extends PickerInput {
   cssClass() {
     return 'pickerInput colorInput';
@@ -1207,7 +1232,9 @@ class ColorInput extends PickerInput {
   }
 
   renderChip(target, value) {
-    const chip = renderColorChip(propertyInputValueSet(value) ? value : 'transparent', target);
+    // an "!important" priority is no part of the value CSSOM takes, and a chip
+    // handed one paints nothing at all
+    const chip = renderColorChip(propertyInputValueSet(value) ? cssValueWithoutImportant(value) : 'transparent', target);
     if(this.valueNeedsNoSwatch(value))
       chip.title = `${cssValueWithoutImportant(value)} - a color picked here replaces it`;
     return chip;
@@ -1219,14 +1246,31 @@ class ColorInput extends PickerInput {
     return this.widget && this.widget.domElement || null;
   }
 
+  // The hex the native swatch shows the value as: the color itself where the
+  // element can show it, otherwise the color without the transparency it cannot
+  // keep. null when the value is no single color at all.
+  swatchHexValue(value) {
+    const host = this.colorHost();
+    const exact = colorInputHexValue(value, host);
+    return exact !== null ? exact : colorInputOpaqueHexValue(value, host);
+  }
+
   // Whether the native swatch would have to stand in for something it cannot
-  // show (a gradient, an image shorthand, a color with alpha or a color space
-  // it does not know): it would be a black square in front of a value the chip
-  // next to it paints correctly.
+  // show at all (a gradient, an image shorthand, a color space it does not
+  // know): it would be a black square in front of a value the chip next to it
+  // paints correctly, so the row leaves it out.
   valueNeedsNoSwatch(value) {
     if(!propertyInputValueSet(value) || cssValueWithoutImportant(value) == 'transparent')
       return false;
-    return colorInputHexValue(value, this.colorHost()) === null;
+    return this.swatchHexValue(value) === null;
+  }
+
+  // Whether the swatch shows the value without its transparency, which the
+  // native dialog has no way to keep.
+  valueSwatchDropsAlpha(value) {
+    if(!propertyInputValueSet(value) || cssValueWithoutImportant(value) == 'transparent')
+      return false;
+    return colorInputHexValue(value, this.colorHost()) === null && this.swatchHexValue(value) !== null;
   }
 
   renderSummaryControls(target, value) {
@@ -1247,7 +1291,7 @@ class ColorInput extends PickerInput {
       colorPicker = document.createElement('input');
       colorPicker.type = 'color';
       colorPicker.title = 'Open the color dialog';
-      colorPicker.value = colorInputHexValue(shown, this.colorHost()) || toHex(this.options.default || '#000000');
+      colorPicker.value = this.swatchHexValue(shown) || toHex(this.options.default || '#000000');
       // some browsers (Firefox on some platforms) only fire "change" when the
       // native dialog closes, so listen to both events
       colorPicker.onchange = colorPicker.oninput = _=>{
@@ -1264,7 +1308,7 @@ class ColorInput extends PickerInput {
         hexInput.classList.remove('inputError');
         this.setValue(v);
         if(colorPicker)
-          colorPicker.value = colorInputHexValue(v, this.colorHost()) || colorPicker.value;
+          colorPicker.value = this.swatchHexValue(v) || colorPicker.value;
       } else if(v === '') {
         hexInput.classList.remove('inputError');
         this.setValue(null);
@@ -1310,7 +1354,7 @@ class ColorInput extends PickerInput {
           setPickerValueText(valueText, propertyInputValueSet(value) ? String(value) : (propertyInputValueSet(shown) ? String(shown) : null));
         const colorPicker = this.summaryDOM.querySelector('input[type=color]');
         if(colorPicker && document.activeElement !== colorPicker && propertyInputValueSet(shown))
-          colorPicker.value = colorInputHexValue(shown, this.colorHost()) || colorPicker.value;
+          colorPicker.value = this.swatchHexValue(shown) || colorPicker.value;
         const hexInput = this.summaryDOM.querySelector('.colorHexInput');
         if(hexInput && document.activeElement !== hexInput)
           hexInput.value = colorHexInputAccepts(value) ? String(value).trim() : '';
@@ -1324,16 +1368,28 @@ class ColorInput extends PickerInput {
       this.renderFooter(value);
   }
 
+  // What the picker says about a value the swatch next to it cannot show: the
+  // lists below do something else to it than the "color behind the image" they
+  // set on every other widget, so the two clicks do not look the same.
+  pickerNoteText(shown) {
+    if(this.valueNeedsNoSwatch(shown))
+      return 'The current value is a gradient, an image or a color the swatch cannot show. Picking a color here replaces it.';
+    if(this.valueSwatchDropsAlpha(shown))
+      return 'The current value has transparency in it. The color dialog cannot keep that, so a color picked there is fully opaque - type an rgba() or #rrggbbaa value in the field next to it to stay transparent.';
+    return null;
+  }
+
   updatePickerNote(shown) {
-    if(this.noteDOM)
-      this.noteDOM.style.display = this.valueNeedsNoSwatch(shown) ? '' : 'none';
+    if(!this.noteDOM)
+      return;
+    const text = this.pickerNoteText(shown);
+    this.noteDOM.style.display = text ? '' : 'none';
+    if(text)
+      this.noteDOM.innerHTML = html(text);
   }
 
   renderPickerContent(target, value) {
-    // a gradient or an image is not a color, so the lists below do something
-    // else to it than the "color behind the image" they set on every other
-    // widget - say so instead of letting the two clicks look the same
-    this.noteDOM = div(target, 'propertyNote', html('The current value is a gradient, an image or a color the swatch cannot show. Picking a color here replaces it.'));
+    this.noteDOM = div(target, 'propertyNote');
     this.updatePickerNote(propertyInputValueSet(value) ? value : this.getEffectiveValue());
     this.addChipList(target, 'Used in this game', usedGameColors(), value, renderColorChip);
     this.addChipList(target, 'Palette (checkerboard = transparent)', propertyInputPalette, value, renderColorChip);
@@ -1829,21 +1885,28 @@ function backgroundColorFromShorthand(css, cssClass) {
 // carries, so it says which one and what that means for an image behind it.
 const backgroundColorHint = 'Sets background-color, so an image on the widget and the way it is scaled stay as they are. A color a game keeps in the background shorthand is read from there and moved here as soon as it is changed - which also ends any image that shorthand was hiding. A background that paints a gradient or an image keeps using the shorthand, and a color picked here replaces it - unless a background-color of its own already sits behind it.';
 
-// The declaration the color row reads and writes: background-color, except
-// where a shorthand that paints more than a color (a gradient, an image) is the
-// one in effect. That shorthand would cover anything set on background-color,
-// so writing the longhand would change nothing on screen - and it has already
-// reset the image properties the longhand exists to protect. A background-color
-// the class declares itself does stay the edited declaration: it paints behind
-// the gradient rather than being covered by it, unless the shorthand follows it
-// in the same rule and resets it.
-function backgroundColorKey(css, cssClass) {
-  const shorthand = parsePropertyFromCSS(css, 'background', null, cssClass);
-  if(shorthand === null || cssBackgroundIsPlainColor(shorthand))
+// Which of the two declarations paints the widget's background color, so the
+// row shows the color that is actually on screen: the shorthand resets
+// background-color, so a longhand only counts when the class declares it after
+// its shorthand - or when the shorthand comes from a less specific class.
+function backgroundColorInEffect(css, cssClass) {
+  if(parsePropertyFromCSS(css, 'background', null, cssClass) === null)
     return 'background-color';
   const names = cssClassOwnDeclarations(css, cssClass).map(declaration=>String(declaration.name).trim());
   const longhandIndex = names.indexOf('background-color');
   return longhandIndex != -1 && longhandIndex > names.indexOf('background') ? 'background-color' : 'background';
+}
+
+// The declaration the color row writes: background-color, except where a
+// shorthand that paints more than a color (a gradient, an image) is the one in
+// effect. That shorthand would cover anything set on background-color, so
+// writing the longhand would change nothing on screen - and it has already
+// reset the image properties the longhand exists to protect. A shorthand that
+// only paints a color moves into the longhand instead, wherever it sits.
+function backgroundColorKey(css, cssClass) {
+  if(backgroundColorInEffect(css, cssClass) == 'background-color')
+    return 'background-color';
+  return cssBackgroundIsPlainColor(parsePropertyFromCSS(css, 'background', null, cssClass)) ? 'background-color' : 'background';
 }
 
 function cssValueOptions(module, widget, key, cssProperty='css', cssClass='default', extraOptions={}) {
@@ -1888,19 +1951,20 @@ function cssValueOptions(module, widget, key, cssProperty='css', cssClass='defau
       const css = widget.get(cssProperty);
       if(!isBackgroundColor)
         return parsePropertyFromCSS(css, key, null, cssClass);
-      // a shorthand that paints more than a color is no color to offer as the
-      // set one - the row shows it as the effective value instead
-      if(backgroundColorKey(css, cssClass) == 'background')
-        return null;
+      // the shorthand in effect resets any background-color under it, so its
+      // color is the set one - and a shorthand that paints more than a color is
+      // no color to offer at all, only an effective value to show
+      if(backgroundColorInEffect(css, cssClass) == 'background')
+        return backgroundColorFromShorthand(css, cssClass);
       const value = parsePropertyFromCSS(css, key, null, cssClass);
-      return value !== null ? value : backgroundColorFromShorthand(css, cssClass);
+      return value !== null ? cssValueWithoutImportant(value) : backgroundColorFromShorthand(css, cssClass);
     },
     getEffective: _=>{
       const css = widget.get(cssProperty);
       if(isBackgroundColor) {
         // whatever the declaration in effect paints is what the widget shows,
         // so the row names it instead of claiming the background is not set
-        const value = parsePropertyFromCSS(css, backgroundColorKey(css, cssClass), null, cssClass);
+        const value = parsePropertyFromCSS(css, backgroundColorInEffect(css, cssClass), null, cssClass);
         if(propertyInputValueSet(value))
           return cssValueWithoutImportant(value);
         const shorthand = parsePropertyFromCSS(css, 'background', null, cssClass);

--- a/client/js/editor/propertyInputs.js
+++ b/client/js/editor/propertyInputs.js
@@ -1158,15 +1158,15 @@ class PickerInput extends PropertyInput {
   }
 }
 
-// Values the color text field takes: a hex, a named color or a color function,
-// i.e. everything css itself would accept there. A value it does not take (a
-// var(), a gradient) is left out of the field rather than shown in it, because
-// typing a single character then turns the field red on a value it was given.
+// Values the color text field takes: everything css itself accepts as a color,
+// minus var(), which stands for a value the field cannot show. A value it does
+// not take is left out of the field rather than shown in it, because typing a
+// single character then turns the field red on a value it was given.
 function colorHexInputAccepts(value) {
   const text = String(value === null || value === undefined ? '' : value).trim();
-  if(text.startsWith('#'))
-    return !!text.match(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/);
-  return cssValueIsColor(text);
+  if(text.match(/^var\(/i))
+    return false;
+  return cssColorIsValid(text);
 }
 
 // The hex an <input type="color"> shows a value as, or null when it cannot show
@@ -1264,7 +1264,7 @@ class ColorInput extends PickerInput {
         hexInput.classList.remove('inputError');
         this.setValue(v);
         if(colorPicker)
-          colorPicker.value = toHex(v);
+          colorPicker.value = colorInputHexValue(v, this.colorHost()) || colorPicker.value;
       } else if(v === '') {
         hexInput.classList.remove('inputError');
         this.setValue(null);
@@ -1827,15 +1827,23 @@ function backgroundColorFromShorthand(css, cssClass) {
 
 // The row edits two different declarations depending on what the widget
 // carries, so it says which one and what that means for an image behind it.
-const backgroundColorHint = 'Sets background-color, so an image on the widget and the way it is scaled stay as they are. A color a game keeps in the background shorthand is read from there and moved here as soon as it is changed - which also ends any image that shorthand was hiding. A background that paints a gradient or an image keeps using the shorthand, and a color picked here replaces it.';
+const backgroundColorHint = 'Sets background-color, so an image on the widget and the way it is scaled stay as they are. A color a game keeps in the background shorthand is read from there and moved here as soon as it is changed - which also ends any image that shorthand was hiding. A background that paints a gradient or an image keeps using the shorthand, and a color picked here replaces it - unless a background-color of its own already sits behind it.';
 
-// A shorthand that paints more than a color (a gradient, an image) stays the
-// declaration the color input writes to: it would cover anything set on
-// background-color, so writing the longhand would change nothing on screen -
-// and it has already reset the image properties the longhand exists to protect.
+// The declaration the color row reads and writes: background-color, except
+// where a shorthand that paints more than a color (a gradient, an image) is the
+// one in effect. That shorthand would cover anything set on background-color,
+// so writing the longhand would change nothing on screen - and it has already
+// reset the image properties the longhand exists to protect. A background-color
+// the class declares itself does stay the edited declaration: it paints behind
+// the gradient rather than being covered by it, unless the shorthand follows it
+// in the same rule and resets it.
 function backgroundColorKey(css, cssClass) {
-  const value = parsePropertyFromCSS(css, 'background', null, cssClass);
-  return value !== null && !cssBackgroundIsPlainColor(value) ? 'background' : 'background-color';
+  const shorthand = parsePropertyFromCSS(css, 'background', null, cssClass);
+  if(shorthand === null || cssBackgroundIsPlainColor(shorthand))
+    return 'background-color';
+  const names = cssClassOwnDeclarations(css, cssClass).map(declaration=>String(declaration.name).trim());
+  const longhandIndex = names.indexOf('background-color');
+  return longhandIndex != -1 && longhandIndex > names.indexOf('background') ? 'background-color' : 'background';
 }
 
 function cssValueOptions(module, widget, key, cssProperty='css', cssClass='default', extraOptions={}) {
@@ -1877,21 +1885,31 @@ function cssValueOptions(module, widget, key, cssProperty='css', cssClass='defau
   };
   return Object.assign({
     getValue: _=>{
-      const value = parsePropertyFromCSS(widget.get(cssProperty), key, null, cssClass);
-      if(value === null && isBackgroundColor)
-        return backgroundColorFromShorthand(widget.get(cssProperty), cssClass);
-      return value;
+      const css = widget.get(cssProperty);
+      if(!isBackgroundColor)
+        return parsePropertyFromCSS(css, key, null, cssClass);
+      // a shorthand that paints more than a color is no color to offer as the
+      // set one - the row shows it as the effective value instead
+      if(backgroundColorKey(css, cssClass) == 'background')
+        return null;
+      const value = parsePropertyFromCSS(css, key, null, cssClass);
+      return value !== null ? value : backgroundColorFromShorthand(css, cssClass);
     },
     getEffective: _=>{
-      const raw = parsePropertyFromCSS(widget.get(cssProperty), key, null, cssClass);
-      if(propertyInputValueSet(raw))
-        return raw;
+      const css = widget.get(cssProperty);
       if(isBackgroundColor) {
-        // whatever the shorthand paints is what the widget shows, so the row
-        // names it instead of claiming the background is not set
-        const shorthand = parsePropertyFromCSS(widget.get(cssProperty), 'background', null, cssClass);
+        // whatever the declaration in effect paints is what the widget shows,
+        // so the row names it instead of claiming the background is not set
+        const value = parsePropertyFromCSS(css, backgroundColorKey(css, cssClass), null, cssClass);
+        if(propertyInputValueSet(value))
+          return cssValueWithoutImportant(value);
+        const shorthand = parsePropertyFromCSS(css, 'background', null, cssClass);
         if(propertyInputValueSet(shorthand))
           return cssValueWithoutImportant(shorthand);
+      } else {
+        const raw = parsePropertyFromCSS(css, key, null, cssClass);
+        if(propertyInputValueSet(raw))
+          return raw;
       }
       return computedCssValue(effectiveElement(), key);
     },

--- a/client/js/editor/propertyInputs.js
+++ b/client/js/editor/propertyInputs.js
@@ -320,6 +320,19 @@ function renderImageChip(value, target) {
   return chip;
 }
 
+// The summary shows the value as text and keeps it in the tooltip as well: a
+// declaration like a background shorthand with an asset url is longer than the
+// row, and only the tooltip has room for all of it.
+function setPickerValueText(element, text) {
+  if(text === null) {
+    element.innerHTML = '<i>not set</i>';
+    element.removeAttribute('title');
+    return;
+  }
+  element.textContent = text;
+  element.title = text;
+}
+
 function renderColorChip(value, target) {
   const chip = div(target, 'propertyValueChip propertyColorChip');
   chip.style.setProperty('--chipColor', value);
@@ -897,8 +910,14 @@ class PickerInput extends PropertyInput {
     // inputs) so opening it does not push the neighboring inputs around;
     // pickers sharing a pickerGroup close each other when one opens
     const group = this.options.pickerGroup;
-    this.pickerDOM = div((group && group.target) || this.options.pickerTarget || target, 'propertyPicker');
+    this.pickerDOM = div((group && group.target) || this.options.pickerTarget || target, `propertyPicker ${this.pickerClass()}`.trim());
     this.pickerDOM.style.display = 'none';
+  }
+
+  // A picker rendered into a pickerGroup sits outside the input it belongs to,
+  // so it carries the kind of input it opens for itself.
+  pickerClass() {
+    return '';
   }
 
   togglePicker() {
@@ -1078,12 +1097,15 @@ class PickerInput extends PropertyInput {
     const isSet = propertyInputValueSet(value);
     this.renderChip(target, this.previewValue());
     this.renderSummaryControls(target, value);
+    const effective = this.getEffectiveValue();
+    const usingDefault = !isSet && propertyInputValueSet(effective) && this.dimDefault();
+    const valueText = div(target, `propertyPickerValueText${usingDefault ? ' usingDefault' : ''}`);
     if(isSet)
-      div(target, 'propertyPickerValueText', html(this.summaryValueText(value)));
-    else if(propertyInputValueSet(this.getEffectiveValue()))
-      div(target, `propertyPickerValueText${this.dimDefault() ? ' usingDefault' : ''}`, this.dimDefault() ? `default: ${html(this.summaryValueText(this.getEffectiveValue()))}` : html(this.summaryValueText(this.getEffectiveValue())));
+      setPickerValueText(valueText, this.summaryValueText(value));
+    else if(propertyInputValueSet(effective))
+      setPickerValueText(valueText, `${usingDefault ? 'default: ' : ''}${this.summaryValueText(effective)}`);
     else
-      div(target, 'propertyPickerValueText', '<i>not set</i>');
+      setPickerValueText(valueText, null);
     const close = document.createElement('button');
     close.setAttribute('icon', 'close');
     close.title = 'Close';
@@ -1136,9 +1158,40 @@ class PickerInput extends PropertyInput {
   }
 }
 
+// Values the color text field takes: a hex, a named color or a color function,
+// i.e. everything css itself would accept there. A value it does not take (a
+// var(), a gradient) is left out of the field rather than shown in it, because
+// typing a single character then turns the field red on a value it was given.
+function colorHexInputAccepts(value) {
+  const text = String(value === null || value === undefined ? '' : value).trim();
+  if(text.startsWith('#'))
+    return !!text.match(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/);
+  return cssValueIsColor(text);
+}
+
+// The hex an <input type="color"> shows a value as, or null when it cannot show
+// it at all: the element only knows opaque hex colors, and toHex answers black
+// both for black and for everything it fails to parse. A var() or a named color
+// is resolved on the widget first, so the swatch shows what is actually painted
+// instead of a black square.
+function colorInputHexValue(value, host) {
+  const text = cssValueWithoutImportant(value);
+  if(!text || text == 'transparent')
+    return null;
+  const direct = cssColorHexValue(text);
+  if(direct !== null)
+    return direct;
+  const resolved = resolveCssColorExpression(host, text);
+  return resolved && resolved != 'transparent' ? cssColorHexValue(resolved) : null;
+}
+
 class ColorInput extends PickerInput {
   cssClass() {
     return 'pickerInput colorInput';
+  }
+
+  pickerClass() {
+    return 'colorPicker';
   }
 
   expandArrow() {
@@ -1154,38 +1207,64 @@ class ColorInput extends PickerInput {
   }
 
   renderChip(target, value) {
-    return renderColorChip(propertyInputValueSet(value) ? value : 'transparent', target);
+    const chip = renderColorChip(propertyInputValueSet(value) ? value : 'transparent', target);
+    if(this.valueNeedsNoSwatch(value))
+      chip.title = `${cssValueWithoutImportant(value)} - a color picked here replaces it`;
+    return chip;
+  }
+
+  // The element the value renders on, so a var() or a named color is resolved
+  // in the widget's own context instead of the document's.
+  colorHost() {
+    return this.widget && this.widget.domElement || null;
+  }
+
+  // Whether the native swatch would have to stand in for something it cannot
+  // show (a gradient, an image shorthand, a color with alpha or a color space
+  // it does not know): it would be a black square in front of a value the chip
+  // next to it paints correctly.
+  valueNeedsNoSwatch(value) {
+    if(!propertyInputValueSet(value) || cssValueWithoutImportant(value) == 'transparent')
+      return false;
+    return colorInputHexValue(value, this.colorHost()) === null;
   }
 
   renderSummaryControls(target, value) {
     const shown = propertyInputValueSet(value) ? value : this.getEffectiveValue();
-    const hexValue = toHex(propertyInputValueSet(shown) ? shown : (this.options.default || '#000000'));
+    const replacesValue = this.valueNeedsNoSwatch(shown);
 
-    const colorPicker = document.createElement('input');
-    colorPicker.type = 'color';
-    colorPicker.title = 'Open the color dialog';
-    colorPicker.value = hexValue;
-    // some browsers (Firefox on some platforms) only fire "change" when the
-    // native dialog closes, so listen to both events
-    colorPicker.onchange = colorPicker.oninput = _=>{
-      this.setValue(colorPicker.value);
-      if(hexInput && document.activeElement !== hexInput)
-        hexInput.value = colorPicker.value;
-    };
-    target.appendChild(colorPicker);
-
-    // let the value be typed in as a hex string too
+    // let the value be typed in as a color string too
     const hexInput = document.createElement('input');
     hexInput.type = 'text';
     hexInput.className = 'colorHexInput';
-    hexInput.placeholder = '#rrggbb or transparent';
-    hexInput.value = propertyInputValueSet(value) ? value : '';
+    hexInput.placeholder = replacesValue ? '#rrggbb' : '#rrggbb or transparent';
+    if(replacesValue)
+      hexInput.title = 'Type a color to replace the current value';
+    hexInput.value = colorHexInputAccepts(value) ? String(value).trim() : '';
+
+    let colorPicker = null;
+    if(!replacesValue) {
+      colorPicker = document.createElement('input');
+      colorPicker.type = 'color';
+      colorPicker.title = 'Open the color dialog';
+      colorPicker.value = colorInputHexValue(shown, this.colorHost()) || toHex(this.options.default || '#000000');
+      // some browsers (Firefox on some platforms) only fire "change" when the
+      // native dialog closes, so listen to both events
+      colorPicker.onchange = colorPicker.oninput = _=>{
+        this.setValue(colorPicker.value);
+        if(document.activeElement !== hexInput)
+          hexInput.value = colorPicker.value;
+      };
+      target.appendChild(colorPicker);
+    }
+
     hexInput.oninput = _=>{
       const v = hexInput.value.trim();
-      if(v == 'transparent' || v.match(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/)) {
+      if(colorHexInputAccepts(v)) {
         hexInput.classList.remove('inputError');
         this.setValue(v);
-        colorPicker.value = toHex(v);
+        if(colorPicker)
+          colorPicker.value = toHex(v);
       } else if(v === '') {
         hexInput.classList.remove('inputError');
         this.setValue(null);
@@ -1209,22 +1288,35 @@ class ColorInput extends PickerInput {
     }
     if(this.summaryDOM) {
       const shown = propertyInputValueSet(value) ? value : this.getEffectiveValue();
-      const chip = this.summaryDOM.querySelector('.propertyValueChip');
-      if(chip) {
-        const newChip = renderColorChip(propertyInputValueSet(shown) ? shown : 'transparent', this.summaryDOM);
-        this.summaryDOM.insertBefore(newChip, chip);
-        chip.remove();
+      const replacesValue = this.valueNeedsNoSwatch(shown);
+      const active = document.activeElement;
+      const activeInSummaryInput = this.summaryDOM.contains(active) && active.matches('input, textarea');
+      // the value moved between one the swatch can show and one it cannot, so
+      // the controls themselves differ - rebuild instead of patching them
+      // (never while the user is typing in one of them)
+      const hasSwatch = !!this.summaryDOM.querySelector('input[type=color]');
+      if(replacesValue == hasSwatch && !activeInSummaryInput) {
+        this.summaryDOM.innerHTML = '';
+        this.renderSummary(this.summaryDOM, value);
+      } else {
+        const chip = this.summaryDOM.querySelector('.propertyValueChip');
+        if(chip) {
+          const newChip = this.renderChip(this.summaryDOM, propertyInputValueSet(shown) ? shown : null);
+          this.summaryDOM.insertBefore(newChip, chip);
+          chip.remove();
+        }
+        const valueText = this.summaryDOM.querySelector('.propertyPickerValueText');
+        if(valueText)
+          setPickerValueText(valueText, propertyInputValueSet(value) ? String(value) : (propertyInputValueSet(shown) ? String(shown) : null));
+        const colorPicker = this.summaryDOM.querySelector('input[type=color]');
+        if(colorPicker && document.activeElement !== colorPicker && propertyInputValueSet(shown))
+          colorPicker.value = colorInputHexValue(shown, this.colorHost()) || colorPicker.value;
+        const hexInput = this.summaryDOM.querySelector('.colorHexInput');
+        if(hexInput && document.activeElement !== hexInput)
+          hexInput.value = colorHexInputAccepts(value) ? String(value).trim() : '';
       }
-      const valueText = this.summaryDOM.querySelector('.propertyPickerValueText');
-      if(valueText)
-        valueText.textContent = propertyInputValueSet(value) ? String(value) : (propertyInputValueSet(shown) ? String(shown) : 'not set');
-      const colorPicker = this.summaryDOM.querySelector('input[type=color]');
-      if(colorPicker && document.activeElement !== colorPicker && propertyInputValueSet(shown) && String(shown).match(/^#/))
-        colorPicker.value = toHex(shown);
-      const hexInput = this.summaryDOM.querySelector('.colorHexInput');
-      if(hexInput && document.activeElement !== hexInput)
-        hexInput.value = propertyInputValueSet(value) ? value : '';
     }
+    this.updatePickerNote(propertyInputValueSet(value) ? value : this.getEffectiveValue());
     for(const chip of $a('.propertyValueChip', this.pickerDOM))
       if(chip.dataset.value !== undefined)
         chip.classList.toggle('selected', chip.dataset.value == this.chipMatchValue(value));
@@ -1232,7 +1324,17 @@ class ColorInput extends PickerInput {
       this.renderFooter(value);
   }
 
+  updatePickerNote(shown) {
+    if(this.noteDOM)
+      this.noteDOM.style.display = this.valueNeedsNoSwatch(shown) ? '' : 'none';
+  }
+
   renderPickerContent(target, value) {
+    // a gradient or an image is not a color, so the lists below do something
+    // else to it than the "color behind the image" they set on every other
+    // widget - say so instead of letting the two clicks look the same
+    this.noteDOM = div(target, 'propertyNote', html('The current value is a gradient, an image or a color the swatch cannot show. Picking a color here replaces it.'));
+    this.updatePickerNote(propertyInputValueSet(value) ? value : this.getEffectiveValue());
     this.addChipList(target, 'Used in this game', usedGameColors(), value, renderColorChip);
     this.addChipList(target, 'Palette (checkerboard = transparent)', propertyInputPalette, value, renderColorChip);
   }
@@ -1723,6 +1825,10 @@ function backgroundColorFromShorthand(css, cssClass) {
   return value !== null && cssBackgroundIsPlainColor(value) ? cssValueWithoutImportant(value) : null;
 }
 
+// The row edits two different declarations depending on what the widget
+// carries, so it says which one and what that means for an image behind it.
+const backgroundColorHint = 'Sets background-color, so an image on the widget and the way it is scaled stay as they are. A color a game keeps in the background shorthand is read from there and moved here as soon as it is changed - which also ends any image that shorthand was hiding. A background that paints a gradient or an image keeps using the shorthand, and a color picked here replaces it.';
+
 // A shorthand that paints more than a color (a gradient, an image) stays the
 // declaration the color input writes to: it would cover anything set on
 // background-color, so writing the longhand would change nothing on screen -
@@ -1811,7 +1917,7 @@ function cssValueOptions(module, widget, key, cssProperty='css', cssClass='defau
         widget.applyDeltaToDOM({ [cssProperty]: widget.get(cssProperty) });
     },
     listenTo: [ cssProperty ]
-  }, extraOptions);
+  }, isBackgroundColor ? { hint: backgroundColorHint } : {}, extraOptions);
 }
 
 // Dual-mode options for color properties that map to a css custom property

--- a/client/js/editor/propertyInputs.js
+++ b/client/js/editor/propertyInputs.js
@@ -1718,9 +1718,18 @@ function computedCssValue(element, key) {
 // a widget shows (and the scaling the room css gives it). A game that keeps its
 // color in the shorthand still has it read from there, and moved to the longhand
 // as soon as the color is changed.
-function legacyBackgroundColor(css, cssClass) {
+function backgroundColorFromShorthand(css, cssClass) {
   const value = parsePropertyFromCSS(css, 'background', null, cssClass);
-  return value !== null && cssBackgroundIsPlainColor(value) ? value : null;
+  return value !== null && cssBackgroundIsPlainColor(value) ? cssValueWithoutImportant(value) : null;
+}
+
+// A shorthand that paints more than a color (a gradient, an image) stays the
+// declaration the color input writes to: it would cover anything set on
+// background-color, so writing the longhand would change nothing on screen -
+// and it has already reset the image properties the longhand exists to protect.
+function backgroundColorKey(css, cssClass) {
+  const value = parsePropertyFromCSS(css, 'background', null, cssClass);
+  return value !== null && !cssBackgroundIsPlainColor(value) ? 'background' : 'background-color';
 }
 
 function cssValueOptions(module, widget, key, cssProperty='css', cssClass='default', extraOptions={}) {
@@ -1752,7 +1761,7 @@ function cssValueOptions(module, widget, key, cssProperty='css', cssClass='defau
   }
 
   let warned = false;
-  const legacyShorthand = key == 'background-color';
+  const isBackgroundColor = key == 'background-color';
   // element the declaration actually renders on, used to preview the effective
   // default when nothing is explicitly set
   const effectiveElement = _=>{
@@ -1763,18 +1772,20 @@ function cssValueOptions(module, widget, key, cssProperty='css', cssClass='defau
   return Object.assign({
     getValue: _=>{
       const value = parsePropertyFromCSS(widget.get(cssProperty), key, null, cssClass);
-      if(value === null && legacyShorthand)
-        return legacyBackgroundColor(widget.get(cssProperty), cssClass);
+      if(value === null && isBackgroundColor)
+        return backgroundColorFromShorthand(widget.get(cssProperty), cssClass);
       return value;
     },
     getEffective: _=>{
       const raw = parsePropertyFromCSS(widget.get(cssProperty), key, null, cssClass);
       if(propertyInputValueSet(raw))
         return raw;
-      if(legacyShorthand) {
-        const legacy = legacyBackgroundColor(widget.get(cssProperty), cssClass);
-        if(propertyInputValueSet(legacy))
-          return legacy;
+      if(isBackgroundColor) {
+        // whatever the shorthand paints is what the widget shows, so the row
+        // names it instead of claiming the background is not set
+        const shorthand = parsePropertyFromCSS(widget.get(cssProperty), 'background', null, cssClass);
+        if(propertyInputValueSet(shorthand))
+          return cssValueWithoutImportant(shorthand);
       }
       return computedCssValue(effectiveElement(), key);
     },
@@ -1789,8 +1800,11 @@ function cssValueOptions(module, widget, key, cssProperty='css', cssClass='defau
         }
         return;
       }
-      let merged = mergePropertyFromCSS(css, key, v, cssClass);
-      if(legacyShorthand && legacyBackgroundColor(css, cssClass) !== null)
+      const writeKey = isBackgroundColor ? backgroundColorKey(css, cssClass) : key;
+      let merged = mergePropertyFromCSS(css, writeKey, v, cssClass);
+      // the color moved out of the shorthand, which would otherwise keep
+      // overriding the longhand it was moved into
+      if(isBackgroundColor && backgroundColorFromShorthand(css, cssClass) !== null)
         merged = mergePropertyFromCSS(merged, 'background', null, cssClass);
       module.inputValueUpdated(widget, cssProperty, merged);
       if(widget.applyDeltaToDOM)

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -956,6 +956,20 @@ function parsePropertyFromCSS(css, prop, defaultValue='', cssClass="default") {
   return defaultValue;
 }
 
+// The declarations a css class writes itself, in the order it has them - what
+// parsePropertyFromCSS cannot say, because it answers a state class with the
+// "default" one when the class does not carry the property, and because two
+// declarations of the same rule are decided by which one comes last.
+function cssClassOwnDeclarations(css, cssClass='default') {
+  const source = typeof css === 'string' ? cssStringToObject(css) : css;
+  if (!isObjectLike(source))
+    return [];
+  const className = cssClass || 'default';
+  if (hasNestedCSSClasses(source))
+    return isObjectLike(source[className]) ? cssDeclarationList(source[className]) : [];
+  return className === 'default' ? cssDeclarationList(source) : [];
+}
+
 function cssStringToObject(str) {
   const out = {};
   if (!str || typeof str !== 'string') return out;
@@ -1128,6 +1142,23 @@ function cssValueIsColor(value) {
   if(text.match(/^(rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch|color)\([^()]*\)$/))
     return true;
   return cssNamedColors.indexOf(text) != -1;
+}
+
+// Whether css takes a value as a color, asked of the css parser instead of
+// matched by hand: a value it does not understand never makes it onto the
+// declaration, so what is left there is the answer. A var() passes - it is a
+// valid color value, whatever the custom property behind it holds.
+let cssColorProbe = null;
+function cssColorIsValid(value) {
+  const text = String(value === null || value === undefined ? '' : value).trim();
+  if(!text)
+    return false;
+  if(typeof document == 'undefined')
+    return cssValueIsColor(text);
+  cssColorProbe = cssColorProbe || document.createElement('div');
+  cssColorProbe.style.color = '';
+  cssColorProbe.style.color = text;
+  return cssColorProbe.style.color !== '';
 }
 
 // A declaration value without its "!important" priority - the color inputs

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1130,11 +1130,20 @@ function cssValueIsColor(value) {
   return cssNamedColors.indexOf(text) != -1;
 }
 
+// A declaration value without its "!important" priority - the color inputs
+// cannot represent it and would show it as part of the color
+function cssValueWithoutImportant(value) {
+  return String(value === null || value === undefined ? '' : value).replace(/\s*!important\s*$/i, '').trim();
+}
+
 // Whether a "background" shorthand only paints a color, so the color inputs can
 // move it into the background-color longhand without losing anything. A
-// gradient, an image or a multi-part shorthand cannot be moved that way.
+// gradient, an image or a multi-part shorthand cannot be moved that way. A
+// var() is taken at its word: a custom property can hold an image just as well
+// (holder.css defines --bgImage), but telling the two apart needs the widget
+// rendered, which this helper does not have.
 function cssBackgroundIsPlainColor(value) {
-  const text = String(value === null || value === undefined ? '' : value).replace(/\s*!important\s*$/i, '').trim();
+  const text = cssValueWithoutImportant(value);
   if(text.match(/^var\(\s*--[^()]*\)$/))
     return true;
   return cssValueIsColor(text);

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1144,6 +1144,13 @@ function cssValueIsColor(value) {
   return cssNamedColors.indexOf(text) != -1;
 }
 
+// The keywords every css property takes, whatever it is: they stand for a value
+// from somewhere else instead of naming one, so a color input can neither show
+// them nor take them for the color a declaration paints.
+function cssValueIsCssWideKeyword(value) {
+  return !!String(value === null || value === undefined ? '' : value).trim().match(/^(inherit|initial|unset|revert|revert-layer)$/i);
+}
+
 // Whether css takes a value as a color, asked of the css parser instead of
 // matched by hand: a value it does not understand never makes it onto the
 // declaration, so what is left there is the answer. A var() passes - it is a
@@ -1151,7 +1158,7 @@ function cssValueIsColor(value) {
 let cssColorProbe = null;
 function cssColorIsValid(value) {
   const text = String(value === null || value === undefined ? '' : value).trim();
-  if(!text)
+  if(!text || cssValueIsCssWideKeyword(text))
     return false;
   if(typeof document == 'undefined')
     return cssValueIsColor(text);
@@ -1177,7 +1184,7 @@ function cssBackgroundIsPlainColor(value) {
   const text = cssValueWithoutImportant(value);
   if(text.match(/^var\(\s*--[^()]*\)$/))
     return true;
-  return cssValueIsColor(text);
+  return cssColorIsValid(text);
 }
 
 // colors an <input type="color"> cannot represent, so the row shows them

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1130,6 +1130,16 @@ function cssValueIsColor(value) {
   return cssNamedColors.indexOf(text) != -1;
 }
 
+// Whether a "background" shorthand only paints a color, so the color inputs can
+// move it into the background-color longhand without losing anything. A
+// gradient, an image or a multi-part shorthand cannot be moved that way.
+function cssBackgroundIsPlainColor(value) {
+  const text = String(value === null || value === undefined ? '' : value).replace(/\s*!important\s*$/i, '').trim();
+  if(text.match(/^var\(\s*--[^()]*\)$/))
+    return true;
+  return cssValueIsColor(text);
+}
+
 // colors an <input type="color"> cannot represent, so the row shows them
 // instead of offering to edit (and silently flatten) them
 function cssColorHasAlpha(value) {
@@ -1366,7 +1376,7 @@ const editorTypeSections = {
     ],
     colors: [
       { label: 'Text',          kind: 'color', labelIcon: 'format_color_text', cssKey: 'color' },
-      { label: 'Background',    kind: 'color', labelIcon: 'format_color_fill', cssKey: 'background' },
+      { label: 'Background',    kind: 'color', labelIcon: 'format_color_fill', cssKey: 'background-color' },
       { label: 'Border',        kind: 'color', labelIcon: 'border_color', cssKey: 'border-color' },
       // only shown where it paints something - see basicColorIsUsed
       { label: 'Icon/Symbol',   property: 'color', kind: 'color', labelIcon: 'category',
@@ -1463,10 +1473,10 @@ const editorTypeSections = {
     // --lineColor from its properties, overriding the css property
     colors: [
       { label: 'Text',          property: 'textColor',    kind: 'color', labelIcon: 'format_color_text' },
-      { label: 'Background',    kind: 'color', labelIcon: 'format_color_fill', cssKey: 'background', cssProperty: 'backgroundCSS', effectiveSelector: '.background' },
+      { label: 'Background',    kind: 'color', labelIcon: 'format_color_fill', cssKey: 'background-color', cssProperty: 'backgroundCSS', effectiveSelector: '.background' },
       { label: 'Line',          property: 'lineColor',    kind: 'color', labelIcon: 'border_color' },
       { label: 'Value text',    kind: 'color', labelIcon: 'counter_1', labelIconNoFill: true, cssKey: 'color', cssProperty: 'valueCSS', effectiveSelector: '.value' },
-      { label: 'Value background', kind: 'color', labelIcon: 'counter_1', cssKey: 'background', cssProperty: 'valueCSS', effectiveSelector: '.value' }
+      { label: 'Value background', kind: 'color', labelIcon: 'counter_1', cssKey: 'background-color', cssProperty: 'valueCSS', effectiveSelector: '.value' }
     ],
     cssProperties: [ 'css', 'backgroundCSS', 'spinnerCSS', 'valueCSS' ]
   },
@@ -1474,7 +1484,7 @@ const editorTypeSections = {
     stateClasses: { '.alert': 'alert', '.paused': 'paused' },
     colors: [
       { label: 'Text',       cssKey: 'color',      kind: 'color', labelIcon: 'format_color_text' },
-      { label: 'Background', cssKey: 'background', kind: 'color', labelIcon: 'format_color_fill' }
+      { label: 'Background', cssKey: 'background-color', kind: 'color', labelIcon: 'format_color_fill' }
     ]
   }
 };
@@ -8748,7 +8758,7 @@ class PropertiesModule extends SidebarModule {
     // width and a style as well - those are one CSS section below
     for(const color of [
       { label: 'Text', key: 'color', labelIcon: 'format_color_text' },
-      { label: 'Background', key: 'background', labelIcon: 'format_color_fill' }
+      { label: 'Background', key: 'background-color', labelIcon: 'format_color_fill' }
     ])
       new ColorInput(this, widget, color.label, cssValueOptions(this, widget, color.key, 'handleCSS', 'default', {
         pickerGroup: handleGroup,
@@ -10372,9 +10382,9 @@ class PropertiesModule extends SidebarModule {
     const row = div(this.moduleDOM, 'colorFlexRow');
     const pickerArea = div(this.moduleDOM, 'contentMediaPickers');
     const group = { target: pickerArea, current: null };
-    new ColorInput(this, widget, 'Text',       cssValueOptions(this, widget, 'color',        'css', cssClass, { pickerGroup: group, labelIcon: 'format_color_text' })).render(row);
-    new ColorInput(this, widget, 'Background', cssValueOptions(this, widget, 'background',   'css', cssClass, { pickerGroup: group, labelIcon: 'format_color_fill' })).render(row);
-    new ColorInput(this, widget, 'Border',     cssValueOptions(this, widget, 'border-color', 'css', cssClass, { pickerGroup: group, labelIcon: 'border_color' })).render(row);
+    new ColorInput(this, widget, 'Text',       cssValueOptions(this, widget, 'color',            'css', cssClass, { pickerGroup: group, labelIcon: 'format_color_text' })).render(row);
+    new ColorInput(this, widget, 'Background', cssValueOptions(this, widget, 'background-color', 'css', cssClass, { pickerGroup: group, labelIcon: 'format_color_fill' })).render(row);
+    new ColorInput(this, widget, 'Border',     cssValueOptions(this, widget, 'border-color',     'css', cssClass, { pickerGroup: group, labelIcon: 'border_color' })).render(row);
 
     new NumberInput(this, widget, 'Brightness', {
       min: 0, max: 1, step: 0.05, slider: true, nullIfEmpty: true, placeholder: '1', listenTo: [ 'css' ],

--- a/tests/client/property-inputs.test.js
+++ b/tests/client/property-inputs.test.js
@@ -74,6 +74,8 @@ const cssHelpers = new Function('SidebarModule', 'widgets', 'positionNames', 'ex
     cssValueFromDeclarations,
     cssValueIsColor,
     cssColorHasAlpha,
+    cssBackgroundIsPlainColor,
+    cssValueOptions,
     cssDeclarationIsValid,
     cssValueSuggestions,
     cssPropertySuggestions: PropertiesModule.prototype.cssPropertySuggestions,
@@ -548,10 +550,55 @@ describe('css helpers', () => {
     expect(inputHelpers.soundName('https://example.com/sounds/My Sound.ogg')).toBe('My Sound');
   });
 
+  test('a background shorthand counts as a plain color only when it paints nothing else', () => {
+    expect(cssHelpers.cssBackgroundIsPlainColor('#ff0000')).toBe(true);
+    expect(cssHelpers.cssBackgroundIsPlainColor('rgba(0, 0, 0, 0.5)')).toBe(true);
+    expect(cssHelpers.cssBackgroundIsPlainColor('transparent')).toBe(true);
+    expect(cssHelpers.cssBackgroundIsPlainColor('var(--color)')).toBe(true);
+    expect(cssHelpers.cssBackgroundIsPlainColor('var(--color) !important')).toBe(true);
+    expect(cssHelpers.cssBackgroundIsPlainColor('linear-gradient(red, blue)')).toBe(false);
+    expect(cssHelpers.cssBackgroundIsPlainColor('url("/assets/1_2") no-repeat')).toBe(false);
+    expect(cssHelpers.cssBackgroundIsPlainColor('red url("/assets/1_2")')).toBe(false);
+    expect(cssHelpers.cssBackgroundIsPlainColor('')).toBe(false);
+    expect(cssHelpers.cssBackgroundIsPlainColor(null)).toBe(false);
+  });
+
   test('the size-ratio lock stays local while honoring a legacy false value', () => {
     const module = { sizeRatioLocks: new WeakMap() };
     expect(cssHelpers.isSizeRatioLockEnabled.call(module, { state: {} })).toBe(true);
     expect(cssHelpers.isSizeRatioLockEnabled.call(module, { state: { lockSizeRatio: false } })).toBe(false);
+  });
+});
+
+describe('the background color input', () => {
+  const widgetWith = css => ({ state: { css }, get(key) { return this.state[key]; } });
+  const backgroundOptions = (widget, cssClass='default') => cssHelpers.cssValueOptions(
+    { inputValueUpdated: (w, property, value) => w.state[property] = value }, widget, 'background-color', 'css', cssClass);
+
+  test('the color goes into the longhand, so an image keeps its size and repeat', () => {
+    const widget = widgetWith({ 'background-size': '310px 480px' });
+    backgroundOptions(widget).setValue('#112233');
+    expect(widget.state.css).toEqual({ 'background-size': '310px 480px', 'background-color': '#112233' });
+  });
+
+  test('a color left in the shorthand is read from there and moved on the next edit', () => {
+    const widget = widgetWith({ background: '#abcdef', 'font-size': '20px' });
+    expect(backgroundOptions(widget).getValue()).toBe('#abcdef');
+    backgroundOptions(widget).setValue('#112233');
+    expect(widget.state.css).toEqual({ 'font-size': '20px', 'background-color': '#112233' });
+  });
+
+  test('a shorthand that paints more than a color is left alone', () => {
+    const widget = widgetWith({ background: 'linear-gradient(red, blue)' });
+    expect(backgroundOptions(widget).getValue()).toBe(null);
+    backgroundOptions(widget).setValue('#112233');
+    expect(widget.state.css).toEqual({ background: 'linear-gradient(red, blue)', 'background-color': '#112233' });
+  });
+
+  test('clearing the color drops both declarations from the state class it was set on', () => {
+    const widget = widgetWith({ default: {}, '.droptarget': { background: '#abcdef' } });
+    backgroundOptions(widget, '.droptarget').setValue(null);
+    expect(widget.state.css).toEqual({ default: {} });
   });
 });
 

--- a/tests/client/property-inputs.test.js
+++ b/tests/client/property-inputs.test.js
@@ -624,12 +624,46 @@ describe('the background color input', () => {
   });
 
   test('the color text field takes every color css takes, and nothing else', () => {
-    for(const value of [ '#abc', '#abcdef', '#abcdef80', 'transparent', 'red', 'rgb(1, 2, 3)', 'oklch(0.5 0.1 20)' ])
+    for(const value of [ '#abc', '#abcd', '#abcdef', '#abcdef80', 'transparent', 'red', 'rebeccapurple', 'rgb(1, 2, 3)',
+                         'rgb(1 2 3 / 0.5)', 'hsl(120 50% 50%)', 'oklch(0.5 0.1 20)', 'color(srgb 1 1 1)' ])
       expect(cssHelpers.colorHexInputAccepts(value)).toBe(true);
     // shown in the value text instead: typing in a field that rejects what it
     // was given turns it red on the first keystroke
-    for(const value of [ 'var(--VTTblue)', 'linear-gradient(red, blue)', 'url("/assets/1_2") no-repeat', '#abcd', '#ghijkl', '', null ])
+    for(const value of [ 'var(--VTTblue)', 'linear-gradient(red, blue)', 'url("/assets/1_2") no-repeat', '#ghijkl', '', null ])
       expect(cssHelpers.colorHexInputAccepts(value)).toBe(false);
+    // a value shaped like a color but written with nonsense in it is not one
+    for(const value of [ 'rgb(banana)', 'oklch(foo bar baz)', 'hsl(1, 2, 3, 4, 5)', 'red !important' ])
+      expect(cssHelpers.colorHexInputAccepts(value)).toBe(false);
+  });
+
+  test('a color declared next to a gradient keeps both, and stays the edited one', () => {
+    const widget = widgetWith({ background: 'linear-gradient(red, blue)', 'background-color': '#ff0000' });
+    const options = backgroundOptions(widget);
+    expect(options.getValue()).toBe('#ff0000');
+    options.setValue('#00ff00');
+    expect(widget.state.css).toEqual({ background: 'linear-gradient(red, blue)', 'background-color': '#00ff00' });
+  });
+
+  test('a color the shorthand behind it resets is not the edited declaration', () => {
+    const widget = widgetWith({ 'background-color': '#ff0000', background: 'linear-gradient(red, blue)' });
+    const options = backgroundOptions(widget);
+    expect(options.getValue()).toBe(null);
+    expect(options.getEffective()).toBe('linear-gradient(red, blue)');
+    options.setValue('#00ff00');
+    expect(widget.state.css).toEqual({ 'background-color': '#ff0000', background: '#00ff00' });
+  });
+
+  test('a state class color wins over a gradient the default class paints', () => {
+    const widget = widgetWith({ default: { background: 'linear-gradient(red, blue)' }, '.droppable': { 'background-color': '#ff0000' } });
+    expect(backgroundOptions(widget, '.droppable').getValue()).toBe('#ff0000');
+    backgroundOptions(widget, '.droppable').setValue('#00ff00');
+    expect(widget.state.css).toEqual({ default: { background: 'linear-gradient(red, blue)' }, '.droppable': { 'background-color': '#00ff00' } });
+  });
+
+  test('a state class without a color of its own replaces the gradient it inherits', () => {
+    const widget = widgetWith({ default: { background: 'linear-gradient(red, blue)' }, '.droppable': {} });
+    backgroundOptions(widget, '.droppable').setValue('#00ff00');
+    expect(widget.state.css).toEqual({ default: { background: 'linear-gradient(red, blue)' }, '.droppable': { background: '#00ff00' } });
   });
 
   test('clearing the color drops both declarations from the state class it was set on', () => {

--- a/tests/client/property-inputs.test.js
+++ b/tests/client/property-inputs.test.js
@@ -75,6 +75,7 @@ const cssHelpers = new Function('SidebarModule', 'widgets', 'positionNames', 'ex
     cssValueIsColor,
     cssColorHasAlpha,
     cssBackgroundIsPlainColor,
+    colorHexInputAccepts,
     cssValueOptions,
     cssDeclarationIsValid,
     cssValueSuggestions,
@@ -614,6 +615,21 @@ describe('the background color input', () => {
     expect(backgroundOptions(widget, '.droppable').getValue()).toBe('#abcdef');
     backgroundOptions(widget, '.droppable').setValue('#112233');
     expect(widget.state.css).toEqual({ default: { background: '#abcdef' }, '.droppable': { 'background-color': '#112233' } });
+  });
+
+  test('the row explains which declaration it writes', () => {
+    expect(backgroundOptions(widgetWith({})).hint).toMatch(/background-color/);
+    // only the background rows edit two different declarations
+    expect(cssHelpers.cssValueOptions({}, widgetWith({}), 'color').hint).toBe(undefined);
+  });
+
+  test('the color text field takes every color css takes, and nothing else', () => {
+    for(const value of [ '#abc', '#abcdef', '#abcdef80', 'transparent', 'red', 'rgb(1, 2, 3)', 'oklch(0.5 0.1 20)' ])
+      expect(cssHelpers.colorHexInputAccepts(value)).toBe(true);
+    // shown in the value text instead: typing in a field that rejects what it
+    // was given turns it red on the first keystroke
+    for(const value of [ 'var(--VTTblue)', 'linear-gradient(red, blue)', 'url("/assets/1_2") no-repeat', '#abcd', '#ghijkl', '', null ])
+      expect(cssHelpers.colorHexInputAccepts(value)).toBe(false);
   });
 
   test('clearing the color drops both declarations from the state class it was set on', () => {

--- a/tests/client/property-inputs.test.js
+++ b/tests/client/property-inputs.test.js
@@ -76,6 +76,8 @@ const cssHelpers = new Function('SidebarModule', 'widgets', 'positionNames', 'ex
     cssColorHasAlpha,
     cssBackgroundIsPlainColor,
     colorHexInputAccepts,
+    colorInputOpaqueHexValue,
+    opaqueHexFromRGBExpression,
     cssValueOptions,
     cssDeclarationIsValid,
     cssValueSuggestions,
@@ -562,6 +564,14 @@ describe('css helpers', () => {
     expect(cssHelpers.cssBackgroundIsPlainColor('red url("/assets/1_2")')).toBe(false);
     expect(cssHelpers.cssBackgroundIsPlainColor('')).toBe(false);
     expect(cssHelpers.cssBackgroundIsPlainColor(null)).toBe(false);
+    // css names ~150 colors, so which ones are one is a question for the parser
+    expect(cssHelpers.cssBackgroundIsPlainColor('steelblue')).toBe(true);
+    expect(cssHelpers.cssBackgroundIsPlainColor('rebeccapurple')).toBe(true);
+    expect(cssHelpers.cssBackgroundIsPlainColor('red !important')).toBe(true);
+    expect(cssHelpers.cssBackgroundIsPlainColor('#12345')).toBe(false);
+    expect(cssHelpers.cssBackgroundIsPlainColor('rgb(banana)')).toBe(false);
+    // a keyword that stands for a value from somewhere else is no color to move
+    expect(cssHelpers.cssBackgroundIsPlainColor('inherit')).toBe(false);
   });
 
   test('the size-ratio lock stays local while honoring a legacy false value', () => {
@@ -598,9 +608,9 @@ describe('the background color input', () => {
     expect(widget.state.css).toEqual({ background: '#112233' });
   });
 
-  test('the color is read without its !important priority', () => {
-    const widget = widgetWith({ background: '#abcdef !important' });
-    expect(backgroundOptions(widget).getValue()).toBe('#abcdef');
+  test('the color is read without its !important priority, in either declaration', () => {
+    expect(backgroundOptions(widgetWith({ background: '#abcdef !important' })).getValue()).toBe('#abcdef');
+    expect(backgroundOptions(widgetWith({ 'background-color': '#abcdef !important' })).getValue()).toBe('#abcdef');
   });
 
   test('a css string is converted and keeps its other declarations', () => {
@@ -633,6 +643,9 @@ describe('the background color input', () => {
       expect(cssHelpers.colorHexInputAccepts(value)).toBe(false);
     // a value shaped like a color but written with nonsense in it is not one
     for(const value of [ 'rgb(banana)', 'oklch(foo bar baz)', 'hsl(1, 2, 3, 4, 5)', 'red !important' ])
+      expect(cssHelpers.colorHexInputAccepts(value)).toBe(false);
+    // css takes these in every property, but none of them names a color
+    for(const value of [ 'inherit', 'initial', 'unset', 'revert', 'revert-layer' ])
       expect(cssHelpers.colorHexInputAccepts(value)).toBe(false);
   });
 
@@ -670,6 +683,38 @@ describe('the background color input', () => {
     const widget = widgetWith({ default: {}, '.droptarget': { background: '#abcdef' } });
     backgroundOptions(widget, '.droptarget').setValue(null);
     expect(widget.state.css).toEqual({ default: {} });
+  });
+
+  test('a named color in the shorthand moves into the longhand, keeping the image sizing', () => {
+    const widget = widgetWith({ background: 'steelblue', 'background-image': 'url("/assets/1_2")', 'background-size': 'contain' });
+    const options = backgroundOptions(widget);
+    expect(options.getValue()).toBe('steelblue');
+    options.setValue('#112233');
+    expect(widget.state.css).toEqual({ 'background-image': 'url("/assets/1_2")', 'background-size': 'contain', 'background-color': '#112233' });
+  });
+
+  test('a plain shorthand behind the longhand is the color the row shows and edits', () => {
+    const widget = widgetWith({ 'background-color': '#ff0000', background: '#00ff00' });
+    const options = backgroundOptions(widget);
+    expect(options.getValue()).toBe('#00ff00');
+    expect(options.getEffective()).toBe('#00ff00');
+    options.setValue('#0000ff');
+    expect(widget.state.css).toEqual({ 'background-color': '#0000ff' });
+  });
+
+  test('the native swatch falls back to the color behind a transparency it cannot show', () => {
+    // the browser resolves a color to rgb()/rgba() before the swatch gets it
+    expect(cssHelpers.opaqueHexFromRGBExpression('rgba(255, 255, 255, 0.4)')).toBe('#ffffff');
+    expect(cssHelpers.opaqueHexFromRGBExpression('rgb(1, 2, 3)')).toBe('#010203');
+    expect(cssHelpers.opaqueHexFromRGBExpression('rgb(1 2 3 / 0.5)')).toBe('#010203');
+    // a color space that stays as it is does not reduce to a swatch color
+    expect(cssHelpers.opaqueHexFromRGBExpression('oklch(0.5 0.1 20)')).toBe(null);
+    expect(cssHelpers.opaqueHexFromRGBExpression('')).toBe(null);
+    // ...whatever the value was written as, and whatever priority it carries
+    expect(cssHelpers.colorInputOpaqueHexValue('#fff6', null)).toBe('#ffffff');
+    expect(cssHelpers.colorInputOpaqueHexValue('steelblue !important', null)).toBe('#4682b4');
+    expect(cssHelpers.colorInputOpaqueHexValue('linear-gradient(red, blue)', null)).toBe(null);
+    expect(cssHelpers.colorInputOpaqueHexValue('', null)).toBe(null);
   });
 });
 

--- a/tests/client/property-inputs.test.js
+++ b/tests/client/property-inputs.test.js
@@ -588,11 +588,32 @@ describe('the background color input', () => {
     expect(widget.state.css).toEqual({ 'font-size': '20px', 'background-color': '#112233' });
   });
 
-  test('a shorthand that paints more than a color is left alone', () => {
+  test('a shorthand that paints more than a color stays the edited declaration', () => {
     const widget = widgetWith({ background: 'linear-gradient(red, blue)' });
-    expect(backgroundOptions(widget).getValue()).toBe(null);
+    const options = backgroundOptions(widget);
+    expect(options.getValue()).toBe(null);
+    expect(options.getEffective()).toBe('linear-gradient(red, blue)');
+    options.setValue('#112233');
+    expect(widget.state.css).toEqual({ background: '#112233' });
+  });
+
+  test('the color is read without its !important priority', () => {
+    const widget = widgetWith({ background: '#abcdef !important' });
+    expect(backgroundOptions(widget).getValue()).toBe('#abcdef');
+  });
+
+  test('a css string is converted and keeps its other declarations', () => {
+    const widget = widgetWith('background: #abcdef; font-size: 20px');
+    expect(backgroundOptions(widget).getValue()).toBe('#abcdef');
     backgroundOptions(widget).setValue('#112233');
-    expect(widget.state.css).toEqual({ background: 'linear-gradient(red, blue)', 'background-color': '#112233' });
+    expect(widget.state.css).toEqual({ 'font-size': '20px', 'background-color': '#112233' });
+  });
+
+  test('a state class without its own background reads the default one', () => {
+    const widget = widgetWith({ default: { background: '#abcdef' }, '.droppable': {} });
+    expect(backgroundOptions(widget, '.droppable').getValue()).toBe('#abcdef');
+    backgroundOptions(widget, '.droppable').setValue('#112233');
+    expect(widget.state.css).toEqual({ default: { background: '#abcdef' }, '.droppable': { 'background-color': '#112233' } });
   });
 
   test('clearing the color drops both declarations from the state class it was set on', () => {

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -429,6 +429,37 @@ test('Renaming a widget keeps its color controls clear and it movable', async t 
   await t.expect(result.y).notEql(200);
 });
 
+test('The background color is set where the image on the widget survives it', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    tile: {
+      id: 'tile', type: 'basic', x: 200, y: 200, width: 200, height: 200,
+      css: { background: 'steelblue', 'background-image': 'url("/i/cards-default/2B.svg")', 'background-size': 'contain' }
+    }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState(propertiesModuleOpen);
+  await setName(t);
+
+  const tileCSS = ClientFunction(() => widgets.get('tile').get('css'));
+  const paintedSize = ClientFunction(() => getComputedStyle(document.querySelector('#w_tile')).backgroundSize);
+  const backgroundRow = Selector('#editorModules .colorInput').find('label[data-label=Background]').parent('.colorInput');
+  // the pickers of a color row open in a shared area below it, not inside the input
+  const backgroundPicker = Selector('#editorModules .propertyPicker.colorPicker').filterVisible();
+
+  await t
+    .click('#editButton')
+    .expect(propertiesModule.exists).ok()
+    .click('#w_tile')
+    .click(backgroundRow.find('.propertyPreviewButton'))
+    // a color a game keeps in the background shorthand is read from there...
+    .expect(backgroundPicker.find('.colorHexInput').value).eql('steelblue')
+    .typeText(backgroundPicker.find('.colorHexInput'), '#112233', { replace: true })
+    // ...and written to the longhand, which leaves the image and its scaling alone
+    .expect(tileCSS()).eql({ 'background-image': 'url("/i/cards-default/2B.svg")', 'background-size': 'contain', 'background-color': '#112233' })
+    .expect(paintedSize()).eql('contain');
+});
+
 test('Dice faces have their own icon, image scale and CSS controls', async t => {
   // Keep this at the narrow layout from the review so the controls remain
   // useful in the smallest supported properties sidebar.

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -399,7 +399,9 @@ test('Renaming a widget keeps its color controls clear and it movable', async t 
   )();
   await t.expect(colorControlTitles).eql([
     { label: null, swatch: null, info: false },
-    { label: null, swatch: null, info: false },
+    // the background names the declaration it writes, which is not the one a
+    // game may already keep its color in
+    { label: null, swatch: null, info: true },
     { label: null, swatch: null, info: false },
     // the icon color says what it paints, since it is the one chip that is
     // only there for some widgets


### PR DESCRIPTION
The **Background** color pickers in the widget editor wrote the `background` shorthand into a widget's `css`. That shorthand also resets `background-image`, `background-size` and `background-repeat`, so as soon as a background color was picked on a widget that shows an image, the `background-size: contain` the room css gives every widget was gone and the image started tiling at its natural size.

The color inputs now write the `background-color` longhand instead, which paints exactly the color and leaves the image (and its scaling) alone.

![background shorthand tiles the image, background-color keeps it scaled](https://agent.virtualtabletop.io/reports/pr/1542916829088059442/background-color-longhand.png)

Both widgets have the same image and the same `#7b1f1f` color — on the left written as `background`, on the right as `background-color`.

## What changed

- Every "Background" (and the spinner's "Value background") color input in the properties sidebar now edits `background-color`: basic widgets, timers, the spinner's `backgroundCSS`/`valueCSS`, the pile handle's `handleCSS` and the holder's `.droppable`/`.droptarget` state colors.
- A widget that still carries its color in the `background` shorthand keeps showing that color in the picker, and the declaration is moved over to the longhand the moment the color is changed — so the two can never disagree. An `!important` priority is stripped for display, since the picker cannot represent it.
- A shorthand that paints more than a color (a gradient, an image, a multi-part value) stays the declaration the picker reads and writes: `background-color` would be painted behind it and change nothing on screen, and such a shorthand has already reset the image properties the longhand exists to protect. The row shows what that shorthand paints — the chip renders the actual gradient — instead of claiming the background is not set.
- A widget that declares a `background-color` of its own behind such a shorthand keeps that longhand as the edited declaration, so the gradient or image survives and the picked color lands where it is actually painted. The row follows the css cascade for this: a declaration in a state class beats one the `default` class carries, and inside one rule the later of the two wins.

- Whether a background is "just a color" is decided by the css parser as well, so every one of the ~150 css color names counts — a widget painted `steelblue` is read as the color it is and edited into the longhand like any other, instead of being taken for a shorthand that paints more than a color.
- The color controls of a row only appear when they can say something true. A value the native color swatch cannot show at all — a gradient, an image shorthand, a color space it does not know — is shown by the chip and the value text, with a line saying that picking a color replaces it, instead of a black square claiming the widget is black. A color that only differs by its transparency keeps the dialog, opened on the color behind that transparency, under a line saying the dialog cannot keep it. A `var()` or a named color is resolved on the widget so the swatch shows the color that is really painted, and the color text field takes every color css takes — asked of the css parser rather than matched against a list of names, so `rebeccapurple` and `color(srgb 1 1 1)` are accepted while `rgb(banana)` and the keywords `inherit`/`initial`/`unset`/`revert` are marked — and stays empty for values it would reject.
- The row shows the declaration that is really in effect. Two declarations in one rule are decided by the later one, in both directions: a `background-color` after a shorthand paints behind it and stays the edited declaration, a plain-color shorthand after a `background-color` resets it and is the color the row shows. An `!important` priority is stripped wherever the value comes from, so the chip paints it.
- The Background row explains which declaration it writes, and what happens to a shorthand it moves, in its `(i)` hint.

![the Background row on a widget with a gradient background](https://agent.virtualtabletop.io/reports/pr/1542916829088059442/ui-3154-gradient-1280.png)

Existing saves are untouched: this only affects what the editor writes, so no migration is needed, and games that already have `background: <color>` keep rendering exactly as before.

One consequence worth knowing when a color *is* edited: because `background-color` no longer resets `background-image`, a `background: #ffffff` that was (deliberately or accidentally) suppressing an image from a class or an inherited rule stops suppressing it once the color is changed and the declaration moves to the longhand — the image reappears. That is the point of the change, but it can surprise whoever hits it.

## Where this came from

A Discord conversation in #Gin Rummy, where an image in a basic widget tiled instead of filling the widget:

> **ArnoldSmith86:** Maybe just had to use `background-color` instead of `background` so it doesn't remove the default scaling.

> **Moshek:** Ahh, maybe.. That background was set by the GUI editor setting the background color

(Source: <https://discord.com/channels/770758631146782780/1538606143000158248/1542916679703462039>)

## Testing

- Jest cases in `tests/client/property-inputs.test.js` cover the longhand write, reading and moving a shorthand color, editing a non-plain shorthand through the shorthand, the `!important` strip, a css string, a gradient declared next to a color longhand in either order, a state class color over a default gradient, and clearing/writing the color inside a state class. Cases for the css-parser classification (`steelblue`, `rebeccapurple`, `#12345`, `rgb(banana)`, `inherit`), for the swatch fallback of a color with alpha, and for both declaration orders were added on top. Full jest suite passes (1506 tests).
- Walked it in a browser (edit mode, Chromium) across six widget css shapes. Setting the Background color on a widget with `background-image` + `background-size: 310px 480px` yields `{"background-image":…,"background-size":"310px 480px","background-color":"#112233"}` and the image keeps its size and `no-repeat`. `background: #abcdef; font-size: 20px` (as an object or as a css string) becomes `{"font-size":"20px","background-color":"#112233"}`. `background: #abcdef !important` shows `#abcdef` in the picker. `background: linear-gradient(red, blue)` shows the gradient in the chip and is replaced by `{"background":"#112233"}` when a color is picked, so the widget visibly changes. Spinner background / value background and the timer background were checked the same way and still paint.
- Eleven css shapes driven through the row in Chromium after the UI review: gradient, image shorthand, image longhands, plain shorthand, `!important` shorthand, `var(--VTTblue)`, `rgba()`, `color(srgb 1 1 1)`, a named color, an unset background and a css string. Each was read (chip, swatch, color field, value text, note) and then edited from the palette, checking what lands in the css and what the widget paints.
- The mixed shapes were driven through the real UI as well: `{"background":"linear-gradient(red, blue)","background-color":"#ff0000"}` reads `#ff0000` and keeps the gradient when a color is picked, the reverse order edits the shorthand that resets the longhand, and a holder whose `.droppable` class sets `background-color` over a `default` gradient edits the state class and leaves the gradient alone. Typing `#abcd`, `rebeccapurple` and `color(srgb 1 1 1)` into the color field paints them; `rgb(banana)`, `oklch(foo bar baz)` and `linear-gradient(red, blue)` are marked as errors and written nowhere.
- A TestCafe case in `tests/testcafe/editor.js` locks the whole point of the PR in end to end: a widget carrying `background: steelblue`, `background-image` and `background-size: contain` is selected, its Background color typed into the row, and the resulting `css` asserted to hold `background-color` and still `background-size` — with the widget still rendering `background-size: contain`.
- The shapes the reviews raised were walked through the real UI again: a named-color shorthand next to an image, a plain shorthand behind a `background-color`, an `!important` longhand, `#fff6` and `rgba(0, 128, 0, 0.35)` (dialog kept, seeded with the opaque color), `oklch()` (no dialog), a gradient, `transparent`, and the five css-wide keywords typed into the field.

![the Background row on a widget with a gradient and a color behind it](https://agent.virtualtabletop.io/reports/pr/1542916829088059442/ui-3154-gradient-with-color.png)

![the Background row on a semi-transparent color](https://agent.virtualtabletop.io/reports/pr/1542916829088059442/ui-3154-alpha-swatch.png)

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3154/pr-test (or any other room on that server)



