### PR TITLE
Fix the Create room button on game links failing with a ReferenceError

### DIFF
--- a/.github/workflows/testcafe-chrome.yml
+++ b/.github/workflows/testcafe-chrome.yml
@@ -22,6 +22,7 @@ jobs:
           - editor.js
           - connection.js
           - gameshelf.js
+          - gamelink.js
           - toolbar.js
           - boardsize.js
           - draglimit.js

--- a/.github/workflows/testcafe-firefox.yml
+++ b/.github/workflows/testcafe-firefox.yml
@@ -22,6 +22,7 @@ jobs:
           - editor.js
           - connection.js
           - gameshelf.js
+          - gamelink.js
           - toolbar.js
           - boardsize.js
           - draglimit.js

--- a/client/js/domhelpers.js
+++ b/client/js/domhelpers.js
@@ -47,6 +47,9 @@ export function progressButton(button, clickHandler, disableWhenDone=true) {
       button.classList.remove('visualProgress');
       button.classList.add('green');
     } catch(e) {
+      // the button label is the only other place this error shows up, and it is reset again a
+      // few seconds later - so log it as well to leave a stack trace behind in the console
+      console.error(e);
       button.setAttribute('icon', 'error');
       button.innerText = e.toString();
       button.classList.remove('progress');

--- a/client/js/overlays/welcome.js
+++ b/client/js/overlays/welcome.js
@@ -82,7 +82,6 @@ async function playButtonClick(updateProgress) {
   updateProgress('Joining room...');
   if(!$('#welcomeJoinRoom').value.match(/^[A-Za-z0-9_-]+$/))
     throw new Error('Invalid room name');
-  lastOverlay = 'linkDetailsOverlay';
   await joinRoom($('#welcomeJoinRoom').value);
   updateProgress('Adding game...');
   toServer('rename', { oldName: playerName, newName: $('#welcomePlayerName').value });

--- a/tests/testcafe/gamelink.js
+++ b/tests/testcafe/gamelink.js
@@ -5,28 +5,53 @@ import { publicGameURL, setupTestEnvironment } from './test-util.js';
 setupTestEnvironment();
 
 const getLocation = ClientFunction(_=>document.location.href);
+const forgetLibraryTypeTab = ClientFunction(_=>localStorage.removeItem('libraryTypeTab'));
 
 // Not the shared testcafe-testing room: adding a game from the public library stars it in the
 // room it lands in, and that star stays there for every test that runs afterwards.
 const roomName = 'testcafe-gamelink';
 
+// The game name is filled in after the room name is, so waiting for it also means the room name
+// typed afterwards is not overwritten by the answer of the details request. That request is what
+// makes the server read the public library, which takes a while when it is cold.
+async function waitForLinkPage(t, gameName) {
+  await t.expect(Selector('#welcomeGameName').innerText).eql(gameName, { timeout: 20000 });
+}
+
+// The button catches whatever its handler throws and only shows it as its own label, so the room
+// it ends up in and the game details it opens are what tell success from failure.
+async function createRoomFromLink(t, gameName) {
+  await t
+    .typeText('#welcomeJoinRoom', roomName, { replace: true })
+    .click('#welcomePlayButton')
+    .expect(getLocation()).contains(`/${roomName}`, { timeout: 20000 })
+    .expect(Selector('#stateDetailsOverlay').visible).ok({ timeout: 20000 })
+    .expect(Selector('#stateDetailsOverlay [data-field=name]').innerText).eql(gameName);
+}
+
 // The page every shared game URL leads to. Its Create room button runs the only code path that
 // joins a room and adds a game to it in one go, so nothing else in the suite covers it.
 test('The Create room button of a game link joins a room and adds the game', async t => {
   await t.navigateTo(publicGameURL('Dots'));
+  await waitForLinkPage(t, 'Dots');
+  await createRoomFromLink(t, 'Dots');
+});
 
-  // the game name is filled in after the room name is, so waiting for it also means the room
-  // name typed below is not overwritten by the answer of the details request afterwards. That
-  // request is what makes the server read the public library, which takes a while when it is cold.
-  await t
-    .expect(Selector('#welcomeGameName').innerText).eql('Dots', { timeout: 20000 })
-    .typeText('#welcomeJoinRoom', roomName, { replace: true })
-    .click('#welcomePlayButton');
+// A tutorial link runs one statement more than a game link does - on yet another name the
+// welcome overlay expects the bundle to provide - so it can break without the game link noticing.
+test('The Create room button of a tutorial link opens the library on the Tutorials tab', async t => {
+  const tutorialName = '100 Tutorials Overview';
+  await t.navigateTo(publicGameURL(tutorialName, 'tutorial'));
 
-  // the button catches whatever its handler throws and only shows it as its own label, so the
-  // room it ends up in and the game details it opens are what tell success from failure
+  // which tab the library opens on is remembered across page loads, so a leftover 'Tutorials'
+  // would make the assertion at the end pass without the handler ever having set it
+  await forgetLibraryTypeTab();
+
+  await waitForLinkPage(t, tutorialName);
   await t
-    .expect(getLocation()).contains(`/${roomName}`, { timeout: 20000 })
-    .expect(Selector('#stateDetailsOverlay').visible).ok({ timeout: 20000 })
-    .expect(Selector('#stateDetailsOverlay [data-field=name]').innerText).eql('Dots');
+    .expect(Selector('#welcomeGameType').innerText).eql('tutorial')
+    .expect(Selector('#welcomeGameTypeHint').innerText).eql('check it out');
+
+  await createRoomFromLink(t, tutorialName);
+  await t.expect(Selector('#filterByType').value).eql('Tutorials', { timeout: 10000 });
 });

--- a/tests/testcafe/gamelink.js
+++ b/tests/testcafe/gamelink.js
@@ -1,0 +1,29 @@
+import { ClientFunction, Selector } from 'testcafe';
+
+import { publicGameURL, setupTestEnvironment } from './test-util.js';
+
+setupTestEnvironment();
+
+const getLocation = ClientFunction(_=>document.location.href);
+
+// Not the shared testcafe-testing room: adding a game from the public library stars it in the
+// room it lands in, and that star stays there for every test that runs afterwards.
+const roomName = 'testcafe-gamelink';
+
+// The page every shared game URL leads to. Its Create room button runs the only code path that
+// joins a room and adds a game to it in one go, so nothing else in the suite covers it.
+test('The Create room button of a game link joins a room and adds the game', async t => {
+  await t.navigateTo(publicGameURL('Dots'));
+
+  await t
+    .expect(Selector('#welcomeGameName').innerText).eql('Dots')
+    .typeText('#welcomeJoinRoom', roomName, { replace: true })
+    .click('#welcomePlayButton');
+
+  // the button catches whatever its handler throws and only shows it as its own label, so the
+  // room it ends up in and the game details it opens are what tell success from failure
+  await t
+    .expect(getLocation()).contains(`/${roomName}`)
+    .expect(Selector('#stateDetailsOverlay').visible).ok()
+    .expect(Selector('#stateDetailsOverlay [data-field=name]').innerText).eql('Dots');
+});

--- a/tests/testcafe/gamelink.js
+++ b/tests/testcafe/gamelink.js
@@ -15,15 +15,18 @@ const roomName = 'testcafe-gamelink';
 test('The Create room button of a game link joins a room and adds the game', async t => {
   await t.navigateTo(publicGameURL('Dots'));
 
+  // the game name is filled in after the room name is, so waiting for it also means the room
+  // name typed below is not overwritten by the answer of the details request afterwards. That
+  // request is what makes the server read the public library, which takes a while when it is cold.
   await t
-    .expect(Selector('#welcomeGameName').innerText).eql('Dots')
+    .expect(Selector('#welcomeGameName').innerText).eql('Dots', { timeout: 20000 })
     .typeText('#welcomeJoinRoom', roomName, { replace: true })
     .click('#welcomePlayButton');
 
   // the button catches whatever its handler throws and only shows it as its own label, so the
   // room it ends up in and the game details it opens are what tell success from failure
   await t
-    .expect(getLocation()).contains(`/${roomName}`)
-    .expect(Selector('#stateDetailsOverlay').visible).ok()
+    .expect(getLocation()).contains(`/${roomName}`, { timeout: 20000 })
+    .expect(Selector('#stateDetailsOverlay').visible).ok({ timeout: 20000 })
     .expect(Selector('#stateDetailsOverlay [data-field=name]').innerText).eql('Dots');
 });

--- a/tests/testcafe/test-util.js
+++ b/tests/testcafe/test-util.js
@@ -42,11 +42,12 @@ export function roomURL() {
   return `${server}/testcafe-testing`;
 }
 
-// The URL a public library game is shared under. Its slug is derived from the game name the same
-// way Room.getStateDetails() derives it when it matches a link back to a game.
-export function publicGameURL(gameName) {
+// The URL a public library game is shared under - 'game' for the Games library, 'tutorial' for
+// the Tutorials one. The slug is derived from the game name the same way Room.getStateDetails()
+// derives it when it matches a link back to a game, so digits and spaces both become separators.
+export function publicGameURL(gameName, category='game') {
   const slug = gameName.replace(/[^A-Za-z]+/g, '-').toLowerCase().replace(/^-+/, '').replace(/-+$/, '');
-  return `${server}/game/${slug}`;
+  return `${server}/${category}/${slug}`;
 }
 
 export function prepareClient() {

--- a/tests/testcafe/test-util.js
+++ b/tests/testcafe/test-util.js
@@ -42,6 +42,13 @@ export function roomURL() {
   return `${server}/testcafe-testing`;
 }
 
+// The URL a public library game is shared under. Its slug is derived from the game name the same
+// way Room.getStateDetails() derives it when it matches a link back to a game.
+export function publicGameURL(gameName) {
+  const slug = gameName.replace(/[^A-Za-z]+/g, '-').toLowerCase().replace(/^-+/, '').replace(/-+$/, '');
+  return `${server}/game/${slug}`;
+}
+
 export function prepareClient() {
   // non random random
   window.customRandomSeed = 1;


### PR DESCRIPTION
## What this does

Pressing **Create room** on a shared game link — e.g. https://virtualtabletop.io/game/kdl6pgrt/beowulf-the-legend — did nothing except turn the button into the error message `ReferenceError: lastOverlay is not defined`, so the room was never created. This removes the stale assignment that caused it.

It is not specific to that game. `playButtonClick()` is the single code path behind every share link, so `/game/<id>/<name>`, `/game/<name>`, `/tutorial/<name>` and `/library/<category>/<name>` were all equally broken. Reproduced locally against a public library game, a tutorial and a custom library link — all three showed the same message and stayed on the link page; all three join the room and open the game's details with the fix.

## Why it happened

`playButtonClick()` in `client/js/overlays/welcome.js` contained

```js
lastOverlay = 'linkDetailsOverlay';
```

`let lastOverlay = null;` used to live in `client/js/connection.js` and was removed by f887eb2 ("Report a lost connection and unconfirmed changes in a status display instead of losing work silently", closes #2891). That left `welcome.js` as the only file in the tree still naming it. The client is served as a single `<script type="module">`, so the bundle is strict-mode and an assignment to an undeclared name throws instead of quietly creating a global; `progressButton()` catches whatever its handler throws and shows it as the button's label, which is exactly the message users saw.

## Why the line is deleted rather than ported to `setCurrentOverlayId()`

`lastOverlay` was one half of a restore-after-reconnect mechanism, and #2891 removed **both** halves of it:

- `connection.onclose` used to record the overlay that was on screen (`lastOverlay = [...$a('.overlay')]...`) and force `connectionLostOverlay` over the whole screen. It now calls the `onConnectionClose` callbacks instead, and a dropped connection is reported in the small corner status display without taking any overlay away.
- `connection.onopen` used to do `showOverlay(null, true); showOverlay(lastOverlay);` — that is what the assignment in `playButtonClick()` was feeding: joining a room opens a socket, and without it the link details overlay would have been cleared as the socket came up. `onopen` no longer touches overlays at all.

With nothing hiding the overlay on connect, there is nothing to restore, so the write has no reader left.

`setCurrentOverlayId()` from the new `client/js/overlaystate.js` is not the successor of `lastOverlay` — it is maintained by `showOverlay()` in `main.js` and only read to tell the server which overlay a player currently has open (`toServer('mouse', { activeOverlay, ... })`), so other players' status displays can say so. Nothing re-shows an overlay from it. Calling it here would push a value `showOverlay('linkDetailsOverlay')` has already set, and would then go stale the moment the room's own overlays open. Deleting the line is the accurate translation.

## Other dangling references from #2891

Checked the rest of that commit for the same kind of leftover: every identifier it deleted and did not reintroduce (`connectionLostOverlay`, the `serverRestarting`/`whileDisconnected`/`whileRestarting`/`playerChange` CSS classes, `overlayClasses`) is gone from the tree as well. `lastOverlay` was the only one still referenced.

Sweeping the whole client for the same bug class — every assignment in the `CLIENT_JS` and `EDITOR_JS` bundles whose target is declared nowhere in that bundle — turns up one unrelated pre-existing case: `client/js/traceviewer.js:66` assigns `playerName = p` in the trace viewer's "Player N" command, but `playerName` is declared in `client/js/overlays/players.js`, which is in the *client* bundle, and it is not among the names `loadEditMode()` hands to the editor bundle. So that command throws the same kind of `ReferenceError`. It is a separate concern in a debug-only tool and wants a different fix (the editor bundle uses `getPlayerDetails().playerName` everywhere else), so it is deliberately left out of this PR and tracked in #3161 instead.

## Test

`tests/testcafe/gamelink.js` opens the game link of a public library game, points the room name at `testcafe-gamelink` and presses Create room, then asserts that the browser ended up in that room with the game's details open. It fails on `main` with the ReferenceError and passes with the fix. A separate room is used on purpose: adding a public library game stars it in the room it lands in, which would leak into every test after it in the shared `testcafe-testing` room.

A second test walks `/tutorial/<slug>` and asserts that the library ends up on the Tutorials tab afterwards. The tutorial branch is the only part of `playButtonClick()` that runs an extra statement - `setLibraryTypeTab('Tutorials')`, yet another name the welcome overlay expects the bundle to provide - so it can reintroduce exactly this `ReferenceError` without the game link test noticing. Renaming that call locally makes the tutorial test fail on the tab assertion while the game link test stays green.

`publicGameURL()` in `test-util.js` builds a game or a tutorial link the way the server derives a game's slug from its name.

## Errors in progress buttons are logged

`progressButton()` showed a failing handler's error only as the button's own label, which resets itself 2.5s later - which is why this crash left no trace anywhere else, not even in the devtools console. It now `console.error(e)`s as well, so the next bug of this kind is visible the first time anyone opens the console.

Both TestCafe workflows name their test files one by one, so `gamelink.js` is added to the Chrome and the Firefox matrix as well - without that entry the new file would never run in CI.

## Verification

- `npm test` — 56 suites, 1650 tests passed (the jest client tests load these files as real ES modules, so they would have caught a broken import)
- `npx testcafe chromium:headless tests/testcafe/gamelink.js tests/testcafe/connection.js` — both pass, including #2891's own connection-monitor test
- `npx testcafe chromium:headless tests/testcafe/gamelink.js tests/testcafe/gameshelf.js` — passes; `gamelink.js` fails as expected when the fix is reverted
- `npx testcafe chromium:headless tests/testcafe/gamelink.js` - both tests pass; renaming `setLibraryTypeTab` in `welcome.js` fails the tutorial test only, renaming/restoring `lastOverlay` fails both
- Real browser against a local server: game, tutorial and custom library links each show `ReferenceError: lastOverlay is not defined` on `main` and each join the room with the fix

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3160/pr-test (or any other room on that server)


