### PR TITLE
Fix the editors claiming a just-renamed widget or deck id is already taken

### DIFF
--- a/client/css/editor/deckeditor.css
+++ b/client/css/editor/deckeditor.css
@@ -383,7 +383,9 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   white-space: nowrap;
 }
 
-/* The current deck's id is an inline editable field that blends into the row until hovered/focused. */
+/* The current deck's id is an inline editable field. It carries the same dashed underline as the widget
+   header's id input, because without one the only editable row of the tree looks exactly like the face and
+   object rows around it; the full box appears on hover/focus. */
 .deckEditorTreeDeckId {
   flex: 1;
   min-width: 0;
@@ -392,18 +394,28 @@ body.deckEditorRoomVisible #deckEditorMainCol > .overlay {
   color: inherit;
   background: transparent;
   border: 1px solid transparent;
+  border-bottom: 1px dashed currentColor;
   border-radius: 4px;
-  padding: 0 3px;
+  padding: 3px;
   margin: 0;
 }
 
 .deckEditorTreeDeckId:hover {
   border-color: rgba(128, 128, 128, 0.4);
+  border-bottom-style: solid;
 }
 
 .deckEditorTreeDeckId:focus {
   outline: none;
   border-color: var(--VTTblue);
+  border-bottom-style: solid;
+}
+
+/* disabled for the duration of a rename, so a second id typed while one runs is
+   refused where the user can see it */
+.deckEditorTreeDeckId:disabled {
+  opacity: 0.6;
+  cursor: progress;
 }
 
 /* Unified add / copy / delete (+ show areas) toolbar, at the top of the left sidebar. */

--- a/client/css/editor/propertyInputs.css
+++ b/client/css/editor/propertyInputs.css
@@ -1284,13 +1284,22 @@
 .editorModule .widgetHeader .widgetHeaderIdInput {
   color: inherit;
   font: inherit;
+  /* the element sizes itself to the id it holds, so this only caps how much of
+     the panel a long one may take */
   max-width: 80%;
-  padding: 0 3px;
+  padding: 2px 3px;
   border: 0;
   border-bottom: 1px dashed currentColor;
   border-radius: 2px;
   background: transparent;
   text-align: left;
+}
+
+/* the field is disabled while its rename runs - the room does not have the
+   widget under either id in that moment, so there is nothing to commit */
+.editorModule .widgetHeader .widgetHeaderIdInput:disabled {
+  opacity: 0.6;
+  cursor: progress;
 }
 
 .editorModule .widgetHeader .widgetHeaderIdInput:hover {

--- a/client/css/editor/sidebarModules.css
+++ b/client/css/editor/sidebarModules.css
@@ -70,6 +70,13 @@
   margin: 10px 5px 15px;
 }
 
