### PR TITLE
Keep the Debug module logging when edit mode is entered again

### DIFF
--- a/client/js/editor/layout.js
+++ b/client/js/editor/layout.js
@@ -115,8 +115,6 @@ export function openEditor() {
 }
 
 function closeEditor() {
-  setJEroutineLogging(jeRoutineLogging = false);
-
   deckEditor.close();
 
   for(const module of sidebarModules)

--- a/client/js/editor/sidebar/json.js
+++ b/client/js/editor/sidebar/json.js
@@ -121,6 +121,15 @@ class DebugModule extends SidebarModule {
     this.updateValidation();
   }
 
+  // Leaving edit mode switches routine logging off (see closeEditor), which the panel itself does
+  // not notice - so a Debug module that is still open when edit mode is entered again switches it
+  // back on. Without this, the log stays empty until the module is closed and opened once more.
+  onEditorOpen() {
+    super.onEditorOpen();
+    if(this.moduleDOM)
+      setJEroutineLogging(jeRoutineLogging = true);
+  }
+
   onStateReceivedWhileActive() {
     this.button_clearButton();
     this.updateValidation();

--- a/client/js/editor/sidebar/json.js
+++ b/client/js/editor/sidebar/json.js
@@ -76,7 +76,6 @@ class DebugModule extends SidebarModule {
 
   button_clearButton() {
     jeLoggingClear();
-    $('#jeLog').innerHTML = '';
   }
 
   button_clearCheckbox() {
@@ -131,7 +130,9 @@ class DebugModule extends SidebarModule {
 
   onEditorOpen() {
     super.onEditorOpen();
-    if(this.moduleDOM) {
+    // Keyed on the flag actually being off rather than on onEditorClose() having run: edit mode can
+    // also be left in ways that never reach it, and then nothing was missed and nothing is stale.
+    if(this.moduleDOM && !jeRoutineLogging) {
       setJEroutineLogging(jeRoutineLogging = true);
       jeLoggingResumed();
     }

--- a/client/js/editor/sidebar/json.js
+++ b/client/js/editor/sidebar/json.js
@@ -121,9 +121,14 @@ class DebugModule extends SidebarModule {
     this.updateValidation();
   }
 
-  // Leaving edit mode switches routine logging off (see closeEditor), which the panel itself does
-  // not notice - so a Debug module that is still open when edit mode is entered again switches it
-  // back on. Without this, the log stays empty until the module is closed and opened once more.
+  // Routines are only logged while this panel is open to show the log, so playing the game costs
+  // nothing - which is why the flag follows edit mode in both directions and not just the panel:
+  // a panel that is still open when the editor is closed and reopened has to log again.
+  onEditorClose() {
+    super.onEditorClose();
+    setJEroutineLogging(jeRoutineLogging = false);
+  }
+
   onEditorOpen() {
     super.onEditorOpen();
     if(this.moduleDOM)

--- a/client/js/editor/sidebar/json.js
+++ b/client/js/editor/sidebar/json.js
@@ -131,8 +131,10 @@ class DebugModule extends SidebarModule {
 
   onEditorOpen() {
     super.onEditorOpen();
-    if(this.moduleDOM)
+    if(this.moduleDOM) {
       setJEroutineLogging(jeRoutineLogging = true);
+      jeLoggingResumed();
+    }
   }
 
   onStateReceivedWhileActive() {
@@ -158,7 +160,7 @@ class DebugModule extends SidebarModule {
     `);
     this.setClearButtonTitle();
     target.append($('#jeLog'));
-    div(target, 'jeLogNote jeLogEmptyNote', 'Nothing has been logged yet. Middle-click a widget to run it as if you were playing - or right-click one that is already selected - and every operation of the routine it starts shows up here.');
+    div(target, 'jeLogNote jeLogEmptyNote', 'Nothing has been logged yet. Middle-click a widget to run it as if you were playing - or right-click one that is already selected - and every operation of the routine it starts shows up here. Routines are only logged while this panel is open in edit mode.');
 
     on('#jeLogFilter', 'input', e=>this.button_filter());
     on('#autoClearLog', 'change', e=>this.button_clearCheckbox());

--- a/client/js/editor/sidebar/json.js
+++ b/client/js/editor/sidebar/json.js
@@ -160,7 +160,7 @@ class DebugModule extends SidebarModule {
     `);
     this.setClearButtonTitle();
     target.append($('#jeLog'));
-    div(target, 'jeLogNote jeLogEmptyNote', 'Nothing has been logged yet. Middle-click a widget to run it as if you were playing - or right-click one that is already selected - and every operation of the routine it starts shows up here. Routines are only logged while this panel is open in edit mode.');
+    div(target, 'jeLogNote jeLogEmptyNote', 'Nothing has been logged yet. Routines are only logged while this Debug panel is open in edit mode.');
 
     on('#jeLogFilter', 'input', e=>this.button_filter());
     on('#autoClearLog', 'change', e=>this.button_clearCheckbox());

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3305,6 +3305,10 @@ function jeFormatHTML(html, baseIndent) {
 // START routine logging
 
 let jeRoutineResetOnNextLog = true;
+// True while the newest thing in the log is the "logging resumed" note. Leaving and entering edit
+// mode again without anything being logged in between would otherwise stack up an identical note
+// for every round trip.
+let jeLoggingResumeNoted = false;
 let jeRoutineAutoReset = true;
 let jeRoutineResult = '';
 let jeLoggingHTML = '';
@@ -3316,6 +3320,7 @@ let jeHTMLStack = [];
 // again and resurrects what was just cleared.
 function jeLoggingClear() {
   jeLoggingHTML = '';
+  jeLoggingResumeNoted = false;
   for(const entry of jeHTMLStack)
     entry[0] = '';
 }
@@ -3376,6 +3381,7 @@ export function jeLoggingRoutineStart(widget, property, variables, byReference) 
         </div>
         <div class="jeLogNested ${jeLoggingDepth ? '' : 'active'}">
     `;
+    jeLoggingResumeNoted = false;
   }
   // a routine that runs by reference works on the variables of the routine that started it, which
   // may have changed a built-in one by now - the enclosing routine's set still says what it started
@@ -3452,6 +3458,7 @@ export function jeLoggingRoutineNotLogged(widget, property) {
       ${routine} was already running when the Debug panel was opened, so it could not be recorded. Run it again to see its log.
     </div>
   `;
+  jeLoggingResumeNoted = false;
   jeLoggingRenderLog(jeLoggingHTML);
 }
 
@@ -3460,8 +3467,9 @@ export function jeLoggingRoutineNotLogged(widget, property) {
 // are still on screen are older than the last thing the user did - mark them instead of letting the
 // panel present them as the most recent interaction.
 function jeLoggingResumed() {
-  if(jeLoggingDepth || jeHTMLStack.length || !$('#jeLog') || !jeLoggingHTML)
+  if(jeLoggingDepth || jeHTMLStack.length || !$('#jeLog') || !jeLoggingHTML || jeLoggingResumeNoted)
     return;
+  jeLoggingResumeNoted = true;
   jeLoggingHTML += `
     <div class="jeLog jeLogNote">
       Logging resumed. Everything above is from before edit mode was left - what you did while playing was not logged.

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3315,14 +3315,18 @@ let jeLoggingHTML = '';
 let jeLoggingDepth = 0;
 let jeHTMLStack = [];
 
-// Empty the log. Operations of a routine that is currently running have the log so far saved on
-// jeHTMLStack, so that has to be emptied too - otherwise jeLoggingRoutineOperationEnd prepends it
-// again and resurrects what was just cleared.
+// Empty the log, both the buffer and what is on screen - a buffer that no longer matches the panel
+// leaves entries on display that look current while nothing knows about them any more. Operations
+// of a routine that is currently running have the log so far saved on jeHTMLStack, so that has to
+// be emptied too - otherwise jeLoggingRoutineOperationEnd prepends it again and resurrects what was
+// just cleared.
 function jeLoggingClear() {
   jeLoggingHTML = '';
   jeLoggingResumeNoted = false;
   for(const entry of jeHTMLStack)
     entry[0] = '';
+  if($('#jeLog'))
+    $('#jeLog').innerHTML = '';
 }
 
 function jeLoggingJSON(obj) {
@@ -3470,12 +3474,16 @@ function jeLoggingResumed() {
   if(jeLoggingDepth || jeHTMLStack.length || !$('#jeLog') || !jeLoggingHTML || jeLoggingResumeNoted)
     return;
   jeLoggingResumeNoted = true;
-  jeLoggingHTML += `
+  const note = `
     <div class="jeLog jeLogNote">
       Logging resumed. Everything above is from before edit mode was left - what you did while playing was not logged.
     </div>
   `;
-  jeLoggingRenderLog(jeLoggingHTML);
+  jeLoggingHTML += note;
+  // Appended instead of rendered from the buffer: a re-render collapses the entries the user
+  // expanded before going off to play, which is the very log this note belongs to. The note carries
+  // no expanders and sits outside .jeLogNested, so neither the click handlers nor the filter apply.
+  $('#jeLog').insertAdjacentHTML('beforeend', note);
 }
 
 export function jeLoggingRoutineOperationStart(original, applied) {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3455,6 +3455,21 @@ export function jeLoggingRoutineNotLogged(widget, property) {
   jeLoggingRenderLog(jeLoggingHTML);
 }
 
+// Called when logging is switched back on because edit mode was opened again with the Debug panel
+// still displayed. Nothing that happened while the game was played was logged, so the entries that
+// are still on screen are older than the last thing the user did - mark them instead of letting the
+// panel present them as the most recent interaction.
+function jeLoggingResumed() {
+  if(jeLoggingDepth || jeHTMLStack.length || !$('#jeLog') || !jeLoggingHTML)
+    return;
+  jeLoggingHTML += `
+    <div class="jeLog jeLogNote">
+      Logging resumed. Everything above is from before edit mode was left - what you did while playing was not logged.
+    </div>
+  `;
+  jeLoggingRenderLog(jeLoggingHTML);
+}
+
 export function jeLoggingRoutineOperationStart(original, applied) {
   let fcn;
   if (typeof applied == 'string')

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -3875,6 +3875,51 @@ test('the Debug module logs again after edit mode was left and entered once more
   await setEditorState(null);
 });
 
+test('the Debug module does not keep unmarked entries when the JSON module clears the log', async t => {
+  await setRoomState({
+    button: { id: 'button', type: 'button', clickRoutine: [ 'var roll = randInt 5 5' ] }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState({ modules: { Debug: 'editorModuleTopLeft', JSON: 'editorModuleBottomLeft' } });
+  await setName(t);
+
+  const runClickRoutine = ClientFunction(() => {
+    return widgets.get('button').evaluateRoutine('clickRoutine', {}, {}).then(()=>{});
+  });
+  const loggedOperations = Selector('#jeLog .jeLogSummary');
+
+  await t
+    .expect(Selector('#w_button').exists).ok('the room renders its widgets', { timeout: 30000 })
+    .click('#editButton')
+    .expect(Selector('#editorModuleTopLeft.pest_control').exists).ok()
+    .expect(Selector('#editorModuleBottomLeft.data_object').exists).ok();
+
+  await runClickRoutine();
+  await t.expect(loggedOperations.count).eql(1);
+
+  await t
+    .click('#editorToolbar [icon=close]')
+    .expect(Selector('body').hasClass('edit')).notOk();
+
+  await runClickRoutine();
+
+  // the JSON editor empties the log when edit mode toggles it, so nothing older is left behind to
+  // be mistaken for the interaction that just happened
+  await t
+    .click('#editButton')
+    .expect(Selector('body').hasClass('edit')).ok()
+    .expect(loggedOperations.count).eql(0)
+    .expect(Selector('.jeLogEmptyNote').visible).ok();
+
+  await runClickRoutine();
+
+  await t
+    .expect(loggedOperations.count).eql(1)
+    .expect(loggedOperations.nth(0).innerText).eql('roll = randInt 5 5');
+
+  await setEditorState(null);
+});
+
 // drags a selection rectangle around the given widgets - the events go to the
 // window, where the editor listens for them, so they need no element to start
 // from. A rectangle around a single widget is treated like a click on it, which

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -3819,9 +3819,9 @@ test('the Debug module logs each operation of a routine with its result', async 
   await setEditorState(null);
 });
 
-// Routine logging is switched off while playing, so the panel that is still open when edit mode
-// comes back has to switch it on again - loading a game leaves edit mode on the way to the game
-// shelf, which is where an always-open Debug module used to end up logging nothing.
+// Routine logging follows edit mode, not just the panel: it is switched off while the game is
+// played so playing costs nothing, which leaves a Debug module that stays open across a round of
+// playing logging nothing at all once edit mode comes back.
 test('the Debug module logs again after edit mode was left and entered once more', async t => {
   await setRoomState({
     button: { id: 'button', type: 'button', clickRoutine: [ 'var roll = randInt 5 5' ] }
@@ -3830,21 +3830,32 @@ test('the Debug module logs again after edit mode was left and entered once more
   await setEditorState({ modules: { Debug: 'editorModuleTopLeft' } });
   await setName(t);
 
+  const runClickRoutine = ClientFunction(() => {
+    return widgets.get('button').evaluateRoutine('clickRoutine', {}, {}).then(()=>{});
+  });
+  const loggedOperations = Selector('#jeLog .jeLogSummary');
+
   await t
+    .expect(Selector('#w_button').exists).ok('the room renders its widgets', { timeout: 30000 })
     .click('#editButton')
     .expect(Selector('#editorModuleTopLeft.pest_control').exists).ok()
     .click('#editorToolbar [icon=close]')
-    .expect(Selector('body').hasClass('edit')).notOk()
+    .expect(Selector('body').hasClass('edit')).notOk();
+
+  // nothing is logged while the game is played, however long the panel has been open
+  await runClickRoutine();
+  await t.expect(loggedOperations.count).eql(0);
+
+  await t
     .click('#editButton')
+    .expect(Selector('body').hasClass('edit')).ok()
     .expect(Selector('#editorModuleTopLeft.pest_control').exists).ok();
 
-  await ClientFunction(() => {
-    return widgets.get('button').evaluateRoutine('clickRoutine', {}, {}).then(()=>{});
-  })();
+  await runClickRoutine();
 
   await t
     .expect(Selector('.jeLogEmptyNote').visible).notOk()
-    .expect(Selector('#jeLog .jeLogSummary').nth(0).innerText).eql('roll = randInt 5 5');
+    .expect(loggedOperations.nth(0).innerText).eql('roll = randInt 5 5');
 
   await setEditorState(null);
 });

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -3838,18 +3838,25 @@ test('the Debug module logs again after edit mode was left and entered once more
   await t
     .expect(Selector('#w_button').exists).ok('the room renders its widgets', { timeout: 30000 })
     .click('#editButton')
-    .expect(Selector('#editorModuleTopLeft.pest_control').exists).ok()
+    .expect(Selector('#editorModuleTopLeft.pest_control').exists).ok();
+
+  await runClickRoutine();
+  await t.expect(loggedOperations.count).eql(1);
+
+  await t
     .click('#editorToolbar [icon=close]')
     .expect(Selector('body').hasClass('edit')).notOk();
 
   // nothing is logged while the game is played, however long the panel has been open
   await runClickRoutine();
-  await t.expect(loggedOperations.count).eql(0);
+  await t.expect(loggedOperations.count).eql(1);
 
   await t
     .click('#editButton')
     .expect(Selector('body').hasClass('edit')).ok()
-    .expect(Selector('#editorModuleTopLeft.pest_control').exists).ok();
+    .expect(Selector('#editorModuleTopLeft.pest_control').exists).ok()
+    // what is left on screen is older than the last thing the user did, so it says so
+    .expect(Selector('#jeLog .jeLogNote').innerText).contains('Logging resumed');
 
   await runClickRoutine();
 

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -3858,6 +3858,14 @@ test('the Debug module logs again after edit mode was left and entered once more
     // what is left on screen is older than the last thing the user did, so it says so
     .expect(Selector('#jeLog .jeLogNote').innerText).contains('Logging resumed');
 
+  // another round of playing says nothing new about the same stale entries
+  await t
+    .click('#editorToolbar [icon=close]')
+    .expect(Selector('body').hasClass('edit')).notOk()
+    .click('#editButton')
+    .expect(Selector('body').hasClass('edit')).ok()
+    .expect(Selector('#jeLog .jeLogNote').withText('Logging resumed').count).eql(1);
+
   await runClickRoutine();
 
   await t

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -3819,6 +3819,36 @@ test('the Debug module logs each operation of a routine with its result', async 
   await setEditorState(null);
 });
 
+// Routine logging is switched off while playing, so the panel that is still open when edit mode
+// comes back has to switch it on again - loading a game leaves edit mode on the way to the game
+// shelf, which is where an always-open Debug module used to end up logging nothing.
+test('the Debug module logs again after edit mode was left and entered once more', async t => {
+  await setRoomState({
+    button: { id: 'button', type: 'button', clickRoutine: [ 'var roll = randInt 5 5' ] }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState({ modules: { Debug: 'editorModuleTopLeft' } });
+  await setName(t);
+
+  await t
+    .click('#editButton')
+    .expect(Selector('#editorModuleTopLeft.pest_control').exists).ok()
+    .click('#editorToolbar [icon=close]')
+    .expect(Selector('body').hasClass('edit')).notOk()
+    .click('#editButton')
+    .expect(Selector('#editorModuleTopLeft.pest_control').exists).ok();
+
+  await ClientFunction(() => {
+    return widgets.get('button').evaluateRoutine('clickRoutine', {}, {}).then(()=>{});
+  })();
+
+  await t
+    .expect(Selector('.jeLogEmptyNote').visible).notOk()
+    .expect(Selector('#jeLog .jeLogSummary').nth(0).innerText).eql('roll = randInt 5 5');
+
+  await setEditorState(null);
+});
+
 // drags a selection rectangle around the given widgets - the events go to the
 // window, where the editor listens for them, so they need no element to start
 // from. A rectangle around a single widget is treated like a click on it, which


### PR DESCRIPTION
## What this does

The Debug module in edit mode switches routine logging on when it is opened and off when it is closed — but leaving edit mode switched it off too, from `closeEditor()` in `client/js/editor/layout.js`, and nothing switched it back on when edit mode was entered again. A Debug panel that stayed open across that boundary therefore kept showing an empty routine log.

Playing a round is exactly such a boundary: close the editor with the ✕ (or Escape, or Ctrl+J) to play, then go back to edit mode with Debug still the open module, and the debugger stays silent — no operation of any routine shows up — until the module is closed and opened again (clicking another sidebar module and coming back), which re-runs `renderModule()` and re-enables logging.

`DebugModule` now owns both directions of the flag: an `onEditorOpen()` hook turns routine logging back on when edit mode opens while the panel is still displayed, and the off-switch moved out of `closeEditor()` into a matching `onEditorClose()`. That mirrors what `JsonModule` already does for the JSON editor and keeps all four writes to the flag inside the one class that cares about it. Logging is still off for everyone who is only playing.

## Saying that the log stopped and started again

Switching logging back on leaves the entries from before the editor was closed on screen, and nothing that happened while the game was played is in them. With **Clear after each interaction** checked — the default — the panel's contract is "this is the most recent interaction", so it would show a minutes-old routine as the thing the user just did; with the box unchecked, the entries simply continue and the gap in the middle is invisible.

Resuming therefore appends a note to the log, in the same `jeLogNote` callout the log already uses for a routine that was running when the panel was opened:

> Logging resumed. Everything above is from before edit mode was left - what you did while playing was not logged.

With auto-clear on, the next interaction wipes the note along with the stale entries, so the panel is back to its normal one-interaction view ([screenshot](https://agent.virtualtabletop.io/reports/pr/1545159296923336805/debugnote-on-2-resumed.png)); with auto-clear off the note stays where it is and marks the gap in the list for good ([screenshot](https://agent.virtualtabletop.io/reports/pr/1545159296923336805/debugnote-off-3-after-run.png)). A log that is empty at that moment gets no note, so the "Nothing has been logged yet…" state is untouched.

One note is all the log needs. It says that everything above it is older than the last thing the user did, which stays true however often edit mode is left and entered again, so the note is only appended while it is not already the newest thing in the log — three round trips through play mode leave the single note the first one added ([screenshot](https://agent.virtualtabletop.io/reports/pr/1545159296923336805/debugnote-5-single-resume-note.png)). Anything that puts a real entry in the log makes the next resume append its note again, because by then there are fresh entries for it to mark as stale.

## Keeping the log buffer and the panel in sync

The log lives in two places: the `jeLoggingHTML` buffer it is rendered from, and the `#jeLog` element on screen. `jeLoggingClear()` used to empty only the buffer, so whatever it dropped stayed visible until the next render swept it away. That split is what decided whether the resume note appeared at all: with the JSON module open in the second panel, `JsonModule.onEditorOpen()` runs first and its `jeToggle()` empties the buffer, so by the time the Debug module resumed there was nothing left for it to mark — and the old entries were still on the screen, unlabelled.

Clearing `#jeLog` along with the buffer removes the split at its source. With both panels open the log now starts empty after a round trip through play mode instead of showing entries nobody is tracking any more, and ticking **Clear after each interaction** empties the panel there and then rather than leaving the entries up until the next interaction.

The note itself is appended to the log rather than re-rendered from the buffer, so an entry the user expanded before going off to play is still expanded when they come back. Logging resumes only when the flag was actually off, so an entry into edit mode that never switched it off does not claim a gap that is not there.

## The empty-state note

The note the panel shows while the log is empty spent most of its length explaining that a widget is run with a middle-click, or a right-click when it is already selected — how to run a routine belongs in the wiki, not in a panel note, and it buried the rule that actually explains an empty log. It now reads ([screenshot](https://agent.virtualtabletop.io/reports/pr/1545159296923336805/debugnote-4-empty-state.png)):

> Nothing has been logged yet. Routines are only logged while this Debug panel is open in edit mode.

## Reproducing it (before this change)

1. Enter edit mode and open **Debug** in the right sidebar.
2. Leave edit mode with the ✕ in the edit toolbar and play a bit.
3. Go back to edit mode — Debug is still the open module.
4. Middle-click a widget with a routine: nothing is logged. Switching to another sidebar module and back to Debug makes it work again.

## Testing

- TestCafe regression test in `tests/testcafe/editor.js` ("the Debug module logs again after edit mode was left and entered once more"): it fails on `main` and passes with this change. It pins every part of the invariant — a routine run in edit mode is logged, running the same routine with the editor closed adds nothing, re-entering edit mode both marks the old entries as resumed and logs again, and a second round trip with nothing logged in between leaves the log with exactly one resumed note.
- A second TestCafe test ("the Debug module does not keep unmarked entries when the JSON module clears the log") covers the Debug + JSON combination: it fails without the `jeLoggingClear()` change, with the stale entry still counted after re-entering edit mode.
- `npm test` (jest, 1650 tests) passes, as does the full `tests/testcafe/editor.js` suite locally (97 tests); the existing Debug tests in `editor.js` and `compute-4.js` (which drives the Debug panel) pass.
- Verified by hand in a browser with the four-step repro above, with auto-clear both on and off and with an empty log.

No widget property, routine operation or saved-state format is touched, so there is nothing to update in the validator or the JSON editor's insert buttons.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3163/pr-test (or any other room on that server)


