### PR TITLE
Ship the transition styles with the client and default new decks to them

### DIFF
--- a/client/css/editor/propertyInputs.css
+++ b/client/css/editor/propertyInputs.css
@@ -138,6 +138,13 @@
 .editorModule .switchInput input.switchbox:checked + label.switchbox::before {
   margin-left: 18px;
 }
+/* an input the panel shows but does not let you change: the reason sits under it */
+.editorModule .propertyInput.disabledInput {
+  opacity: 0.5;
+}
+.editorModule .propertyInput.disabledInput label.switchbox {
+  cursor: default;
+}
 .editorModule .switchInput input.switchbox {
   /* keep the hidden checkbox at its DOM position: moving it far off-screen
      makes the browser scroll it into view when the label click focuses it */

--- a/client/css/widgets/classes.css
+++ b/client/css/widgets/classes.css
@@ -207,7 +207,10 @@
 /* Widgets carrying this class glide to wherever they end up instead of jumping there. The duration
    can be changed per widget by setting --transitionDuration, or the whole rule can be replaced from
    the room's custom CSS - a rule defined there wins because it is added after this stylesheet.
-   A widget being dragged is excluded: it follows the pointer every frame and would lag behind it. */
+   A widget being dragged is excluded on every client, not only on the one holding it: a drag writes a
+   new position per mouse event, so the animation would restart before finishing and trail the pointer
+   for everyone. On the dragging client it also has to be off because the drop target is read from where
+   the widget is drawn, which mid-animation is not where the drag put it. */
 .transition {
   transition: transform var(--transitionDuration, 300ms);
 }

--- a/client/css/widgets/classes.css
+++ b/client/css/widgets/classes.css
@@ -203,3 +203,14 @@
   line-height: 1;
   text-align:center;
 }
