### PR TITLE
Post the library validation comment from a workflow_run job so fork PRs get it

### DIFF
--- a/.github/workflows/check-library-comment.yml
+++ b/.github/workflows/check-library-comment.yml
@@ -1,0 +1,59 @@
+name: Check Library Comment
+
+# Posts the validation result rendered by "Check Library". That workflow runs with a
+# read-only token for pull requests from forks, so the comment is posted from here,
+# where the job runs in base repository context and no pull request code is executed.
+
+on:
+  workflow_run:
+    workflows: ["Check Library"]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download validation result
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: validation-result
+          path: validation-result
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Post or update the comment
+        if: steps.download.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- check-library-validation -->';
+            const issue_number = Number(fs.readFileSync('validation-result/pr-number', 'utf8').trim());
+            if (!Number.isInteger(issue_number) || issue_number <= 0)
+              return;
+            const issues = fs.existsSync('validation-result/comment.md')
+              ? fs.readFileSync('validation-result/comment.md', 'utf8').trim() : '';
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (!issues) {
+              if (existing)
+                await github.rest.issues.deleteComment({ ...context.repo, comment_id: existing.id });
+              return;
+            }
+
+            const body = `${issues}\n\n${marker}`;
+            if (existing)
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body });
+            else
+              await github.rest.issues.createComment({ ...context.repo, issue_number, body });

--- a/.github/workflows/check-library-comment.yml
+++ b/.github/workflows/check-library-comment.yml
@@ -13,6 +13,12 @@ permissions:
   actions: read
   pull-requests: write
 
+# Serialize per head branch so two runs cannot both create the comment, and so a run
+# that finishes late cannot overwrite a newer result.
+concurrency:
+  group: check-library-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
 jobs:
   comment:
     if: github.event.workflow_run.event == 'pull_request'
@@ -38,6 +44,19 @@ jobs:
             const issue_number = Number(fs.readFileSync('validation-result/pr-number', 'utf8').trim());
             if (!Number.isInteger(issue_number) || issue_number <= 0)
               return;
+
+            // "Check Library" runs the workflow file from the pull request head, so the
+            // number in the artifact is contributor-controlled. Only comment on a pull
+            // request whose head is the very commit that produced this artifact —
+            // otherwise a fork could make this job write on any pull request.
+            const run = context.payload.workflow_run;
+            const pr = await github.rest.pulls.get({ ...context.repo, pull_number: issue_number })
+              .then(r => r.data, () => null);
+            if (!pr || pr.head.sha !== run.head_sha || pr.head.repo?.full_name !== run.head_repository?.full_name) {
+              core.warning(`Ignoring result for #${issue_number}: it does not match the head of run ${run.id}.`);
+              return;
+            }
+
             const issues = fs.existsSync('validation-result/comment.md')
               ? fs.readFileSync('validation-result/comment.md', 'utf8').trim() : '';
 

--- a/.github/workflows/check-library.yml
+++ b/.github/workflows/check-library.yml
@@ -13,14 +13,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Every check writes its findings to $RUNNER_TEMP/check-results as a one-line
+      # <id>.summary (the table cell) and an <id>.md section, which "Prepare validation
+      # comment" assembles into the comment posted on the pull request.
       - name: Check and fix asset file names
         id: asset-names
         continue-on-error: true
         run: |
+          mkdir -p "$RUNNER_TEMP/check-results"
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           found_error=false
-          fixed_any=false
+          crlf_files=()
+          bad_files=()
           while IFS= read -r file; do
             if [[ "$file" =~ library/.*/assets/ ]] && [[ -f "$file" ]]; then
               expected=$(python3 -c "import sys,os,zlib; f=sys.argv[1]; d=open(f,'rb').read(); c=zlib.crc32(d); s=os.path.getsize(f); print(f'{c-0x100000000 if c>0x7fffffff else c}_{s}')" "$file")
@@ -36,29 +41,65 @@ jobs:
                 if [[ "$(basename "$file")" == "$expected" ]]; then
                   echo "✅ $file (auto-fixed)"
                   git add "$file"
-                  fixed_any=true
+                  crlf_files+=("$file")
                 else
                   echo "❌ $file (expected: $expected)"
                   git checkout "$file"
+                  bad_files+=("$file|$expected")
                   found_error=true
                 fi
               fi
             fi
           done < <(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }})