+/* the panel while a rename is in flight: an in-between state, not an offer to
+   do something, so it stays quiet and gets no buttons */
+.editorModule .renameInProgress {
+  color: var(--textHelpColor, #666);
+  font-style: italic;
+}
+
 .editorModule .noSelectionButton {
   display: flex;
   align-items: center;
@@ -1185,6 +1192,10 @@
   border-bottom: 1px dashed currentColor;
   border-radius: 2px;
   background: transparent;
+}
+.editorModule .lineStopList input.lineStopIdInput:disabled {
+  opacity: 0.6;
+  cursor: progress;
 }
 .editorModule .lineStopList input.lineStopIdInput:hover {
   background: var(--backgroundHighlightColor1);

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -2641,7 +2641,7 @@ class DeckEditor {
         const deckExpanded = !this.collapsedDecks.has(deck.id) && (isCurrent || this.expandedDecks.has(deck.id));
         // The current deck's id is editable inline; other decks show a plain label.
         const deckRow = div(tree, 'deckEditorTreeNode deckEditorTreeDeck', `<span class=deckEditorTreeIcon icon=style></span>` + (isCurrent
-          ? `<input class=deckEditorTreeDeckId title="Edit the deck's id">`
+          ? `<input class=deckEditorTreeDeckId title="Edit the deck's id (Enter applies)">`
           : `<span class=deckEditorTreeLabel>${html(deck.id)}</span>`));
         if(isCurrent) {
           const idInput = $('.deckEditorTreeDeckId', deckRow);
@@ -2651,8 +2651,23 @@ class DeckEditor {
           idInput.onkeydown = e=>{ if(e.key == 'Enter') idInput.blur(); };
           // this.deckID rather than deck.id: the Widget object keeps the id it had, so a change event this
           // input sends a second time (browsers do that on the blur that follows the commit) would otherwise
-          // read as a fresh rename to the id the first one just created.
-          idInput.onchange = _=>{ const v = idInput.value.trim(); if(v && v != this.deckID) this.changeDeckId(v); else idInput.value = this.deckID; };
+          // read as a fresh rename to the id the first one just created. The field is disabled for the
+          // duration of the rename, so a commit typed while it runs is visibly refused rather than dropped.
+          idInput.onchange = async _=>{
+            const v = idInput.value.trim();
+            if(idInput.disabled)
+              return;
+            if(!v || v == this.deckID) {
+              idInput.value = this.deckID;
+              return;
+            }
+            idInput.disabled = true;
+            try {
+              await this.changeDeckId(v);
+            } finally {
+              idInput.disabled = false;
+            }
+          };
         }
         const deckSel = isCurrent && this.treeLevel == 'deck';
         deckRow.classList.toggle('selected', deckSel && this.activeArea == 'tree');

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -2649,7 +2649,10 @@ class DeckEditor {
           // Clicking the field still selects the deck node (so the tree toolbar acts on the deck); the caret is
           // restored below after the resulting re-render so typing isn't interrupted. Enter/blur commits the id.
           idInput.onkeydown = e=>{ if(e.key == 'Enter') idInput.blur(); };
-          idInput.onchange = _=>{ const v = idInput.value.trim(); if(v && v != deck.id) this.changeDeckId(v); else idInput.value = deck.id; };
+          // this.deckID rather than deck.id: the Widget object keeps the id it had, so a change event this
+          // input sends a second time (browsers do that on the blur that follows the commit) would otherwise
+          // read as a fresh rename to the id the first one just created.
+          idInput.onchange = _=>{ const v = idInput.value.trim(); if(v && v != this.deckID) this.changeDeckId(v); else idInput.value = this.deckID; };
         }
         const deckSel = isCurrent && this.treeLevel == 'deck';
         deckRow.classList.toggle('selected', deckSel && this.activeArea == 'tree');
@@ -4265,17 +4268,19 @@ class DeckEditor {
     newID = String(newID).trim();
     const deck = this.deck();
     const oldID = this.deckID;
-    if(!deck || !newID || newID == oldID)
+    if(this.renamingDeck || !deck || !newID || newID == oldID)
       return;
     if(widgets.has(newID)) {
       alert(`A widget with the id "${newID}" already exists. Please choose a different deck id.`);
       this.renderLeftSidebar();
       return;
     }
+    // set before the first await: the new deck exists partway through updateWidgetId, so a second change
+    // event arriving while this runs must not start a rename of its own
+    this.renamingDeck = true;
     await this.flushPendingCommits(); // save pending edits onto the old deck first
     const newState = JSON.parse(JSON.stringify(deck.state));
     newState.id = newID;
-    this.renamingDeck = true;
     batchStart();
     setDeltaCause(`${getPlayerDetails().playerName} renamed deck ${oldID} to ${newID} in deck editor`);
     await updateWidgetId(newState, oldID);

--- a/client/js/editor/deckeditor.js
+++ b/client/js/editor/deckeditor.js
@@ -4293,14 +4293,27 @@ class DeckEditor {
     // set before the first await: the new deck exists partway through updateWidgetId, so a second change
     // event arriving while this runs must not start a rename of its own
     this.renamingDeck = true;
-    await this.flushPendingCommits(); // save pending edits onto the old deck first
-    const newState = JSON.parse(JSON.stringify(deck.state));
-    newState.id = newID;
-    batchStart();
-    setDeltaCause(`${getPlayerDetails().playerName} renamed deck ${oldID} to ${newID} in deck editor`);
-    await updateWidgetId(newState, oldID);
-    batchEnd();
-    this.renamingDeck = false;
+    let batched = false;
+    try {
+      await this.flushPendingCommits(); // save pending edits onto the old deck first
+      const newState = JSON.parse(JSON.stringify(deck.state));
+      newState.id = newID;
+      batchStart();
+      batched = true;
+      setDeltaCause(`${getPlayerDetails().playerName} renamed deck ${oldID} to ${newID} in deck editor`);
+      await updateWidgetId(newState, oldID);
+    } catch(error) {
+      // the tree still shows the id that was typed - put it back on the one the room actually has
+      alert(`Could not rename deck: ${error}`);
+      this.renderLeftSidebar();
+      return;
+    } finally {
+      // both have to be given back even when the rename threw: the editor ignores every delta while
+      // renamingDeck is set, and an open batch collects every later edit into a delta nothing sends
+      if(batched)
+        batchEnd();
+      this.renamingDeck = false;
+    }
     // Migrate the editor's per-deck tree state to the new id.
     for(const set of [ this.expandedDecks, this.collapsedDecks ])
       if(set.has(oldID)) { set.delete(oldID); set.add(newID); }

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -2015,6 +2015,8 @@ class PropertiesModule extends SidebarModule {
       // into (its routines are edited there)
       if(widget.get('type') != 'pile' && this.moduleDOM)
         this.renderEvents(widget);
+    } else if(this.renamingWidget) {
+      this.addRenameInProgress();
     } else {
       this.addDeck();
     }
@@ -2500,6 +2502,18 @@ class PropertiesModule extends SidebarModule {
     sidebarHint.className = 'noSelectionIntro';
     sidebarHint.innerText = 'The other editor tools are in the sidebar on the right.';
     this.moduleDOM.append(sidebarHint);
+  }
+
+  // Shown instead of the "nothing selected" module while a rename started from this panel is still running:
+  // the widget briefly leaves the room, which empties the selection, and the empty module with its two big
+  // call-to-action buttons reads as if the rename had thrown the selection away.
+  addRenameInProgress() {
+    this.addHeader('Edit widgets');
+
+    const status = document.createElement('p');
+    status.className = 'noSelectionIntro renameInProgress';
+    status.innerText = `Renaming ${this.renamingWidget.oldID} to ${this.renamingWidget.newID}…`;
+    this.moduleDOM.append(status);
   }
 
   async deckTraditional(target) {
@@ -5472,8 +5486,16 @@ class PropertiesModule extends SidebarModule {
     idInput.type = 'text';
     idInput.className = options.className || 'widgetHeaderIdInput';
     idInput.value = widget.id;
-    idInput.title = options.title || 'Rename widget';
+    // the two ways out of the field are worth spelling out: nothing on screen says that Enter applies the
+    // rename and that Escape puts the id back
+    idInput.title = `${options.title || 'Rename widget'} (Enter applies, Esc cancels)`;
     idInput.setAttribute('aria-label', options.ariaLabel || 'Widget id');
+
+    // the box is as wide as the id it holds instead of the browser's 20 character default, so a long id stays
+    // readable without scrolling through it (the CSS max-width caps how much of the panel it can take)
+    const fitToValue = _=>idInput.size = Math.max(12, idInput.value.length + 1);
+    fitToValue();
+    idInput.oninput = fitToValue;
 
     // The id the input stands for. The Widget object it was created from keeps the id it had when it was
     // renamed, so this is what tells a repeated change event - a browser fires one when the input is blurred
@@ -5495,8 +5517,9 @@ class PropertiesModule extends SidebarModule {
         return;
       }
       if(widgets.has(newID)) {
-        alert(`A widget with the id "${newID}" already exists.`);
+        alert(`A widget with the id "${newID}" already exists. Please choose a different id.`);
         idInput.value = oldID;
+        fitToValue();
         return;
       }
 
@@ -5506,6 +5529,9 @@ class PropertiesModule extends SidebarModule {
       // the new id already exists partway through the rename, so the input stands for it from here on rather
       // than only once the rename has finished
       currentID = newID;
+      // the widget is gone from the room between the remove and the add inside updateWidgetId, so without
+      // this the panel would drop to its "nothing selected" state for as long as the rename takes
+      this.renamingWidget = { oldID, newID };
       batchStart();
       try {
         setDeltaCause(`${getPlayerDetails().playerName} renamed widget ${oldID} to ${newID} in editor`);
@@ -5517,15 +5543,22 @@ class PropertiesModule extends SidebarModule {
         currentID = oldID;
         alert(`Could not rename widget: ${error}`);
         idInput.value = oldID;
+        fitToValue();
       } finally {
         batchEnd();
         idInput.disabled = false;
+        this.renamingWidget = null;
+        // a rename that ended without a widget landing back in the selection - it threw, or the widget it put
+        // there is not one this panel shows - leaves the busy state above with nothing to replace it
+        if(this.moduleDOM && this.moduleDOM.querySelector('.renameInProgress'))
+          this.onSelectionChangedWhileActive([ ...selectedWidgets ]);
       }
     };
 
     idInput.onkeydown = event => {
       if(event.key == 'Escape') {
         idInput.value = currentID;
+        fitToValue();
         idInput.blur();
       }
     };

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -5481,6 +5481,8 @@ class PropertiesModule extends SidebarModule {
     let currentID = widget.id;
 
     idInput.onchange = async () => {
+      if(idInput.disabled) // a rename started by an earlier event of this input is still running
+        return;
       const oldID = currentID;
       const newID = idInput.value.trim();
       if(newID == oldID) {
@@ -5499,17 +5501,20 @@ class PropertiesModule extends SidebarModule {
       }
 
       idInput.disabled = true;
+      const state = JSON.parse(JSON.stringify((widgets.get(oldID) || widget).state));
+      state.id = newID;
+      // the new id already exists partway through the rename, so the input stands for it from here on rather
+      // than only once the rename has finished
+      currentID = newID;
       batchStart();
       try {
         setDeltaCause(`${getPlayerDetails().playerName} renamed widget ${oldID} to ${newID} in editor`);
-        const state = JSON.parse(JSON.stringify(widget.state));
-        state.id = newID;
         await updateWidgetId(state, oldID);
-        currentID = newID;
         const renamedWidget = widgets.get(newID);
         if(renamedWidget && options.onRenamed)
           options.onRenamed(renamedWidget);
       } catch(error) {
+        currentID = oldID;
         alert(`Could not rename widget: ${error}`);
         idInput.value = oldID;
       } finally {

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -5475,8 +5475,13 @@ class PropertiesModule extends SidebarModule {
     idInput.title = options.title || 'Rename widget';
     idInput.setAttribute('aria-label', options.ariaLabel || 'Widget id');
 
+    // The id the input stands for. The Widget object it was created from keeps the id it had when it was
+    // renamed, so this is what tells a repeated change event - a browser fires one when the input is blurred
+    // after its value was already committed - from a second, real rename.
+    let currentID = widget.id;
+
     idInput.onchange = async () => {
-      const oldID = widget.id;
+      const oldID = currentID;
       const newID = idInput.value.trim();
       if(newID == oldID) {
         idInput.value = oldID;
@@ -5500,6 +5505,7 @@ class PropertiesModule extends SidebarModule {
         const state = JSON.parse(JSON.stringify(widget.state));
         state.id = newID;
         await updateWidgetId(state, oldID);
+        currentID = newID;
         const renamedWidget = widgets.get(newID);
         if(renamedWidget && options.onRenamed)
           options.onRenamed(renamedWidget);
@@ -5514,7 +5520,7 @@ class PropertiesModule extends SidebarModule {
 
     idInput.onkeydown = event => {
       if(event.key == 'Escape') {
-        idInput.value = widget.id;
+        idInput.value = currentID;
         idInput.blur();
       }
     };

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -5509,11 +5509,13 @@ class PropertiesModule extends SidebarModule {
       const newID = idInput.value.trim();
       if(newID == oldID) {
         idInput.value = oldID;
+        fitToValue();
         return;
       }
       if(!newID) {
         alert('Widget id cannot be empty.');
         idInput.value = oldID;
+        fitToValue();
         return;
       }
       if(widgets.has(newID)) {

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -1,6 +1,6 @@
 import { ClientFunction, Selector } from 'testcafe';
 
-import { compareState, prepareClient, setName, setRoomState, setupTestEnvironment } from './test-util.js';
+import { compareState, expectEventually, getStateObject, prepareClient, setName, setRoomState, setupTestEnvironment } from './test-util.js';
 
 setupTestEnvironment();
 
@@ -546,6 +546,64 @@ test('The deck editor id field does not start a second rename when its change ev
     .expect(await t.getNativeDialogHistory()).eql([])
     .expect(ClientFunction(deckID=>widgets.has(deckID))(deckID)).notOk()
     .expect(Selector('.deckEditorTreeDeckId').value).eql('renamedDeck');
+  await t.pressKey('esc');
+});
+
+// updateWidgetId runs game-authored id routines, so it can throw halfway through a rename. What it must not
+// leave behind is the state the rename put up for its own duration: the editor ignores every delta while a
+// rename of its deck runs, and the delta batch it opened swallows every later edit until it is closed.
+test('A deck rename that throws leaves neither the deck editor nor its deltas stuck', async t => {
+  await t.setNativeDialogHandler(() => true);
+  await t.resizeWindow(1280, 800);
+  await setRoomState({});
+  await ClientFunction(prepareClient)();
+  await setEditorState(null);
+  await setName(t);
+
+  await t
+    .click('#editButton')
+    .click('#editorToolbar > div > [icon=add]')
+    .click('#add-empty-deck')
+    .expect(Selector('#editorModuleTopLeft.tune').exists).ok();
+  const currentDeckID = ClientFunction(() => {
+    let id = null;
+    widgets.forEach(w => { if(w.get('type') == 'deck') id = w.get('id'); });
+    return id;
+  });
+  await t.expect(currentDeckID()).notEql(null, { timeout: 10000 });
+  const deckID = await currentDeckID();
+
+  await t
+    .click(`#w_${deckID}`)
+    .click('#propertiesOpenDeckEditor')
+    .expect(Selector('.deckEditorTreeDeckId').exists).ok()
+    .click('.deckEditorTreeDeckId')
+    .wait(300);
+
+  // fail the rename where it hurts: after the batch was opened and with the deck already taken apart
+  await ClientFunction(() => {
+    window.originalUpdateWidgetId = window.updateWidgetId;
+    window.updateWidgetId = _=>Promise.reject(new Error('rename failed'));
+  })();
+  await t
+    .typeText('.deckEditorTreeDeckId', 'failedRename', { replace: true })
+    .pressKey('enter')
+    .wait(500);
+  await t.expect((await t.getNativeDialogHistory())[0].text).eql('Could not rename deck: Error: rename failed');
+  await t
+    .expect(Selector('.deckEditorTreeDeckId').value).eql(deckID)
+    .expect(Selector('.deckEditorTreeDeckId').hasAttribute('disabled')).notOk();
+
+  await ClientFunction(() => { window.updateWidgetId = window.originalUpdateWidgetId; })();
+  await t
+    .click('.deckEditorTreeDeckId') // the tree was redrawn, so let the click settle before typing into it
+    .wait(300)
+    .typeText('.deckEditorTreeDeckId', 'workingRename', { replace: true })
+    .pressKey('enter')
+    .expect(ClientFunction(()=>widgets.has('workingRename'))()).ok({ timeout: 10000 });
+  // the server seeing it is what tells an open batch from a closed one - a leaked one keeps the delta local
+  await expectEventually(t, async _=>Object.keys(await getStateObject()).includes('workingRename'), true,
+    'the rename after the failed one reaches the server');
   await t.pressKey('esc');
 });
 

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -429,12 +429,27 @@ test('Renaming a widget keeps its color controls clear and it movable', async t 
 
 // Committing a widget id and then blurring the input can hand the same change event to the client twice -
 // Chrome does that once the rename has replaced the widget under the input. The second one must not be read
-// as an attempt to take the id that the first one just created.
+// as an attempt to take the id that the first one just created, whether it arrives after the rename or while
+// it is still running. The waiter widget's id routine holds every rename open long enough for the latter.
+const idRenameDelay = 1500;
+const idRenameWaiter = { id: 'waiter', type: 'basic', x: 600, y: 200, idGlobalUpdateRoutine: [ { func: 'DELAY', milliseconds: idRenameDelay } ] };
+
+// Commit a new id through the input and hand the same change event over a second time while the rename is
+// still running, the way the browser does on the blur that follows the commit.
+const commitIdTwice = ClientFunction((selector, newID, delay) => {
+  const input = document.querySelector(selector);
+  input.value = newID;
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+  setTimeout(() => input.dispatchEvent(new Event('change', { bubbles: true })), delay);
+});
+
 test('The id input renaming a widget does not claim the id is taken when its change event repeats', async t => {
   await t.setNativeDialogHandler(() => true);
   await t.resizeWindow(1280, 800);
   await setRoomState({
-    old: { id: 'old', type: 'basic', x: 200, y: 200 }
+    old: { id: 'old', type: 'basic', x: 200, y: 200 },
+    other: { id: 'other', type: 'basic', x: 400, y: 200 },
+    waiter: idRenameWaiter
   });
   await ClientFunction(prepareClient)();
   await setEditorState(null);
@@ -452,13 +467,82 @@ test('The id input renaming a widget does not claim the id is taken when its cha
   await t
     .typeText('[aria-label="Widget id"]', 'new', { replace: true })
     .pressKey('enter')
-    .expect(Selector('#w_new').exists).ok();
+    .expect(Selector('#w_new').exists).ok({ timeout: 10000 })
+    .expect(Selector('[aria-label="Widget id"]').value).eql('new');
 
   await ClientFunction(() => window.renamedIdInput.dispatchEvent(new Event('change', { bubbles: true })))();
   await t.wait(500);
 
+  const widgetIDs = ClientFunction(()=>Array.from(widgets.keys()).sort());
   await t.expect(await t.getNativeDialogHistory()).eql([]);
-  await t.expect(await ClientFunction(()=>Array.from(widgets.keys()))()).eql([ 'new' ]);
+  await t.expect(await widgetIDs()).eql([ 'new', 'other', 'waiter' ]);
+
+  // Escape restores the id the input stands for now, not the one the widget carried when the panel was drawn.
+  // Dispatched without bubbling so the editor's own Escape handling doesn't drop the selection along with it.
+  const escapeIdInput = ClientFunction(() => {
+    const input = document.querySelector('[aria-label="Widget id"]');
+    input.value = 'discarded';
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    return input.value;
+  });
+  await t.expect(await escapeIdInput()).eql('new');
+
+  // an id that really is taken still says so and puts the input back
+  await t
+    .typeText('[aria-label="Widget id"]', 'other', { replace: true })
+    .pressKey('enter');
+  await t.expect((await t.getNativeDialogHistory())[0].text).eql('A widget with the id "other" already exists.');
+  await t
+    .expect(Selector('[aria-label="Widget id"]').value).eql('new')
+    .expect(await widgetIDs()).eql([ 'new', 'other', 'waiter' ]);
+
+  // the repeat arriving mid-rename: the new id exists at that point, so it is the one that used to alert
+  await commitIdTwice('[aria-label="Widget id"]', 'renamed', Math.round(idRenameDelay / 3));
+  await t
+    .expect(Selector('#w_renamed').exists).ok({ timeout: 10000 })
+    .wait(1000)
+    .expect((await t.getNativeDialogHistory()).length).eql(1) // still only the one the taken id put there
+    .expect(await widgetIDs()).eql([ 'other', 'renamed', 'waiter' ]);
+});
+
+// The deck editor's inline deck-id field commits the same way and renames through the same helper, so the
+// repeated change event reaches it too.
+test('The deck editor id field does not start a second rename when its change event repeats', async t => {
+  await t.setNativeDialogHandler(() => true);
+  await t.resizeWindow(1280, 800);
+  await setRoomState({ waiter: idRenameWaiter });
+  await ClientFunction(prepareClient)();
+  await setEditorState(null);
+  await setName(t);
+
+  await t
+    .click('#editButton')
+    .click('#editorToolbar > div > [icon=add]')
+    .click('#add-empty-deck')
+    .expect(Selector('#editorModuleTopLeft.tune').exists).ok();
+  const currentDeckID = ClientFunction(() => {
+    let id = null;
+    widgets.forEach(w => { if(w.get('type') == 'deck') id = w.get('id'); });
+    return id;
+  });
+  await t.expect(currentDeckID()).notEql(null, { timeout: 10000 }); // every widget added waits for the id routine
+  const deckID = await currentDeckID();
+
+  await t
+    .click(`#w_${deckID}`)
+    .click('#propertiesOpenDeckEditor')
+    .expect(Selector('.deckEditorTreeDeckId').exists).ok()
+    .click('.deckEditorTreeDeckId') // also selects the deck node, which redraws the tree and the field
+    .wait(300);
+
+  await commitIdTwice('.deckEditorTreeDeckId', 'renamedDeck', Math.round(idRenameDelay / 3));
+  await t
+    .expect(ClientFunction(()=>widgets.has('renamedDeck'))()).ok({ timeout: 10000 })
+    .wait(1000)
+    .expect(await t.getNativeDialogHistory()).eql([])
+    .expect(ClientFunction(deckID=>widgets.has(deckID))(deckID)).notOk()
+    .expect(Selector('.deckEditorTreeDeckId').value).eql('renamedDeck');
+  await t.pressKey('esc');
 });
 
 test('Dice faces have their own icon, image scale and CSS controls', async t => {

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -427,6 +427,40 @@ test('Renaming a widget keeps its color controls clear and it movable', async t 
   await t.expect(result.y).notEql(200);
 });
 
+// Committing a widget id and then blurring the input can hand the same change event to the client twice -
+// Chrome does that once the rename has replaced the widget under the input. The second one must not be read
+// as an attempt to take the id that the first one just created.
+test('The id input renaming a widget does not claim the id is taken when its change event repeats', async t => {
+  await t.setNativeDialogHandler(() => true);
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    old: { id: 'old', type: 'basic', x: 200, y: 200 }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState(null);
+  await setName(t);
+  await t
+    .click('#editButton')
+    .expect(propertiesModule.exists).ok()
+    .click('#w_old')
+    .expect(Selector('[aria-label="Widget id"]').exists).ok();
+
+  // the input the rename is typed into: the panel draws a new one for the renamed widget, so a repeated
+  // change event is one this element sends after the widget it was drawn for is gone
+  await ClientFunction(() => { window.renamedIdInput = document.querySelector('[aria-label="Widget id"]'); })();
+
+  await t
+    .typeText('[aria-label="Widget id"]', 'new', { replace: true })
+    .pressKey('enter')
+    .expect(Selector('#w_new').exists).ok();
+
+  await ClientFunction(() => window.renamedIdInput.dispatchEvent(new Event('change', { bubbles: true })))();
+  await t.wait(500);
+
+  await t.expect(await t.getNativeDialogHistory()).eql([]);
+  await t.expect(await ClientFunction(()=>Array.from(widgets.keys()))()).eql([ 'new' ]);
+});
+
 test('Dice faces have their own icon, image scale and CSS controls', async t => {
   // Keep this at the narrow layout from the review so the controls remain
   // useful in the smallest supported properties sidebar.

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -491,14 +491,18 @@ test('The id input renaming a widget does not claim the id is taken when its cha
   await t
     .typeText('[aria-label="Widget id"]', 'other', { replace: true })
     .pressKey('enter');
-  await t.expect((await t.getNativeDialogHistory())[0].text).eql('A widget with the id "other" already exists.');
+  await t.expect((await t.getNativeDialogHistory())[0].text).eql('A widget with the id "other" already exists. Please choose a different id.');
   await t
     .expect(Selector('[aria-label="Widget id"]').value).eql('new')
     .expect(await widgetIDs()).eql([ 'new', 'other', 'waiter' ]);
 
   // the repeat arriving mid-rename: the new id exists at that point, so it is the one that used to alert
   await commitIdTwice('[aria-label="Widget id"]', 'renamed', Math.round(idRenameDelay / 3));
+  // the widget is out of the room while the rename runs, so the panel says what it is waiting for instead of
+  // falling back to the module that offers to add a widget
   await t
+    .expect(Selector('.renameInProgress').innerText).eql('Renaming new to renamed…')
+    .expect(Selector('.noSelectionButton').exists).notOk()
     .expect(Selector('#w_renamed').exists).ok({ timeout: 10000 })
     .wait(1000)
     .expect((await t.getNativeDialogHistory()).length).eql(1) // still only the one the taken id put there


### PR DESCRIPTION
Renaming a widget in edit mode alerts *A widget with the id "new" already exists.* immediately after the rename it just did, and puts the old id back into the input. The rename itself goes through, so the editor and the room disagree about what the widget is called until the panel is redrawn. On Chrome 152 this happens on every rename, which is also why `tests/testcafe/editor.js` → *Renaming a widget keeps its color controls clear and it movable* fails on the CI runners that have moved to that version:

```
1) A native alert dialog was invoked on page ".../testcafe-testing", but no handler was set for it.
   Browser: Chrome 152.0.0.0 / Ubuntu 24.04
```

Chrome 152 hands the client a second `change` event when the id input is blurred after its value has already been committed — the rename disables the input and the panel redraws underneath it — and `createWidgetIdInput()` read the id to rename *from* off the `Widget` object the input was drawn for. That object keeps the id it had, so the second event read as "rename `old` to `new`" at a point where `new` already existed.

**The base of that fix reached `main` in #3168** (the `currentID`/`renaming` pair in `createWidgetIdInput()`, the state read off `widgets.get(oldID)`, and one regression test), so `main` no longer alerts on a plain rename. This PR is what is left: the window while the rename is *running*, the deck editor's field, and the surrounding UI of both.

## The window while the rename is running

`widgets.has(newID)` goes true partway through `updateWidgetId()` — `addWidgetLocal()` adds the widget and then awaits every `idGlobalUpdateRoutine` listener — so a repeat arriving before the rename resolves saw the new id exist while the input still stood for the old one. The input now takes on the new id before `batchStart()` (restoring it if the rename throws). Without that, a room whose widgets carry a slow id routine ends up holding *both* the old and the new widget, which reproduces on Chrome 151 as well:

```
AssertionError: expected [ 'new', 'old', 'other', 'waiter' ] to deeply equal [ 'new', 'other', 'waiter' ]
```

That window used to be invisible: the widget is out of the room until `updateWidgetId()` has re-added it, so the properties panel fell back to its *"You do not have a widget selected"* module — two big call-to-action buttons — for the whole rename, which reads as if the rename had destroyed the selection. It now names the rename it is waiting for instead, and comes back to the normal module if the rename throws.

![the properties panel during a slow rename](https://agent.virtualtabletop.io/reports/pr/1545290661186633820/ui-fixes/b-during-rename.png)

## The deck editor's id field

`client/js/editor/deckeditor.js` had the same stale capture: its inline deck-id field compared the typed value against the `Widget` object's id instead of the id the editor is on, and `changeDeckId()` could be re-entered before it marked itself as running, starting a second rename of the same deck. It now compares against `this.deckID`, sets `renamingDeck` before its first `await`, and disables the field for the duration of the rename the way the widget one is — so an id typed while a rename runs is refused where the user can see it rather than left on screen as an id the deck does not have.

A rename that throws no longer leaks `renamingDeck` or the delta batch it opened: both are given back in a `finally`, and the failure says `Could not rename deck: …` and re-renders the tree instead of vanishing into the input's handler.

![the deck id field greyed out during its rename](https://agent.virtualtabletop.io/reports/pr/1545290661186633820/ui-fixes/e-deck-during-rename.png)

## Around the two fields

- The widget header's field sizes itself to the id it holds — a 28-character id was clipped at the browser's 208 px default in a 584 px panel — and is put back at full width in every branch that restores the value.
- `.deckEditorTreeDeckId` carries the widget header's dashed underline, so the one editable row of the deck tree no longer looks like the face and object rows around it.
- Both fields say in their tooltip how a rename is applied and taken back, and both got enough vertical padding to be a usable touch target.
- The widget duplicate-id alert closes with the same *"Please choose a different id."* the deck-side messages have.

## Tests

`tests/testcafe/editor.js` keeps #3168's *A rename that the browser commits twice does not claim the new id is taken* and adds:

- *The id input renaming a widget does not claim the id is taken when its change event repeats* — renames through the sidebar and dispatches the second `change` event by hand, so it reproduces in any browser instead of only on Chrome 152. It also pins the branches around it: Escape restores the id the input stands for, an id that is genuinely taken still alerts and restores the input, and a repeat landing mid-rename (held open by a widget with an `idGlobalUpdateRoutine` `DELAY`) leaves exactly one widget behind while the panel shows the busy state.
- *The deck editor id field does not start a second rename when its change event repeats* — the same walk through the deck editor's inline field.
- *A deck rename that throws leaves neither the deck editor nor its deltas stuck* — swaps `updateWidgetId` for one that rejects after the batch is open, then asserts the alert, the field back on the old id and not disabled, and that a following rename reaches the server (a leaked batch would keep it local).

## Verification

- `npm test` — 1651 passed.
- The five `tests/testcafe/editor.js` tests that walk the two id fields — *Renaming a widget keeps its color controls clear and it movable*, the two repeated-`change` ones and the deck-rename ones — pass on the merge commit on **Chrome 152.0.7977.82** as well as on Chrome 151. The whole file passed on Chrome 151 on the commit before the merge.
- Driven with Playwright on Chrome 152 against a local server: committing a new id with Enter and by blurring the field both rename the widget and raise no dialog at all.
- Driven in Chromium against a local server: renaming twice in a row works through the widget header, a line's *Stop 1 id* field and the deck tree; renaming to an id that exists still alerts and restores the input; the slow rename shows the busy state and no empty-state buttons.

Split out of #3162 at @96LawDawg's request, so it stays separate from that PR's transition-class work.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3164/pr-test (or any other room on that server)