+
+/* Widgets carrying this class glide to wherever they end up instead of jumping there. The duration
+   can be changed per widget by setting --transitionDuration, or the whole rule can be replaced from
+   the room's custom CSS - a rule defined there wins because it is added after this stylesheet.
+   A widget being dragged is excluded: it follows the pointer every frame and would lag behind it. */
+.transition {
+  transition: transform var(--transitionDuration, 300ms);
+}
+.transition.dragging {
+  transition: none;
+}

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -35,7 +35,7 @@ function generateCardDeckWidgets(id, x, y, addCards) {
     parent: id,
     x: 12,
     y: 41,
-    cardDefaults: { classes: 'transition' },
+    cardDefaults: cardDefaultsWithTransition(),
     cardTypes: types,
     faceTemplates: [ {
       border: false, radius: false, objects: [ back  ]
@@ -120,7 +120,9 @@ function generateChipPileWidgets(id, x, y, type) {
       y: -2,
       scale: 0.5,
       cardDefaults: {
-        classes: type==2 ? 'pokerChip transition' : 'pokerChip3D transition',
+        // The holder above accepts exactly this string of classes, so nothing cosmetic - the transition
+        // class the decks get, for instance - may be appended to it: the chips would stop fitting it.
+        classes: type==2 ? 'pokerChip' : 'pokerChip3D',
         width: 73,
         height: 73,
         onPileCreation: {
@@ -1536,9 +1538,7 @@ async function addLibraryDeckToGame(entry) {
 
   const deckWidth  = details.deck.width  || 86;
   const deckHeight = details.deck.height || 86;
-  // Like every other deck the editor creates, the cards glide to wherever they are moved to unless the
-  // library deck brings classes of its own.
-  const cardDefaults = Object.assign({ classes: 'transition' }, details.deck.cardDefaults);
+  const cardDefaults = cardDefaultsWithTransition(details.deck.cardDefaults);
   // Without a holder the cards still go into a pile in the middle of the table, and the deck widget (which is
   // invisible outside edit mode) is placed next to it instead of below it.
   await addWidgetLocal(Object.assign({}, details.deck, { id: id+'D', cardDefaults }, placement.holder ? {

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -35,6 +35,7 @@ function generateCardDeckWidgets(id, x, y, addCards) {
     parent: id,
     x: 12,
     y: 41,
+    cardDefaults: { classes: 'transition' },
     cardTypes: types,
     faceTemplates: [ {
       border: false, radius: false, objects: [ back  ]
@@ -119,7 +120,7 @@ function generateChipPileWidgets(id, x, y, type) {
       y: -2,
       scale: 0.5,
       cardDefaults: {
-        classes: type==2 ? 'pokerChip' : 'pokerChip3D',
+        classes: type==2 ? 'pokerChip transition' : 'pokerChip3D transition',
         width: 73,
         height: 73,
         onPileCreation: {
@@ -1535,9 +1536,12 @@ async function addLibraryDeckToGame(entry) {
 
   const deckWidth  = details.deck.width  || 86;
   const deckHeight = details.deck.height || 86;
+  // Like every other deck the editor creates, the cards glide to wherever they are moved to unless the
+  // library deck brings classes of its own.
+  const cardDefaults = Object.assign({ classes: 'transition' }, details.deck.cardDefaults);
   // Without a holder the cards still go into a pile in the middle of the table, and the deck widget (which is
   // invisible outside edit mode) is placed next to it instead of below it.
-  await addWidgetLocal(Object.assign({}, details.deck, { id: id+'D' }, placement.holder ? {
+  await addWidgetLocal(Object.assign({}, details.deck, { id: id+'D', cardDefaults }, placement.holder ? {
     parent: id,
     x: Math.round((holderWidth -deckWidth )/2),
     y: Math.round((holderHeight-deckHeight)/2)

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -4500,8 +4500,11 @@ function cardDefaultsHaveTransition(cardDefaults) {
 // where the deck panel's "Cards glide when they move" switch - and one line in the JSON editor - can take
 // it away again, and it is added to whatever the deck already asks for: a class of its own says how the
 // cards look and has to survive. It must not be added to classes a dropTarget matches on, which compares
-// them as one whole string (see the chip stacks in editmode.js).
+// them as one whole string (see the chip stacks in editmode.js) - which is also why a class list that
+// already glides is handed back exactly as it was written instead of being rebuilt.
 function cardDefaultsWithTransition(cardDefaults, transition=true) {
+  if(transition && cardDefaultsHaveTransition(cardDefaults))
+    return Object.assign({}, cardDefaults);
   const classes = cardDefaultsClassList(cardDefaults).filter(className=>className != 'transition');
   if(transition)
     classes.push('transition');

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -4486,14 +4486,31 @@ const deckEditorCardSizes = [
   { label: 'Token',       width:  50, height:  50 }
 ];
 
-// The cardDefaults every deck creation flow builds on: cards that glide to wherever they are moved to
-// instead of jumping there. The class goes into cardDefaults, where removing it again is one line, and it
-// is appended to whatever the deck already asks for - a class of its own says how the cards look and has
-// to survive. It must not be appended to classes a dropTarget matches on, which compares them as one
-// whole string (see the chip stacks in editmode.js).
-function cardDefaultsWithTransition(cardDefaults) {
-  const classes = cardDefaults && cardDefaults.classes;
-  return Object.assign({}, cardDefaults, { classes: classes ? classes + ' transition' : 'transition' });
+// The classes a deck hands to every one of its cards, as a list.
+function cardDefaultsClassList(cardDefaults) {
+  return String(cardDefaults && cardDefaults.classes || '').split(/\s+/).filter(className=>className);
+}
+
+// Whether a deck's cards glide to wherever they are moved to instead of jumping there.
+function cardDefaultsHaveTransition(cardDefaults) {
+  return cardDefaultsClassList(cardDefaults).indexOf('transition') != -1;
+}
+
+// The cardDefaults every deck creation flow builds on: cards that glide. The class goes into cardDefaults,
+// where the deck panel's "Cards glide when they move" switch - and one line in the JSON editor - can take
+// it away again, and it is added to whatever the deck already asks for: a class of its own says how the
+// cards look and has to survive. It must not be added to classes a dropTarget matches on, which compares
+// them as one whole string (see the chip stacks in editmode.js).
+function cardDefaultsWithTransition(cardDefaults, transition=true) {
+  const classes = cardDefaultsClassList(cardDefaults).filter(className=>className != 'transition');
+  if(transition)
+    classes.push('transition');
+  const result = Object.assign({}, cardDefaults);
+  if(classes.length)
+    result.classes = classes.join(' ');
+  else
+    delete result.classes;
+  return result;
 }
 
 // The "Recall & Shuffle" button all deck creation flows put below their holder: it recalls the deck's cards,

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -4555,7 +4555,7 @@ async function createStarterDeck(deckID, size, placement) {
     type: 'deck',
     id: dID
   }, placement.holder ? { parent: id, x: 12, y: 41 } : { x: 748 - 96, y: 400 }, {
-    cardDefaults: { width: cardWidth, height: cardHeight },
+    cardDefaults: { classes: 'transition', width: cardWidth, height: cardHeight },
     cardTypes: { 'type 1': {} },
     faceTemplates: [
       { objects: [ { type: 'image', x: 0, y: 0, width: cardWidth, height: cardHeight, color: VTTblue } ] },

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -4486,6 +4486,16 @@ const deckEditorCardSizes = [
   { label: 'Token',       width:  50, height:  50 }
 ];
 
+// The cardDefaults every deck creation flow builds on: cards that glide to wherever they are moved to
+// instead of jumping there. The class goes into cardDefaults, where removing it again is one line, and it
+// is appended to whatever the deck already asks for - a class of its own says how the cards look and has
+// to survive. It must not be appended to classes a dropTarget matches on, which compares them as one
+// whole string (see the chip stacks in editmode.js).
+function cardDefaultsWithTransition(cardDefaults) {
+  const classes = cardDefaults && cardDefaults.classes;
+  return Object.assign({}, cardDefaults, { classes: classes ? classes + ' transition' : 'transition' });
+}
+
 // The "Recall & Shuffle" button all deck creation flows put below their holder: it recalls the deck's cards,
 // flips them to their back and shuffles them. Offered as an option by the "Add New Deck" wizard.
 function deckResetButton(holderID, width, y) {
@@ -4555,7 +4565,7 @@ async function createStarterDeck(deckID, size, placement) {
     type: 'deck',
     id: dID
   }, placement.holder ? { parent: id, x: 12, y: 41 } : { x: 748 - 96, y: 400 }, {
-    cardDefaults: { classes: 'transition', width: cardWidth, height: cardHeight },
+    cardDefaults: cardDefaultsWithTransition({ width: cardWidth, height: cardHeight }),
     cardTypes: { 'type 1': {} },
     faceTemplates: [
       { objects: [ { type: 'image', x: 0, y: 0, width: cardWidth, height: cardHeight, color: VTTblue } ] },

--- a/client/js/editor/sidebar/gameSettings.js
+++ b/client/js/editor/sidebar/gameSettings.js
@@ -629,7 +629,12 @@ class GameSettingsModule extends SidebarModule {
 
     const p1 = document.createElement('p');
     p1.textContent = 'You can add custom CSS to your game. This is an advanced feature and should be used with care. VTT updates may break your custom CSS.';
-    target.append(p1);
+
+    // Rules here are applied after the built-in stylesheet, so they win against a built-in class of the
+    // same specificity - which is how a game changes what one of them does instead of inventing its own.
+    const p2 = document.createElement('p');
+    p2.textContent = 'Rules here also override the built-in classes. Widgets with the "transition" class glide to a new position over 300ms, for example, which ".transition { transition: transform 600ms; }" slows down.';
+    target.append(p1, p2);
 
     const gameSettings = getCurrentGameSettings();
     const currentCss = gameSettings ? gameSettings.globalCss || '' : '';

--- a/client/js/editor/sidebar/gameSettings.js
+++ b/client/js/editor/sidebar/gameSettings.js
@@ -633,7 +633,7 @@ class GameSettingsModule extends SidebarModule {
     // Rules here are applied after the built-in stylesheet, so they win against a built-in class of the
     // same specificity - which is how a game changes what one of them does instead of inventing its own.
     const p2 = document.createElement('p');
-    p2.textContent = 'Rules here also override the built-in classes. Widgets with the "transition" class glide to a new position over 300ms, for example, which ".transition { transition: transform 600ms; }" slows down.';
+    p2.innerHTML = 'Rules here also override VTT\'s own classes. Widgets with the <code>transition</code> class glide to a new position over 300ms, for example, which <code>.transition { transition: transform 600ms; }</code> slows down.';
     target.append(p1, p2);
 
     const gameSettings = getCurrentGameSettings();

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -3768,6 +3768,10 @@ class PropertiesModule extends SidebarModule {
     batchStart();
     setDeltaCause(`${getPlayerDetails().playerName} added ${type} deck "${deck.id}" in editor`);
 
+    // Cards of a new deck glide to wherever they are moved to instead of jumping there. It sits in
+    // cardDefaults so a game author can simply remove it again, or restyle .transition in the room CSS.
+    deck = Object.assign({}, deck, { cardDefaults: Object.assign({ classes: 'transition' }, deck.cardDefaults) });
+
     // Match the public-library flow: a holder sized to the cards, a Recall & Shuffle button, the deck
     // centered in it and the cards stacked in a pile - rather than spreading loose cards across the table.
     const cardWidth  = deck.cardDefaults && deck.cardDefaults.width  || deck.width  || 103;
@@ -7220,7 +7224,7 @@ class PropertiesModule extends SidebarModule {
       new TextInput(this, widget, 'User defined active classes', {
         property: 'classes',
         nullIfEmpty: true,
-        hint: 'Space separated list of CSS classes applied to the widget, like "transparent" for holders or classes defined in the room\'s custom css. Classes can also be triggered by some properties of the widget and be inherited from parent widgets.'
+        hint: 'Space separated list of CSS classes applied to the widget, like "transparent" for holders, "transition" to make the widget glide to a new position instead of jumping there, or classes defined in the room\'s custom css. Classes can also be triggered by some properties of the widget and be inherited from parent widgets.'
       }).render(body);
 
       this.renderTriggeredClassesNote(widget, body);

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1280,6 +1280,10 @@ const editorTypeNames = {
   timer: 'Timer'
 };
 
+// The part of a drop target the match rows cannot show: every condition is an exact comparison of the
+// whole property, so a widget carrying more classes than the one asked for is not a match.
+const dropTargetMatchInfo = '<p>A condition matches only when the property is exactly the value given. <code>classes</code> holds the widget\'s whole class list, so a widget whose classes are <code>pokerChip transition</code> does not match <code>pokerChip</code>.</p>';
+
 // Explanations shown by the info buttons next to the curated inputs. The text
 // usually comes from the wiki summary of the property.
 const editorPropertyHints = {
@@ -7222,7 +7226,7 @@ class PropertiesModule extends SidebarModule {
       new TextInput(this, widget, 'User defined active classes', {
         property: 'classes',
         nullIfEmpty: true,
-        hint: 'Space separated list of CSS classes applied to the widget, like "transparent" for holders, "transition" to make the widget glide to a new position instead of jumping there, or classes defined in the room\'s custom css. Classes can also be triggered by some properties of the widget and be inherited from parent widgets.'
+        hint: 'Space separated list of CSS classes applied to the widget. Two of them come with VTT: "transparent" hides the frame of a holder, "transition" makes the widget glide to a new position instead of jumping there. Any other class is one the room\'s custom css defines. Classes can also be triggered by some properties of the widget and be inherited from parent widgets.'
       }).render(body);
 
       this.renderTriggeredClassesNote(widget, body);
@@ -9610,7 +9614,37 @@ class PropertiesModule extends SidebarModule {
     `);
     $('button', deckEditorButton).onclick = _=>deckEditor.open(widget.id);
     this.renderBasicSection(widget);
+    this.renderDeckCardsSection(widget);
     this.renderOtherPropertiesSection(widget, [ 'cardDefaults', 'cardTypes', 'faceTemplates' ]);
+  }
+
+  // The cards of a deck are drawn in the deck editor, but whether they glide to where they are moved to is
+  // a property of them the pictures do not cover - and it lives in cardDefaults, which this panel otherwise
+  // never shows. Without a control here the class every new deck starts with could only be taken away again
+  // in the JSON editor.
+  renderDeckCardsSection(widget) {
+    this.addSubHeader('Cards');
+    const matchedBy = this.widgetsMatchingCardClasses(widget);
+    const glide = new CheckboxInput(this, widget, 'Glide when they move', {
+      listenTo: [ 'cardDefaults' ],
+      getValue: _=>cardDefaultsHaveTransition(widget.get('cardDefaults')),
+      setValue: on=>this.inputValueTransformed(widget, 'cardDefaults', current=>cardDefaultsWithTransition(current, on)),
+      hint: 'Cards of this deck glide to a new position over 300ms instead of jumping there, whether they are dealt, dragged or recalled. It puts the "transition" class into the deck\'s cardDefaults; a rule in the room\'s custom css can retime or replace it.'
+    }).render(this.moduleDOM);
+    if(matchedBy.length) {
+      $('input', glide).disabled = true;
+      glide.classList.add('disabledInput');
+      div(this.moduleDOM, 'pileHelp', `${html(matchedBy.join(', '))} accepts these cards by their classes, which are matched as one whole string - so gliding would have to be turned on there as well and is switched off here. The chip stacks the Add Widget overlay creates work that way.`);
+    }
+  }
+
+  // The widgets whose dropTarget filters for exactly the classes this deck's cards carry: adding a class to
+  // those cards would stop them fitting, so the deck keeps the classes it has.
+  widgetsMatchingCardClasses(widget) {
+    const classes = (widget.get('cardDefaults') || {}).classes;
+    if(!classes)
+      return [];
+    return widgetFilter(w=>asArray(w.get('dropTarget')).some(entry=>isObjectLike(entry) && entry.classes === classes)).map(w=>w.id);
   }
 
   // --- dice face editor ---
@@ -10263,7 +10297,7 @@ class PropertiesModule extends SidebarModule {
     // in the JSON editor - the shared dropTarget editor (the one the line widget
     // uses) says the same thing for every widget type, with the decks kept as
     // the shortcut for the case they cover.
-    propertyInfoButton(this.addSubHeader('Target widgets'), html('Which widgets can be dropped into this holder'));
+    propertyInfoButton(this.addSubHeader('Target widgets'), `<p>Which widgets can be dropped into this holder</p>${dropTargetMatchInfo}`);
     this.renderDropTargetEditor(widget, {
       label: '',
       emptyText: 'Nothing can be dropped into this holder - add a match to let widgets in.',
@@ -10678,7 +10712,7 @@ class PropertiesModule extends SidebarModule {
       value.type = 'text';
       value.className = 'dropTargetValue';
       value.placeholder = 'value';
-      value.title = 'The value that property has to have, compared as a whole - matching on classes means the widget\'s entire class list, like "pokerChip transition"';
+      value.title = 'The value that property has to have';
       value.value = conditionText(condition.value);
       property.onchange = value.onchange = _=>{
         condition.property = property.value;
@@ -11380,7 +11414,7 @@ class PropertiesModule extends SidebarModule {
     // What a line takes in - a widget dropped on the path becomes a stop of it,
     // matched the same way a holder matches its dropTarget. One name for it:
     // the section header carries the hint so the label does not repeat it.
-    propertyInfoButton(this.addSubHeader('Target widgets'), html('Which widgets become a stop when they are dropped onto the line'));
+    propertyInfoButton(this.addSubHeader('Target widgets'), `<p>Which widgets become a stop when they are dropped onto the line</p>${dropTargetMatchInfo}`);
     this.renderDropTargetEditor(widget, {
       edit: lineEdit,
       label: '',

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -1282,7 +1282,7 @@ const editorTypeNames = {
 
 // The part of a drop target the match rows cannot show: every condition is an exact comparison of the
 // whole property, so a widget carrying more classes than the one asked for is not a match.
-const dropTargetMatchInfo = '<p>A condition matches only when the property is exactly the value given. <code>classes</code> holds the widget\'s whole class list, so a widget whose classes are <code>pokerChip transition</code> does not match <code>pokerChip</code>.</p>';
+const dropTargetMatchInfo = '<p>A condition compares the whole property to the value given; the one exception is <code>type: card</code>, which also accepts a deck. <code>classes</code> holds the widget\'s whole class list, so a widget whose classes are <code>pokerChip transition</code> does not match <code>pokerChip</code>.</p>';
 
 // Explanations shown by the info buttons next to the curated inputs. The text
 // usually comes from the wiki summary of the property.

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -3768,9 +3768,7 @@ class PropertiesModule extends SidebarModule {
     batchStart();
     setDeltaCause(`${getPlayerDetails().playerName} added ${type} deck "${deck.id}" in editor`);
 
-    // Cards of a new deck glide to wherever they are moved to instead of jumping there. It sits in
-    // cardDefaults so a game author can simply remove it again, or restyle .transition in the room CSS.
-    deck = Object.assign({}, deck, { cardDefaults: Object.assign({ classes: 'transition' }, deck.cardDefaults) });
+    deck = Object.assign({}, deck, { cardDefaults: cardDefaultsWithTransition(deck.cardDefaults) });
 
     // Match the public-library flow: a holder sized to the cards, a Recall & Shuffle button, the deck
     // centered in it and the cards stacked in a pile - rather than spreading loose cards across the table.
@@ -10680,7 +10678,7 @@ class PropertiesModule extends SidebarModule {
       value.type = 'text';
       value.className = 'dropTargetValue';
       value.placeholder = 'value';
-      value.title = 'The value that property has to have';
+      value.title = 'The value that property has to have, compared as a whole - matching on classes means the widget\'s entire class list, like "pokerChip transition"';
       value.value = conditionText(condition.value);
       property.onchange = value.onchange = _=>{
         condition.property = property.value;

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -281,15 +281,22 @@ export class Widget extends StateManaged {
       if(this.parent)
         this.parent.applyChildRemove(this);
 
-      newParent.appendChild(this.domElement);
-      if (fromTransform) {
-        // If we changed parents, we apply a transform to the previous location
-        // to allow for a smooth transition animation.
-        this.domElement.style.transform = fromTransform;
-        // Force style recalc to commit from transform and start a transition
-        // on applying the destination transform.
-        this.domElement.offsetTop;
-        this.domElement.style.transform = this.targetTransform;
+      // Taking the element out of the DOM and putting it back cancels the CSS
+      // transitions running on it and on everything below it, so a delta that
+      // names the parent the widget already sits in is left alone: a pile that
+      // is re-applied right after it was created would otherwise stop the cards
+      // that just started gliding into it.
+      if(this.domElement.parentElement !== newParent) {
+        newParent.appendChild(this.domElement);
+        if (fromTransform) {
+          // If we changed parents, we apply a transform to the previous location
+          // to allow for a smooth transition animation.
+          this.domElement.style.transform = fromTransform;
+          // Force style recalc to commit from transform and start a transition
+          // on applying the destination transform.
+          this.domElement.offsetTop;
+          this.domElement.style.transform = this.targetTransform;
+        }
       }
 
       if(delta.parent !== null && widgets.has(delta.parent)) {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -283,20 +283,20 @@ export class Widget extends StateManaged {
 
       // Taking the element out of the DOM and putting it back cancels the CSS
       // transitions running on it and on everything below it, so a delta that
-      // names the parent the widget already sits in is left alone: a pile that
-      // is re-applied right after it was created would otherwise stop the cards
-      // that just started gliding into it.
-      if(this.domElement.parentElement !== newParent) {
+      // names the parent the widget already sits in does not re-append it: a
+      // pile that is re-applied right after it was created would otherwise stop
+      // the cards that just started gliding into it.
+      if(this.domElement.parentElement !== newParent)
         newParent.appendChild(this.domElement);
-        if (fromTransform) {
-          // If we changed parents, we apply a transform to the previous location
-          // to allow for a smooth transition animation.
-          this.domElement.style.transform = fromTransform;
-          // Force style recalc to commit from transform and start a transition
-          // on applying the destination transform.
-          this.domElement.offsetTop;
-          this.domElement.style.transform = this.targetTransform;
-        }
+
+      if (fromTransform) {
+        // If we changed parents, we apply a transform to the previous location
+        // to allow for a smooth transition animation.
+        this.domElement.style.transform = fromTransform;
+        // Force style recalc to commit from transform and start a transition
+        // on applying the destination transform.
+        this.domElement.offsetTop;
+        this.domElement.style.transform = this.targetTransform;
       }
 
       if(delta.parent !== null && widgets.has(delta.parent)) {

--- a/tests/client/deck-transition-class.test.js
+++ b/tests/client/deck-transition-class.test.js
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// deckeditor.js is a plain script that gets concatenated by server/minify.mjs, and its editor instance at
+// "const deckEditor = new DeckEditor()" would need the whole editor around it - so evaluate only the part
+// after that line, which is where the deck creation flows keep their helpers.
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const source = fs.readFileSync(path.join(dir, '../../client/js/editor/deckeditor.js'), 'utf8');
+const instance = 'const deckEditor = new DeckEditor();';
+const helpers = source.slice(source.indexOf(instance) + instance.length);
+const { cardDefaultsWithTransition, cardDefaultsHaveTransition } = new Function(`${helpers}\nreturn { cardDefaultsWithTransition, cardDefaultsHaveTransition };`)();
+
+describe('the transition class the deck creation flows put into cardDefaults', () => {
+  test('adds the class to a deck that does not glide yet, keeping the classes it brings', () => {
+    expect(cardDefaultsWithTransition()).toEqual({ classes: 'transition' });
+    expect(cardDefaultsWithTransition({ width: 103 })).toEqual({ width: 103, classes: 'transition' });
+    expect(cardDefaultsWithTransition({ classes: 'fancy' })).toEqual({ classes: 'fancy transition' });
+  });
+
+  test('hands back a class list that already glides exactly as it was written', () => {
+    // dropTargets compare classes as one whole string, so reordering "transition fancy" into "fancy transition"
+    // would take the deck's cards out of every holder accepting them
+    for(const classes of [ 'transition', 'transition fancy', 'fancy transition', 'a transition b' ])
+      expect(cardDefaultsWithTransition({ classes })).toEqual({ classes });
+  });
+
+  test('removes only the transition class, and the key with the last class', () => {
+    expect(cardDefaultsWithTransition({ classes: 'fancy transition' }, false)).toEqual({ classes: 'fancy' });
+    expect(cardDefaultsWithTransition({ classes: 'transition fancy' }, false)).toEqual({ classes: 'fancy' });
+    expect(cardDefaultsWithTransition({ width: 103, classes: 'transition' }, false)).toEqual({ width: 103 });
+    expect(cardDefaultsWithTransition({ classes: 'fancy' }, false)).toEqual({ classes: 'fancy' });
+  });
+
+  test('does not mistake a class that merely contains the word for the class itself', () => {
+    expect(cardDefaultsHaveTransition({ classes: 'transitional' })).toBe(false);
+    expect(cardDefaultsWithTransition({ classes: 'transitional' })).toEqual({ classes: 'transitional transition' });
+  });
+});

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -1430,6 +1430,29 @@ test('A card keeps gliding into a pile that the same move creates', async t => {
     .expect(glidedCards()).contains('card3');
 });
 
+// A widget that is moved out of a holder is parked on the top surface first, carrying a temporary transform
+// that keeps it where it was until its real one is written back. When the delta sends it to the top surface
+// itself the element is already there, so nothing about it moves in the DOM - but the transform still has to
+// be restored, or the widget stays drawn inside the holder it left on every client that watched it go.
+test('A widget whose routine only detaches it is drawn at its own coordinates', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    holder: { id: 'holder', type: 'holder', x: 400, y: 300, width: 120, height: 120, dropTarget: {} },
+    child:  { id: 'child', type: 'basic', parent: 'holder', x: 0, y: 0, width: 50, height: 50 },
+    detach: { id: 'detach', type: 'button', x: 20, y: 500, text: 'detach', clickRoutine: [
+      { func: 'SET', collection: [ 'child' ], property: 'parent', value: null } ] }
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  const transformOf = ClientFunction(id => getComputedStyle(document.getElementById('w_'+id)).transform);
+
+  await t
+    .expect(Selector('#w_child').exists).ok()
+    .click('#w_detach')
+    .expect(transformOf('child')).eql('matrix(1, 0, 0, 1, 0, 0)');
+});
+
 // A widget the editor creates carrying a class it does not need is not free: compareDropTarget() compares
 // classes as one whole string, so a chip that says "pokerChip transition" no longer matches the stack's
 // dropTarget of "pokerChip" and cannot be put back. A state hash cannot see a drop target that stopped

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -1364,7 +1364,7 @@ test('Create game using edit mode', async t => {
     .click('#buttonInputGo')
     .rightClick('#w_dice2')
     .click('#w_dice2');
-  await compareState(t, '3878b15bd31f8ad1d0972a20b69d7ea5');
+  await compareState(t, 'f1b7028d28a75d5d0dd88a8380c1c4e2');
 });
 
 test('Deck editor: add card type, dynamic object, delete face, undo', async t => {
@@ -1409,7 +1409,7 @@ test('Deck editor: add card type, dynamic object, delete face, undo', async t =>
     .click('#deckEditorTreeDelete')                   // delete the just-added (current) face
     .pressKey('esc') // closes the deck editor, since no face object is selected at this point
     .click('#editorToolbar [icon=undo]'); // undoes the face deletion through the normal room undo protocol
-  await compareState(t, '58a003635d5de3dca9db433bf7862c09');
+  await compareState(t, '37fe748a394f5a132255e27e6db76cf3');
 });
 
 // Both the object form of the css property and the css of an html face object are put into a style element
@@ -1521,7 +1521,7 @@ test('Deck editor: symbol pickers and JSON fallback', async t => {
     .click('#editorSidebar [icon=data_object]')
     .pressKey('esc')
     .pressKey('esc');
-  await compareState(t, 'd052dc1c0a50f93896325518bee01ac8');
+  await compareState(t, '252a788d6293626108c2b98ad1789b7d');
 });
 
 test('The symbol picker says an image-only search found nothing', async t => {
@@ -1974,7 +1974,7 @@ test('Deck editor: breadcrumb undo and redo', async t => {
     .click('#deckEditorRedo')                 // restore and then remove it again to exercise redo without changing the old final state
     .click('#deckEditorUndo')
     .pressKey('esc');
-  await compareState(t, '261ba6765efc84b628f1d62ba7e679d6');
+  await compareState(t, '7ef83e2dd103ebf9aee47ad826501803');
 });
 
 test('Deck editor: remote update preserves an unrelated pending edit', async t => {
@@ -2032,7 +2032,7 @@ test('Deck editor: remote update preserves an unrelated pending edit', async t =
   await t
     .expect(getEditedValues(deckID)).eql({ text: 'Pending local edit', receivedProperty: 'Remote value' })
     .pressKey('esc');
-  await compareState(t, 'c6db1d55c7f0bc9fe6f061f61662d046');
+  await compareState(t, 'b10bc909499a3eb29ca43c74fc34bce8');
 });
 
 // Two different fields edited within one debounce window, then a structural action right after, must stay
@@ -2105,7 +2105,7 @@ test('Deck editor: rapid cross-field edits stay separate undo steps', async t =>
     .click('#deckEditorUndo') // reverts only the fontSize edit
     .expect(getTextObject(deckID)).eql({ value: 'RapidValue', fontSize: 20 })
     .pressKey('esc');
-  await compareState(t, '5aa7273ddccb7e6f55a8a57715e83437');
+  await compareState(t, 'f9090c713dc230a6b077bf0f219aa493');
 });
 
 // Regression test for the crash reported on switching games while a deck was being edited (the previously
@@ -2295,7 +2295,7 @@ test('Deck editor: create deck from scratch with color box, face and defaults', 
   await t.pressKey('esc');          // closes the deck editor - and only the deck editor
   await t.expect(Selector('body').hasClass('deckEditorActive')).notOk();
   await t.expect(Selector('body').hasClass('edit')).ok(); // Escape must not have left edit mode
-  await compareState(t, 'a3826d837df312e2612e461c40a1bf15');
+  await compareState(t, '08fd4fc28330d11cb0c32b07d01455be');
 });
 
 test('Deck editor: toolbar button toggles the editor and stays in sync with Escape', async t => {
@@ -2514,7 +2514,7 @@ test('Deck editor: add a deck of text cards from the new deck wizard', async t =
     .typeText('.textCardsCopies', '2', { replace: true })
     .click('#deckEditorNewDeckPanel .goButton [icon=add]')
     .expect(Selector('#deckEditorStrip .deckEditorStripCard').count).eql(3); // the wizard's deck is now open
-  await compareState(t, 'bac90198761e33be360df604952691bd');
+  await compareState(t, '56acdbdb0ac9ae1ff387bdbf3ffca089');
 });
 
 // The other way of cutting the typed text into cards: with a blank line as the separator a card's text keeps

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -1384,6 +1384,52 @@ test('The transition class glides a widget over a duration --transitionDuration 
     .expect(durations([ 'plain', 'glide', 'slow' ])).eql([ '0s', '0.3s', '1.5s' ]);
 });
 
+// A card that is dealt onto a card it piles up with travels while the pile it lands in is being created, and
+// applying a delta re-attached the pile to the parent it was already in - which takes the card out of the DOM
+// with it and cancels the glide it just started. Only the move that creates the pile was affected, so a deal
+// onto an empty holder and the next one onto the finished pile both animate on either side of the fix.
+test('A card keeps gliding into a pile that the same move creates', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    deck:   { id: 'deck', type: 'deck', x: 20, y: 20, cardTypes: { plain: {} }, cardDefaults: { classes: 'transition' } },
+    source: { id: 'source', type: 'holder', x: 20, y: 200, dropTarget: { type: 'card' } },
+    target: { id: 'target', type: 'holder', x: 800, y: 200, dropTarget: { type: 'card' } },
+    card1:  { id: 'card1', type: 'card', deck: 'deck', cardType: 'plain', parent: 'source' },
+    card2:  { id: 'card2', type: 'card', deck: 'deck', cardType: 'plain', parent: 'source' },
+    card3:  { id: 'card3', type: 'card', deck: 'deck', cardType: 'plain', parent: 'source' },
+    deal:   { id: 'deal', type: 'button', x: 800, y: 500, text: 'deal', clickRoutine: [
+      { func: 'MOVE', from: 'source', to: 'target', count: 1 } ] }
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+
+  // a transition that is cancelled before the first frame is rendered reports no running animation and fires
+  // no event afterwards, so the cards are watched frame by frame from before the deal rather than sampled once
+  const watchGlides = ClientFunction(() => {
+    window.glidedCards = new Set();
+    const step = () => {
+      for(const card of document.querySelectorAll('.card'))
+        if(card.getAnimations().length)
+          window.glidedCards.add(card.id.replace('w_', ''));
+      requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+  });
+  const glidedCards = ClientFunction(() => [ ...window.glidedCards ].sort());
+  const parentOf = ClientFunction(id => document.getElementById('w_'+id).parentElement.id);
+
+  await t.expect(Selector('#w_card3').exists).ok();
+  await watchGlides();
+  await t
+    .click('#w_deal')
+    .expect(glidedCards()).contains('card1')
+    .click('#w_deal')
+    .expect(parentOf('card2')).notEql('w_target') // the second card lands in a pile, not in the holder itself
+    .expect(glidedCards()).contains('card2')
+    .click('#w_deal')
+    .expect(glidedCards()).contains('card3');
+});
+
 // A widget the editor creates carrying a class it does not need is not free: compareDropTarget() compares
 // classes as one whole string, so a chip that says "pokerChip transition" no longer matches the stack's
 // dropTarget of "pokerChip" and cannot be put back. A state hash cannot see a drop target that stopped

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -1364,7 +1364,55 @@ test('Create game using edit mode', async t => {
     .click('#buttonInputGo')
     .rightClick('#w_dice2')
     .click('#w_dice2');
-  await compareState(t, 'f1b7028d28a75d5d0dd88a8380c1c4e2');
+  await compareState(t, 'a59b94e1ee5f2beef49f6fe5983ee5b3');
+});
+
+// The rule behind the transition class is the client's, so nothing in a save file pins it: a game that wants
+// gliding widgets only asks for the class. These are the three answers the rule gives.
+test('The transition class glides a widget over a duration --transitionDuration changes', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    plain: { id: 'plain', type: 'basic', x: 20, y: 20, width: 50, height: 50 },
+    glide: { id: 'glide', type: 'basic', x: 20, y: 100, width: 50, height: 50, classes: 'transition' },
+    slow:  { id: 'slow',  type: 'basic', x: 20, y: 180, width: 50, height: 50, classes: 'transition', css: '--transitionDuration: 1500ms' }
+  });
+  await ClientFunction(prepareClient)();
+
+  const durations = ClientFunction(ids => ids.map(id => getComputedStyle(document.getElementById('w_'+id)).transitionDuration));
+  await t
+    .expect(Selector('#w_slow').exists).ok()
+    .expect(durations([ 'plain', 'glide', 'slow' ])).eql([ '0s', '0.3s', '1.5s' ]);
+});
+
+// A widget the editor creates carrying a class it does not need is not free: compareDropTarget() compares
+// classes as one whole string, so a chip that says "pokerChip transition" no longer matches the stack's
+// dropTarget of "pokerChip" and cannot be put back. A state hash cannot see a drop target that stopped
+// matching, which is why the two halves are asserted here.
+test('A new deck hands the transition class to its cards, a new chip stack leaves its chips alone', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState();
+  await ClientFunction(prepareClient)();
+  await setEditorState(null);
+  await setName(t);
+
+  const cardDefaultClasses = ClientFunction(id => (widgets.get(id).get('cardDefaults') || {}).classes);
+  const cardDuration = ClientFunction(id => getComputedStyle(widgets.get(id).domElement).transitionDuration);
+  const dropTargetIDs = ClientFunction(id => widgets.get(id).validDropTargets().map(w => w.get('id')));
+
+  // the chip stack comes first: the holder of a card deck accepts every card, chips included, so its
+  // presence would hide whether the chip still matches the stack it belongs to
+  await t
+    .click('#editButton')
+    .click('#editorToolbar > div > [icon=add]')
+    .click('#add-2D-chips')
+    .pressKey('esc')
+    .expect(cardDefaultClasses('chips1D')).eql('pokerChip')
+    .expect(dropTargetIDs('chips1C1')).eql([ 'chips1' ])
+    .click('#editorToolbar > div > [icon=add]')
+    .click('#add-deck_K_S')
+    .pressKey('esc')
+    .expect(cardDefaultClasses('deck1D')).eql('transition')
+    .expect(cardDuration('deck1_A_C')).eql('0.3s');
 });
 
 test('Deck editor: add card type, dynamic object, delete face, undo', async t => {
@@ -2295,7 +2343,7 @@ test('Deck editor: create deck from scratch with color box, face and defaults', 
   await t.pressKey('esc');          // closes the deck editor - and only the deck editor
   await t.expect(Selector('body').hasClass('deckEditorActive')).notOk();
   await t.expect(Selector('body').hasClass('edit')).ok(); // Escape must not have left edit mode
-  await compareState(t, '08fd4fc28330d11cb0c32b07d01455be');
+  await compareState(t, '5904dc26cd93f0b3ef9634ded10bbf19');
 });
 
 test('Deck editor: toolbar button toggles the editor and stays in sync with Escape', async t => {
@@ -2514,7 +2562,7 @@ test('Deck editor: add a deck of text cards from the new deck wizard', async t =
     .typeText('.textCardsCopies', '2', { replace: true })
     .click('#deckEditorNewDeckPanel .goButton [icon=add]')
     .expect(Selector('#deckEditorStrip .deckEditorStripCard').count).eql(3); // the wizard's deck is now open
-  await compareState(t, '56acdbdb0ac9ae1ff387bdbf3ffca089');
+  await compareState(t, '4079d9c5507c65d71441004f891cce75');
 });
 
 // The other way of cutting the typed text into cards: with a blank line as the separator a card's text keeps

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -1413,6 +1413,21 @@ test('A new deck hands the transition class to its cards, a new chip stack leave
     .pressKey('esc')
     .expect(cardDefaultClasses('deck1D')).eql('transition')
     .expect(cardDuration('deck1_A_C')).eql('0.3s');
+
+  // the deck's own properties panel can take the class away again and put it back - it is not something only
+  // the JSON editor knows about
+  const glideSwitch = Selector('.editorModule .propertyInput.switchInput').withText('Glide when they move').find('label.switchbox');
+  await t
+    .click('#editButton') // the esc above left edit mode, where the deck widget is the only thing visible of it
+    .click('#editorSidebar [icon=tune]') // and closed the properties module the switch lives in
+    .click('#w_deck1D')
+    .expect(glideSwitch.exists).ok()
+    .click(glideSwitch)
+    .expect(cardDefaultClasses('deck1D')).notOk()
+    .expect(cardDuration('deck1_A_C')).eql('0s')
+    .click(glideSwitch)
+    .expect(cardDefaultClasses('deck1D')).eql('transition')
+    .expect(cardDuration('deck1_A_C')).eql('0.3s');
 });
 
 test('Deck editor: add card type, dynamic object, delete face, undo', async t => {


### PR DESCRIPTION
## What this changes

Widgets can now be told to **glide** to a new position instead of jumping there by putting `transition` into their `classes` property, and the decks the editor creates carry that class in their `cardDefaults`, so a freshly added card deck animates its cards out of the box.

`transition` has been offered as a class in the JSON editor's `classes` picker for a long time, but nothing in the client ever defined it — every game that wanted gliding cards had to paste a rule like `"_, .transition": { "transition": "transform 600ms" }` into some widget's `css` to make the class mean anything. This PR ships those few lines with the client instead.

## The change

* `client/css/widgets/classes.css` gains the class:

  ```css
  .transition {
    transition: transform var(--transitionDuration, 300ms);
  }
  .transition.dragging {
    transition: none;
  }
  ```

  It animates the whole transform, so `x`, `y`, `rotation` and `scale` all glide. Dragging is excluded on every client, not only on the one holding the widget: a drag writes a new position per mouse event, so the animation would restart before finishing and trail the pointer for everyone — and on the dragging client the drop target is hit-tested against where the widget is *drawn*, which mid-animation is not where the drag put it.
* Every deck-creation flow in the editor puts `transition` into the new deck's `cardDefaults` — the Add Widget overlay (empty deck, 52-card deck), all six flows behind `addDeckWithCards` (traditional, custom, image, front/back image, text, TTS), the deck editor's *Empty deck* starter, and the public-library deck browser. They share one helper, `cardDefaultsWithTransition()` in `deckeditor.js`, which **appends** the class, so a library deck or TTS import that brings `cardDefaults.classes` of its own keeps them and still glides - and hands a class list that already contains `transition` back exactly as it was written, because a dropTarget matching on it compares the whole string. It goes into `cardDefaults`, so removing it again is one line in the JSON editor.
* The two **poker chip stacks** deliberately do *not* get it. Their holder filters what it accepts with `dropTarget: { classes: 'pokerChip' }`, and `compareDropTarget()` compares `classes` as one whole string — a chip saying `"pokerChip transition"` would no longer fit the stack it came from. Keeping both sides in sync would not help either: chips of a stack created before this change would then not fit a stack created after it, and vice versa. A comment at both ends says so, and a test pins it.
* A deck's properties panel gets a **Cards / Glide when they move** switch, which reads and writes that class in `cardDefaults` - see *UI support* below.
* The `classes` input in the widget editor and the *Global Room CSS* panel in game settings mention the class and how to retime it, and the *Target widgets* info popup of the drop-target editor says that a condition is compared against the whole property, so `classes` means the widget's entire class list.

## What this means for existing games

* A game that defines `.transition` itself keeps its own timing: the rule uses a single class as its selector and the client bundle is loaded before any game CSS, so widget `css` and *Global Room CSS* both still win on source order (Feta, Tres, Loot the Louvre, Cube Conveyor, …). Same for a widget that sets `transition` in its own `css`, which is a `#w_<id>` rule and wins outright.
* Six published games use `classes: "transition"` **without** defining a rule for it, so they do change:
  * `Henny_s Herd Hoard`, `Marble Mania`, `Moroccan Moolah`, `Rolling Monarch` and `Wildwood` have it in a deck's `cardDefaults` — their cards start gliding at 300ms, which is what clicking that class in the editor was meant to do.
  * `The Diamond Dilemma` has it on six meeples and on a holder. The meeples each set `css: { transition: "opacity 1s …" }`, which overrides the class completely — their computed `transition-duration` is `1s, 0.65s` before and after. The holder gains a transform transition it never uses, since a holder does not move in play; dropping a meeple into it still works (checked in the browser).
* Everything else is unaffected — the class does nothing unless a widget asks for it — so this needs no file version bump and no legacy mode. Only decks created *after* this change get the class; existing decks are untouched.

Two ways to change it without touching any widget:

* `"css": "--transitionDuration: 800ms"` on a widget (or in a deck's `cardDefaults`) retimes just that one.
* `.transition { transition: transform 800ms; }` in the room's *Global Room CSS* retimes the whole game.

## Where it comes from

From #general on Discord ([message](https://discord.com/channels/770758631146782780/770758631146782783/1544871878999416973)), after Retorikal shared a pile inspector that used exactly this trick:

> **mousewax:** Would it be a good idea to have the transition styles in the custom CSS of a room by default so it's there but can be changed if you want it to?

> **LawDawg:** Yes. And that should be the default on card decks. I mean, it is just a couple of lines of css and a classes declaration.

> **mousewax:** Tell the bot to make it so!

The one thing this does differently from the literal request: the rule ships in the client stylesheet rather than being written into every room's custom CSS. That keeps it out of every save file while still being overridable from the room's custom CSS, which the Global Room CSS panel now says out loud.

## UI support

No new property is introduced — `transition` is a value of the existing `classes` property, which is editable in the widget editor's *User defined active classes* field (its hint now names the class) and has had a one-click button in the JSON editor's `classes` picker all along.

What that field could not reach is a deck's `cardDefaults`, which is exactly where this PR writes the class: the deck's properties panel showed nothing about it, so a first-time user who did not want the gliding had no way to switch it off short of the JSON editor. The panel now has a **Cards** section with one switch:

* **Glide when they move** — on for every deck whose `cardDefaults.classes` contain `transition`. Turning it off removes just that class and keeps every other class the deck asks for; turning it on adds it back. Its (i) hint says what it writes and that the room's custom css can retime or replace it.
* On a deck whose cards are accepted somewhere by their exact class list — the chip stacks the Add Widget overlay creates — the switch is shown disabled with the reason underneath, because turning it on is precisely what would stop the chips fitting their own stack. That also answers "why do my chips not glide" in the place the question is asked.

## Gliding into a pile

Reported on this PR: dealing the same demo deck several times in a row, the batch that lands on the cards already lying there jumped while every batch before and after it glided. That is the deal which makes those cards form a **pile**, and it was an engine bug rather than something about the class.

A routine reaches the DOM as one delta at the end of its batch, and that delta carries both the card's new parent and the pile that was just created. `receiveDelta()` re-applies the pile's own properties — `parent` among them — although the pile already sits in that holder, and `applyDeltaToDOM()` then ran `newParent.appendChild()` for the parent the element was already in. Re-appending an element detaches and reattaches it, which cancels the CSS transitions running on it *and on everything below it*: the card that had just started gliding into the pile stopped dead at its destination.

`client/js/widgets/widget.js` now skips the `appendChild()` when the delta names the parent the element is already a child of. Everything else in that block still runs: a widget whose delta names a parent is parked on `#topSurface` by `receiveDelta()`'s first loop with a temporary transform that keeps it visually in place, and the transform written at the end of the block is what puts it back on its own coordinates — so that write has to happen even when nothing moved in the DOM. Widgets whose parent really changes are on the top surface at that point, so their parent element is never the new one and the reparent animation is untouched.

## Testing

* `npm test` (jest) passes, including `tests/client/deck-transition-class.test.js`, which pins what `cardDefaultsWithTransition()` does to a deck's class string: appending the class when it is missing, leaving an existing list untouched (`"transition fancy"` stays `"transition fancy"`), and removing only that one class - and the `classes` key with the last of them.
* `tests/testcafe/editor.js` passes, with three new tests:
  * *The transition class glides a widget over a duration --transitionDuration changes* — asserts the computed `transition-duration` of a plain widget, one with the class and one that also sets `--transitionDuration: 1500ms` (`0s` / `0.3s` / `1.5s`), so deleting the CSS rule fails the suite.
  * *A new deck hands the transition class to its cards, a new chip stack leaves its chips alone* — asserts that a chip of a freshly created chip stack has exactly its own stack as a valid drop target, and that a card of a freshly created deck computes `0.3s`. A state hash cannot see a drop target that stopped matching, which is how the chip regression got in. It then flips the deck panel's *Glide when they move* switch off and on again, asserting the class and the computed duration follow it both ways.
  * *A card keeps gliding into a pile that the same move creates* — three deals in a row onto the same holder, watched frame by frame (a transition cancelled before the first frame fires no `transitionrun`/`transitioncancel` event, so events cannot see this). The middle deal, the one that creates the pile, fails without the guard.
  * *A widget whose routine only detaches it is drawn at its own coordinates* — a widget inside a holder, moved out by a routine that only sets `parent` to `null`, has to end up drawn at its own `x`/`y` on the surface. A state hash cannot see a widget painted in the wrong place, so this asserts the computed transform.
* State hashes changed in the tests that create a deck; each diff was checked against the reference state from `main` and is exactly `cardDefaults: { classes: "transition" }` on the created deck and nothing else.
* Verified in a real browser: a widget with the class is genuinely mid-way between the two positions during the animation, cards dealt from a newly created deck inherit the `0.3s` from `cardDefaults`, and `The Diamond Dilemma` still plays as before.

* CI note: `tests/testcafe/editor.js` fails on the GitHub runners that have moved to **Chrome 152** — on `main` as much as on this branch — in *Renaming a widget keeps its color controls clear and it movable*. That is a separate editor bug (the widget id input gets its `change` event twice and reads the second one as a rename onto an id that now exists); the fix has been taken back off this branch and is waiting for a PR of its own, see the comment below. A red Chrome 152 run here with only that failure does not come from this change.

## Demo room

A tutorial-quality demo room, **Appearance - Transitions**, with two variants — *Basic* (the class on any widget: movement, rotation, scale, custom duration, and that dragging stays instant) and *Cards* (two identical decks, one with the class in `cardDefaults` and one without, plus how to turn it off or retime it) — is deliberately **not** part of this diff. It lives on this PR's test server in the [`pr-test-ai` room](https://test.virtualtabletop.io/PR-3162/pr-test-ai) — open it and the room's game shelf offers both variants — and can be moved into `library/tutorials/` on request. The save file itself: [Appearance - Transitions.vtt](https://agent.virtualtabletop.io/reports/pr/1544872089654394890/Appearance%20-%20Transitions.vtt).

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3162/pr-test (or any other room on that server)