-          if [ "$fixed_any" = true ]; then
+          if [ ${#crlf_files[@]} -gt 0 ]; then
             # On a fork PR, origin is the base repository and the token is read-only,
             # so the fix cannot be pushed back to the contributor's branch.
             if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
               git commit -m "fix: convert asset to DOS line endings"
               git push origin HEAD:${GITHUB_HEAD_REF}
+              crlf_files=()
             else
-              echo "⚠️ Asset files need DOS line endings. This PR comes from a fork, so the fix"
-              echo "   cannot be pushed for you — please apply it locally and push again."
+              echo "⚠️ These asset files need DOS line endings. This PR comes from a fork, so"
+              echo "   the fix cannot be pushed for you — please apply it locally and push again:"
+              for f in "${crlf_files[@]}"; do echo "     unix2dos \"$f\""; done
               # Undo the local fix so the remaining checks see what was actually submitted.
               git checkout HEAD -- .
               found_error=true
             fi
           fi
+
+          count=$(( ${#crlf_files[@]} + ${#bad_files[@]} ))
+          if [ "$count" -gt 0 ]; then
+            if [ "$count" -eq 1 ]; then
+              echo "❌ 1 asset file is named wrong" > "$RUNNER_TEMP/check-results/asset-names.summary"
+            else
+              echo "❌ $count asset files are named wrong" > "$RUNNER_TEMP/check-results/asset-names.summary"
+            fi
+            {
+              echo '### ❌ Asset file names'
+              echo
+              echo 'Assets are named `<crc32>_<size>` after their own content, so the name has to match the file byte for byte.'
+              echo
+              if [ ${#crlf_files[@]} -gt 0 ]; then
+                echo 'These assets only differ in their line endings. The fix cannot be pushed to a fork, so please apply it locally and push again:'
+                echo
+                echo '```sh'
+                for f in "${crlf_files[@]}"; do echo "unix2dos \"$f\""; done
+                echo '```'
+                echo
+              fi
+              if [ ${#bad_files[@]} -gt 0 ]; then
+                echo 'These assets could not be fixed automatically. Re-export the game from VirtualTabletop, or rename each file to the expected name and update the reference in the game file:'
+                echo
+                for entry in "${bad_files[@]}"; do
+                  echo "- \`${entry%%|*}\` — expected \`${entry##*|}\`"
+                done
+                echo
+              fi
+            } > "$RUNNER_TEMP/check-results/asset-names.md"
+            cat "$RUNNER_TEMP/check-results/asset-names.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
           if [ "$found_error" = true ]; then
             echo "Found files with inconsistent naming patterns"
             exit 1
@@ -68,6 +109,7 @@ jobs:
         id: square-images
         continue-on-error: true
         run: |
+          mkdir -p "$RUNNER_TEMP/check-results"
           set +e
           output=$(python3 -m pip install Pillow 2>&1)
           if [ $? -ne 0 ]; then
@@ -75,7 +117,7 @@ jobs:
             echo "$output"
             exit 1
           fi
-          found_non_square=false
+          non_square=()
           while IFS= read -r file; do
             if [[ "$file" =~ library/(games|tutorials)/.*\.json$ ]] && [[ -f "$file" ]]; then
               image_path=$(python3 -c "import json, sys; data = json.load(open(sys.argv[1])); print(data.get('_meta', {}).get('info', {}).get('image', ''))" "$file")
@@ -95,7 +137,7 @@ jobs:
                     height=$(echo "$dimensions" | cut -d'x' -f2)
                     if [ "$width" != "$height" ]; then
                       echo "❌ $file: library image $asset_file is not square (${width}x${height})"
-                      found_non_square=true
+                      non_square+=("$file|$asset_file|${width}x${height}")
                     else
                       echo "✅ $file: library image $asset_file is square (${width}x${height})"
                     fi
@@ -104,11 +146,28 @@ jobs:
               fi
             fi
           done < <(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }})
-          if [ "$found_non_square" = true ]; then
+
+          if [ ${#non_square[@]} -gt 0 ]; then
+            if [ ${#non_square[@]} -eq 1 ]; then
+              echo "❌ 1 library image is not square" > "$RUNNER_TEMP/check-results/square-images.summary"
+            else
+              echo "❌ ${#non_square[@]} library images are not square" > "$RUNNER_TEMP/check-results/square-images.summary"
+            fi
+            {
+              echo '### ❌ Library images are not square'
+              echo
+              echo 'The library image (`_meta.info.image`) is the tile shown in the game list, so it has to be square:'
+              echo
+              for entry in "${non_square[@]}"; do
+                image="${entry#*|}"
+                echo "- \`${entry%%|*}\` — \`${image%%|*}\` is ${entry##*|}"
+              done
+              echo
+            } > "$RUNNER_TEMP/check-results/square-images.md"
+            cat "$RUNNER_TEMP/check-results/square-images.md" >> "$GITHUB_STEP_SUMMARY"
             exit 1
-          else
-            exit 0
           fi
+          exit 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -118,92 +177,222 @@ jobs:
       - name: Run validator on changed game files
         id: validate
         run: |
+          mkdir -p "$RUNNER_TEMP/check-results"
           changed_files=()
           while IFS= read -r file; do
             if [[ "$file" =~ library/(games|tutorials)/.*\.json$ ]] && [[ -f "$file" ]]; then
               changed_files+=("$file")
             fi
           done < <(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }})
-          
-          summary_only=false
-          [[ ${#changed_files[@]} -gt 10 ]] && summary_only=true
 
-          # The comment API rejects bodies over 65536 characters, so the comment carries
-          # whole file sections up to this budget only. The step summary gets everything.
-          max_comment=55000
-          validation_output=""
-          full_output=""
-          found_issues=false
-          truncated=false
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          # The comment API rejects bodies over 65536 characters and a job summary over
+          # 1 MiB, so both are assembled from whole file sections up to a budget. The raw
+          # log of this step always contains every line.
+          max_comment=50000
+          max_summary=900000
+          # Lines per file in the comment, so one broken file cannot bury all the others.
+          max_lines=60
+
+          body="$RUNNER_TEMP/validation-body.md"
+          full="$RUNNER_TEMP/validation-full.md"
+          comment_section="$RUNNER_TEMP/validation-section.md"
+          full_section="$RUNNER_TEMP/validation-section-full.md"
+          stderr_file="$RUNNER_TEMP/validation-stderr"
+          : > "$body"
+          : > "$full"
+          reported=0
+          with_issues=0
+          crashed=0
+          shown=0
+          summary_shown=0
+          body_used=0
+          full_used=0
+
+          # <summary line> <note> <output> <footer>: one collapsible section per file.
+          section() {
+            local ticks fence
+            # Fence with one backtick more than the longest run in the output itself, so
+            # validator output containing a code fence cannot break out of the block.
+            ticks=$( { printf '%s' "$3" | grep -o '`\+' || true; } | awk '{ if (length($0) > m) m = length($0) } END { print (m > 2 ? m + 1 : 3) }')
+            fence=$(printf '`%.0s' $(seq "$ticks"))
+            printf '%s\n\n' "$1"
+            if [ -n "$2" ]; then printf '%s\n\n' "$2"; fi
+            printf '%s\n%s\n%s\n\n' "$fence" "$3" "$fence"
+            if [ -n "$4" ]; then printf '%s\n\n' "$4"; fi
+            printf '</details>\n\n'
+          }
 
           for file in "${changed_files[@]}"; do
-            if [ "$summary_only" = true ]; then
-              if output=$(node validator/validate_gamefile_node.js "$file" 2>&1); then
-                echo "✅ $file - No issues found"
-                section="✅ \`$file\` - No issues found\n"
-              else
-                echo "❌ $file - Issues found"
-                section="❌ \`$file\` - Issues found\n"
-                found_issues=true
-              fi
-            else
-              if output=$(node validator/validate_gamefile_node.js "$file" 2>&1); then
-                echo "✅ $file - No issues found"
-                continue
-              fi
-              echo "❌ $file - Issues found:"
-              echo "$output"
-              # Fence with one backtick more than the longest run in the output itself, so
-              # validator output containing a code fence cannot break out of the block.
-              ticks=$(printf '%s' "$output" | grep -o '`\+' | awk '{ if (length($0) > m) m = length($0) } END { print (m > 2 ? m + 1 : 3) }')
-              fence=$(printf '`%.0s' $(seq "$ticks"))
-              section="### Issues in \`$file\`\n$fence\n$output\n$fence\n\n"
-              found_issues=true
+            if output=$(node validator/validate_gamefile_node.js "$file" 2>"$stderr_file"); then
+              echo "✅ $file - No issues found"
+              continue
             fi
-            full_output+="$section"
-            if [ $((${#validation_output} + ${#section})) -le "$max_comment" ]; then
-              validation_output+="$section"
+            reported=$((reported + 1))
+            crash=$(cat "$stderr_file")
+            if [ -n "$crash" ]; then
+              # The validator only writes to stderr when it throws, so this is a broken
+              # validator rather than a game file the contributor can do anything about.
+              crashed=$((crashed + 1))
+              echo "❌ $file - the validator itself failed:"
+              echo "$crash"
+              head_line="<details><summary>⚠️ <code>$file</code> — the validator itself failed</summary>"
+              section "$head_line" 'This is a bug in the validator rather than a problem with the game file. Please report it.' "$crash" '' > "$full_section"
+              cp "$full_section" "$comment_section"
             else
-              truncated=true
+              with_issues=$((with_issues + 1))
+              issues=$(printf '%s\n' "$output" | wc -l)
+              if [ "$issues" -eq 1 ]; then label='1 issue'; else label="$issues issues"; fi
+              echo "❌ $file - $label found:"
+              echo "$output"
+              head_line="<details><summary>❌ <code>$file</code> — $label</summary>"
+              section "$head_line" '' "$output" '' > "$full_section"
+              if [ "$issues" -gt "$max_lines" ]; then
+                short=$(printf '%s\n' "$output" | sed -n "1,${max_lines}p")
+                section "$head_line" '' "$short" "_${issues} issues in total — see the [Actions run summary]($run_url) for the rest._" > "$comment_section"
+              else
+                cp "$full_section" "$comment_section"
+              fi
+            fi
+
+            size=$(wc -c < "$comment_section")
+            if [ "$size" -gt "$max_comment" ]; then
+              # A handful of pathologically long lines can still blow the budget.
+              printf '%s\n\n_Too large to show here — see the [Actions run summary](%s)._\n\n</details>\n\n' "$head_line" "$run_url" > "$comment_section"
+              size=$(wc -c < "$comment_section")
+            fi
+            if [ $((body_used + size)) -le "$max_comment" ]; then
+              cat "$comment_section" >> "$body"
+              body_used=$((body_used + size))
+              shown=$((shown + 1))
+            fi
+
+            size=$(wc -c < "$full_section")
+            if [ $((full_used + size)) -le "$max_summary" ]; then
+              cat "$full_section" >> "$full"
+              full_used=$((full_used + size))
+              summary_shown=$((summary_shown + 1))
             fi
           done
 
-          if [ "$truncated" = true ]; then
-            run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-            validation_output+="_Too many issues to list here — see the [run summary]($run_url) for the full report._\n"
+          if [ "$reported" -eq 0 ]; then
+            echo '✅ No game file validation issues.' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
 
-          if [ "$found_issues" = true ]; then
-            delimiter="VALIDATION_$(openssl rand -hex 8)"
-            echo "validation_output<<$delimiter" >> $GITHUB_OUTPUT
-            echo -e "$validation_output" >> $GITHUB_OUTPUT
-            echo "$delimiter" >> $GITHUB_OUTPUT
-            {
-              echo '## Game File Validation Issues'
-              echo
-              echo -e "$full_output"
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo '✅ No game file validation issues.' >> "$GITHUB_STEP_SUMMARY"
+          # The table cell and the section header name whichever of the two failure kinds
+          # actually occurred, so neither is reported as the other.
+          total=${#changed_files[@]}
+          parts=()
+          cells=()
+          if [ "$with_issues" -gt 0 ]; then
+            if [ "$total" -eq 1 ]; then
+              parts+=('this game file has validation issues')
+            elif [ "$with_issues" -eq 1 ]; then
+              parts+=("1 of $total changed game files has validation issues")
+            else
+              parts+=("$with_issues of $total changed game files have validation issues")
+            fi
+            if [ "$with_issues" -eq 1 ]; then
+              cells+=('1 game file has validation issues')
+            else
+              cells+=("$with_issues game files have validation issues")
+            fi
+          fi
+          if [ "$crashed" -gt 0 ]; then
+            if [ "$crashed" -eq 1 ]; then
+              parts+=('the validator itself failed on 1 game file')
+              cells+=('the validator failed on 1 game file')
+            else
+              parts+=("the validator itself failed on $crashed game files")
+              cells+=("the validator failed on $crashed game files")
+            fi
+          fi
+          sentence="${parts[0]}"
+          cell="${cells[0]}"
+          if [ ${#parts[@]} -eq 2 ]; then
+            sentence="${parts[0]} and ${parts[1]}"
+            cell="${cells[0]}, ${cells[1]}"
+          fi
+          echo "⚠️ ${cell^}" > "$RUNNER_TEMP/check-results/validation.summary"
+
+          header="$RUNNER_TEMP/validation-header.md"
+          {
+            echo '### ⚠️ Game file validation'
+            echo
+            echo "**${sentence^}.** Validation issues are advisory — they do not block merging, but please fix what you can."
+            echo
+            echo 'Reproduce them locally with `node validator/validate_gamefile_node.js <file>`. The property names come from the [Widgets](https://github.com/ArnoldSmith86/virtualtabletop/wiki/Widgets) wiki page.'
+            echo
+          } > "$header"
+
+          # A single file is expanded right away; more than one would be a wall of text.
+          if [ "$reported" -eq 1 ]; then
+            sed -i '0,/^<details>/s//<details open>/' "$body"
+            sed -i '0,/^<details>/s//<details open>/' "$full"
+          fi
+
+          cat "$header" "$body" > "$RUNNER_TEMP/check-results/validation.md"
+          if [ "$shown" -lt "$reported" ]; then
+            printf '_Showing %s of %s files — see the [Actions run summary](%s) for the rest._\n\n' \
+              "$shown" "$reported" "$run_url" >> "$RUNNER_TEMP/check-results/validation.md"
+          fi
+
+          cat "$header" "$full" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$summary_shown" -lt "$reported" ]; then
+            printf '_Showing %s of %s files — the raw log of this step has all of them._\n\n' \
+              "$summary_shown" "$reported" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       # A pull_request event from a fork only gets a read-only token, so the comment is
       # rendered here and posted by check-library-comment.yml, which runs privileged.
-      # The artifact only exists when validation actually ran: without it the posting
-      # workflow leaves any existing comment alone, rather than reading a broken run as
-      # "nothing to report" and deleting the comment.
+      # The artifact only exists when all three checks actually ran: without it the
+      # posting workflow leaves any existing comment alone, rather than reading a broken
+      # run as "nothing to report" and deleting the comment.
       - name: Prepare validation comment
         if: always() && steps.validate.outcome == 'success'
         env:
-          VALIDATION_OUTPUT: ${{ steps.validate.outputs.validation_output }}
+          ASSET_NAMES_OUTCOME: ${{ steps.asset-names.outcome }}
+          SQUARE_IMAGES_OUTCOME: ${{ steps.square-images.outcome }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          results="$RUNNER_TEMP/check-results"
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           mkdir -p validation-result
-          echo "${{ github.event.pull_request.number }}" > validation-result/pr-number
-          if [ -n "$VALIDATION_OUTPUT" ]; then
+          echo "$PR_NUMBER" > validation-result/pr-number
+
+          # A check with no findings of its own still gets a cell, so the comment always
+          # says what passed as well as what did not.
+          cell() {
+            if [ -s "$results/$1.summary" ]; then
+              tr -d '\n' < "$results/$1.summary"
+            elif [ "$2" = failure ]; then
+              printf '❌ Failed — see the [run log](%s)' "$run_url"
+            else
+              printf '✅'
+            fi
+          }
+
+          if [ -s "$results/asset-names.md" ] || [ -s "$results/square-images.md" ] || [ -s "$results/validation.md" ] \
+             || [ "$ASSET_NAMES_OUTCOME" = failure ] || [ "$SQUARE_IMAGES_OUTCOME" = failure ]; then
             {
-              echo '## Game File Validation Issues'
+              echo '## Library check results'
               echo
-              printf '%s\n' "$VALIDATION_OUTPUT"
+              echo '| Check | Result |'
+              echo '| --- | --- |'
+              echo "| Asset file names | $(cell asset-names "$ASSET_NAMES_OUTCOME") |"
+              echo "| Library images square | $(cell square-images "$SQUARE_IMAGES_OUTCOME") |"
+              echo "| Game file validation | $(cell validation success) |"
+              echo
+              echo '❌ fails this check, ⚠️ is advisory and does not block merging.'
+              echo
+              for check in asset-names square-images validation; do
+                if [ -s "$results/$check.md" ]; then
+                  cat "$results/$check.md"
+                fi
+              done
+              echo "<sub>Checked <code>${HEAD_SHA:0:7}</code> · <a href=\"$run_url\">Actions run summary</a></sub>"
             } > validation-result/comment.md
           else
             # An empty comment tells the posting workflow to remove a stale comment.

--- a/.github/workflows/check-library.yml
+++ b/.github/workflows/check-library.yml
@@ -54,6 +54,8 @@ jobs:
             else
               echo "⚠️ Asset files need DOS line endings. This PR comes from a fork, so the fix"
               echo "   cannot be pushed for you — please apply it locally and push again."
+              # Undo the local fix so the remaining checks see what was actually submitted.
+              git checkout HEAD -- .
               found_error=true
             fi
           fi
@@ -125,42 +127,73 @@ jobs:
           
           summary_only=false
           [[ ${#changed_files[@]} -gt 10 ]] && summary_only=true
-          
+
+          # The comment API rejects bodies over 65536 characters, so the comment carries
+          # whole file sections up to this budget only. The step summary gets everything.
+          max_comment=55000
           validation_output=""
+          full_output=""
           found_issues=false
-          
+          truncated=false
+
           for file in "${changed_files[@]}"; do
             if [ "$summary_only" = true ]; then
               if output=$(node validator/validate_gamefile_node.js "$file" 2>&1); then
                 echo "✅ $file - No issues found"
-                validation_output+="✅ \`$file\` - No issues found\n"
+                section="✅ \`$file\` - No issues found\n"
               else
                 echo "❌ $file - Issues found"
-                validation_output+="❌ \`$file\` - Issues found\n"
+                section="❌ \`$file\` - Issues found\n"
                 found_issues=true
               fi
             else
               if output=$(node validator/validate_gamefile_node.js "$file" 2>&1); then
                 echo "✅ $file - No issues found"
-              else
-                echo "❌ $file - Issues found:"
-                echo "$output"
-                validation_output+="### Issues in \`$file\`\n\`\`\`\n$output\n\`\`\`\n\n"
-                found_issues=true
+                continue
               fi
+              echo "❌ $file - Issues found:"
+              echo "$output"
+              # Fence with one backtick more than the longest run in the output itself, so
+              # validator output containing a code fence cannot break out of the block.
+              ticks=$(printf '%s' "$output" | grep -o '`\+' | awk '{ if (length($0) > m) m = length($0) } END { print (m > 2 ? m + 1 : 3) }')
+              fence=$(printf '`%.0s' $(seq "$ticks"))
+              section="### Issues in \`$file\`\n$fence\n$output\n$fence\n\n"
+              found_issues=true
+            fi
+            full_output+="$section"
+            if [ $((${#validation_output} + ${#section})) -le "$max_comment" ]; then
+              validation_output+="$section"
+            else
+              truncated=true
             fi
           done
-          
+
+          if [ "$truncated" = true ]; then
+            run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            validation_output+="_Too many issues to list here — see the [run summary]($run_url) for the full report._\n"
+          fi
+
           if [ "$found_issues" = true ]; then
-            echo "validation_output<<EOF" >> $GITHUB_OUTPUT
+            delimiter="VALIDATION_$(openssl rand -hex 8)"
+            echo "validation_output<<$delimiter" >> $GITHUB_OUTPUT
             echo -e "$validation_output" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
+            echo "$delimiter" >> $GITHUB_OUTPUT
+            {
+              echo '## Game File Validation Issues'
+              echo
+              echo -e "$full_output"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '✅ No game file validation issues.' >> "$GITHUB_STEP_SUMMARY"
           fi
 
       # A pull_request event from a fork only gets a read-only token, so the comment is
       # rendered here and posted by check-library-comment.yml, which runs privileged.
+      # The artifact only exists when validation actually ran: without it the posting
+      # workflow leaves any existing comment alone, rather than reading a broken run as
+      # "nothing to report" and deleting the comment.
       - name: Prepare validation comment
-        if: always()
+        if: always() && steps.validate.outcome == 'success'
         env:
           VALIDATION_OUTPUT: ${{ steps.validate.outputs.validation_output }}
         run: |
@@ -172,19 +205,18 @@ jobs:
               echo
               printf '%s\n' "$VALIDATION_OUTPUT"
             } > validation-result/comment.md
-            cat validation-result/comment.md >> "$GITHUB_STEP_SUMMARY"
           else
             # An empty comment tells the posting workflow to remove a stale comment.
             : > validation-result/comment.md
-            echo '✅ No game file validation issues.' >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload validation result
-        if: always()
+        if: always() && steps.validate.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: validation-result
           path: validation-result/
+          retention-days: 1
 
       - name: Fail if any check failed
         if: always() && (steps.asset-names.outcome == 'failure' || steps.square-images.outcome == 'failure')

--- a/.github/workflows/check-library.yml
+++ b/.github/workflows/check-library.yml
@@ -231,13 +231,13 @@ jobs:
             reported=$((reported + 1))
             crash=$(cat "$stderr_file")
             if [ -n "$crash" ]; then
-              # The validator only writes to stderr when it throws, so this is a broken
-              # validator rather than a game file the contributor can do anything about.
+              # Findings go to stdout, a file that cannot be parsed among them. Anything on
+              # stderr means the validator stopped without producing a verdict at all.
               crashed=$((crashed + 1))
-              echo "❌ $file - the validator itself failed:"
+              echo "❌ $file - the validator could not process this file:"
               echo "$crash"
-              head_line="<details><summary>⚠️ <code>$file</code> — the validator itself failed</summary>"
-              section "$head_line" 'This is a bug in the validator rather than a problem with the game file. Please report it.' "$crash" '' > "$full_section"
+              head_line="<details><summary>⚠️ <code>$file</code> — the validator could not process this file</summary>"
+              section "$head_line" 'The validator stopped with an error instead of reporting on the file. That is usually a bug in the validator rather than a problem with the game file — please report it, including this output.' "$crash" '' > "$full_section"
               cp "$full_section" "$comment_section"
             else
               with_issues=$((with_issues + 1))
@@ -301,11 +301,11 @@ jobs:
           fi
           if [ "$crashed" -gt 0 ]; then
             if [ "$crashed" -eq 1 ]; then
-              parts+=('the validator itself failed on 1 game file')
-              cells+=('the validator failed on 1 game file')
+              parts+=('the validator could not process 1 game file')
+              cells+=('the validator could not process 1 game file')
             else
-              parts+=("the validator itself failed on $crashed game files")
-              cells+=("the validator failed on $crashed game files")
+              parts+=("the validator could not process $crashed game files")
+              cells+=("the validator could not process $crashed game files")
             fi
           fi
           sentence="${parts[0]}"
@@ -320,9 +320,14 @@ jobs:
           {
             echo '### ⚠️ Game file validation'
             echo
-            echo "**${sentence^}.** Validation issues are advisory — they do not block merging, but please fix what you can."
-            echo
-            echo 'Reproduce them locally with `node validator/validate_gamefile_node.js <file>`. The property names come from the [Widgets](https://github.com/ArnoldSmith86/virtualtabletop/wiki/Widgets) wiki page.'
+            if [ "$with_issues" -gt 0 ]; then
+              echo "**${sentence^}.** Validation issues are advisory — they do not block merging, but please fix what you can."
+              echo
+              echo 'Reproduce them locally with `node validator/validate_gamefile_node.js <file>`. The property names come from the [Widgets](https://github.com/ArnoldSmith86/virtualtabletop/wiki/Widgets) wiki page.'
+            else
+              # Nothing for the contributor to fix, so the advice to fix it is left out.
+              echo "**${sentence^}.** This does not block merging."
+            fi
             echo
           } > "$header"
 

--- a/.github/workflows/check-library.yml
+++ b/.github/workflows/check-library.yml
@@ -46,8 +46,16 @@ jobs:
             fi
           done < <(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }})
           if [ "$fixed_any" = true ]; then
-            git commit -m "fix: convert asset to DOS line endings"
-            git push origin HEAD:${GITHUB_HEAD_REF}
+            # On a fork PR, origin is the base repository and the token is read-only,
+            # so the fix cannot be pushed back to the contributor's branch.
+            if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
+              git commit -m "fix: convert asset to DOS line endings"
+              git push origin HEAD:${GITHUB_HEAD_REF}
+            else
+              echo "⚠️ Asset files need DOS line endings. This PR comes from a fork, so the fix"
+              echo "   cannot be pushed for you — please apply it locally and push again."
+              found_error=true
+            fi
           fi
           if [ "$found_error" = true ]; then
             echo "Found files with inconsistent naming patterns"
@@ -149,19 +157,34 @@ jobs:
             echo "EOF" >> $GITHUB_OUTPUT
           fi
 
-      - name: Comment on PR with validation issues
-        if: always() && steps.validate.outputs.validation_output != ''
-        uses: actions/github-script@v6
+      # A pull_request event from a fork only gets a read-only token, so the comment is
+      # rendered here and posted by check-library-comment.yml, which runs privileged.
+      - name: Prepare validation comment
+        if: always()
         env:
           VALIDATION_OUTPUT: ${{ steps.validate.outputs.validation_output }}
+        run: |
+          mkdir -p validation-result
+          echo "${{ github.event.pull_request.number }}" > validation-result/pr-number
+          if [ -n "$VALIDATION_OUTPUT" ]; then
+            {
+              echo '## Game File Validation Issues'
+              echo
+              printf '%s\n' "$VALIDATION_OUTPUT"
+            } > validation-result/comment.md
+            cat validation-result/comment.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            # An empty comment tells the posting workflow to remove a stale comment.
+            : > validation-result/comment.md
+            echo '✅ No game file validation issues.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload validation result
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '## Game File Validation Issues\n\n' + process.env.VALIDATION_OUTPUT
-            });
+          name: validation-result
+          path: validation-result/
 
       - name: Fail if any check failed
         if: always() && (steps.asset-names.outcome == 'failure' || steps.square-images.outcome == 'failure')

--- a/tests/server/validate-gamefile-cli.test.js
+++ b/tests/server/validate-gamefile-cli.test.js
@@ -1,0 +1,57 @@
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// The library check on a pull request tells findings and a broken validator apart by
+// looking at stderr: everything it can say about a game file goes to stdout, so anything
+// on stderr means the validator stopped without a verdict. A file it cannot read or
+// parse is a problem with the file, so it has to come out as a finding like any other.
+const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), '../../validator/validate_gamefile_node.js');
+let directory = null;
+
+function validate(content) {
+  const filename = `${directory}/game.json`;
+  fs.writeFileSync(filename, content);
+  const result = spawnSync('node', [ cli, filename ], { encoding: 'utf8' });
+  return { status: result.status, stdout: result.stdout.trim(), stderr: result.stderr };
+}
+
+beforeEach(function() {
+  directory = fs.mkdtempSync(os.tmpdir() + '/vtt-validate-cli-');
+});
+
+afterEach(function() {
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+describe('validator/validate_gamefile_node.js', function() {
+  test('reports invalid JSON as a finding', function() {
+    const result = validate('{ invalid json');
+    expect(result.stdout).toMatch(/^\[\]: Not valid JSON: /);
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(1);
+  });
+
+  test('reports a file that is not an object as a finding', function() {
+    const result = validate('null');
+    expect(result.stdout).toBe('[]: Game file must be a JSON object');
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(1);
+  });
+
+  test('reports a missing file as a finding', function() {
+    const result = spawnSync('node', [ cli, `${directory}/nothing.json` ], { encoding: 'utf8' });
+    expect(result.stdout.trim()).toMatch(/^\[\]: ENOENT/);
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(1);
+  });
+
+  test('reports what is wrong with a game file', function() {
+    const result = validate(JSON.stringify({ b: { id: 'b', type: 'button' } }));
+    expect(result.stdout).toBe('[_meta]: Missing required _meta object');
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(1);
+  });
+});

--- a/validator/validate_gamefile.js
+++ b/validator/validate_gamefile.js
@@ -1196,11 +1196,7 @@ function getCustomPropertyUsage(data) {
 function validateGameFile(data, checkMeta) {
     const problems = [];
     
-    // Get all custom properties used in the game file
-    const customProperties = getCustomPropertyUsage(data);
-    const calledCustomRoutines = [];
-    
-    // Basic structure validation
+    // Basic structure validation, before anything walks the data
     if (typeof data !== 'object' || data === null) {
         problems.push({
             widget: '',
@@ -1209,6 +1205,10 @@ function validateGameFile(data, checkMeta) {
         });
         return problems;
     }
+    
+    // Get all custom properties used in the game file
+    const customProperties = getCustomPropertyUsage(data);
+    const calledCustomRoutines = [];
     
     // Check for _meta
     if (checkMeta && !data._meta) {

--- a/validator/validate_gamefile_node.js
+++ b/validator/validate_gamefile_node.js
@@ -21,8 +21,16 @@ if (!filePath) {
     process.exit(1);
 }
 
-// Read and validate file
-const data = readUpdatedGameFile(filePath);
+// Read and validate file. A file that cannot be read or parsed is a problem with the
+// file itself, so it is reported like any other finding instead of throwing.
+let data;
+try {
+    data = readUpdatedGameFile(filePath);
+} catch (error) {
+    const message = error instanceof SyntaxError ? `Not valid JSON: ${error.message}` : error.message;
+    console.log(`[]: ${message}`);
+    process.exit(1);
+}
 
 const problems = validateGameFile(data, true);
 


### PR DESCRIPTION
The "Check Library" workflow could not comment its validator output on pull requests coming from a fork: for a `pull_request` event whose head branch lives in a fork, GitHub hands the job a read-only `GITHUB_TOKEN` regardless of any `permissions:` block, so `issues.createComment` came back `403 Resource not accessible by integration`. The contributor saw a red cross with no explanation — and that red cross was the `github-script` step crashing, not the validator. Confirmed live on #3156 (`markusrosskopf:PL-add-Wildwood`), run 33319029141, four runs in a row.

This splits the commenting into a second, privileged workflow, following the pattern GitHub documents for exactly this case, and rewrites the comment so it reports every check rather than only the validator.

## What changed

**`.github/workflows/check-library.yml`**

- The "Comment on PR with validation issues" step is replaced by "Prepare validation comment" + "Upload validation result": the comment is rendered into `validation-result/` (`comment.md` plus a `pr-number` file) and uploaded with `actions/upload-artifact@v4`, and the full report is mirrored into `$GITHUB_STEP_SUMMARY` so it stays readable even if the second workflow never runs.
- The artifact is written on every run in which the validator actually ran, including clean ones (an empty `comment.md`). That is what lets the second workflow take a stale "issues found" comment back down once the contributor has pushed a fix, instead of leaving it contradicting a green check. If the checkout, the Node setup or the validate step itself breaks, no artifact is produced at all, so the poster leaves any existing comment untouched rather than reading a broken run as "nothing to report".
- **All three checks report into the comment.** Each of `asset-names`, `square-images` and `validate` writes a one-line result and a detail section to `$RUNNER_TEMP/check-results`, and the comment opens with a status table covering all three. Previously the comment was assembled from validator output alone, so the two checks that actually *fail* the job — asset filenames and non-square library images — produced a bare red cross with no explanation. That is the #3156 case, and it is the one that most needed a comment.
- **The report has a shape.** Each file is a collapsible `<details>` section headed by its issue count, the comment says in words that validator issues are advisory and do not block merging, it names the command to reproduce them locally, and a footer records the commit it describes — which matters now that a single comment is updated in place across pushes. The `summary_only` mode (>10 changed files) is gone: it collapsed every file to a bare `❌` and wrote the detail to neither the comment, the log nor the step summary. The size problem it existed for is handled by capping each file at 60 lines in the comment, with a link to the run summary for the rest.
- **A validator that stops with an error is told apart from a game file with issues.** Everything the validator can say about a file goes to stdout, so output on stderr means it produced no verdict at all; that case is reported separately instead of dumping a Node stack trace under a heading saying the contributor's game file has issues. The wording stays neutral about whose fault it is, and when nothing was found that the contributor could fix, the comment no longer asks them to fix it.
- The comment is assembled from whole per-file sections up to a 50000-character budget and links to the run summary for the rest, so a single badly broken game file cannot push the body past the 65536-character limit of the comment API; the step summary has the same treatment against the 1 MiB job-summary limit, and the raw step log always holds every line. Validator output is fenced with one backtick more than the longest backtick run it contains, so output containing a code fence cannot break out of the block.
- "Check and fix asset file names" only `git push`es the auto-fix when the PR head repo is this repository. On a fork, `origin` is the *base* repo (that is what `actions/checkout` configures on a `pull_request` event), so the push would create a stray branch here rather than update the fork — and it 403s first anyway. Worse, the fix has already been applied to the working copy at that point, so everything after it validated files the fork does not actually contain and the step could report success for a PR that is still wrong. It now restores the working copy with `git checkout HEAD -- .` so the remaining checks inspect what was actually submitted, sets `found_error=true`, and reports the affected files by name together with the `unix2dos` command that fixes them.

**`.github/workflows/check-library-comment.yml`** (new)

Triggered by `workflow_run` on "Check Library" completing, gated on `github.event.workflow_run.event == 'pull_request'`, with `permissions: actions: read` and `pull-requests: write`. It downloads the artifact from the triggering run (`actions/download-artifact@v4` with `run-id`/`github-token`, tolerating a missing artifact via `continue-on-error`) and posts, updates or deletes **one** comment identified by a hidden `<!-- check-library-validation -->` marker — so repeated pushes update a single comment instead of stacking one per run. A `workflow_run` workflow is always taken from the default branch and this job checks out no pull request code, so nothing from the PR ever executes with the write token.

The pull request number travels in the artifact, which is built by a workflow file that GitHub runs **from the pull request head** — so it is contributor-controlled. Before it writes anything, the job therefore resolves that number and requires the pull request's head commit and head repository to be exactly the ones recorded in the `workflow_run` payload; otherwise it warns and stops. Without that check a fork could edit `check-library.yml` in its own PR and have `github-actions[bot]` comment on, or delete comments from, any issue in this repository. The same check discards a run whose head has since been superseded by a newer push. The job is additionally serialized with a `concurrency` group keyed on the head repository and branch (`cancel-in-progress: false`), so two runs cannot both create the comment and a late-finishing run cannot overwrite a newer result.

**`validator/validate_gamefile_node.js`**

A game file that cannot be read or parsed is a problem with the file, so the command line validator now catches the error and prints it as a finding (`[]: Not valid JSON: …`) instead of letting it escape as an uncaught exception. Malformed JSON used to produce a `SyntaxError` stack trace on stderr and nothing on stdout, which the library check reads as "the validator itself failed" — telling the contributor their game file is fine when it is the one thing they can actually fix. `validator/validate_library.js` already treated a parse error this way; this brings the single-file entry point in line with it.

**`validator/validate_gamefile.js`**

`validateGameFile()` checks that it was handed an object before anything walks the data, so a file holding `null` reports "Game file must be a JSON object" instead of throwing out of `Object.entries()`. The order is the only thing that changes; valid game files take exactly the same path as before.

## What the comment looks like

Rendered preview of five cases — including the asset-filename failure that produced no comment before, and the 40-file case that used to be a wall of bare crosses: <https://agent.virtualtabletop.io/reports/pr/1543659189866602557/check-library-comment-preview.html> (the `<details>` sections are clickable). Each block there was produced by running this workflow's own shell and rendering the output through GitHub's GFM API.

For the same three real `library/games/**` files, the comment went from 428 lines to 103, 90 of which are inside collapsed sections.

## Deliberately not changed

- Validator issues still do **not** fail the check — that is the current behavior on purpose, so no `exit 1` was added to the validate step and the "Fail if any check failed" gate is untouched. The comment now says so in words.
- The trigger is **not** switched to `pull_request_target`, which would run pull request code with a write token.
- No `permissions:` block was added to `check-library.yml`; the auto-fix push for same-repo PRs relies on the repository default being read/write.
- On a fully clean run the comment is deleted rather than replaced by a green one, so a fixed PR does not keep a stale conversation entry. The green check is the positive signal; happy to invert this if you would rather see an explicit "all clear" comment.

## Verifying this

A `workflow_run` workflow only fires once it is on the default branch, so **nothing will visibly happen on this PR itself** — that is expected, not a failure. Real verification after merge means pushing a deliberately invalid `library/**` file from a fork and checking that the comment appears, updates on the next push, and disappears when the file is fixed.

What was verified here: both YAML files parse (`js-yaml`), the embedded `github-script` body parses as JavaScript, every referenced step id and output exists, and the `workflows: ["Check Library"]` reference matches the `name:` of the other file. Each `run:` block was then extracted and executed under `bash -eo pipefail` — the shell GitHub actually uses — against the real validator and real `library/games/**` files, and against a stub for the failure modes: clean, one file, several files, a file that crashes the validator, output containing a ``` fence, 3 x 4000 validator lines, 40 x 4000 lines (comment 49.5 KB, under the 65536 limit; step summary 801 KB, under the 1 MiB limit), a fork PR with a wrongly named asset and a non-square image, the same on a same-repo PR (auto-fix committed and pushed, working copy restored), and a check that failed without recording a result. Every resulting comment was rendered through GitHub's `/markdown` GFM API to confirm the table, the `<details>` sections and the nested fences render as intended.

`npm test` passes (1527 tests), including four new cases in `tests/server/validate-gamefile-cli.test.js` that pin down what the library check depends on: invalid JSON, a file that is not an object, a missing file and an ordinary game file all report on stdout and leave stderr empty.

An earlier run also caught a pre-existing bug in this branch: `grep -o` exits 1 when the validator output contains no backticks at all, which under `-o pipefail` failed the fence-width assignment and killed the step. Fixed.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3157/pr-test (or any other room on that server)

