### PR TITLE
Hold Ctrl to open the widget-stack list and have it follow the pointer

### DIFF
--- a/client/css/editor/controls/selectionbar.css
+++ b/client/css/editor/controls/selectionbar.css
@@ -63,6 +63,14 @@
   color: yellow;
 }
 
+/* The stack can follow the pointer without its list being on screen - a bar
+   showing the tree keeps it - and then the button and the count in its corner
+   are all there is to say the key is doing anything. It is not the blue of an
+   open dropdown: nothing has opened. */
+.selectionBar > button.peeking {
+  color: yellow;
+}
+
 /* the count sits in the corner of the button, so it needs an edge of its own:
    the active button is the same blue and would otherwise swallow it whole */
 .selectionBarStackCount {

--- a/client/js/editor/controls/selectionbar.js
+++ b/client/js/editor/controls/selectionbar.js
@@ -30,7 +30,6 @@ let selectionBarSwallowEscapeUp = false;
 let selectionBarTabHeld = false;    // Tab+Left / Tab+Right walk the history
 let selectionBarPeekActive = false; // the peek key is down, see selectionBarPeekStart
 let selectionBarPeekBar = null;     // the bar whose list the peek opened and has to close again
-let selectionBarPeekTreeBar = null; // ... and whose tree it had to push aside to do so
 let selectionBarScanFrame = null;
 
 const SELECTION_BAR_SCAN_DELAY = 120; // ms the pointer has to rest before the stack under it is taken
@@ -318,6 +317,12 @@ function selectionBarInstallListeners() {
       return;
     if(e.key == SELECTION_BAR_PEEK_KEY)
       selectionBarPeekStart();
+    // an OS-level menu or a shortcut handled outside the page can take the
+    // keyup of the peek key without ever blurring the window, which would leave
+    // the list latched open and scanning every frame - the next keystroke says
+    // the key is not down after all, so let it out of that
+    else if(!e.getModifierState(SELECTION_BAR_PEEK_KEY))
+      selectionBarPeekStop();
     if(selectionBarHandleHistoryKey(e))
       return;
     if(selectionBarHandleDropdownKey(e))
@@ -328,16 +333,11 @@ function selectionBarInstallListeners() {
       return;
     e.preventDefault();
     // Shift is what holds the list open, so it cannot also mean "add to the
-    // selection" while it does: the key of a row selects that row on its own,
-    // the way it did in the panel this list replaces. Shift+Enter and a
-    // shift-click on a row still add to the selection while the peek is up.
-    const addToSelection = e.shiftKey && !selectionBarPeekActive;
+    // selection": the key of a row selects that row on its own, the way it did
+    // in the panel this list replaces. Shift+Enter on the keyboard cursor and a
+    // shift-click on a row are what add to the selection.
     if(e.ctrlKey && jeEnabled)
       jePasteText(jeContext[jeContext.length-1] == '"null"' ? `"${widget.id}"` : widget.id, true);
-    else if(addToSelection && selectedWidgets.indexOf(widget) != -1)
-      setSelection(selectedWidgets.filter(w=>w!=widget));
-    else if(addToSelection)
-      setSelection([ widget ].concat(selectedWidgets));
     else
       setSelection([ widget ]);
   });
@@ -386,13 +386,19 @@ function selectionBarInstallListeners() {
 // mouse move. Holding Shift brings that back for as long as the key is down -
 // the list opens, follows the pointer without waiting for it to settle, and goes
 // away again with the key. A list that was already open is only made live: it
-// belongs to whoever opened it, and so does the tree it would have pushed aside.
+// belongs to whoever opened it.
 function selectionBarPeekStart() {
   // the key answers "what is under the pointer", so it only does anything while
   // the pointer is in the room - a dropdown covers the panel it hangs in, and a
   // shift-click somewhere in the sidebar must not have the list drop onto what
   // it was aimed at
   if(selectionBarPeekActive || !selectionBarPointerInRoom || !selectionBarKeyboardIsFree())
+    return;
+  // the tree's filter box is a text field like any other as far as this key is
+  // concerned: the exemption it gets in selectionBarKeyboardIsFree() is there so
+  // the arrow keys reach the tree while it is being filtered, and a capital
+  // typed into it is not somebody asking for the stack under the pointer
+  if($('#jeWidgetSearchBox') && document.activeElement === $('#jeWidgetSearchBox'))
     return;
   if(document.body.classList.contains('overlayActive') || document.body.classList.contains('deckEditorActive'))
     return;
@@ -402,9 +408,16 @@ function selectionBarPeekStart() {
   if(!selectionBars.some(bar=>bar.options.stack && bar.dom.classList.contains('stackVisible'))) {
     const bar = selectionBarKeyboardBar && selectionBarKeyboardBar.options.stack
               ? selectionBarKeyboardBar : selectionBars.find(bar=>bar.options.stack);
-    if(bar) {
+    // The two dropdowns share the space below the bar, so putting the list
+    // where the tree is means taking the tree down. That tree is something
+    // somebody opened and is working in - the keyboard can be in its filter
+    // box, and it comes back scrolled to the selection rather than to wherever
+    // it was left - and a key that gets tapped all day long must not be able to
+    // do that to it. A bar showing its tree keeps it, and the key only makes
+    // the stack follow the pointer: the count on the button and the widget the
+    // function keys address are live either way.
+    if(bar && !bar.dom.classList.contains('treeVisible')) {
       selectionBarPeekBar = bar;
-      selectionBarPeekTreeBar = bar.dom.classList.contains('treeVisible') ? bar : null;
       selectionBarToggleStack(bar, false, true);
     }
   }
@@ -420,14 +433,10 @@ function selectionBarPeekStop() {
   selectionBarPeekActive = false;
   selectionBarCancelScan();
   const bar = selectionBarPeekBar;
-  const treeBar = selectionBarPeekTreeBar;
   selectionBarPeekBar = null;
-  selectionBarPeekTreeBar = null;
   selectionBarPrune();
   if(bar && bar.dom.isConnected)
     selectionBarToggleStack(bar, true, true);
-  if(treeBar && treeBar.dom.isConnected)
-    selectionBarToggleTree(treeBar, false);
   updateSelectionBars(); // a list that stays open says what the keys do, and that just changed
 }
 

--- a/client/js/editor/controls/selectionbar.js
+++ b/client/js/editor/controls/selectionbar.js
@@ -22,13 +22,19 @@ let selectionBarStack = [];         // widgets under the pointer, topmost first
 let selectionBarStackFromTouch = false; // ... or under the finger that tapped, see selectionBarWhere
 let selectionBarCoords = null;      // pointer position in room coordinates
 let selectionBarPointer = null;
+let selectionBarPointerInRoom = false;
 let selectionBarScanTimer = null;
 let selectionBarListening = false;
 let selectionBarKeyboardBar = null; // the bar whose dropdown the arrow keys walk
 let selectionBarSwallowEscapeUp = false;
 let selectionBarTabHeld = false;    // Tab+Left / Tab+Right walk the history
+let selectionBarPeekActive = false; // the peek key is down, see selectionBarPeekStart
+let selectionBarPeekBar = null;     // the bar whose list the peek opened and has to close again
+let selectionBarPeekTreeBar = null; // ... and whose tree it had to push aside to do so
+let selectionBarScanFrame = null;
 
 const SELECTION_BAR_SCAN_DELAY = 120; // ms the pointer has to rest before the stack under it is taken
+const SELECTION_BAR_PEEK_KEY = 'Shift'; // held down, the list opens and follows the pointer without that delay
 
 // Alt+click needs a mouse and a modifier key, so it is not something to advise
 // on a tablet - the list works there and is the only way in.
@@ -147,8 +153,7 @@ function selectionBarSetStack(stack) {
 // is the stack the bar should be showing - otherwise the list can say "nothing
 // under the pointer" right next to a drill readout counting five of them.
 function selectionBarAdoptStack(stack, clientX, clientY) {
-  clearTimeout(selectionBarScanTimer);
-  selectionBarScanTimer = null;
+  selectionBarCancelScan();
   selectionBarStackFromTouch = false; // the drill is an Alt+click, so a mouse took this one
   selectionBarPointer = { x: clientX, y: clientY };
   selectionBarSetStack(stack);
@@ -200,6 +205,27 @@ function selectionBarIsActive() {
   return !!selectionBars.length && document.body.classList.contains('edit');
 }
 
+function selectionBarCancelScan() {
+  clearTimeout(selectionBarScanTimer);
+  selectionBarScanTimer = null;
+  if(selectionBarScanFrame !== null) {
+    cancelAnimationFrame(selectionBarScanFrame);
+    selectionBarScanFrame = null;
+  }
+}
+
+// While the peek key is held the list follows the pointer itself rather than the
+// spot it came to rest on, so the scan runs on every move - at most once per
+// frame, since what it costs is a hit test of the whole document.
+function selectionBarScanNextFrame() {
+  if(selectionBarScanFrame !== null)
+    return;
+  selectionBarScanFrame = requestAnimationFrame(function() {
+    selectionBarScanFrame = null;
+    selectionBarScan();
+  });
+}
+
 function selectionBarScan(fromTouch) {
   if(!selectionBarIsActive() || !selectionBarPointer)
     return;
@@ -241,13 +267,15 @@ function selectionBarInstallListeners() {
     if(!selectionBarIsActive())
       return;
     selectionBarSetPointerCoords(e.clientX, e.clientY);
+    selectionBarPointerInRoom = selectionBarPointerIsInRoom(e.target);
     if(e.buttons)
       return;
-    clearTimeout(selectionBarScanTimer);
-    selectionBarScanTimer = null;
-    if(!selectionBarPointerIsInRoom(e.target))
+    selectionBarCancelScan();
+    if(!selectionBarPointerInRoom)
       return;
     selectionBarPointer = { x: e.clientX, y: e.clientY };
+    if(selectionBarPeekActive)
+      return selectionBarScanNextFrame();
     selectionBarScanTimer = setTimeout(function() {
       selectionBarScanTimer = null;
       selectionBarScan();
@@ -266,8 +294,7 @@ function selectionBarInstallListeners() {
     if(!selectionBarIsActive() || e.touches.length != 1)
       return;
     selectionBarSetPointerCoords(e.touches[0].clientX, e.touches[0].clientY);
-    clearTimeout(selectionBarScanTimer);
-    selectionBarScanTimer = null;
+    selectionBarCancelScan();
     if(!selectionBarPointerIsInRoom(e.target))
       return;
     selectionBarPointer = { x: e.touches[0].clientX, y: e.touches[0].clientY };
@@ -289,6 +316,8 @@ function selectionBarInstallListeners() {
       selectionBarTabHeld = true;
     if(!selectionBarIsActive())
       return;
+    if(e.key == SELECTION_BAR_PEEK_KEY)
+      selectionBarPeekStart();
     if(selectionBarHandleHistoryKey(e))
       return;
     if(selectionBarHandleDropdownKey(e))
@@ -298,11 +327,16 @@ function selectionBarInstallListeners() {
     if(!widget)
       return;
     e.preventDefault();
+    // Shift is what holds the list open, so it cannot also mean "add to the
+    // selection" while it does: the key of a row selects that row on its own,
+    // the way it did in the panel this list replaces. Shift+Enter and a
+    // shift-click on a row still add to the selection while the peek is up.
+    const addToSelection = e.shiftKey && !selectionBarPeekActive;
     if(e.ctrlKey && jeEnabled)
       jePasteText(jeContext[jeContext.length-1] == '"null"' ? `"${widget.id}"` : widget.id, true);
-    else if(e.shiftKey && selectedWidgets.indexOf(widget) != -1)
+    else if(addToSelection && selectedWidgets.indexOf(widget) != -1)
       setSelection(selectedWidgets.filter(w=>w!=widget));
-    else if(e.shiftKey)
+    else if(addToSelection)
       setSelection([ widget ].concat(selectedWidgets));
     else
       setSelection([ widget ]);
@@ -317,14 +351,19 @@ function selectionBarInstallListeners() {
     // there), so the release has to be seen before it does
     if(e.key == 'Tab')
       selectionBarTabHeld = false;
+    if(e.key == SELECTION_BAR_PEEK_KEY)
+      selectionBarPeekStop();
     if(e.key == 'Escape' && selectionBarSwallowEscapeUp) {
       selectionBarSwallowEscapeUp = false;
       e.stopImmediatePropagation();
     }
   }, true);
 
-  // switching windows while Tab is down never delivers its keyup
-  window.addEventListener('blur', _=>selectionBarTabHeld = false);
+  // switching windows while a key is down never delivers its keyup
+  window.addEventListener('blur', function() {
+    selectionBarTabHeld = false;
+    selectionBarPeekStop();
+  });
 
   // A click in the editor's own panels that is not in a bar means the user has
   // moved on to something else in the sidebar - and a dropdown covers the very
@@ -337,6 +376,59 @@ function selectionBarInstallListeners() {
     if(e.target.closest('#editorSidebar, #editorModules, #editorModuleInOverlay'))
       selectionBarCloseDropdowns();
   }, true);
+}
+
+/* Peeking at the stack with a key held down */
+
+// The list costs a click to open and takes the stack where the pointer came to
+// rest, which is a step and a wait more than the fixed function-key panel it
+// replaces: that one stood permanently in the JSON editor and followed every
+// mouse move. Holding Shift brings that back for as long as the key is down -
+// the list opens, follows the pointer without waiting for it to settle, and goes
+// away again with the key. A list that was already open is only made live: it
+// belongs to whoever opened it, and so does the tree it would have pushed aside.
+function selectionBarPeekStart() {
+  // the key answers "what is under the pointer", so it only does anything while
+  // the pointer is in the room - a dropdown covers the panel it hangs in, and a
+  // shift-click somewhere in the sidebar must not have the list drop onto what
+  // it was aimed at
+  if(selectionBarPeekActive || !selectionBarPointerInRoom || !selectionBarKeyboardIsFree())
+    return;
+  if(document.body.classList.contains('overlayActive') || document.body.classList.contains('deckEditorActive'))
+    return;
+  selectionBarPrune();
+  selectionBarPeekActive = true;
+
+  if(!selectionBars.some(bar=>bar.options.stack && bar.dom.classList.contains('stackVisible'))) {
+    const bar = selectionBarKeyboardBar && selectionBarKeyboardBar.options.stack
+              ? selectionBarKeyboardBar : selectionBars.find(bar=>bar.options.stack);
+    if(bar) {
+      selectionBarPeekBar = bar;
+      selectionBarPeekTreeBar = bar.dom.classList.contains('treeVisible') ? bar : null;
+      selectionBarToggleStack(bar, false, true);
+    }
+  }
+  // whatever the last resting scan found can be a room and a pointer position
+  // ago, and the point of the key is that the list says what is under the
+  // pointer now
+  selectionBarScan();
+}
+
+function selectionBarPeekStop() {
+  if(!selectionBarPeekActive)
+    return;
+  selectionBarPeekActive = false;
+  selectionBarCancelScan();
+  const bar = selectionBarPeekBar;
+  const treeBar = selectionBarPeekTreeBar;
+  selectionBarPeekBar = null;
+  selectionBarPeekTreeBar = null;
+  selectionBarPrune();
+  if(bar && bar.dom.isConnected)
+    selectionBarToggleStack(bar, true, true);
+  if(treeBar && treeBar.dom.isConnected)
+    selectionBarToggleTree(treeBar, false);
+  updateSelectionBars(); // a list that stays open says what the keys do, and that just changed
 }
 
 /* Walking the history */
@@ -769,8 +861,12 @@ function selectionBarRenderStack(bar) {
   if(selectionBarStack.length)
     div(bar.stackList, 'selectionBarStackHelp', selectionBarStackFromTouch
       ? 'Tap a row to select that widget.'
+      : selectionBarPeekActive
+      ? 'Following the pointer while Shift is held - press the key shown to select that widget,'
+        + ' shift-click a row to add it to the selection.'
       : 'Click to select, shift-click to add to the selection, or press the key shown.'
-        + '<br>↑ ↓ step through the list, Enter selects, Esc closes it.');
+        + '<br>↑ ↓ step through the list, Enter selects, Esc closes it.'
+        + '<br>Hold Shift to have the list follow the pointer instead of waiting for it to settle.');
 
   for(const [ index, widget ] of selectionBarStack.entries()) {
     const hotkey = index < 3 ? `F${index+1}` : index < 10 ? `F${index+3}` : '';
@@ -804,7 +900,9 @@ function selectionBarRenderStack(bar) {
   }
 
   if(!selectionBarStack.length)
-    div(bar.stackList, 'selectionBarStackEmpty', 'Rest the pointer on a widget in the room, or tap one - everything stacked at that spot is listed here.');
+    div(bar.stackList, 'selectionBarStackEmpty', selectionBarPeekActive
+      ? 'Nothing under the pointer - move it over a widget while Shift is held.'
+      : 'Rest the pointer on a widget in the room, or tap one - everything stacked at that spot is listed here.');
 
   selectionBarRenderStackCursor(bar);
 }
@@ -824,7 +922,9 @@ function selectionBarRenderDrill(bar) {
     : '';
 }
 
-function selectionBarToggleStack(bar, forceClose) {
+// transient is a list that is only up while a key is held: it must not become
+// the dropdown that comes back with the module the next time it is opened.
+function selectionBarToggleStack(bar, forceClose, transient) {
   if(!bar.options.stack)
     return;
   const open = !forceClose && !bar.dom.classList.contains('stackVisible');
@@ -835,7 +935,8 @@ function selectionBarToggleStack(bar, forceClose) {
   else
     selectionBarClearHover(); // the keyboard cursor outlines its row's widget, and the list is about to be gone
   bar.stackKeyIndex = -1;
-  selectionBarStoreState({ stackOpen: open });
+  if(!transient)
+    selectionBarStoreState({ stackOpen: open });
   bar.dom.classList.toggle('stackVisible', open);
   bar.stackButton.classList.toggle('active', open);
   selectionBarRenderStack(bar);
@@ -957,7 +1058,7 @@ function renderSelectionBar(target, options = {}) {
     bar.treeButton = selectionBarButton(bar.dom, 'account_tree', 'The widget tree of the room', _=>selectionBarToggleTree(bar, false, true));
   if(options.stack) {
     const stackTitle = 'The widgets under the pointer, or where you last tapped'
-                     + (selectionBarCanAltClick() ? ' - Alt+click in the room steps through them' : '');
+                     + (selectionBarCanAltClick() ? ' - hold Shift to open this while the pointer moves, Alt+click in the room steps through them' : '');
     bar.stackButton = selectionBarButton(bar.dom, 'layers', stackTitle, _=>selectionBarToggleStack(bar));
     bar.stackCount = document.createElement('span');
     bar.stackCount.className = 'selectionBarStackCount';
@@ -1036,11 +1137,12 @@ function selectionBarDeltaReceived(delta) {
 // be left on a widget while the game is played, and the rows and F keys of a
 // stack from another session must not still point somewhere.
 function selectionBarResetStack() {
-  clearTimeout(selectionBarScanTimer);
-  selectionBarScanTimer = null;
+  selectionBarPeekStop();
+  selectionBarCancelScan();
   selectionBarStack = [];
   selectionBarResetStackCursor();
   selectionBarPointer = null;
+  selectionBarPointerInRoom = false;
   selectionBarSetPointerCoords(null);
   selectionBarClearHover();
   updateSelectionBars();

--- a/client/js/editor/controls/selectionbar.js
+++ b/client/js/editor/controls/selectionbar.js
@@ -272,12 +272,19 @@ function selectionBarInstallListeners() {
     if(!selectionBarIsActive())
       return;
     selectionBarSetPointerCoords(e.clientX, e.clientY);
+    const wasInRoom = selectionBarPointerInRoom;
     selectionBarPointerInRoom = selectionBarPointerIsInRoom(e.target);
     if(e.buttons)
       return;
     selectionBarCancelScan();
-    if(!selectionBarPointerInRoom)
+    if(!selectionBarPointerInRoom) {
+      // the list stops following the pointer that has left the room, and what it
+      // says about itself changes with that: from out here its rows are what the
+      // pointer can reach, and the key on it is the modifier again
+      if(selectionBarPeekActive && wasInRoom)
+        updateSelectionBars();
       return;
+    }
     selectionBarPointer = { x: e.clientX, y: e.clientY };
     // The key is very often already down by the time the pointer gets here:
     // putting the caret on a line of the JSON text leaves the pointer over the
@@ -596,20 +603,24 @@ function selectionBarCloseDropdown(dropdown) {
 
 // Ctrl is what pastes the id of a row into the JSON editor, and it is also what
 // holds the peeked list open - so while it is doing that it is not read as a
-// modifier at all. A list that follows the pointer answers to exactly the keys
-// its rows and its help line name, the same ones as a list opened by hand. Which
-// of the two the key is has to hold from the moment it goes down rather than
-// from the moment the list appears, so it is decided by where the pointer is:
-// over the room the key belongs to the peek, and on a row of the list - or
-// anywhere else outside the room - it is the modifier it always was.
+// modifier at all. Which of the two the key is is decided by where the pointer
+// is, and by nothing else: over the room the key belongs to the peek, and on a
+// row of the list - or anywhere else outside the room - it is the modifier it
+// always was. Reading it off the pointer rather than off whether a list is up
+// keeps the same keystroke meaning the same thing throughout a hold, which the
+// arm delay would otherwise have made a race.
 function selectionBarPeekKeyIsModifier(e) {
-  return e.ctrlKey && !selectionBarPeekActive && !selectionBarPointerInRoom;
+  return e.ctrlKey && !selectionBarPointerInRoom;
 }
 
 // Escape closes the open dropdown, the arrow keys step through it and Enter
 // picks what they landed on. Returns true when the key was used up.
 function selectionBarHandleDropdownKey(e) {
-  if(selectionBarPeekKeyIsModifier(e) || e.metaKey || e.altKey)
+  // Ctrl+Z and every other chord of the editor reaches it untouched. A list the
+  // key is holding open is the exception: it is the peek key then, so the keys
+  // the list answers to are its own - including with the pointer on a row, where
+  // the key is the modifier for a click but the list is still the peeked one.
+  if((selectionBarPeekKeyIsModifier(e) && !selectionBarPeekActive) || e.metaKey || e.altKey)
     return false;
   if([ 'Escape', 'ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight', 'Enter' ].indexOf(e.key) == -1)
     return false;
@@ -960,16 +971,19 @@ function selectionBarRenderStack(bar) {
   // The keys are the same either way, so only the first line differs: a list the
   // pointer is towing along has moved on by the time the pointer has travelled
   // to one of its rows, so it names the keys rather than sending anyone clicking.
+  // Once the pointer has left the room the list is standing still and its rows
+  // are back within reach, so it says what a list that is not moving says.
   // Escape reaches the list whatever owns the keyboard, but the arrows and Enter
   // belong to the text field that has it - the caret sitting in a line of JSON is
   // the posture the peek gets used in, so the line only offers what will answer.
   const keyHelp = selectionBarKeyboardIsFree()
     ? '<br>↑ ↓ step through the list, Enter selects, Esc closes it.'
     : '<br>Esc closes it.';
+  const following = selectionBarPeekActive && selectionBarPointerInRoom;
   if(selectionBarStack.length)
     div(bar.stackList, 'selectionBarStackHelp', selectionBarStackFromTouch
       ? 'Tap a row to select that widget.'
-      : selectionBarPeekActive
+      : following
       ? 'Following the pointer while Ctrl is held - the key shown selects, Shift with it adds.' + keyHelp
       : 'Click to select, shift-click to add to the selection, or press the key shown.' + keyHelp);
 
@@ -989,7 +1003,7 @@ function selectionBarRenderStack(bar) {
     // there is nothing left to give
     row.title = `${widget.id}${notes ? ` - ${notes}` : ''} - z ${widget.calculateZ()}`
               + ' - click to select, shift-click to add to the selection'
-              + (jeEnabled && !selectionBarPeekActive ? '\nCtrl+click pastes the id into the JSON text' : '');
+              + (jeEnabled ? '\nCtrl+click pastes the id into the JSON text' : '');
     row.onmouseenter = _=>widget.domElement.classList.add('selectionBarHover');
     row.onmouseleave = _=>widget.domElement.classList.remove('selectionBarHover');
     row.onclick = function(e) {
@@ -1006,7 +1020,7 @@ function selectionBarRenderStack(bar) {
   }
 
   if(!selectionBarStack.length)
-    div(bar.stackList, 'selectionBarStackEmpty', selectionBarPeekActive
+    div(bar.stackList, 'selectionBarStackEmpty', following
       ? 'Nothing under the pointer - move it over a widget while Ctrl is held.'
       : 'Rest the pointer on a widget in the room, or tap one - everything stacked at that spot is listed here.');
 

--- a/client/js/editor/controls/selectionbar.js
+++ b/client/js/editor/controls/selectionbar.js
@@ -422,17 +422,18 @@ function selectionBarPeekStart() {
   selectionBarPeekActive = true;
 
   if(!selectionBars.some(bar=>bar.options.stack && bar.dom.classList.contains('stackVisible'))) {
-    const bar = selectionBarKeyboardBar && selectionBarKeyboardBar.options.stack
-              ? selectionBarKeyboardBar : selectionBars.find(bar=>bar.options.stack);
     // The two dropdowns share the space below the bar, so putting the list
     // where the tree is means taking the tree down. That tree is something
     // somebody opened and is working in - the keyboard can be in its filter
     // box, and it comes back scrolled to the selection rather than to wherever
     // it was left - and a key that gets tapped all day long must not be able to
-    // do that to it. A bar showing its tree keeps it, and the key only makes
-    // the stack follow the pointer: the count on the button and the widget the
-    // function keys address are live either way.
-    if(bar && !bar.dom.classList.contains('treeVisible')) {
+    // do that to it. So the list goes to a bar that is not showing one, which
+    // with two docked modules can be the other one; where every bar is showing
+    // its tree the key only makes the stack follow the pointer, and the count on
+    // the button and the widget the function keys address are live either way.
+    const free = selectionBars.filter(bar=>bar.options.stack && !bar.dom.classList.contains('treeVisible'));
+    const bar = free.indexOf(selectionBarKeyboardBar) != -1 ? selectionBarKeyboardBar : free[0];
+    if(bar) {
       selectionBarPeekBar = bar;
       selectionBarToggleStack(bar, false, true);
     }

--- a/client/js/editor/controls/selectionbar.js
+++ b/client/js/editor/controls/selectionbar.js
@@ -388,17 +388,14 @@ function selectionBarInstallListeners() {
 // away again with the key. A list that was already open is only made live: it
 // belongs to whoever opened it.
 function selectionBarPeekStart() {
-  // the key answers "what is under the pointer", so it only does anything while
-  // the pointer is in the room - a dropdown covers the panel it hangs in, and a
-  // shift-click somewhere in the sidebar must not have the list drop onto what
-  // it was aimed at
-  if(selectionBarPeekActive || !selectionBarPointerInRoom || !selectionBarKeyboardIsFree())
-    return;
-  // the tree's filter box is a text field like any other as far as this key is
-  // concerned: the exemption it gets in selectionBarKeyboardIsFree() is there so
-  // the arrow keys reach the tree while it is being filtered, and a capital
-  // typed into it is not somebody asking for the stack under the pointer
-  if($('#jeWidgetSearchBox') && document.activeElement === $('#jeWidgetSearchBox'))
+  // Where the pointer is is the whole condition, the way it was for the panel
+  // this list replaces: that one was up whenever the pointer was in the room and
+  // hid as soon as it moved over the editor, and it did not care where the
+  // keyboard was - reading a widget's name while the caret sits in the JSON text
+  // area is the case it was there for. Outside the room the key does nothing at
+  // all: a dropdown covers the panel it hangs in, so a shift-click in the
+  // sidebar must not have the list drop onto what it was aimed at.
+  if(selectionBarPeekActive || !selectionBarPointerInRoom)
     return;
   if(document.body.classList.contains('overlayActive') || document.body.classList.contains('deckEditorActive'))
     return;

--- a/client/js/editor/controls/selectionbar.js
+++ b/client/js/editor/controls/selectionbar.js
@@ -371,9 +371,13 @@ function selectionBarInstallListeners() {
     }
   }, true);
 
-  // switching windows while a key is down never delivers its keyup
+  // Switching windows while a key is down never delivers its keyup - and an
+  // Escape whose keyup is owed to nobody must not eat the next one: Ctrl+Escape
+  // opens the Start menu on Windows, so the release of the very keystroke that
+  // closed a dropdown can be the one that never arrives.
   window.addEventListener('blur', function() {
     selectionBarTabHeld = false;
+    selectionBarSwallowEscapeUp = false;
     selectionBarPeekRelease();
   });
 

--- a/client/js/editor/controls/selectionbar.js
+++ b/client/js/editor/controls/selectionbar.js
@@ -951,7 +951,12 @@ function selectionBarRenderStack(bar) {
   // The keys are the same either way, so only the first line differs: a list the
   // pointer is towing along has moved on by the time the pointer has travelled
   // to one of its rows, so it names the keys rather than sending anyone clicking.
-  const keyHelp = '<br>↑ ↓ step through the list, Enter selects, Esc closes it.';
+  // Escape reaches the list whatever owns the keyboard, but the arrows and Enter
+  // belong to the text field that has it - the caret sitting in a line of JSON is
+  // the posture the peek gets used in, so the line only offers what will answer.
+  const keyHelp = selectionBarKeyboardIsFree()
+    ? '<br>↑ ↓ step through the list, Enter selects, Esc closes it.'
+    : '<br>Esc closes it.';
   if(selectionBarStack.length)
     div(bar.stackList, 'selectionBarStackHelp', selectionBarStackFromTouch
       ? 'Tap a row to select that widget.'

--- a/client/js/editor/controls/selectionbar.js
+++ b/client/js/editor/controls/selectionbar.js
@@ -33,6 +33,7 @@ let selectionBarPeekBar = null;     // the bar whose list the peek opened and ha
 let selectionBarPeekArmTimer = null;
 let selectionBarPeekArmed = false;  // the key has been held long enough to mean the list, see selectionBarPeekArm
 let selectionBarPeekBlocked = false; // ... or it turned out to be the first half of a chord after all
+let selectionBarPeekRestPoint = null; // the spot the peeked list stops on, see selectionBarPeekSettle
 let selectionBarScanFrame = null;
 
 const SELECTION_BAR_SCAN_DELAY = 120; // ms the pointer has to rest before the stack under it is taken
@@ -282,7 +283,7 @@ function selectionBarInstallListeners() {
       // says about itself changes with that: from out here its rows are what the
       // pointer can reach, and the key on it is the modifier again
       if(selectionBarPeekActive && wasInRoom)
-        updateSelectionBars();
+        selectionBarPeekSettle();
       return;
     }
     selectionBarPointer = { x: e.clientX, y: e.clientY };
@@ -300,8 +301,16 @@ function selectionBarInstallListeners() {
     // long as somebody keeps a finger on Ctrl.
     if(!selectionBarPeekActive && e.getModifierState(SELECTION_BAR_PEEK_KEY))
       selectionBarPeekArm();
-    if(selectionBarPeekActive)
-      return selectionBarScanNextFrame();
+    if(selectionBarPeekActive) {
+      selectionBarScanNextFrame();
+      // the spot the pointer stops on is the stack the list is read at, and the
+      // one it goes back to when the pointer leaves for a row, see selectionBarPeekSettle
+      selectionBarScanTimer = setTimeout(function() {
+        selectionBarScanTimer = null;
+        selectionBarPeekNoteRestPoint();
+      }, SELECTION_BAR_SCAN_DELAY);
+      return;
+    }
     selectionBarScanTimer = setTimeout(function() {
       selectionBarScanTimer = null;
       selectionBarScan();
@@ -449,6 +458,29 @@ function selectionBarPeekStart() {
   // ago, and the point of the key is that the list says what is under the
   // pointer now
   selectionBarScan();
+  selectionBarPeekNoteRestPoint(); // the pointer is standing still on this one, that is what armed the key
+}
+
+// A spot with nothing under it is not one the list can be read at, so it is not
+// one to stop on either: the empty space around the board is the last thing the
+// pointer crosses on its way out of the room.
+function selectionBarPeekNoteRestPoint() {
+  if(selectionBarStack.length)
+    selectionBarPeekRestPoint = selectionBarPointer;
+}
+
+// A pointer on its way to a row of the list crosses everything that lies between
+// the widget it was reading and the panel - the rest of the room, and the empty
+// space around the board - and a list that followed it all the way there would
+// arrive showing that instead, with the row that was aimed at gone from under
+// the click. What the pointer last came to rest on is what the list was read at,
+// so that is the stack it stops on when the pointer leaves the room.
+function selectionBarPeekSettle() {
+  if(selectionBarPeekRestPoint)
+    selectionBarPointer = selectionBarPeekRestPoint;
+  // the rows change back and the help line with them: a list that has stopped
+  // following the pointer says so rather than going on claiming to follow it
+  selectionBarScan();
 }
 
 function selectionBarPeekStop() {
@@ -500,6 +532,7 @@ function selectionBarPeekBlock() {
 function selectionBarPeekRelease() {
   selectionBarPeekBlocked = false;
   selectionBarPeekArmed = false;
+  selectionBarPeekRestPoint = null;
   selectionBarPeekCancelArm();
   selectionBarPeekStop();
 }

--- a/client/js/editor/controls/selectionbar.js
+++ b/client/js/editor/controls/selectionbar.js
@@ -33,7 +33,7 @@ let selectionBarPeekBar = null;     // the bar whose list the peek opened and ha
 let selectionBarScanFrame = null;
 
 const SELECTION_BAR_SCAN_DELAY = 120; // ms the pointer has to rest before the stack under it is taken
-const SELECTION_BAR_PEEK_KEY = 'Shift'; // held down, the list opens and follows the pointer without that delay
+const SELECTION_BAR_PEEK_KEY = 'Control'; // held down, the list opens and follows the pointer without that delay
 
 // Alt+click needs a mouse and a modifier key, so it is not something to advise
 // on a tablet - the list works there and is the only way in.
@@ -335,12 +335,12 @@ function selectionBarInstallListeners() {
     if(!widget)
       return;
     e.preventDefault();
-    // Shift is what holds the list open, so it cannot also mean "add to the
-    // selection": the key of a row selects that row on its own, the way it did
-    // in the panel this list replaces. Shift+Enter on the keyboard cursor and a
-    // shift-click on a row are what add to the selection.
-    if(e.ctrlKey && jeEnabled)
+    if(selectionBarPeekKeyIsModifier(e) && jeEnabled)
       jePasteText(jeContext[jeContext.length-1] == '"null"' ? `"${widget.id}"` : widget.id, true);
+    else if(e.shiftKey && selectedWidgets.indexOf(widget) != -1)
+      setSelection(selectedWidgets.filter(w=>w!=widget));
+    else if(e.shiftKey)
+      setSelection([ widget ].concat(selectedWidgets));
     else
       setSelection([ widget ]);
   });
@@ -385,7 +385,7 @@ function selectionBarInstallListeners() {
 // The list costs a click to open and takes the stack where the pointer came to
 // rest, which is a step and a wait more than the fixed function-key panel it
 // replaces: that one stood permanently in the JSON editor and followed every
-// mouse move. Holding Shift brings that back for as long as the key is down -
+// mouse move. Holding Ctrl brings that back for as long as the key is down -
 // the list opens, follows the pointer without waiting for it to settle, and goes
 // away again with the key. A list that was already open is only made live: it
 // belongs to whoever opened it. The key and the pointer being in the room are
@@ -397,8 +397,9 @@ function selectionBarPeekStart() {
   // hid as soon as it moved over the editor, and it did not care where the
   // keyboard was - reading a widget's name while the caret sits in the JSON text
   // area is the case it was there for. Outside the room the key does nothing at
-  // all: a dropdown covers the panel it hangs in, so a shift-click in the
-  // sidebar must not have the list drop onto what it was aimed at.
+  // all: a dropdown covers the panel it hangs in, so a Ctrl+click in the sidebar
+  // - which is how a module is docked in the lower slot - must not have the list
+  // drop onto what it was aimed at.
   if(selectionBarPeekActive || !selectionBarPointerInRoom)
     return;
   if(document.body.classList.contains('overlayActive') || document.body.classList.contains('deckEditorActive'))
@@ -537,10 +538,18 @@ function selectionBarCloseDropdown(dropdown) {
     button.focus();
 }
 
+// Ctrl is what pastes the id of a row into the JSON editor, and it is also what
+// holds the peeked list open - so while it is doing that it is not read as a
+// modifier at all. A list that follows the pointer answers to exactly the keys
+// its rows and its help line name, the same ones as a list opened by hand.
+function selectionBarPeekKeyIsModifier(e) {
+  return e.ctrlKey && !selectionBarPeekActive;
+}
+
 // Escape closes the open dropdown, the arrow keys step through it and Enter
 // picks what they landed on. Returns true when the key was used up.
 function selectionBarHandleDropdownKey(e) {
-  if(e.ctrlKey || e.metaKey || e.altKey)
+  if(selectionBarPeekKeyIsModifier(e) || e.metaKey || e.altKey)
     return false;
   if([ 'Escape', 'ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight', 'Enter' ].indexOf(e.key) == -1)
     return false;
@@ -883,11 +892,11 @@ function selectionBarRenderStack(bar) {
     div(bar.stackList, 'selectionBarStackHelp', selectionBarStackFromTouch
       ? 'Tap a row to select that widget.'
       : selectionBarPeekActive
-      ? 'Following the pointer while Shift is held - press the key shown to select that widget,'
-        + ' shift-click a row to add it to the selection.'
+      ? 'Following the pointer while Ctrl is held - press the key shown to select that widget,'
+        + ' shift-click a row or hold Shift with the key to add it to the selection.'
       : 'Click to select, shift-click to add to the selection, or press the key shown.'
         + '<br>↑ ↓ step through the list, Enter selects, Esc closes it.'
-        + '<br>Hold Shift to have the list follow the pointer instead of waiting for it to settle.');
+        + '<br>Hold Ctrl to have the list follow the pointer instead of waiting for it to settle.');
 
   for(const [ index, widget ] of selectionBarStack.entries()) {
     const hotkey = index < 3 ? `F${index+1}` : index < 10 ? `F${index+3}` : '';
@@ -909,7 +918,7 @@ function selectionBarRenderStack(bar) {
     row.onmouseleave = _=>widget.domElement.classList.remove('selectionBarHover');
     row.onclick = function(e) {
       selectionBarClearHover();
-      if(e.ctrlKey && jeEnabled)
+      if(selectionBarPeekKeyIsModifier(e) && jeEnabled)
         jePasteText(jeContext[jeContext.length-1] == '"null"' ? `"${widget.id}"` : widget.id, true);
       else if(e.shiftKey && selectedWidgets.indexOf(widget) != -1)
         setSelection(selectedWidgets.filter(w=>w!=widget));
@@ -922,7 +931,7 @@ function selectionBarRenderStack(bar) {
 
   if(!selectionBarStack.length)
     div(bar.stackList, 'selectionBarStackEmpty', selectionBarPeekActive
-      ? 'Nothing under the pointer - move it over a widget while Shift is held.'
+      ? 'Nothing under the pointer - move it over a widget while Ctrl is held.'
       : 'Rest the pointer on a widget in the room, or tap one - everything stacked at that spot is listed here.');
 
   selectionBarRenderStackCursor(bar);
@@ -1079,7 +1088,7 @@ function renderSelectionBar(target, options = {}) {
     bar.treeButton = selectionBarButton(bar.dom, 'account_tree', 'The widget tree of the room', _=>selectionBarToggleTree(bar, false, true));
   if(options.stack) {
     const stackTitle = 'The widgets under the pointer, or where you last tapped'
-                     + (selectionBarCanAltClick() ? ' - hold Shift to open this while the pointer moves, Alt+click in the room steps through them' : '');
+                     + (selectionBarCanAltClick() ? ' - hold Ctrl to open this while the pointer moves, Alt+click in the room steps through them' : '');
     bar.stackButton = selectionBarButton(bar.dom, 'layers', stackTitle, _=>selectionBarToggleStack(bar));
     bar.stackCount = document.createElement('span');
     bar.stackCount.className = 'selectionBarStackCount';

--- a/client/js/editor/controls/selectionbar.js
+++ b/client/js/editor/controls/selectionbar.js
@@ -286,9 +286,13 @@ function selectionBarInstallListeners() {
     // the modifier state a mouse event carries says whether the key is down,
     // whether or not its keydown ever reached the page. Only opening is done
     // here: what closes the list is the key coming up, and a move that reports
-    // no modifier while it is still held would take it away mid-gesture.
+    // no modifier while it is still held would take it away mid-gesture. A key
+    // that is still down after it turned out to be a chord arms nothing, and the
+    // list then goes on being taken where the pointer rests like any other: the
+    // stack the count and the function keys are read off must not freeze for as
+    // long as somebody keeps a finger on Ctrl.
     if(!selectionBarPeekActive && e.getModifierState(SELECTION_BAR_PEEK_KEY))
-      return selectionBarPeekArm();
+      selectionBarPeekArm();
     if(selectionBarPeekActive)
       return selectionBarScanNextFrame();
     selectionBarScanTimer = setTimeout(function() {

--- a/client/js/editor/controls/selectionbar.js
+++ b/client/js/editor/controls/selectionbar.js
@@ -343,6 +343,42 @@ function selectionBarInstallListeners() {
       selectionBarSetPointerCoords(e.touches[0].clientX, e.touches[0].clientY);
   }, true);
 
+  // A list the peek key is holding open answers to the arrows and Enter even
+  // where the keyboard belongs to a text field, and those keys have to be taken
+  // on the way down: #jeText turns an Enter into a newline in its own handler,
+  // so a keystroke claimed only on the way back up would have edited the JSON
+  // before the row it picked was ever selected. Escape is left where it was - it
+  // reaches the list whatever owns the keyboard, and everything else in the page
+  // that watches for it still gets to see it.
+  window.addEventListener('keydown', function(e) {
+    if(!selectionBarIsActive() || selectionBarKeyboardIsFree())
+      return;
+    if([ 'ArrowUp', 'ArrowDown', 'Enter' ].indexOf(e.key) == -1)
+      return;
+    selectionBarSyncPeek(e); // a key nobody is holding any more owns nothing
+    if(selectionBarPeekedListBar() && selectionBarHandleDropdownKey(e))
+      e.stopImmediatePropagation();
+  }, true);
+
+  // The wheel walks the peeked list the way the arrows do - the hand holding the
+  // key is already on the mouse. The room zooms to the cursor on a turn of the
+  // wheel, so while the key holds the list open that zoom gives way: what the
+  // gesture is aimed at is the list of what lies under the pointer. Capture
+  // phase and stopPropagation, since the zoom listens on #roomArea on the way
+  // back up.
+  window.addEventListener('wheel', function(e) {
+    if(!selectionBarIsActive() || !selectionBarPeekActive)
+      return;
+    if(!e.getModifierState(SELECTION_BAR_PEEK_KEY))
+      return selectionBarPeekRelease();
+    const bar = selectionBarPeekedListBar();
+    if(!bar || !e.deltaY)
+      return;
+    e.preventDefault();
+    e.stopPropagation();
+    selectionBarStepStack(bar, e.deltaY > 0 ? 1 : -1);
+  }, { capture: true, passive: false });
+
   // F1, F2, F3, F6 ... F12 pick the rows of the list without opening it - the
   // keys the panel this replaces was built around. Ctrl pastes the id into the
   // JSON editor, which only means anything while that one is open.
@@ -621,6 +657,17 @@ function selectionBarKeyboardIsFree() {
   return !focused.isContentEditable && !focused.matches('input:not([type=button]), textarea, select');
 }
 
+// The list the peek key is holding open, when that is the dropdown the keys are
+// on: opening it hands it the keyboard, so it is the one selectionBarKeyboardDropdown
+// finds - with two modules docked the bar the peek landed in can be the one that
+// is not showing its tree, and there the keys stay with that tree.
+function selectionBarPeekedListBar() {
+  if(!selectionBarPeekActive)
+    return null;
+  const dropdown = selectionBarKeyboardDropdown();
+  return dropdown && dropdown.kind == 'stack' ? dropdown.bar : null;
+}
+
 function selectionBarCloseDropdown(dropdown) {
   const button = dropdown.kind == 'stack' ? dropdown.bar.stackButton : dropdown.bar.treeButton;
   const focusWasInside = document.activeElement && dropdown.bar.dom.contains(document.activeElement);
@@ -678,7 +725,12 @@ function selectionBarHandleDropdownKey(e) {
     return true;
   }
 
-  if(!selectionBarKeyboardIsFree())
+  // The arrows and Enter go back to whatever owns the keyboard: they move the
+  // caret in the JSON text area and step every number input in the editor. A
+  // list the peek key is holding open is the exception - the caret sitting in a
+  // line of JSON is the posture the key gets held in, so that list would
+  // otherwise be the one list its own keys never reach.
+  if(!selectionBarKeyboardIsFree() && !selectionBarPeekedListBar())
     return false;
 
   const step = e.key == 'ArrowDown' ? 1 : e.key == 'ArrowUp' ? -1 : 0;
@@ -1006,10 +1058,15 @@ function selectionBarRenderStack(bar) {
   // to one of its rows, so it names the keys rather than sending anyone clicking.
   // Once the pointer has left the room the list is standing still and its rows
   // are back within reach, so it says what a list that is not moving says.
-  // Escape reaches the list whatever owns the keyboard, but the arrows and Enter
-  // belong to the text field that has it - the caret sitting in a line of JSON is
-  // the posture the peek gets used in, so the line only offers what will answer.
-  const keyHelp = selectionBarKeyboardIsFree()
+  // Escape reaches the list whatever owns the keyboard, and so do the arrows and
+  // Enter while the peek key holds it open - the wheel with them, since the hand
+  // that holds the key is on the mouse. A list nobody is holding open leaves
+  // those keys to the text field that owns them, so the line only offers what
+  // will answer.
+  const peeked = selectionBarPeekedListBar() === bar;
+  const keyHelp = peeked
+    ? '<br>↑ ↓ or the wheel step through the list, Enter selects, Esc closes it.'
+    : selectionBarKeyboardIsFree()
     ? '<br>↑ ↓ step through the list, Enter selects, Esc closes it.'
     : '<br>Esc closes it.';
   const following = selectionBarPeekActive && selectionBarPointerInRoom;

--- a/client/js/editor/controls/selectionbar.js
+++ b/client/js/editor/controls/selectionbar.js
@@ -273,6 +273,16 @@ function selectionBarInstallListeners() {
     if(!selectionBarPointerInRoom)
       return;
     selectionBarPointer = { x: e.clientX, y: e.clientY };
+    // The key is very often already down by the time the pointer gets here:
+    // putting the caret on a line of the JSON text leaves the pointer over the
+    // editor, and holding the key there and then moving onto the room is the
+    // whole gesture. So the pointer arriving in the room opens the list too -
+    // the modifier state a mouse event carries says whether the key is down,
+    // whether or not its keydown ever reached the page. Only opening is done
+    // here: what closes the list is the key coming up, and a move that reports
+    // no modifier while it is still held would take it away mid-gesture.
+    if(!selectionBarPeekActive && e.getModifierState(SELECTION_BAR_PEEK_KEY))
+      return selectionBarPeekStart();
     if(selectionBarPeekActive)
       return selectionBarScanNextFrame();
     selectionBarScanTimer = setTimeout(function() {
@@ -315,14 +325,7 @@ function selectionBarInstallListeners() {
       selectionBarTabHeld = true;
     if(!selectionBarIsActive())
       return;
-    if(e.key == SELECTION_BAR_PEEK_KEY)
-      selectionBarPeekStart();
-    // an OS-level menu or a shortcut handled outside the page can take the
-    // keyup of the peek key without ever blurring the window, which would leave
-    // the list latched open and scanning every frame - the next keystroke says
-    // the key is not down after all, so let it out of that
-    else if(!e.getModifierState(SELECTION_BAR_PEEK_KEY))
-      selectionBarPeekStop();
+    selectionBarSyncPeek(e);
     if(selectionBarHandleHistoryKey(e))
       return;
     if(selectionBarHandleDropdownKey(e))
@@ -351,8 +354,7 @@ function selectionBarInstallListeners() {
     // there), so the release has to be seen before it does
     if(e.key == 'Tab')
       selectionBarTabHeld = false;
-    if(e.key == SELECTION_BAR_PEEK_KEY)
-      selectionBarPeekStop();
+    selectionBarSyncPeek(e);
     if(e.key == 'Escape' && selectionBarSwallowEscapeUp) {
       selectionBarSwallowEscapeUp = false;
       e.stopImmediatePropagation();
@@ -386,7 +388,9 @@ function selectionBarInstallListeners() {
 // mouse move. Holding Shift brings that back for as long as the key is down -
 // the list opens, follows the pointer without waiting for it to settle, and goes
 // away again with the key. A list that was already open is only made live: it
-// belongs to whoever opened it.
+// belongs to whoever opened it. The key and the pointer being in the room are
+// two halves of one condition and either can arrive last, so both the key going
+// down and the pointer coming in open the list.
 function selectionBarPeekStart() {
   // Where the pointer is is the whole condition, the way it was for the panel
   // this list replaces: that one was up whenever the pointer was in the room and
@@ -435,6 +439,17 @@ function selectionBarPeekStop() {
   if(bar && bar.dom.isConnected)
     selectionBarToggleStack(bar, true, true);
   updateSelectionBars(); // a list that stays open says what the keys do, and that just changed
+}
+
+// Whether the peek should be up is read off the event in hand rather than
+// remembered from a keydown: a keyup lost to an OS-level menu or shortcut would
+// otherwise leave the list latched open and scanning every frame, and the next
+// keystroke that reports the key as up puts it away.
+function selectionBarSyncPeek(e) {
+  if(e.getModifierState(SELECTION_BAR_PEEK_KEY))
+    selectionBarPeekStart();
+  else
+    selectionBarPeekStop();
 }
 
 /* Walking the history */

--- a/client/js/editor/controls/selectionbar.js
+++ b/client/js/editor/controls/selectionbar.js
@@ -379,6 +379,31 @@ function selectionBarInstallListeners() {
     selectionBarStepStack(bar, e.deltaY > 0 ? 1 : -1);
   }, { capture: true, passive: false });
 
+  // The middle button finishes what the wheel started: it takes the row the
+  // wheel and the arrows are on, which is what Enter does on it - so the whole
+  // gesture can be made by the hand that is already on the mouse, without the
+  // pointer ever leaving the widget it is reading. Only a row the keys have
+  // actually stepped to is taken; a middle press that was aimed at no row is
+  // left alone, since in edit mode that is the press that plays a widget.
+  // Capture phase, so the room's own input handling never sees it - and its
+  // default with it, which is the autoscroll of a middle press on Windows and
+  // the primary-selection paste of one on X11.
+  window.addEventListener('mousedown', function(e) {
+    if(e.button != 1 || !selectionBarIsActive() || !selectionBarPeekActive)
+      return;
+    if(!e.getModifierState(SELECTION_BAR_PEEK_KEY))
+      return selectionBarPeekRelease();
+    const bar = selectionBarPeekedListBar();
+    const widget = bar && selectionBarStack[bar.stackKeyIndex];
+    // out on a row of the list the pointer has a row of its own to click, and
+    // the button means there whatever it means anywhere else in the editor
+    if(!widget || !selectionBarPointerIsInRoom(e.target))
+      return;
+    e.preventDefault();
+    e.stopPropagation();
+    selectionBarPickCursorRow(bar, widget, e.shiftKey);
+  }, true);
+
   // F1, F2, F3, F6 ... F12 pick the rows of the list without opening it - the
   // keys the panel this replaces was built around. Ctrl pastes the id into the
   // JSON editor, which only means anything while that one is open.
@@ -755,17 +780,24 @@ function selectionBarHandleDropdownKey(e) {
     const widget = dropdown.kind == 'stack' ? selectionBarStack[dropdown.bar.stackKeyIndex] : widgets.get(dropdown.bar.treeKeyID);
     if(!widget)
       return false;
-    if(e.shiftKey && selectedWidgets.indexOf(widget) != -1)
-      setSelection(selectedWidgets.filter(w=>w!=widget));
-    else if(e.shiftKey)
-      setSelection([ widget ].concat(selectedWidgets));
-    else
-      dropdown.bar.options.onPick(widget);
+    selectionBarPickCursorRow(dropdown.bar, widget, e.shiftKey);
     e.preventDefault();
     return true;
   }
 
   return false;
+}
+
+// Taking the row the keys landed on: Enter, and the middle mouse button while
+// the peek key holds the list open. Shift with either adds the widget to the
+// selection or takes it out again, the way shift-clicking a row does.
+function selectionBarPickCursorRow(bar, widget, add) {
+  if(add && selectedWidgets.indexOf(widget) != -1)
+    setSelection(selectedWidgets.filter(w=>w!=widget));
+  else if(add)
+    setSelection([ widget ].concat(selectedWidgets));
+  else
+    bar.options.onPick(widget);
 }
 
 function selectionBarResetStackCursor() {
@@ -1059,13 +1091,13 @@ function selectionBarRenderStack(bar) {
   // Once the pointer has left the room the list is standing still and its rows
   // are back within reach, so it says what a list that is not moving says.
   // Escape reaches the list whatever owns the keyboard, and so do the arrows and
-  // Enter while the peek key holds it open - the wheel with them, since the hand
-  // that holds the key is on the mouse. A list nobody is holding open leaves
-  // those keys to the text field that owns them, so the line only offers what
-  // will answer.
+  // Enter while the peek key holds it open - the wheel and the middle button
+  // with them, since the hand that holds the key is on the mouse. A list nobody
+  // is holding open leaves those keys to the text field that owns them, so the
+  // line only offers what will answer.
   const peeked = selectionBarPeekedListBar() === bar;
   const keyHelp = peeked
-    ? '<br>↑ ↓ or the wheel step through the list, Enter selects, Esc closes it.'
+    ? '<br>↑ ↓ or the wheel step through the list, Enter or the middle mouse button selects, Esc closes it.'
     : selectionBarKeyboardIsFree()
     ? '<br>↑ ↓ step through the list, Enter selects, Esc closes it.'
     : '<br>Esc closes it.';

--- a/client/js/editor/controls/selectionbar.js
+++ b/client/js/editor/controls/selectionbar.js
@@ -30,10 +30,16 @@ let selectionBarSwallowEscapeUp = false;
 let selectionBarTabHeld = false;    // Tab+Left / Tab+Right walk the history
 let selectionBarPeekActive = false; // the peek key is down, see selectionBarPeekStart
 let selectionBarPeekBar = null;     // the bar whose list the peek opened and has to close again
+let selectionBarPeekArmTimer = null;
+let selectionBarPeekArmed = false;  // the key has been held long enough to mean the list, see selectionBarPeekArm
+let selectionBarPeekBlocked = false; // ... or it turned out to be the first half of a chord after all
 let selectionBarScanFrame = null;
 
 const SELECTION_BAR_SCAN_DELAY = 120; // ms the pointer has to rest before the stack under it is taken
 const SELECTION_BAR_PEEK_KEY = 'Control'; // held down, the list opens and follows the pointer without that delay
+const SELECTION_BAR_PEEK_ARM_DELAY = 200; // ms the peek key has to be held before the list drops, see selectionBarPeekArm
+// what a peeked list answers to itself - any other key makes the keystroke a chord
+const SELECTION_BAR_PEEK_KEYS = [ 'Control', 'Shift', 'Alt', 'Meta', 'Escape', 'Enter', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight' ];
 
 // Alt+click needs a mouse and a modifier key, so it is not something to advise
 // on a tablet - the list works there and is the only way in.
@@ -282,7 +288,7 @@ function selectionBarInstallListeners() {
     // here: what closes the list is the key coming up, and a move that reports
     // no modifier while it is still held would take it away mid-gesture.
     if(!selectionBarPeekActive && e.getModifierState(SELECTION_BAR_PEEK_KEY))
-      return selectionBarPeekStart();
+      return selectionBarPeekArm();
     if(selectionBarPeekActive)
       return selectionBarScanNextFrame();
     selectionBarScanTimer = setTimeout(function() {
@@ -364,7 +370,7 @@ function selectionBarInstallListeners() {
   // switching windows while a key is down never delivers its keyup
   window.addEventListener('blur', function() {
     selectionBarTabHeld = false;
-    selectionBarPeekStop();
+    selectionBarPeekRelease();
   });
 
   // A click in the editor's own panels that is not in a bar means the user has
@@ -442,15 +448,56 @@ function selectionBarPeekStop() {
   updateSelectionBars(); // a list that stays open says what the keys do, and that just changed
 }
 
+// Ctrl also starts Ctrl+Z, Ctrl+J, Ctrl+S and every other chord of the editor,
+// and the pointer is usually over the room while those are typed - a list the
+// width of the panel must not drop over it and snap shut again for the length of
+// a keystroke. So the key has to be held for a moment before the list appears: a
+// chord is over long before that, a hold is not. Once the key has been held that
+// long it stays armed, so the other order - key first, pointer into the room
+// afterwards - opens the list the moment the pointer arrives.
+function selectionBarPeekArm() {
+  if(selectionBarPeekBlocked || selectionBarPeekActive || selectionBarPeekArmTimer !== null)
+    return;
+  if(selectionBarPeekArmed)
+    return selectionBarPeekStart();
+  selectionBarPeekArmTimer = setTimeout(function() {
+    selectionBarPeekArmTimer = null;
+    selectionBarPeekArmed = true;
+    selectionBarPeekStart();
+  }, SELECTION_BAR_PEEK_ARM_DELAY);
+}
+
+function selectionBarPeekCancelArm() {
+  clearTimeout(selectionBarPeekArmTimer);
+  selectionBarPeekArmTimer = null;
+}
+
+// The keystroke turned out to be a chord, or the list was dismissed with Escape:
+// either way the key is still down, and it must not bring the list back until it
+// has been let go of and pressed again.
+function selectionBarPeekBlock() {
+  selectionBarPeekBlocked = true;
+  selectionBarPeekCancelArm();
+  selectionBarPeekStop();
+}
+
+function selectionBarPeekRelease() {
+  selectionBarPeekBlocked = false;
+  selectionBarPeekArmed = false;
+  selectionBarPeekCancelArm();
+  selectionBarPeekStop();
+}
+
 // Whether the peek should be up is read off the event in hand rather than
 // remembered from a keydown: a keyup lost to an OS-level menu or shortcut would
 // otherwise leave the list latched open and scanning every frame, and the next
 // keystroke that reports the key as up puts it away.
 function selectionBarSyncPeek(e) {
-  if(e.getModifierState(SELECTION_BAR_PEEK_KEY))
-    selectionBarPeekStart();
-  else
-    selectionBarPeekStop();
+  if(!e.getModifierState(SELECTION_BAR_PEEK_KEY))
+    return selectionBarPeekRelease();
+  if(e.type == 'keydown' && SELECTION_BAR_PEEK_KEYS.indexOf(e.key) == -1 && !/^F\d+$/.test(e.key))
+    return selectionBarPeekBlock();
+  selectionBarPeekArm();
 }
 
 /* Walking the history */
@@ -541,9 +588,13 @@ function selectionBarCloseDropdown(dropdown) {
 // Ctrl is what pastes the id of a row into the JSON editor, and it is also what
 // holds the peeked list open - so while it is doing that it is not read as a
 // modifier at all. A list that follows the pointer answers to exactly the keys
-// its rows and its help line name, the same ones as a list opened by hand.
+// its rows and its help line name, the same ones as a list opened by hand. Which
+// of the two the key is has to hold from the moment it goes down rather than
+// from the moment the list appears, so it is decided by where the pointer is:
+// over the room the key belongs to the peek, and on a row of the list - or
+// anywhere else outside the room - it is the modifier it always was.
 function selectionBarPeekKeyIsModifier(e) {
-  return e.ctrlKey && !selectionBarPeekActive;
+  return e.ctrlKey && !selectionBarPeekActive && !selectionBarPointerInRoom;
 }
 
 // Escape closes the open dropdown, the arrow keys step through it and Enter
@@ -565,6 +616,10 @@ function selectionBarHandleDropdownKey(e) {
 
   if(e.key == 'Escape') {
     selectionBarCloseDropdown(dropdown);
+    // a list Escape has just put away must not come straight back on the next
+    // mouse move while the key that opened it is still held
+    if(e.getModifierState(SELECTION_BAR_PEEK_KEY))
+      selectionBarPeekBlock();
     selectionBarSwallowEscapeUp = true;
     e.preventDefault();
     return true;
@@ -870,6 +925,11 @@ function selectionBarRenderStack(bar) {
 
   bar.stackCount.textContent = selectionBarStack.length || '';
 
+  // A bar showing its tree keeps it, so there the peek has no list to show and
+  // the count in the corner of the button is the only thing that moves - which
+  // reads as a key that does nothing. The button it belongs to says so instead.
+  bar.stackButton.classList.toggle('peeking', selectionBarPeekActive && !bar.dom.classList.contains('stackVisible'));
+
   if(!bar.dom.classList.contains('stackVisible'))
     return;
 
@@ -888,15 +948,16 @@ function selectionBarRenderStack(bar) {
   // carried that sentence permanently, and a tooltip is no place for it. A
   // finger has neither the modifiers nor the keys, so a list it filled is only
   // told the one thing it can do.
+  // The keys are the same either way, so only the first line differs: a list the
+  // pointer is towing along has moved on by the time the pointer has travelled
+  // to one of its rows, so it names the keys rather than sending anyone clicking.
+  const keyHelp = '<br>↑ ↓ step through the list, Enter selects, Esc closes it.';
   if(selectionBarStack.length)
     div(bar.stackList, 'selectionBarStackHelp', selectionBarStackFromTouch
       ? 'Tap a row to select that widget.'
       : selectionBarPeekActive
-      ? 'Following the pointer while Ctrl is held - press the key shown to select that widget,'
-        + ' shift-click a row or hold Shift with the key to add it to the selection.'
-      : 'Click to select, shift-click to add to the selection, or press the key shown.'
-        + '<br>↑ ↓ step through the list, Enter selects, Esc closes it.'
-        + '<br>Hold Ctrl to have the list follow the pointer instead of waiting for it to settle.');
+      ? 'Following the pointer while Ctrl is held - the key shown selects, Shift with it adds.' + keyHelp
+      : 'Click to select, shift-click to add to the selection, or press the key shown.' + keyHelp);
 
   for(const [ index, widget ] of selectionBarStack.entries()) {
     const hotkey = index < 3 ? `F${index+1}` : index < 10 ? `F${index+3}` : '';
@@ -913,7 +974,8 @@ function selectionBarRenderStack(bar) {
     // tooltip carries them - together with the id, which can be cut off too once
     // there is nothing left to give
     row.title = `${widget.id}${notes ? ` - ${notes}` : ''} - z ${widget.calculateZ()}`
-              + ' - click to select, shift-click to add to the selection';
+              + ' - click to select, shift-click to add to the selection'
+              + (jeEnabled && !selectionBarPeekActive ? '\nCtrl+click pastes the id into the JSON text' : '');
     row.onmouseenter = _=>widget.domElement.classList.add('selectionBarHover');
     row.onmouseleave = _=>widget.domElement.classList.remove('selectionBarHover');
     row.onclick = function(e) {
@@ -1088,7 +1150,7 @@ function renderSelectionBar(target, options = {}) {
     bar.treeButton = selectionBarButton(bar.dom, 'account_tree', 'The widget tree of the room', _=>selectionBarToggleTree(bar, false, true));
   if(options.stack) {
     const stackTitle = 'The widgets under the pointer, or where you last tapped'
-                     + (selectionBarCanAltClick() ? ' - hold Ctrl to open this while the pointer moves, Alt+click in the room steps through them' : '');
+                     + (selectionBarCanAltClick() ? '\nHold Ctrl to open the list and have it follow the pointer.\nAlt+click in the room steps through them.' : '');
     bar.stackButton = selectionBarButton(bar.dom, 'layers', stackTitle, _=>selectionBarToggleStack(bar));
     bar.stackCount = document.createElement('span');
     bar.stackCount.className = 'selectionBarStackCount';
@@ -1167,7 +1229,7 @@ function selectionBarDeltaReceived(delta) {
 // be left on a widget while the game is played, and the rows and F keys of a
 // stack from another session must not still point somewhere.
 function selectionBarResetStack() {
-  selectionBarPeekStop();
+  selectionBarPeekRelease();
   selectionBarCancelScan();
   selectionBarStack = [];
   selectionBarResetStackCursor();

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -4425,6 +4425,18 @@ test('The keyboard walks an open dropdown and Escape closes it', async t => {
 const holdPeekKey = ClientFunction(down => {
   window.dispatchEvent(new KeyboardEvent(down ? 'keydown' : 'keyup', { key: 'Shift', shiftKey: down, bubbles: true, cancelable: true }));
 });
+// A real browser carries the modifier state into the mouse events as well, which
+// is what opens the list when the key went down before the pointer ever reached
+// the room. The move is dispatched on the element it lands on, since testcafe
+// cannot hold a key down across a hover either.
+const movePointerWithPeekKey = ClientFunction(selector => {
+  const rect = document.querySelector(selector).getBoundingClientRect();
+  const x = Math.round(rect.left + rect.width/2), y = Math.round(rect.top + rect.height/2);
+  document.elementFromPoint(x, y).dispatchEvent(new MouseEvent('mousemove', { clientX: x, clientY: y, shiftKey: true, bubbles: true }));
+});
+const pressKeyWithoutPeekKey = ClientFunction(key => {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+});
 const pressFunctionKeyWithShift = ClientFunction(key => {
   const event = new KeyboardEvent('keydown', { key, shiftKey: true, bubbles: true, cancelable: true });
   window.dispatchEvent(event);
@@ -4491,6 +4503,15 @@ test('Holding Shift opens the stack list and has it follow the pointer', async t
     // a list that only stood while the key was down is not the dropdown that
     // comes back with the module the next time it is opened
     .expect(storedStackOpen()).notOk();
+
+  // an OS-level menu or shortcut can take the keyup without ever blurring the
+  // window, which would leave the list latched open and scanning every frame -
+  // the next keystroke says the key is not down after all
+  await t.hover('#w_checker');
+  await holdPeekKey(true);
+  await t.expect(bar.hasClass('stackVisible')).ok();
+  await pressKeyWithoutPeekKey('Control');
+  await t.expect(bar.hasClass('stackVisible')).notOk();
 
   // a list somebody opened themselves is only made live by the key, and stays
   // open when it is let go
@@ -4566,6 +4587,21 @@ test('The peek key works with the caret in the JSON text area', async t => {
     .expect(bar.hasClass('stackVisible')).notOk()
     .expect(activeElementID()).eql('jeText')
     .expect(storedStackOpen()).notOk();
+
+  // Putting the caret on a line leaves the pointer over the editor, so in this
+  // module the key is normally down before the pointer gets anywhere near the
+  // room: the pointer arriving there has to open the list just as the key going
+  // down does.
+  await t.hover(bar.find('.selectionBarCrumbs'));
+  await holdPeekKey(true);
+  await t.expect(bar.hasClass('stackVisible')).notOk();
+  await movePointerWithPeekKey('#w_checker');
+  await t
+    .expect(bar.hasClass('stackVisible')).ok()
+    .expect(stackRows.count).eql(2)
+    .expect(activeElementID()).eql('jeText');
+  await holdPeekKey(false);
+  await t.expect(bar.hasClass('stackVisible')).notOk();
   await setEditorState(null);
 });
 

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -4418,12 +4418,12 @@ test('The keyboard walks an open dropdown and Escape closes it', async t => {
 
 // The list is a click away and takes the stack where the pointer came to rest,
 // which the panel it replaces did not: that one stood permanently in the JSON
-// editor and followed every mouse move. Holding Shift is that panel back.
+// editor and followed every mouse move. Holding Ctrl is that panel back.
 // testcafe cannot hold a key down across other actions, so the two events the
 // peek is built on are dispatched by hand - together with the modifier state a
 // real browser would carry into whatever is pressed in between.
 const holdPeekKey = ClientFunction(down => {
-  window.dispatchEvent(new KeyboardEvent(down ? 'keydown' : 'keyup', { key: 'Shift', shiftKey: down, bubbles: true, cancelable: true }));
+  window.dispatchEvent(new KeyboardEvent(down ? 'keydown' : 'keyup', { key: 'Control', ctrlKey: down, bubbles: true, cancelable: true }));
 });
 // A real browser carries the modifier state into the mouse events as well, which
 // is what opens the list when the key went down before the pointer ever reached
@@ -4432,13 +4432,13 @@ const holdPeekKey = ClientFunction(down => {
 const movePointerWithPeekKey = ClientFunction(selector => {
   const rect = document.querySelector(selector).getBoundingClientRect();
   const x = Math.round(rect.left + rect.width/2), y = Math.round(rect.top + rect.height/2);
-  document.elementFromPoint(x, y).dispatchEvent(new MouseEvent('mousemove', { clientX: x, clientY: y, shiftKey: true, bubbles: true }));
+  document.elementFromPoint(x, y).dispatchEvent(new MouseEvent('mousemove', { clientX: x, clientY: y, ctrlKey: true, bubbles: true }));
 });
 const pressKeyWithoutPeekKey = ClientFunction(key => {
   window.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
 });
-const pressFunctionKeyWithShift = ClientFunction(key => {
-  const event = new KeyboardEvent('keydown', { key, shiftKey: true, bubbles: true, cancelable: true });
+const pressFunctionKeyWithPeekKey = ClientFunction((key, shift) => {
+  const event = new KeyboardEvent('keydown', { key, ctrlKey: true, shiftKey: !!shift, bubbles: true, cancelable: true });
   window.dispatchEvent(event);
   return event.defaultPrevented;
 });
@@ -4451,7 +4451,7 @@ const storedTreeOpen = ClientFunction(_=>{
   return !!(state.selectionBar || {}).treeOpen;
 });
 
-test('Holding Shift opens the stack list and has it follow the pointer', async t => {
+test('Holding Ctrl opens the stack list and has it follow the pointer', async t => {
   await t.resizeWindow(1280, 800);
   await setRoomState({
     board:   { id: 'board',   type: 'basic',  x: 0,   y: 0,   width: 1600, height: 1000, layer: -4, movableInEdit: false },
@@ -4473,7 +4473,7 @@ test('Holding Shift opens the stack list and has it follow the pointer', async t
     .expect(bar.hasClass('stackVisible')).notOk()
     // the key says "what is under the pointer", so it does nothing while the
     // pointer is not in the room - a dropdown covers the panel it hangs in, and
-    // a shift-click in the sidebar must not have the list drop onto it
+    // a Ctrl+click in the sidebar must not have the list drop onto it
     .hover(bar.find('.selectionBarCrumbs'));
   await holdPeekKey(true);
   await t.expect(bar.hasClass('stackVisible')).notOk();
@@ -4491,11 +4491,15 @@ test('Holding Shift opens the stack list and has it follow the pointer', async t
     .expect(stackRows.nth(0).textContent).contains('board')
     .hover('#w_checker')
     .expect(stackRows.count).eql(3)
-    // Shift is what holds the list open, so the key of a row selects that row on
-    // its own rather than adding it to the selection
-    .expect(pressFunctionKeyWithShift('F3')).ok()
+    // the key that holds the list open is not read as a modifier while it does,
+    // so the keys of the rows mean what the rows say they mean: the key of a row
+    // selects it, and Shift with that key adds it to the selection
+    .expect(pressFunctionKeyWithPeekKey('F3')).ok()
     .expect(Selector('#w_board').hasClass('selectedInEdit')).ok()
-    .expect(Selector('#w_checker').hasClass('selectedInEdit')).notOk();
+    .expect(Selector('#w_checker').hasClass('selectedInEdit')).notOk()
+    .expect(pressFunctionKeyWithPeekKey('F1', true)).ok()
+    .expect(Selector('#w_board').hasClass('selectedInEdit')).ok()
+    .expect(Selector('#w_checker').hasClass('selectedInEdit')).ok();
 
   await holdPeekKey(false);
   await t

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -4673,6 +4673,66 @@ test('The peek key works with the caret in the JSON text area', async t => {
   await setEditorState(null);
 });
 
+// Pasting the id of a row into the JSON text is what Ctrl has always meant here,
+// and it is now also the key that holds the peeked list open. Which of the two it
+// is is decided by where the pointer is: from a row of the list - or anywhere
+// else outside the room - it is the modifier, whether the list was opened by hand
+// or is being held open by the key.
+test('Ctrl pastes the id of a row into the JSON text from outside the room', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    board:   { id: 'board',   type: 'basic', x: 0,  y: 0,  width: 1600, height: 1000, layer: -4, movableInEdit: false },
+    checker: { id: 'checker', type: 'basic', x: 40, y: 60, width: 100,  height: 100 }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState({ modules: { JSON: 'editorModuleTopLeft' } });
+  await setName(t);
+
+  const bar = Selector('#editorModuleTopLeft .selectionBar');
+  const stackRows = bar.find('.selectionBarStackRow');
+
+  await t
+    .click('#editButton')
+    .expect(Selector('#editorModuleTopLeft.data_object').exists).ok()
+    .click('#w_checker')
+    .click(bar.find('button[icon=layers]'))
+    .hover('#w_checker')
+    .expect(stackRows.count).eql(2)
+    // the rows say so themselves while the JSON editor is what an id would go into
+    .expect(stackRows.nth(1).getAttribute('title')).contains('Ctrl+click pastes the id')
+    // travelling to the list takes the pointer out of the room, which is where
+    // the key goes back to being the modifier
+    .hover(stackRows.nth(1));
+  await putCursorBehind('"width": 100');
+  await t
+    .expect(pressFunctionKeyWithPeekKey('F2')).ok()
+    .expect(jsonEditorText()).contains('"width": 100board')
+    // the row the key names pastes the same id when it is clicked with Ctrl
+    .expect(Selector('#w_board').hasClass('selectedInEdit')).notOk();
+  await putCursorBehind('"width": 100');
+  await t
+    .click(stackRows.nth(0), { modifiers: { ctrl: true } })
+    .expect(jsonEditorText()).contains('"width": 100checker')
+    .expect(Selector('#w_checker').hasClass('selectedInEdit')).ok();
+
+  // a list the key is holding open is no different once the pointer is on one of
+  // its rows: it stopped following the pointer when that left the room, and it
+  // says so rather than going on claiming to follow it
+  await t.hover('#w_checker');
+  await holdPeekKey(true);
+  await t
+    .expect(bar.hasClass('stackVisible')).ok()
+    .expect(bar.find('.selectionBarStackHelp').textContent).contains('Following the pointer')
+    .hover(stackRows.nth(1))
+    .expect(bar.find('.selectionBarStackHelp').textContent).notContains('Following the pointer');
+  await putCursorBehind('"width": 100');
+  await t
+    .click(stackRows.nth(1), { modifiers: { ctrl: true } })
+    .expect(jsonEditorText()).contains('"width": 100board');
+  await holdPeekKey(false);
+  await setEditorState(null);
+});
+
 // What the panel paints under an open dropdown. A widget preview is a real
 // widget, so it carries the widget's own z-index ((layer + 10) * 100000 + z) -
 // which, off the table, beats everything the module draws around it. The seat

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -4434,6 +4434,10 @@ const storedStackOpen = ClientFunction(_=>{
   const state = JSON.parse(localStorage.getItem('editorState') || '{}');
   return !!(state.selectionBar || {}).stackOpen;
 });
+const storedTreeOpen = ClientFunction(_=>{
+  const state = JSON.parse(localStorage.getItem('editorState') || '{}');
+  return !!(state.selectionBar || {}).treeOpen;
+});
 
 test('Holding Shift opens the stack list and has it follow the pointer', async t => {
   await t.resizeWindow(1280, 800);
@@ -4448,6 +4452,7 @@ test('Holding Shift opens the stack list and has it follow the pointer', async t
 
   const bar = Selector('#editorModuleTopLeft .selectionBar');
   const stackRows = bar.find('.selectionBarStackRow');
+  const tree = Selector('#editorModuleTopLeft .selectionBarTree #jeTree');
 
   await t
     .click('#editButton')
@@ -4499,6 +4504,57 @@ test('Holding Shift opens the stack list and has it follow the pointer', async t
     .expect(bar.hasClass('stackVisible')).ok()
     .expect(storedStackOpen()).ok()
     .click(bar.find('button[icon=layers]'));
+
+  // the tree is the other dropdown and they share the space below the bar, so
+  // showing the list where the tree is would mean taking the tree down - which
+  // is somebody's filter box, keyboard and scroll position. The key leaves it
+  // standing and only makes the stack follow the pointer.
+  await t
+    .click(bar.find('button[icon=account_tree]'))
+    .expect(tree.exists).ok()
+    .expect(activeElementID()).eql('jeWidgetSearchBox')
+    .hover('#w_checker');
+  await holdPeekKey(true);
+  await t
+    .expect(tree.exists).ok()
+    .expect(bar.hasClass('stackVisible')).notOk()
+    // so a capital typed into the filter box still goes into it
+    .expect(activeElementID()).eql('jeWidgetSearchBox')
+    .expect(storedTreeOpen()).ok();
+  await holdPeekKey(false);
+  await t
+    .expect(tree.exists).ok()
+    .expect(storedTreeOpen()).ok()
+    .click(bar.find('button[icon=account_tree]'));
+  await setEditorState(null);
+});
+
+// Shift is how capitals are typed, so a text field has first claim on it: the
+// JSON text area keeps the key even with the pointer parked over the room.
+test('The peek key does nothing while a text field has the keyboard', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    board:   { id: 'board',   type: 'basic', x: 0,  y: 0,  width: 1600, height: 1000, layer: -4, movableInEdit: false },
+    checker: { id: 'checker', type: 'basic', x: 40, y: 60, width: 100,  height: 100 }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState({ modules: { JSON: 'editorModuleTopLeft' } });
+  await setName(t);
+
+  const bar = Selector('#editorModuleTopLeft .selectionBar');
+
+  await t
+    .click('#editButton')
+    .expect(Selector('#editorModuleTopLeft.data_object').exists).ok()
+    .click('#w_checker')
+    .click('#jeText')
+    .expect(activeElementID()).eql('jeText')
+    .hover('#w_checker');
+  await holdPeekKey(true);
+  await t
+    .expect(bar.hasClass('stackVisible')).notOk()
+    .expect(activeElementID()).eql('jeText');
+  await holdPeekKey(false);
   await setEditorState(null);
 });
 

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -4416,6 +4416,92 @@ test('The keyboard walks an open dropdown and Escape closes it', async t => {
   await setEditorState(null);
 });
 
+// The list is a click away and takes the stack where the pointer came to rest,
+// which the panel it replaces did not: that one stood permanently in the JSON
+// editor and followed every mouse move. Holding Shift is that panel back.
+// testcafe cannot hold a key down across other actions, so the two events the
+// peek is built on are dispatched by hand - together with the modifier state a
+// real browser would carry into whatever is pressed in between.
+const holdPeekKey = ClientFunction(down => {
+  window.dispatchEvent(new KeyboardEvent(down ? 'keydown' : 'keyup', { key: 'Shift', shiftKey: down, bubbles: true, cancelable: true }));
+});
+const pressFunctionKeyWithShift = ClientFunction(key => {
+  const event = new KeyboardEvent('keydown', { key, shiftKey: true, bubbles: true, cancelable: true });
+  window.dispatchEvent(event);
+  return event.defaultPrevented;
+});
+const storedStackOpen = ClientFunction(_=>{
+  const state = JSON.parse(localStorage.getItem('editorState') || '{}');
+  return !!(state.selectionBar || {}).stackOpen;
+});
+
+test('Holding Shift opens the stack list and has it follow the pointer', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    board:   { id: 'board',   type: 'basic',  x: 0,   y: 0,   width: 1600, height: 1000, layer: -4, movableInEdit: false },
+    point:   { id: 'point',   type: 'holder', x: 300, y: 200, width: 200,  height: 400, classes: 'transparent' },
+    checker: { id: 'checker', type: 'basic',  x: 40,  y: 60,  width: 100,  height: 100, parent: 'point' }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState(propertiesModuleOpen);
+  await setName(t);
+
+  const bar = Selector('#editorModuleTopLeft .selectionBar');
+  const stackRows = bar.find('.selectionBarStackRow');
+
+  await t
+    .click('#editButton')
+    .expect(propertiesModule.exists).ok()
+    .click('#w_checker')
+    .expect(bar.hasClass('stackVisible')).notOk()
+    // the key says "what is under the pointer", so it does nothing while the
+    // pointer is not in the room - a dropdown covers the panel it hangs in, and
+    // a shift-click in the sidebar must not have the list drop onto it
+    .hover(bar.find('.selectionBarCrumbs'));
+  await holdPeekKey(true);
+  await t.expect(bar.hasClass('stackVisible')).notOk();
+  await holdPeekKey(false);
+
+  await t.hover('#w_checker');
+  await holdPeekKey(true);
+  await t
+    .expect(bar.hasClass('stackVisible')).ok()
+    .expect(stackRows.count).eql(3)
+    // and it follows the pointer while the key is down instead of standing on
+    // the spot the pointer last came to rest on
+    .hover('#w_board', { offsetX: 20, offsetY: 20 })
+    .expect(stackRows.count).eql(1)
+    .expect(stackRows.nth(0).textContent).contains('board')
+    .hover('#w_checker')
+    .expect(stackRows.count).eql(3)
+    // Shift is what holds the list open, so the key of a row selects that row on
+    // its own rather than adding it to the selection
+    .expect(pressFunctionKeyWithShift('F3')).ok()
+    .expect(Selector('#w_board').hasClass('selectedInEdit')).ok()
+    .expect(Selector('#w_checker').hasClass('selectedInEdit')).notOk();
+
+  await holdPeekKey(false);
+  await t
+    .expect(bar.hasClass('stackVisible')).notOk()
+    // a list that only stood while the key was down is not the dropdown that
+    // comes back with the module the next time it is opened
+    .expect(storedStackOpen()).notOk();
+
+  // a list somebody opened themselves is only made live by the key, and stays
+  // open when it is let go
+  await t
+    .click(bar.find('button[icon=layers]'))
+    .hover('#w_checker')
+    .expect(stackRows.count).eql(3);
+  await holdPeekKey(true);
+  await holdPeekKey(false);
+  await t
+    .expect(bar.hasClass('stackVisible')).ok()
+    .expect(storedStackOpen()).ok()
+    .click(bar.find('button[icon=layers]'));
+  await setEditorState(null);
+});
+
 // What the panel paints under an open dropdown. A widget preview is a real
 // widget, so it carries the widget's own z-index ((layer + 10) * 100000 + z) -
 // which, off the table, beats everything the module draws around it. The seat

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -4538,6 +4538,17 @@ test('Holding Ctrl opens the stack list and has it follow the pointer', async t 
   await t
     .wait(600)
     .expect(bar.hasClass('stackVisible')).notOk();
+  // the list stays away, but the stack behind it goes on being taken where the
+  // pointer rests: the count on the button and the widget an F key addresses are
+  // the ones under the pointer now, not the ones it was over when the chord was
+  // typed. The move carries the key that is still held, the way a real one does.
+  await movePointerWithPeekKey('#w_board');
+  await t
+    .expect(bar.find('.selectionBarStackCount').textContent).eql('1')
+    .expect(pressFunctionKeyWithPeekKey('F1')).ok()
+    .expect(Selector('#w_board').hasClass('selectedInEdit')).ok()
+    .expect(Selector('#w_checker').hasClass('selectedInEdit')).notOk()
+    .expect(bar.hasClass('stackVisible')).notOk();
   await holdPeekKey(false);
   // pressed again, on its own, it opens as before
   await holdPeekKey(true);

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -4500,6 +4500,9 @@ test('Holding Ctrl opens the stack list and has it follow the pointer', async t 
     .expect(peekKeyDownOpensListAtOnce()).notOk()
     .expect(bar.hasClass('stackVisible')).ok()
     .expect(stackRows.count).eql(3)
+    // nothing else holds the keyboard here, so the arrows and Enter reach the
+    // list and the help line offers them
+    .expect(bar.find('.selectionBarStackHelp').textContent).contains('step through the list')
     // and it follows the pointer while the key is down instead of standing on
     // the spot the pointer last came to rest on
     .hover('#w_board', { offsetX: 20, offsetY: 20 })
@@ -4630,6 +4633,10 @@ test('The peek key works with the caret in the JSON text area', async t => {
     // the caret stays where it was: the list is a dropdown of the bar, not
     // something that takes the keyboard off what is being typed in
     .expect(activeElementID()).eql('jeText')
+    // ... which is why the arrows and Enter do not reach the list here, so the
+    // help line names only the keys that do
+    .expect(bar.find('.selectionBarStackHelp').textContent).notContains('step through the list')
+    .expect(bar.find('.selectionBarStackHelp').textContent).contains('Esc closes it.')
     .hover('#w_board', { offsetX: 20, offsetY: 20 })
     .expect(stackRows.count).eql(1);
   await holdPeekKey(false);

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -4437,6 +4437,19 @@ const movePointerWithPeekKey = ClientFunction(selector => {
 const pressKeyWithoutPeekKey = ClientFunction(key => {
   window.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
 });
+const pressKeyWithPeekKey = ClientFunction(key => {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key, ctrlKey: true, bubbles: true, cancelable: true }));
+});
+// The list must not be there in the same tick the key goes down: a chord starts
+// with the same key, and a dropdown the width of the panel flashing over it for
+// the length of a keystroke is what the hold has to be told apart from.
+const peekKeyDownOpensListAtOnce = ClientFunction(_=>{
+  window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Control', ctrlKey: true, bubbles: true, cancelable: true }));
+  return document.querySelector('#editorModuleTopLeft .selectionBar').classList.contains('stackVisible');
+});
+const pressEscapeWithPeekKey = ClientFunction(_=>{
+  window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', ctrlKey: true, bubbles: true, cancelable: true }));
+});
 const pressFunctionKeyWithPeekKey = ClientFunction((key, shift) => {
   const event = new KeyboardEvent('keydown', { key, ctrlKey: true, shiftKey: !!shift, bubbles: true, cancelable: true });
   window.dispatchEvent(event);
@@ -4479,9 +4492,12 @@ test('Holding Ctrl opens the stack list and has it follow the pointer', async t 
   await t.expect(bar.hasClass('stackVisible')).notOk();
   await holdPeekKey(false);
 
+  // the same key starts Ctrl+Z, Ctrl+J and every other chord of the editor, so
+  // it has to be held to mean the list: nothing drops over the panel in the tick
+  // the key goes down
   await t.hover('#w_checker');
-  await holdPeekKey(true);
   await t
+    .expect(peekKeyDownOpensListAtOnce()).notOk()
     .expect(bar.hasClass('stackVisible')).ok()
     .expect(stackRows.count).eql(3)
     // and it follows the pointer while the key is down instead of standing on
@@ -4507,6 +4523,32 @@ test('Holding Ctrl opens the stack list and has it follow the pointer', async t 
     // a list that only stood while the key was down is not the dropdown that
     // comes back with the module the next time it is opened
     .expect(storedStackOpen()).notOk();
+
+  // a chord is the key plus a key the list knows nothing about, and it leaves
+  // the list away for the rest of the hold rather than opening it once the chord
+  // is over. The letter stands for Ctrl+Z, Ctrl+J and the rest of them - it is
+  // one the editor has no shortcut on, so the room it is typed over is left
+  // exactly as it was.
+  await t.hover('#w_checker');
+  await holdPeekKey(true);
+  await pressKeyWithPeekKey('q');
+  await t
+    .wait(600)
+    .expect(bar.hasClass('stackVisible')).notOk();
+  await holdPeekKey(false);
+  // pressed again, on its own, it opens as before
+  await holdPeekKey(true);
+  await t.expect(bar.hasClass('stackVisible')).ok();
+
+  // Escape puts a peeked list away like any other, and the key that is still
+  // held must not bring it straight back
+  await pressEscapeWithPeekKey();
+  await t.expect(bar.hasClass('stackVisible')).notOk();
+  await movePointerWithPeekKey('#w_checker');
+  await t
+    .wait(600)
+    .expect(bar.hasClass('stackVisible')).notOk();
+  await holdPeekKey(false);
 
   // an OS-level menu or shortcut can take the keyup without ever blurring the
   // window, which would leave the list latched open and scanning every frame -
@@ -4541,6 +4583,9 @@ test('Holding Ctrl opens the stack list and has it follow the pointer', async t 
     .hover('#w_checker');
   await holdPeekKey(true);
   await t
+    // with no list on screen the button the stack belongs to is what says the
+    // key is doing anything
+    .expect(bar.find('button[icon=layers]').hasClass('peeking')).ok()
     .expect(tree.exists).ok()
     .expect(bar.hasClass('stackVisible')).notOk()
     // so a capital typed into the filter box still goes into it
@@ -4548,6 +4593,7 @@ test('Holding Ctrl opens the stack list and has it follow the pointer', async t 
     .expect(storedTreeOpen()).ok();
   await holdPeekKey(false);
   await t
+    .expect(bar.find('button[icon=layers]').hasClass('peeking')).notOk()
     .expect(tree.exists).ok()
     .expect(storedTreeOpen()).ok()
     .click(bar.find('button[icon=account_tree]'));

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -4477,6 +4477,26 @@ const turnWheel = ClientFunction((selector, deltaY, withPeekKey) => {
   document.elementFromPoint(x, y).dispatchEvent(event);
   return event.defaultPrevented;
 });
+// A click of the middle button where the pointer is, dispatched on the element
+// under it the way the wheel turn above is. The release goes with it, or a press
+// the room did get to see would leave the widget latched into a drag. Returns
+// whether the list took the press: the room's own input handling listens on the
+// window on the way back up, so a press the list used up never gets there - and
+// the room preventDefault()s everything it does see, which makes the default the
+// wrong thing to ask about here.
+const pressMiddleButton = ClientFunction((selector, withPeekKey, shift) => {
+  const rect = document.querySelector(selector).getBoundingClientRect();
+  const x = Math.round(rect.left + rect.width/2), y = Math.round(rect.top + rect.height/2);
+  const options = { button: 1, buttons: 4, ctrlKey: withPeekKey, shiftKey: !!shift, clientX: x, clientY: y, bubbles: true, cancelable: true };
+  const target = document.elementFromPoint(x, y);
+  let reachedRoom = false;
+  const spy = _=>{ reachedRoom = true; };
+  window.addEventListener('mousedown', spy);
+  target.dispatchEvent(new MouseEvent('mousedown', options));
+  window.removeEventListener('mousedown', spy);
+  target.dispatchEvent(new MouseEvent('mouseup', Object.assign({}, options, { buttons: 0 })));
+  return !reachedRoom;
+});
 const roomZoom = ClientFunction(_=>getComputedStyle(document.documentElement).getPropertyValue('--zoom').trim());
 const storedStackOpen = ClientFunction(_=>{
   const state = JSON.parse(localStorage.getItem('editorState') || '{}');
@@ -4791,6 +4811,70 @@ test('The wheel steps the peeked list instead of zooming the room', async t => {
   await t.expect(bar.hasClass('stackVisible')).notOk();
   await t.expect(await turnWheel('#w_checker', -120, false)).ok();
   await t.expect(roomZoom()).notEql(zoom);
+  await setEditorState(null);
+});
+
+// Stepping the list with the wheel leaves the hand on the mouse, so the middle
+// button takes the row it landed on - the same thing Enter does on it, and the
+// half of the gesture that keeps the pointer on the widget being read.
+test('The middle mouse button takes the row the wheel stepped to', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    board:   { id: 'board',   type: 'basic',  x: 0,   y: 0,   width: 1600, height: 1000, layer: -4, movableInEdit: false },
+    point:   { id: 'point',   type: 'holder', x: 300, y: 200, width: 200,  height: 400, classes: 'transparent' },
+    checker: { id: 'checker', type: 'basic',  x: 40,  y: 60,  width: 100,  height: 100, parent: 'point' }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState(propertiesModuleOpen);
+  await setName(t);
+
+  const bar = Selector('#editorModuleTopLeft .selectionBar');
+  const stackRows = bar.find('.selectionBarStackRow');
+
+  await t
+    .click('#editButton')
+    .expect(propertiesModule.exists).ok()
+    .click('#w_board')
+    .hover('#w_checker');
+  await holdPeekKey(true);
+  await t
+    .expect(bar.hasClass('stackVisible')).ok()
+    .expect(stackRows.count).eql(3)
+    // the help line names the button next to the key that does the same thing
+    .expect(bar.find('.selectionBarStackHelp').textContent).contains('Enter or the middle mouse button selects');
+
+  // a press that no key and no wheel has aimed at a row is left where it was:
+  // in edit mode the middle button is what plays a widget
+  await t.expect(await pressMiddleButton('#w_checker', true)).notOk();
+  await t.expect(Selector('#w_checker').hasClass('selectedInEdit')).notOk();
+
+  await turnWheel('#w_checker', 120, true);
+  await turnWheel('#w_checker', 120, true);
+  await t.expect(stackRows.nth(1).hasClass('selectionBarKeyRow')).ok();
+  await t.expect(await pressMiddleButton('#w_checker', true)).ok();
+  await t
+    .expect(Selector('#w_point').hasClass('selectedInEdit')).ok()
+    .expect(Selector('#w_board').hasClass('selectedInEdit')).notOk();
+
+  // Shift with it adds the row to the selection, the way it does with Enter
+  await turnWheel('#w_checker', 120, true);
+  await t.expect(stackRows.nth(2).hasClass('selectionBarKeyRow')).ok();
+  await t.expect(await pressMiddleButton('#w_checker', true, true)).ok();
+  await t
+    .expect(Selector('#w_board').hasClass('selectedInEdit')).ok()
+    .expect(Selector('#w_point').hasClass('selectedInEdit')).ok();
+
+  // out on a row of the list the pointer has a row of its own to click, so the
+  // button is left to whatever it means in the editor
+  await movePointerWithPeekKey([ '#editorModuleTopLeft .selectionBarCrumbs' ]);
+  await t.expect(await pressMiddleButton('#editorModuleTopLeft .selectionBarStackRow', true)).notOk();
+  await holdPeekKey(false);
+
+  // and with nothing holding the list open the button is the room's again
+  await t
+    .expect(bar.hasClass('stackVisible')).notOk()
+    .hover('#w_checker');
+  await t.expect(await pressMiddleButton('#w_checker', false)).notOk();
   await setEditorState(null);
 });
 

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -4529,9 +4529,10 @@ test('Holding Shift opens the stack list and has it follow the pointer', async t
   await setEditorState(null);
 });
 
-// Shift is how capitals are typed, so a text field has first claim on it: the
-// JSON text area keeps the key even with the pointer parked over the room.
-test('The peek key does nothing while a text field has the keyboard', async t => {
+// Reading a widget's name off the room while the caret sits in the JSON text
+// area is what the panel this list replaces was there for, so the key works
+// with the keyboard in a text field - it takes nothing away from it.
+test('The peek key works with the caret in the JSON text area', async t => {
   await t.resizeWindow(1280, 800);
   await setRoomState({
     board:   { id: 'board',   type: 'basic', x: 0,  y: 0,  width: 1600, height: 1000, layer: -4, movableInEdit: false },
@@ -4542,6 +4543,7 @@ test('The peek key does nothing while a text field has the keyboard', async t =>
   await setName(t);
 
   const bar = Selector('#editorModuleTopLeft .selectionBar');
+  const stackRows = bar.find('.selectionBarStackRow');
 
   await t
     .click('#editButton')
@@ -4552,9 +4554,18 @@ test('The peek key does nothing while a text field has the keyboard', async t =>
     .hover('#w_checker');
   await holdPeekKey(true);
   await t
-    .expect(bar.hasClass('stackVisible')).notOk()
-    .expect(activeElementID()).eql('jeText');
+    .expect(bar.hasClass('stackVisible')).ok()
+    .expect(stackRows.count).eql(2)
+    // the caret stays where it was: the list is a dropdown of the bar, not
+    // something that takes the keyboard off what is being typed in
+    .expect(activeElementID()).eql('jeText')
+    .hover('#w_board', { offsetX: 20, offsetY: 20 })
+    .expect(stackRows.count).eql(1);
   await holdPeekKey(false);
+  await t
+    .expect(bar.hasClass('stackVisible')).notOk()
+    .expect(activeElementID()).eql('jeText')
+    .expect(storedStackOpen()).notOk();
   await setEditorState(null);
 });
 

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -4443,10 +4443,14 @@ const movePointerWithPeekKey = ClientFunction(selectors => {
   return [].concat(selectors).reduce((chain, selector)=>chain.then(_=>{ move(selector); return frame(); }), Promise.resolve());
 });
 const pressKeyWithoutPeekKey = ClientFunction(key => {
-  window.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+  window.dispatchEvent(event);
+  return event.defaultPrevented;
 });
 const pressKeyWithPeekKey = ClientFunction(key => {
-  window.dispatchEvent(new KeyboardEvent('keydown', { key, ctrlKey: true, bubbles: true, cancelable: true }));
+  const event = new KeyboardEvent('keydown', { key, ctrlKey: true, bubbles: true, cancelable: true });
+  window.dispatchEvent(event);
+  return event.defaultPrevented;
 });
 // The list must not be there in the same tick the key goes down: a chord starts
 // with the same key, and a dropdown the width of the panel flashing over it for
@@ -4463,6 +4467,17 @@ const pressFunctionKeyWithPeekKey = ClientFunction((key, shift) => {
   window.dispatchEvent(event);
   return event.defaultPrevented;
 });
+// A turn of the wheel where the pointer is, dispatched on the element under it
+// so it travels the same way a real one does - the room's zoom-to-cursor listens
+// on #roomArea on the way back up. Returns whether the event was used up.
+const turnWheel = ClientFunction((selector, deltaY, withPeekKey) => {
+  const rect = document.querySelector(selector).getBoundingClientRect();
+  const x = Math.round(rect.left + rect.width/2), y = Math.round(rect.top + rect.height/2);
+  const event = new WheelEvent('wheel', { deltaY, ctrlKey: withPeekKey, clientX: x, clientY: y, bubbles: true, cancelable: true });
+  document.elementFromPoint(x, y).dispatchEvent(event);
+  return event.defaultPrevented;
+});
+const roomZoom = ClientFunction(_=>getComputedStyle(document.documentElement).getPropertyValue('--zoom').trim());
 const storedStackOpen = ClientFunction(_=>{
   const state = JSON.parse(localStorage.getItem('editorState') || '{}');
   return !!(state.selectionBar || {}).stackOpen;
@@ -4652,10 +4667,20 @@ test('The peek key works with the caret in the JSON text area', async t => {
     // the caret stays where it was: the list is a dropdown of the bar, not
     // something that takes the keyboard off what is being typed in
     .expect(activeElementID()).eql('jeText')
-    // ... which is why the arrows and Enter do not reach the list here, so the
-    // help line names only the keys that do
-    .expect(bar.find('.selectionBarStackHelp').textContent).notContains('step through the list')
-    .expect(bar.find('.selectionBarStackHelp').textContent).contains('Esc closes it.')
+    // ... and the keys of the list reach it all the same while the key holds it
+    // open, which is the whole posture: caret in a line of JSON, pointer on a
+    // widget. The arrows step the rows and the caret stays where it is.
+    .expect(bar.find('.selectionBarStackHelp').textContent).contains('or the wheel step through the list');
+  await t.expect(await pressKeyWithPeekKey('ArrowDown')).ok();
+  await t
+    .expect(stackRows.nth(0).hasClass('selectionBarKeyRow')).ok()
+    .expect(activeElementID()).eql('jeText');
+  await pressKeyWithPeekKey('ArrowDown');
+  await t.expect(stackRows.nth(1).hasClass('selectionBarKeyRow')).ok();
+  await pressKeyWithPeekKey('ArrowUp');
+  await t
+    .expect(stackRows.nth(0).hasClass('selectionBarKeyRow')).ok()
+    .expect(activeElementID()).eql('jeText')
     .hover('#w_board', { offsetX: 20, offsetY: 20 })
     .expect(stackRows.count).eql(1);
   await holdPeekKey(false);
@@ -4716,6 +4741,91 @@ test('The peeked list stops on the stack the pointer last rested on', async t =>
     .expect(stackRows.nth(0).find('.selectionBarStackId').textContent).eql('checker')
     .expect(bar.find('.selectionBarStackHelp').textContent).notContains('Following the pointer');
   await holdPeekKey(false);
+  await setEditorState(null);
+});
+
+// The hand that holds the key is on the mouse, so the wheel walks the list the
+// way the arrow keys do - and the room's zoom-to-cursor, which is what a turn of
+// the wheel means there otherwise, gives way for as long as the key is held.
+test('The wheel steps the peeked list instead of zooming the room', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    board:   { id: 'board',   type: 'basic',  x: 0,   y: 0,   width: 1600, height: 1000, layer: -4, movableInEdit: false },
+    point:   { id: 'point',   type: 'holder', x: 300, y: 200, width: 200,  height: 400, classes: 'transparent' },
+    checker: { id: 'checker', type: 'basic',  x: 40,  y: 60,  width: 100,  height: 100, parent: 'point' }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState(propertiesModuleOpen);
+  await setName(t);
+
+  const bar = Selector('#editorModuleTopLeft .selectionBar');
+  const stackRows = bar.find('.selectionBarStackRow');
+
+  await t
+    .click('#editButton')
+    .expect(propertiesModule.exists).ok()
+    .hover('#w_checker');
+  const zoom = await roomZoom();
+  await holdPeekKey(true);
+  await t
+    .expect(bar.hasClass('stackVisible')).ok()
+    .expect(stackRows.count).eql(3);
+
+  await t.expect(await turnWheel('#w_checker', 120, true)).ok();
+  await t
+    .expect(stackRows.nth(0).hasClass('selectionBarKeyRow')).ok()
+    // the row the wheel is on is outlined in the room, the way the arrows do it
+    .expect(Selector('#w_checker').hasClass('selectionBarHover')).ok()
+    .expect(roomZoom()).eql(zoom);
+  await turnWheel('#w_checker', 120, true);
+  await turnWheel('#w_checker', 120, true);
+  await t.expect(stackRows.nth(2).hasClass('selectionBarKeyRow')).ok();
+  // it wraps at the end of the list and turns back the other way
+  await turnWheel('#w_checker', 120, true);
+  await t.expect(stackRows.nth(0).hasClass('selectionBarKeyRow')).ok();
+  await turnWheel('#w_checker', -120, true);
+  await t.expect(stackRows.nth(2).hasClass('selectionBarKeyRow')).ok();
+  await holdPeekKey(false);
+
+  // with the list gone the wheel is the room zoom again
+  await t.expect(bar.hasClass('stackVisible')).notOk();
+  await t.expect(await turnWheel('#w_checker', -120, false)).ok();
+  await t.expect(roomZoom()).notEql(zoom);
+  await setEditorState(null);
+});
+
+// The list only has the arrow keys for as long as the key is held: they belong
+// to whatever owns the keyboard, and with the caret in a line of JSON that is
+// the text area. A keystroke that reports the key as up hands them back - which
+// is also what puts a list away whose keyup went to an OS-level shortcut.
+test('The arrow keys go back to the caret when the peek key is let go of', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    board:   { id: 'board',   type: 'basic', x: 0,  y: 0,  width: 1600, height: 1000, layer: -4, movableInEdit: false },
+    checker: { id: 'checker', type: 'basic', x: 40, y: 60, width: 100,  height: 100 }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState({ modules: { JSON: 'editorModuleTopLeft' } });
+  await setName(t);
+
+  const bar = Selector('#editorModuleTopLeft .selectionBar');
+  const stackRows = bar.find('.selectionBarStackRow');
+
+  await t
+    .click('#editButton')
+    .expect(Selector('#editorModuleTopLeft.data_object').exists).ok()
+    .click('#w_checker')
+    .click('#jeText')
+    .hover('#w_checker');
+  await holdPeekKey(true);
+  await t.expect(bar.hasClass('stackVisible')).ok();
+  await t.expect(await pressKeyWithPeekKey('ArrowDown')).ok();
+  await t.expect(stackRows.nth(0).hasClass('selectionBarKeyRow')).ok();
+
+  await t.expect(await pressKeyWithoutPeekKey('ArrowDown')).notOk();
+  await t
+    .expect(bar.hasClass('stackVisible')).notOk()
+    .expect(activeElementID()).eql('jeText');
   await setEditorState(null);
 });
 

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -4428,11 +4428,19 @@ const holdPeekKey = ClientFunction(down => {
 // A real browser carries the modifier state into the mouse events as well, which
 // is what opens the list when the key went down before the pointer ever reached
 // the room. The move is dispatched on the element it lands on, since testcafe
-// cannot hold a key down across a hover either.
-const movePointerWithPeekKey = ClientFunction(selector => {
-  const rect = document.querySelector(selector).getBoundingClientRect();
-  const x = Math.round(rect.left + rect.width/2), y = Math.round(rect.top + rect.height/2);
-  document.elementFromPoint(x, y).dispatchEvent(new MouseEvent('mousemove', { clientX: x, clientY: y, ctrlKey: true, bubbles: true }));
+// cannot hold a key down across a hover either. Given several selectors the
+// pointer travels over them one frame at a time: the list takes the stack of
+// every spot on the way, and no spot is held long enough to count as the pointer
+// having come to rest on it - which is the trip to a row of the list, and which
+// a hover cannot do either since it moves at a speed of its own.
+const movePointerWithPeekKey = ClientFunction(selectors => {
+  const move = selector => {
+    const rect = document.querySelector(selector).getBoundingClientRect();
+    const x = Math.round(rect.left + rect.width/2), y = Math.round(rect.top + rect.height/2);
+    document.elementFromPoint(x, y).dispatchEvent(new MouseEvent('mousemove', { clientX: x, clientY: y, ctrlKey: true, bubbles: true }));
+  };
+  const frame = _=>new Promise(resolve=>requestAnimationFrame(_=>requestAnimationFrame(resolve)));
+  return [].concat(selectors).reduce((chain, selector)=>chain.then(_=>{ move(selector); return frame(); }), Promise.resolve());
 });
 const pressKeyWithoutPeekKey = ClientFunction(key => {
   window.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
@@ -4673,6 +4681,44 @@ test('The peek key works with the caret in the JSON text area', async t => {
   await setEditorState(null);
 });
 
+// Getting to a row of the list means taking the pointer off the widget it was
+// read on and across the rest of the room, and a list that followed it all the
+// way out would be showing whatever it crossed by the time the pointer arrived -
+// the row that was aimed at gone from under the click.
+test('The peeked list stops on the stack the pointer last rested on', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    board:   { id: 'board',   type: 'basic', x: 0,  y: 0,  width: 1600, height: 1000, layer: -4, movableInEdit: false },
+    checker: { id: 'checker', type: 'basic', x: 40, y: 60, width: 100,  height: 100 }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState(propertiesModuleOpen);
+  await setName(t);
+
+  const bar = Selector('#editorModuleTopLeft .selectionBar');
+  const stackRows = bar.find('.selectionBarStackRow');
+
+  await t
+    .click('#editButton')
+    .expect(propertiesModule.exists).ok()
+    .hover('#w_checker');
+  await holdPeekKey(true);
+  await t
+    .expect(stackRows.count).eql(2)
+    .expect(stackRows.nth(0).find('.selectionBarStackId').textContent).eql('checker');
+
+  // the trip to a row: across the middle of the board, where the checker is not,
+  // and out of the room. The list takes the board on the way, and is back on the
+  // stack it was read at by the time the pointer is out
+  await movePointerWithPeekKey([ '#w_board', '#editorModuleTopLeft .selectionBarCrumbs' ]);
+  await t
+    .expect(stackRows.count).eql(2)
+    .expect(stackRows.nth(0).find('.selectionBarStackId').textContent).eql('checker')
+    .expect(bar.find('.selectionBarStackHelp').textContent).notContains('Following the pointer');
+  await holdPeekKey(false);
+  await setEditorState(null);
+});
+
 // Pasting the id of a row into the JSON text is what Ctrl has always meant here,
 // and it is now also the key that holds the peeked list open. Which of the two it
 // is is decided by where the pointer is: from a row of the list - or anywhere
@@ -4723,12 +4769,16 @@ test('Ctrl pastes the id of a row into the JSON text from outside the room', asy
   await t
     .expect(bar.hasClass('stackVisible')).ok()
     .expect(bar.find('.selectionBarStackHelp').textContent).contains('Following the pointer')
-    .hover(stackRows.nth(1))
+    .hover(stackRows.nth(0))
     .expect(bar.find('.selectionBarStackHelp').textContent).notContains('Following the pointer');
+  // the list stops on the stack the pointer set out from, but a hover travels at
+  // a speed of its own and can come to rest again on the way, so which widget the
+  // top row names is read off the list rather than assumed
+  const rowID = await stackRows.nth(0).find('.selectionBarStackId').textContent;
   await putCursorBehind('"width": 100');
   await t
-    .click(stackRows.nth(1), { modifiers: { ctrl: true } })
-    .expect(jsonEditorText()).contains('"width": 100board');
+    .click(stackRows.nth(0), { modifiers: { ctrl: true } })
+    .expect(jsonEditorText()).contains(`"width": 100${rowID}`);
   await holdPeekKey(false);
   await setEditorState(null);
 });


### PR DESCRIPTION
## Goal

Give keyboard users back the one-glance way to a covered widget in edit mode. The list of widgets under the pointer that the [selection bar](https://github.com/ArnoldSmith86/virtualtabletop/pull/3004) carries costs a click to open and only takes the stack once the pointer has come to rest for 120 ms. The eleven function-key rows it replaced stood permanently in the JSON editor and updated on every mouse move — so "hover a widget, read its name, press its F key" had turned into two steps and a wait.

This came out of a Discord conversation about exactly that loss:

> While editing with the JSON menu open, when you hover over a widget, its name is no longer previewed in an overlay. Has this feature purposefully been removed? I found it very useful.
>
> — Mitch

> I'm sure that stuff is useful for some people but the extra click loses so much efficiency. Being able to see the F-button and widget name was so efficient and convenient and it's something that I used tens, if not hundreds of times per mod.
>
> — Mitch

> It should also be better on touch devices now. But we can probably find a solution to give the power back to keyboard users. Maybe something like holding SHIFT or whatever button keeps that selector thing open and makes it update instantly instead of with a delay?
>
> — ArnoldSmith86, [#general](https://discord.com/channels/770758631146782780/770758631146782783/1543724423662665748)

Shift was what that suggestion named, but it is also the room's add-to-selection modifier, so the key moved after a maintainer picked the replacement:

> Use Ctrl instead
>
> — lawdawg96

The one thing the key costs in the JSON editor went to the maintainers as well: `Ctrl`+`F<n>` with the pointer on the widget used to paste that row's id into the JSON text and now selects the row instead. It stays that way —

> Leave it - ctrl-click on a row is enough
>
> — lawdawg96

— so the paste keeps every other route to it: a ctrl-click on a row, and `Ctrl`+`F<n>` with the pointer anywhere outside the room.

## What changed

Holding **Ctrl** while the pointer is over the room opens the stack list of the selection bar and has it follow the pointer for as long as the key is down:

- no click to open it, and no resting delay — the stack is taken on every mouse move, coalesced to at most one hit test per animation frame
- **the key has to be held.** Ctrl also starts `Ctrl`+`Z`, `Ctrl`+`J`, `Ctrl`+`S` and every other chord of the editor, and those are typed with the pointer over the room — a list the width of the panel must not drop over it for the length of a keystroke. Nothing appears until the key has been down for 200 ms, and any key the list does not answer to (anything but `F<n>`, `Shift`, `Esc`, the arrows and `Enter`) abandons the peek until the key is released. The delay is paid once: after it the key stays armed, so the pointer arriving in the room opens the list in the same frame. `Esc` uses the same latch — it puts the list away and the key does not bring it back until it is let go of
- releasing the key closes it again. A list that was **already** open is only made live: it belongs to whoever opened it
- a list the key opened is transient — it is not stored as the dropdown that comes back with the module the next time it is opened
- **the key that holds the list open is not read as a modifier while it does.** A peeked list answers to exactly the keys its rows and its help line name, the same ones as a list opened by hand: `F<n>` selects its row, `Shift`+`F<n>` and a shift-click add it to the selection, Escape closes the list, and `↑` `↓` step through its rows while `Enter` picks the one they land on. Those three reach a list the key is holding open **whatever owns the keyboard** — the caret sitting in a line of JSON is the posture the key gets held in, and that list would otherwise be the one list its own keys never reach. They are taken on the way down, before the text area can make a newline out of an `Enter`, and the caret stays exactly where it was. A list nothing is holding open is unchanged: there those keys belong to whatever has the keyboard, and the help line offers them only when they will answer. The one thing `Ctrl` otherwise means here — pasting a row's id into the JSON text — keeps the key wherever the peek is not what it means, and which of the two it is is decided by **where the pointer is** rather than by whether the list has appeared yet: over the room the key belongs to the peek, on a row of the list or anywhere else outside the room it is the modifier it always was. A ctrl-click on a row therefore still pastes — on a peeked list as much as on one opened by hand — and the row tooltip says so. A list the pointer has left has stopped following it, so it stops saying that it is and carries the sentence a standing list carries
- **the wheel steps the list as well.** The hand that holds the key is already on the mouse, so a turn of the wheel walks the rows the way `↑` `↓` do — including with the caret in the JSON text, where the keyboard is busy. The room zooms to the cursor on a turn of the wheel otherwise; while the key holds the list open that zoom gives way, which is the one thing `Ctrl` costs here. Without the key held the wheel is the room zoom exactly as before
- **the middle mouse button takes the row they landed on.** It does what `Enter` does on that row, and `Shift` with it adds to the selection the same way — so the whole gesture belongs to the hand that is already on the mouse: hold the key, turn the wheel to the row, press the button, without the pointer ever leaving the widget it is reading. Only a row the wheel or the arrows have actually stepped to is taken, and only with the pointer in the room — a middle press that was aimed at no row is still the press that plays a widget in edit mode, and out on a row of the list the pointer has a row of its own to click
- **the list stops on the stack it was read at.** Getting to one of its rows means taking the pointer off the widget and across the rest of the room — and the empty space around the board, which is the last thing it crosses on the way out. A list that followed the pointer all the way there was showing that by the time it arrived, with the row that was aimed at gone from under the click and the list often empty. The peeked list now goes back to the last stack the pointer came to rest on as soon as the pointer leaves the room, so the rows that are there to click are the ones that were aimed at
- **where the pointer is is the whole condition, and the key and the pointer can arrive in either order.** The key works with the caret in the JSON text area, in the tree's filter box or anywhere else — that is the posture the question "which widget is that?" gets asked in, and it is what the old panel did (it was up whenever the pointer was in the room and hid as soon as it moved over the editor, regardless of the keyboard). The list takes nothing from the text field it hangs over: the caret stays put and capitals still type through. Outside the room the key does nothing at all — a dropdown covers the panel it hangs in, so a `Ctrl`+click in the sidebar (which docks a module in the lower slot) must not have the list drop onto what it was aimed at, and a fullscreen overlay or the deck editor owns the keyboard while it is up. Pressing the key *before* the pointer reaches the room works just as well as the other way round: putting the caret on a line of JSON leaves the pointer sitting over the text area, so holding the key there and then moving out onto the room is the usual order in that module, and the pointer arriving is what opens the list then. A mouse event carries the modifier state, so this holds even for a keydown the page never saw — the key already held while the window took focus, say. Only opening happens on a mouse move: the list is closed by the key coming up, so a move that reports no modifier while the key is still held cannot take it away mid-gesture
- **a bar showing the widget tree keeps it.** The two dropdowns share the space below the bar, so showing the list there would mean taking the tree down and putting it back — losing the keyboard out of its filter box and its scroll position, on a key that gets tapped all day long. The key still makes the stack follow the pointer there, which is what the count on the `layers` button and the widget an F key addresses are read off — and the button carries a yellow accent while it does, so the key is not silent with nothing else on screen to show for it

Both modules that mount a bar get this, so it works in Edit Widgets and with the JSON editor open — the right-hand shot is taken with the caret sitting in the JSON text area:

| Edit Widgets | JSON editor, caret in the text area |
| --- | --- |
| ![Edit Widgets](https://agent.virtualtabletop.io/reports/pr/1543736314179100712/ctrl-peek-edit-widgets.png) | ![JSON editor](https://agent.virtualtabletop.io/reports/pr/1543736314179100712/ctrl-peek-json-editor-caret.png) |

The row the arrows and the wheel are on is outlined in the room as well, and the help line at the top of the list names every way to it:

![the peeked list with a keyboard cursor on its first row](https://agent.virtualtabletop.io/reports/pr/1543736314179100712/ctrl-peek-arrows-and-wheel.png)

## Demo room

A tutorial-quality demo of the list lives in this PR's own test-server room, [**pr-test-ai**](https://test.virtualtabletop.io/PR-3159/pr-test-ai) - deliberately **not** in the diff and not in `library/tutorials/`. It is *Xtras - Widget Stack List* and it has two variants:

- **1) Holding Ctrl** - four piles to hold the key over: three widgets in one spot, a widget completely covered by another one (no click can reach it, the list can), a card on a holder on a mat, and a child widget inside its parent.
- **2) Rows and keys** - what a row tells you (`invisible`, `on layer 2`, `locked in edit mode`), a stack eleven deep so the list runs past the tenth key, a pair to try `Shift`+`F<n>` on, and a band on which keys — and which mouse gestures — reach the list.

| 1) Holding Ctrl | 2) Rows and keys | the notes on the rows |
| --- | --- | --- |
| ![](https://agent.virtualtabletop.io/reports/pr/1543736314179100712/stack-list-demo-holding-ctrl.png) | ![](https://agent.virtualtabletop.io/reports/pr/1543736314179100712/stack-list-demo-rows-and-keys.png) | ![](https://agent.virtualtabletop.io/reports/pr/1543736314179100712/stack-list-demo-notes.png) |

The save file is also downloadable: [Xtras - Widget Stack List.vtt](https://agent.virtualtabletop.io/reports/pr/1543736314179100712/Xtras%20-%20Widget%20Stack%20List.vtt). It follows `docs/tutorials.md` - band layout, semantic ids, 60/25/22px typography, `_meta` mirrored field for field off *Types - Scoreboard* and *Properties - dragLimit*, and a square 530x530 SVG library image in the house style. Both variants pass `node validator/validate_gamefile_node.js` and were walked end to end. It can be moved into `library/tutorials/` on request.

## Testing

- TestCafe `Holding Ctrl opens the stack list and has it follow the pointer` in `tests/testcafe/editor.js`: the key does nothing off the room, nothing is on screen in the tick it goes down, a hold opens the list and follows the pointer, an F key selects its row and `Shift`+`F<n>` adds it to the selection, a `Ctrl`+`z` chord never opens it and it stays away for the rest of that hold, `Escape` puts a peeked list away and the held key does not bring it back, the list closes on release without being stored, a list opened with the button survives the key, and an open tree — with the keyboard in its filter box — is left standing with `treeOpen` unchanged and the `layers` button carrying the accent
- TestCafe `The peek key works with the caret in the JSON text area`: with the caret in `#jeText` and the pointer over a widget, the list opens, follows the pointer, closes on release and never moves the caret — and, in the other order, the key held down while the pointer is still over the editor opens the list the moment the pointer reaches the widget
- TestCafe `The peeked list stops on the stack the pointer last rested on`: with the key held over a widget, the pointer crossing the middle of the board — where that widget is not — and leaving the room one frame at a time, too fast for any spot on the way to count as having been rested on, leaves the list back on the stack it was read at and no longer saying it is following the pointer
- TestCafe `Ctrl pastes the id of a row into the JSON text from outside the room`: with the caret in `#jeText` and the pointer travelled to a row, `Ctrl`+`F<n>` pastes that row's id at the caret and a `Ctrl`+click on a row does the same — on a list the key is holding open too, after the help line has stopped saying it is following the pointer
- the stack goes on being taken where the pointer rests even while a chord (`Ctrl`+`z`) keeps the peek blocked, so the count and the widget an F key addresses are never the ones the pointer has left
- TestCafe `The wheel steps the peeked list instead of zooming the room`: with the key held over a widget, a turn of the wheel dispatched where the pointer is steps the list, wraps at its end and turns back the other way, and `--zoom` does not move while it does — and once the key is let go of, the same turn of the wheel zooms the room again
- TestCafe `The middle mouse button takes the row the wheel stepped to`: with the key held over a widget, a middle press that no key and no wheel has aimed at a row goes to the room as before, one aimed at a row selects that row and never reaches the room, `Shift` with it adds to the selection, a press on a row of the list itself is left to the editor, and once the key is let go of the button is the room's again
- TestCafe `The arrow keys go back to the caret when the peek key is let go of`: with the caret in `#jeText` and the list held open, `↑` `↓` step it and the keystroke is consumed; the next arrow key that reports the peek key as up is left to the caret and puts the list away
- TestCafe `The peek key works with the caret in the JSON text area` also walks the arrows with the caret in `#jeText`: the rows step, the keystrokes are consumed and the caret stays in the text area
- the peek tests assert the help line as well: a list the key is holding open offers `↑ ↓` and the wheel, and a list nothing is holding open offers the arrows only where they will answer
- a keyup the page never gets (an OS-level menu or shortcut can swallow it) is covered too: the next keystroke that reports the key as up closes the list rather than leaving it latched open
- full `tests/testcafe/editor.js` suite (96 tests) and `npm test` (1523 tests) pass locally
- walked through in a browser in both modules with the caret on a line of JSON: the list opens and follows the pointer, `Ctrl`+`F<n>` selects and `Ctrl`+`Shift`+`F<n>` adds, Escape reaches the list, the caret never moves, and a ctrl-click on a row still pastes the id — plus the chord, hold, Escape and tree cases above
- walked through with a real middle click in a browser: the wheel steps the list, the middle button selects the row it landed on, and the room neither zooms nor plays the widget while it does

No game file, save format or state format changes.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3159/pr-test (or any other room on that server)










