### PR TITLE
Keep the client alive when a widget is gone or was never created

### DIFF
--- a/client/css/jsonedit.css
+++ b/client/css/jsonedit.css
@@ -432,6 +432,11 @@ body.jsonEdit #toolbar {
   margin: 10px 0 10px 20px;
   font-family: Arial, sans-serif;
 }
+/* a note about a problem rather than about the log itself, so it carries the problem color */
+.jeLogProblemNote {
+  color: var(--textHighlightColor3);
+  border-left-color: var(--textHighlightColor3);
+}
 .jeLogNote .jeLogWidget,
 .jeLogNote .jeLogProperty {
   font-family: monospace;

--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -1632,8 +1632,23 @@ async function updateWidget(currentState, oldState, applyChangesFromUI) {
   if(widget.id !== previousState.id) {
     await updateWidgetId(widget, previousState.id);
   } else if (widget.type !== previousState.type) {
+    // A type change is a remove followed by a re-add of the same id, so a re-add the client would
+    // refuse has to be caught before the removal: afterwards there is nothing left to put back and
+    // the widget would be gone from the room for good.
+    const typeProblem = widgetAdditionProblem(widget);
+    if(typeProblem) {
+      alert(`${typeProblem} Nothing was saved.`);
+      batchEnd();
+      return;
+    }
+
     await removeWidgetLocal(previousState.id, true);
     const id = await addWidgetLocal(widget);
+    if(id === null) {
+      alert(`Changing the type of '${previousState.id}' to '${widget.type}' failed: the widget could not be added back and is gone. Its children and cards are on the top level now.`);
+      batchEnd();
+      return;
+    }
 
     // Handle special case where type is removed
     if(widget.type === undefined)

--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -132,12 +132,12 @@ async function setCardCount(deck, cardType, count) {
         // If the desired count is greater than the current count, add cards
         for (let i = 0; i < count - currentCount; i++) {
             const card = { deck: deck.id, type: 'card', cardType: cardType };
-            await addWidgetLocal(card);
-
-            if (deck.get('parent')) {
-                await widgets.get(card.id).moveToHolder(widgets.get(deck.get('parent')));
-            } else {
-                await widgets.get(card.id).updatePiles();
+            if (await addWidgetLocal(card)) {
+                if (deck.get('parent')) {
+                    await widgets.get(card.id).moveToHolder(widgets.get(deck.get('parent')));
+                } else {
+                    await widgets.get(card.id).updatePiles();
+                }
             }
         }
     }

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -655,11 +655,12 @@ const jeCommands = [
     context: '^deck ↦ cardTypes ↦ [^"↦]+',
     call: async function() {
       const card = { deck:jeStateNow.id, type:'card', cardType:jeContext[2] };
-      await addWidgetLocal(card);
-      if(jeStateNow.parent)
-        await widgets.get(card.id).moveToHolder(widgets.get(jeStateNow.parent));
-      else
-        await widgets.get(card.id).updatePiles();
+      if(await addWidgetLocal(card)) {
+        if(jeStateNow.parent)
+          await widgets.get(card.id).moveToHolder(widgets.get(jeStateNow.parent));
+        else
+          await widgets.get(card.id).updatePiles();
+      }
     }
   },
   {
@@ -670,11 +671,12 @@ const jeCommands = [
     call: async function() {
       for(const cardType in jeStateNow.cardTypes) {
         const card = { deck:jeStateNow.id, type:'card', cardType };
-        await addWidgetLocal(card);
-        if(jeStateNow.parent)
-          await widgets.get(card.id).moveToHolder(widgets.get(jeStateNow.parent));
-        else
-          await widgets.get(card.id).updatePiles();
+        if(await addWidgetLocal(card)) {
+          if(jeStateNow.parent)
+            await widgets.get(card.id).moveToHolder(widgets.get(jeStateNow.parent));
+          else
+            await widgets.get(card.id).updatePiles();
+        }
       }
     }
   },
@@ -828,7 +830,7 @@ const jeCommands = [
         const currentCount = widgetFilter(w=>w.get('deck')==jeStateNow.id&&w.get('cardType')==id).length;
         for(let i=0; i<targetCount-currentCount; ++i) {
           const cardId = await addWidgetLocal({ deck:jeStateNow.id, type:'card', cardType:id });
-          if(jeStateNow.parent)
+          if(cardId && jeStateNow.parent)
             await widgets.get(cardId).moveToHolder(widgets.get(jeStateNow.parent));
         }
         for(let i=0; i<currentCount-targetCount; ++i) {

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -153,10 +153,14 @@ const jeCommands = [
           const macroProblems = [];
           for(const w of [...widgets.values()]) { // shallow copy because we might create new widgets by changing the id
             const s = JSON.stringify(w.state);
+            const previousState = JSON.parse(s);
             const newState = JSON.parse(s);
             macro(newState, variableState);
-            // updateWidget would show one modal alert per widget, so collect the problems instead
-            const problem = widgetParentProblem(newState, JSON.parse(s));
+            // updateWidget would show one modal alert per widget, so collect the problems instead.
+            // A changed type makes it remove the widget before it adds the new one back, so a
+            // state the client cannot build has to be caught here rather than halfway through
+            const problem = widgetParentProblem(newState, previousState)
+              || (newState.type !== previousState.type ? widgetAdditionProblem(newState) : null);
             if(problem)
               macroProblems.push(`${w.id}: ${problem}`);
             else

--- a/client/js/jsonedit.js
+++ b/client/js/jsonedit.js
@@ -3490,6 +3490,24 @@ export function jeLoggingRoutineNotLogged(widget, property) {
   jeLoggingRenderLog(jeLoggingHTML);
 }
 
+// A problem that was found outside of any routine - an automatic pile that could not be created, a
+// drop into a holder that is gone. There is no logged operation to hang it on, so it becomes an
+// entry of its own rather than a console line the panel never shows.
+export function jeLoggingProblemNote(message) {
+  if(jeLoggingDepth || jeHTMLStack.length || !$('#jeLog'))
+    return;
+  if(jeRoutineResetOnNextLog) {
+    jeLoggingHTML = '';
+    jeRoutineResetOnNextLog = false;
+  }
+  jeLoggingHTML += `
+    <div class="jeLog jeLogNote jeLogProblemNote">
+      ${html(message)}
+    </div>
+  `;
+  jeLoggingRenderLog(jeLoggingHTML);
+}
+
 export function jeLoggingRoutineOperationStart(original, applied) {
   let fcn;
   if (typeof applied == 'string')
@@ -3565,13 +3583,15 @@ export function jeLoggingRoutineOperationEnd(problems, variables, collections, s
           </div>
         </div>` : '';
 
+  // An operation that failed opens itself as well, so that the pre-expanded Problems block below is
+  // on screen instead of sitting inside a collapsed parent.
   jeLoggingHTML =  `
     ${savedHTML[0]}
     <div class="jeLogOperation ${skipped ? 'jeLogSkipped' : ''} ${problems.length ? 'jeLogHasProblems' : 'jeLogHasNoProblems'}">
-      <div class="jeExpander">
+      <div class="jeExpander${problems.length ? ' jeExpander-down' : ''}">
         <span class="jeLogName">${opFunction}</span> ${jeRoutineResult} ${problems.length ? '<span class="jeLogFailed">failed</span>' : ''} <span class="jeLogTime" title="how long this operation took">(${+new Date() - startTime}ms)</span>
       </div>
-      <div class="jeLogNested">
+      <div class="jeLogNested${problems.length ? ' active' : ''}">
         ${opProblems}
         ${opOperation}
         ${jeLoggingHTML}

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -851,7 +851,7 @@ async function loadEditMode() {
         $, $a, $c, div, progressButton, loadImage, on, onMessage, showOverlay, confirmOverlay, sleep, rand, shuffleArray,
         setJEenabled, setJEroutineLogging, setZoomAndOffset, resetZoomAndPan, toggleEditMode, getEdit,
         toServer, batchStart, batchEnd, setDeltaCause, sendPropertyUpdate, getUndoProtocol, setUndoProtocol, sendRawDelta, getDelta,
-        addWidgetLocal, updateWidgetId, removeWidgetLocal,
+        addWidgetLocal, updateWidgetId, removeWidgetLocal, widgetAdditionProblem,
         loadZipLibrary, waitForZipLibrary, zipBlob,
         generateUniqueWidgetID, unescapeID, regexEscape, stringifyForDisplay, setScale, getScale, getRoomRectangle, getMaxZ, getZoomLevel,
         uploadAsset, _uploadAsset, mapAssetURLs, fetchSVG, pickSymbol, pickAudio, cancelAudioPicker, toNotoMonochrome, skipForNotoMonochrome, selectFile, triggerDownload,

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -1115,6 +1115,8 @@ function setJEenabled(v) {
 
 function setJEroutineLogging(v) {
   jeRoutineLogging = v;
+  if(v)
+    forgetReportedProblems();
 }
 
 window.onresize = function(event) {

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -210,12 +210,13 @@ async function handleInput(name, e, dragTarget) {
         delete mouseStatus[target.id];
         const timeSinceStart = +new Date() - ms.start;
         const pixelsMoved = ms.coords ? Math.abs(ms.coords.x - ms.downCoords.x) + Math.abs(ms.coords.y - ms.downCoords.y) : 0;
-        if(ms.status != 'initial' && ms.moveTarget && !dragTargetGone(ms)) {
+        if(ms.status != 'initial' && ms.moveTarget) {
           setDeltaCause(`${playerName} dragged ${widget.id}`);
           // let every mousemove that is still being processed finish first so that the
           // drop happens after the last one instead of racing with it
           await ms.dragChain;
-          await ms.moveTarget.moveEnd(coords, ms.localAnchor);
+          if(!dragTargetGone(ms))
+            await ms.moveTarget.moveEnd(coords, ms.localAnchor);
         }
         if(ms.status == 'initial' || timeSinceStart < 250 && pixelsMoved < 10) {
           let editClickHandled = false;
@@ -258,8 +259,6 @@ async function handleInput(name, e, dragTarget) {
         if(isFirstMove)
           ms.status = 'moving';
         ms.coords = coords;
-        if(dragTargetGone(ms))
-          ms.moveTarget = null;
         if(ms.moveTarget) {
           setDeltaCause(`${playerName} dragged ${widget.id}`);
           // Mouse events are handled asynchronously, so several of them can be in
@@ -273,8 +272,15 @@ async function handleInput(name, e, dragTarget) {
             // widget visibly lags behind the cursor.
             if(!isFirstMove && ms.coords !== coords)
               return;
+            // The widget can leave the room at any of these awaits - moveStart() sets 'dragging',
+            // which runs game logic that is free to remove it - so every one of them is followed by
+            // the check instead of it being made once before the move is queued.
+            if(dragTargetGone(ms))
+              return;
             if(isFirstMove)
               await ms.moveTarget.moveStart();
+            if(dragTargetGone(ms))
+              return;
             await ms.moveTarget.move(coords, ms.localAnchor);
           }).catch(error => {
             // keep the chain resolvable - a rejected one would make every later move

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -43,6 +43,13 @@ function eventCoords(name, e) {
   return {x, y, clientX: coords.clientX, clientY: coords.clientY};
 }
 
+// The widget a drag holds on to can leave the room while the drag is still running - another
+// player deletes it, or game logic reacting to the move itself does. Everything the drag would
+// still do to it writes to a widget the room no longer has, so it lets go of it instead. (#2317)
+function dragTargetGone(ms) {
+  return ms.moveTarget && widgets.get(ms.moveTarget.get('id')) !== ms.moveTarget;
+}
+
 // Finish a drag whose mouseup never reached the drag handling below, because one
 // of the checks in handleInput() returned before it. The widget would otherwise
 // stay detached from its holder and flagged as being dragged for every player
@@ -56,7 +63,7 @@ async function endDrag(target) {
   delete mouseStatus[target.id];
 
   // while the state is being replaced the dragged widget may already be gone
-  if(isLoading || ms.status == 'initial' || !ms.moveTarget || widgets.get(ms.moveTarget.get('id')) !== ms.moveTarget)
+  if(isLoading || ms.status == 'initial' || !ms.moveTarget || dragTargetGone(ms))
     return;
 
   batchStart();
@@ -203,7 +210,7 @@ async function handleInput(name, e, dragTarget) {
         delete mouseStatus[target.id];
         const timeSinceStart = +new Date() - ms.start;
         const pixelsMoved = ms.coords ? Math.abs(ms.coords.x - ms.downCoords.x) + Math.abs(ms.coords.y - ms.downCoords.y) : 0;
-        if(ms.status != 'initial' && ms.moveTarget) {
+        if(ms.status != 'initial' && ms.moveTarget && !dragTargetGone(ms)) {
           setDeltaCause(`${playerName} dragged ${widget.id}`);
           // let every mousemove that is still being processed finish first so that the
           // drop happens after the last one instead of racing with it
@@ -251,6 +258,8 @@ async function handleInput(name, e, dragTarget) {
         if(isFirstMove)
           ms.status = 'moving';
         ms.coords = coords;
+        if(dragTargetGone(ms))
+          ms.moveTarget = null;
         if(ms.moveTarget) {
           setDeltaCause(`${playerName} dragged ${widget.id}`);
           // Mouse events are handled asynchronously, so several of them can be in

--- a/client/js/mousehandling.js
+++ b/client/js/mousehandling.js
@@ -46,8 +46,10 @@ function eventCoords(name, e) {
 // The widget a drag holds on to can leave the room while the drag is still running - another
 // player deletes it, or game logic reacting to the move itself does. Everything the drag would
 // still do to it writes to a widget the room no longer has, so it lets go of it instead. (#2317)
+// A widget removeWidgetLocal() has only queued counts as gone here as everywhere else: the batch
+// around the drag keeps it in the map until the delta is sent.
 function dragTargetGone(ms) {
-  return ms.moveTarget && widgets.get(ms.moveTarget.get('id')) !== ms.moveTarget;
+  return ms.moveTarget && liveWidget(ms.moveTarget.get('id')) !== ms.moveTarget;
 }
 
 // Finish a drag whose mouseup never reached the drag handling below, because one
@@ -62,8 +64,8 @@ async function endDrag(target) {
     return;
   delete mouseStatus[target.id];
 
-  // while the state is being replaced the dragged widget may already be gone
-  if(isLoading || ms.status == 'initial' || !ms.moveTarget || dragTargetGone(ms))
+  // nothing to end: no drag was running, or the whole state is being replaced
+  if(isLoading || ms.status == 'initial' || !ms.moveTarget)
     return;
 
   batchStart();
@@ -72,7 +74,10 @@ async function endDrag(target) {
     // like the mouseup branch below: let a mousemove that is still being
     // processed finish first, so no move lands after the drag has ended
     await ms.dragChain;
-    await ms.moveTarget.moveEnd(ms.coords, ms.localAnchor);
+    if(dragTargetGone(ms))
+      await ms.moveTarget.abandonDrag();
+    else
+      await ms.moveTarget.moveEnd(ms.coords, ms.localAnchor);
   } finally {
     batchEnd();
   }
@@ -215,7 +220,9 @@ async function handleInput(name, e, dragTarget) {
           // let every mousemove that is still being processed finish first so that the
           // drop happens after the last one instead of racing with it
           await ms.dragChain;
-          if(!dragTargetGone(ms))
+          if(dragTargetGone(ms))
+            await ms.moveTarget.abandonDrag();
+          else
             await ms.moveTarget.moveEnd(coords, ms.localAnchor);
         }
         if(ms.status == 'initial' || timeSinceStart < 250 && pixelsMoved < 10) {

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -155,19 +155,28 @@ async function addWidgetLocal(widget, useTypeBasedID = true) {
     return null;
   }
 
-  if(widget.type == 'card' && widget.deck && !widgets.has(widget.deck)) {
+  // A card is only a card together with its deck: addWidget() holds one whose deck is missing back
+  // until that deck arrives, which for a widget created here never happens - it would wait forever.
+  if(widget.type == 'card' && (!widgets.has(widget.deck) || widgets.get(widget.deck).get('type') != 'deck')) {
     console.error(`Refusing to add widget ${widget.id} with invalid deck ${widget.deck}.`);
     return null;
   }
 
-  if(widget.type == 'card' && widget.deck && !widgets.get(widget.deck).get('cardTypes')[widget.cardType]) {
+  if(widget.type == 'card' && !widgets.get(widget.deck).get('cardTypes')[widget.cardType]) {
     console.error(`Refusing to add widget ${widget.id} with invalid cardType ${widget.cardType}.`);
     return null;
   }
 
   const isNewWidget = !widgets.has(widget.id);
-  if(isNewWidget)
+  if(isNewWidget) {
     addWidget(widget);
+    // Only an ID the room actually has is of any use to the caller: one that names nothing ends up
+    // in a parent property, where it puts the child in limbo instead of into a widget.
+    if(!widgets.has(widget.id)) {
+      console.error(`Refusing to add widget ${widget.id}.`);
+      return null;
+    }
+  }
   sendPropertyUpdate(widget.id, widget);
   sendDelta();
   batchStart();
@@ -359,7 +368,7 @@ function receiveDelta(delta) {
 
   // the order of widget changes is not necessarily correct and in order to avoid cyclic children, this first moves affected widgets to the top level
   for(const widgetID in delta.s)
-    if(delta.s[widgetID] && delta.s[widgetID].parent !== undefined && delta.s[widgetID].id === undefined)
+    if(delta.s[widgetID] && delta.s[widgetID].parent !== undefined && delta.s[widgetID].id === undefined && widgets.has(widgetID))
       widgets.get(widgetID).setLimbo(true);
 
   for(const widgetID in delta.s)
@@ -414,7 +423,9 @@ function addDeltaEntryToUndoProtocol(delta) {
         undoDelta[widgetID] = JSON.parse(JSON.stringify(widgets.get(widgetID).unalteredState));
     } else if(delta.s[widgetID].id) {
       undoDelta[widgetID] = null;
-    } else {
+    } else if(widgets.has(widgetID)) {
+      // a property update can name a widget the room no longer has, when something kept writing to
+      // it after it was removed - there is no state left to undo back to, so it gets no entry
       undoDelta[widgetID] = {};
       for(const property in delta.s[widgetID]) {
         undoDelta[widgetID][property] = widgets.get(widgetID).unalteredState[property];

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -140,6 +140,29 @@ export function addWidget(widget, instance, allowMissingParent) {
   delete deferredChildren[widget.id];
 }
 
+// Why the room cannot be given this widget as it stands, or null when it can. These are the
+// refusals that only look at the state and at what the room already holds, so a caller that has to
+// tear something down before it can add - the editor changing a widget's type is a remove followed
+// by a re-add of the same ID - can ask before rather than after, when there is nothing left to
+// put back.
+export function widgetAdditionProblem(widget) {
+  if(widget.parent && !widgets.has(widget.parent))
+    return `Refusing to add widget '${widget.id}': there is no widget '${widget.parent}' to use as its parent.`;
+
+  // A card is only a card together with its deck: addWidget() holds one whose deck is missing back
+  // until that deck arrives, which for a widget created here never happens - it would wait forever.
+  if(widget.type == 'card' && !widget.deck)
+    return `Refusing to add card '${widget.id}': it names no deck to take its cardTypes from.`;
+
+  if(widget.type == 'card' && (!widgets.has(widget.deck) || widgets.get(widget.deck).get('type') != 'deck'))
+    return `Refusing to add card '${widget.id}': '${widget.deck}' is not a deck in this room.`;
+
+  if(widget.type == 'card' && !widgets.get(widget.deck).get('cardTypes')[widget.cardType])
+    return `Refusing to add card '${widget.id}': deck '${widget.deck}' has no cardType '${widget.cardType}'.`;
+
+  return null;
+}
+
 // useTypeBasedID is false on runtime engine paths (CLONE, automatic pile
 // creation) so live gameplay keeps random IDs - type-based IDs are an
 // authoring/edit-mode convenience and give no benefit during play, while
@@ -152,25 +175,9 @@ async function addWidgetLocal(widget, useTypeBasedID = true, problems = null) {
   else
     widget.id = String(widget.id);
 
-  if(widget.parent && !widgets.has(widget.parent)) {
-    reportProblem(`Refusing to add widget '${widget.id}': there is no widget '${widget.parent}' to use as its parent.`, problems);
-    return null;
-  }
-
-  // A card is only a card together with its deck: addWidget() holds one whose deck is missing back
-  // until that deck arrives, which for a widget created here never happens - it would wait forever.
-  if(widget.type == 'card' && !widget.deck) {
-    reportProblem(`Refusing to add card '${widget.id}': it names no deck to take its cardTypes from.`, problems);
-    return null;
-  }
-
-  if(widget.type == 'card' && (!widgets.has(widget.deck) || widgets.get(widget.deck).get('type') != 'deck')) {
-    reportProblem(`Refusing to add card '${widget.id}': '${widget.deck}' is not a deck in this room.`, problems);
-    return null;
-  }
-
-  if(widget.type == 'card' && !widgets.get(widget.deck).get('cardTypes')[widget.cardType]) {
-    reportProblem(`Refusing to add card '${widget.id}': deck '${widget.deck}' has no cardType '${widget.cardType}'.`, problems);
+  const additionProblem = widgetAdditionProblem(widget);
+  if(additionProblem) {
+    reportProblem(additionProblem, problems);
     return null;
   }
 
@@ -456,7 +463,9 @@ function addDeltaEntryToUndoProtocol(delta) {
       undoDelta[widgetID] = null;
     } else if(widgets.has(widgetID)) {
       // a property update can name a widget the room no longer has, when something kept writing to
-      // it after it was removed - there is no state left to undo back to, so it gets no entry
+      // it after it was removed - there is no state left to undo back to, so it gets no entry.
+      // A card still parked in deferredCards because its deck has not arrived is the one widget
+      // this also skips while it is perfectly legitimate; it gets its entries once the deck lands
       undoDelta[widgetID] = {};
       for(const property in delta.s[widgetID]) {
         undoDelta[widgetID][property] = widgets.get(widgetID).unalteredState[property];

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -187,10 +187,26 @@ async function addWidgetLocal(widget, useTypeBasedID = true, problems = null) {
   sendPropertyUpdate(widget.id, widget);
   sendDelta();
   batchStart();
-  if(isNewWidget)
-    for(const [ w, routine ] of StateManaged.globalUpdateListeners['id'] || [])
-      await w.evaluateRoutine(routine, { widgetID: widget.id, oldValue: null, value: widget.id }, { widget: [ widgets.get(widget.id) ] });
+  if(isNewWidget) {
+    for(const [ w, routine ] of StateManaged.globalUpdateListeners['id'] || []) {
+      // Any of these routines is free to select the new widget and delete it again. The ones after
+      // it would be told about a creation that no longer stands, so they get nothing rather than a
+      // collection holding an entry the room does not have.
+      const newWidget = liveWidget(widget.id);
+      if(!newWidget)
+        break;
+      await w.evaluateRoutine(routine, { widgetID: widget.id, oldValue: null, value: widget.id }, { widget: [ newWidget ] });
+    }
+  }
   batchEnd();
+
+  // A widget that did not survive its own creation is as useless to the caller as one that was
+  // never created: its ID keeps naming something until the removal is sent, so handing it back is
+  // exactly what puts the caller's children in limbo once it is.
+  if(isNewWidget && !liveWidget(widget.id)) {
+    reportProblem(`Refusing to add widget '${widget.id}': it was removed again while it was being created.`, problems);
+    return null;
+  }
   return widget.id;
 }
 
@@ -657,6 +673,15 @@ function removeWidget(widgetID) {
   }
   widgets.delete(widgetID);
   dropTargets.delete(widgetID);
+}
+
+// The widget an ID names, if it is still a part of the room. removeWidgetLocal() only marks a
+// widget and records its null delta - it stays in `widgets` until the batch around it is sent - so
+// asking whether the room has an ID also finds widgets that are already on their way out. Anything
+// parented into one of those lands in limbo the moment that batch ends.
+export function liveWidget(widgetID) {
+  const widget = widgets.get(widgetID);
+  return widget && !widget.isBeingRemoved && !widget.inRemovalQueue ? widget : null;
 }
 
 async function removeWidgetLocal(widgetID, keepChildren) {

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -203,6 +203,14 @@ async function updateWidgetId(widget, oldID) {
 
   const id = await addWidgetLocal(widget);
 
+  // A rename is a remove followed by a re-add, so a refused re-add leaves nothing to rename to.
+  // The children and cards keep the top level removeWidgetLocal() put them on rather than being
+  // pointed at an ID that names no widget.
+  if(id === null) {
+    console.error(`Renaming ${oldID} to ${widget.id} failed, the widget is gone.`);
+    return;
+  }
+
   // Restore children
   for(const child of children)
     sendPropertyUpdate(child.get('id'), 'parent', id);

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -144,26 +144,33 @@ export function addWidget(widget, instance, allowMissingParent) {
 // creation) so live gameplay keeps random IDs - type-based IDs are an
 // authoring/edit-mode convenience and give no benefit during play, while
 // sequential IDs would raise the collision risk between concurrent clients.
-async function addWidgetLocal(widget, useTypeBasedID = true) {
+// A caller that reports a refusal itself hands in a problems array to collect the reason in;
+// without one it goes wherever reportProblem() puts a problem found outside a routine.
+async function addWidgetLocal(widget, useTypeBasedID = true, problems = null) {
   if (!widget.id)
     widget.id = generateUniqueWidgetID(useTypeBasedID ? widget.type : undefined);
   else
     widget.id = String(widget.id);
 
   if(widget.parent && !widgets.has(widget.parent)) {
-    console.error(`Refusing to add widget ${widget.id} with invalid parent ${widget.parent}.`);
+    reportProblem(`Refusing to add widget '${widget.id}': there is no widget '${widget.parent}' to use as its parent.`, problems);
     return null;
   }
 
   // A card is only a card together with its deck: addWidget() holds one whose deck is missing back
   // until that deck arrives, which for a widget created here never happens - it would wait forever.
+  if(widget.type == 'card' && !widget.deck) {
+    reportProblem(`Refusing to add card '${widget.id}': it names no deck to take its cardTypes from.`, problems);
+    return null;
+  }
+
   if(widget.type == 'card' && (!widgets.has(widget.deck) || widgets.get(widget.deck).get('type') != 'deck')) {
-    console.error(`Refusing to add widget ${widget.id} with invalid deck ${widget.deck}.`);
+    reportProblem(`Refusing to add card '${widget.id}': '${widget.deck}' is not a deck in this room.`, problems);
     return null;
   }
 
   if(widget.type == 'card' && !widgets.get(widget.deck).get('cardTypes')[widget.cardType]) {
-    console.error(`Refusing to add widget ${widget.id} with invalid cardType ${widget.cardType}.`);
+    reportProblem(`Refusing to add card '${widget.id}': deck '${widget.deck}' has no cardType '${widget.cardType}'.`, problems);
     return null;
   }
 
@@ -173,7 +180,7 @@ async function addWidgetLocal(widget, useTypeBasedID = true) {
     // Only an ID the room actually has is of any use to the caller: one that names nothing ends up
     // in a parent property, where it puts the child in limbo instead of into a widget.
     if(!widgets.has(widget.id)) {
-      console.error(`Refusing to add widget ${widget.id}.`);
+      reportProblem(`Refusing to add widget '${widget.id}': it could not be created - check its type and properties.`, problems);
       return null;
     }
   }
@@ -207,7 +214,7 @@ async function updateWidgetId(widget, oldID) {
   // The children and cards keep the top level removeWidgetLocal() put them on rather than being
   // pointed at an ID that names no widget.
   if(id === null) {
-    console.error(`Renaming ${oldID} to ${widget.id} failed, the widget is gone.`);
+    alert(`Renaming '${oldID}' to '${widget.id}' failed: the widget could not be added back under its new id and is gone. Its children and cards are on the top level now.`);
     return;
   }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -73,6 +73,17 @@ async function whileSuspended(promise) {
   }
 }
 
+// Problems found outside the routine interpreter - a pile that could not be created, a drop into a
+// holder that is gone. A routine that is running takes them over so that they appear in its log
+// next to its own problems; a drag or a plain click has only the console to report to. (#1402, #1504)
+const problemsFromOutsideRoutines = [];
+function reportProblem(message) {
+  if(routineDepth)
+    problemsFromOutsideRoutines.push(message);
+  else
+    console.log(message);
+}
+
 // wouldCreateParentCycle reads the parent of every widget it walks, which can come back into
 // getDefaultValue for a widget whose inherited parent is still being resolved. StateManaged's own
 // inheritance guard is released by then, so the check keeps its own re-entrancy set. (#684)
@@ -647,15 +658,22 @@ export class Widget extends StateManaged {
     if(widgets.has(newID)) { // cloning can fail for example with invalid cardType
       const cWidget = widgets.get(newID);
 
+      // The parent was there when this started, but creating the clone runs every routine that
+      // listens on 'id' - one of those can have removed it by now, and the clone then stays where
+      // it was created instead of going into a widget that is gone. (#1504)
+      const parentWidget = parent && widgets.has(parent) ? widgets.get(parent) : null;
+      if(parent && !parentWidget)
+        reportProblem(`Widget ${parent} disappeared while ${this.get('id')} was being cloned into it.`);
+
       // use moveToHolder so that CLONE triggers onEnter and similar features
       cWidget.movedByButton = problems != null;
-      if(parent)
-        await cWidget.moveToHolder(widgets.get(parent));
+      if(parentWidget)
+        await cWidget.moveToHolder(parentWidget);
       if(inheritFrom)
         await cWidget.set('inheritFrom', inheritFrom);
 
       // moveToHolder causes the position to be wrong if the target holder does not have alignChildren
-      if(!parent || !widgets.get(parent).get('alignChildren')) {
+      if(!parentWidget || !parentWidget.get('alignChildren')) {
         await cWidget.set('x', (overrideProperties.x !== undefined ? overrideProperties.x : this.get('x')) + xOffset);
         await cWidget.set('y', (overrideProperties.y !== undefined ? overrideProperties.y : this.get('y')) + yOffset);
         await cWidget.updatePiles();
@@ -1277,9 +1295,10 @@ export class Widget extends StateManaged {
         // was aborted by an exception, or when every routine that is still alive is suspended in
         // DELAY or INPUT. The message names the routine it came from, so the console still tells
         // the whole story.
-        for(const problem of [ routineDepthProblem, routineDepthProblemForOutermost ])
+        for(const problem of [ ...problemsFromOutsideRoutines, routineDepthProblem, routineDepthProblemForOutermost ])
           if(problem)
             console.log(problem);
+        problemsFromOutsideRoutines.length = 0;
         routineDepthProblem = routineDepthProblemForOutermost = null;
       }
     }
@@ -2859,6 +2878,9 @@ export class Widget extends StateManaged {
         }
       }
 
+      while(problemsFromOutsideRoutines.length)
+        problems.push(problemsFromOutsideRoutines.shift());
+
       if(routineDepthProblem) {
         problems.push(routineDepthProblem);
         routineDepthProblem = null;
@@ -3070,6 +3092,14 @@ export class Widget extends StateManaged {
   async moveToHolder(holder) {
     if(this.inRemovalQueue)
       return;
+
+    // A routine that moves several widgets one after another looks the holder up once per widget,
+    // and every move it makes can run game logic that removes it in between - so by the time this
+    // widget's turn comes there may be nothing left to move it into. (#1504)
+    if(!holder || !widgets.has(holder.get('id'))) {
+      reportProblem(`Could not move ${this.id} into ${holder ? holder.get('id') : 'a holder'} because it does not exist.`);
+      return;
+    }
 
     await this.bringToFront();
     if(this.get('parent') && !this.currentParent)
@@ -3965,6 +3995,13 @@ export class Widget extends StateManaged {
           if(thisOwner !== null)
             pile.owner = thisOwner;
           const pileId = await addWidgetLocal(pile, false); // runtime path: keep random IDs
+          // An onPileCreation that does not describe a widget the client can build - "type": "card"
+          // without a deck, for example - yields no pile. Handing the cards to it anyway put them in
+          // limbo, from where the next update tried to pile them up again, forever. (#1402)
+          if(pileId === null) {
+            reportProblem(`Could not create a pile for ${this.id} and ${widgetID}. Check the onPileCreation property of ${this.id}.`);
+            break;
+          }
           await widget.set('parent', pileId);
           await this.bringToFront();
           await this.set('parent', pileId);

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2166,8 +2166,8 @@ export class Widget extends StateManaged {
             c.movedByButton = true;
             if(target.get('type') == 'seat') {
               if(target.get('hand') && target.get('player')) {
-                if(widgets.has(target.get('hand'))) {
-                  const targetHand = widgets.get(target.get('hand'));
+                const targetHand = liveWidget(target.get('hand'));
+                if(targetHand) {
                   let wasMoved = true;
                   await applyFlip();
                   if (targetHand == source) {
@@ -2178,11 +2178,14 @@ export class Widget extends StateManaged {
                     wasMoved = await c.moveToHolder(targetHand, problems);
                     delete c.targetPlayer;
                   }
-                  await c.bringToFront();
-                  if(targetHand.get('type') == 'holder')
-                    await targetHand.updateAfterShuffle(); // this arranges the cards in the new owner's hand
-                  if(wasMoved)
+                  // a refused move left the card where it was, so there is no hand to rearrange
+                  // and no card in it to raise
+                  if(wasMoved) {
+                    await c.bringToFront();
+                    if(targetHand.get('type') == 'holder')
+                      await targetHand.updateAfterShuffle(); // this arranges the cards in the new owner's hand
                     ++moved;
+                  }
                 } else {
                   problems.push(`Seat ${target.id} declares 'hand: ${target.get('hand')}' which does not exist.`);
                 }
@@ -3139,14 +3142,25 @@ export class Widget extends StateManaged {
 
     if(this.get('parent') && !this.currentParent)
       this.currentParent = widgets.get(this.get('parent'));
+
+    // Where the widget came from, so that a refusal after checkParent(true) has taken it out of
+    // there can put it back: x and y are the numbers it had inside that holder, and left on the
+    // top level they are read as the room's and draw the widget somewhere else entirely.
+    const parentBefore = this.get('parent');
+    const putBack = async ()=> {
+      if(this.get('parent') !== parentBefore && liveWidget(this.id) === this && liveWidget(parentBefore))
+        await this.set('parent', parentBefore);
+      return false;
+    };
+
     if(this.currentParent != holder)
       await this.checkParent(true);
     if(cannotMove())
-      return false;
+      return await putBack();
 
     await this.set('owner',  null);
     if(cannotMove())
-      return false;
+      return await putBack();
 
     await this.set('parent', holder.get('id'));
     return true;
@@ -3418,9 +3432,11 @@ export class Widget extends StateManaged {
   // write to that widget is pointless, but the marks the drag left on other widgets
   // outlive it: the drop targets keep the 'droppable' class, which move() takes as
   // reason enough to drop the next dragged widget there whatever the holder accepts,
-  // the hovered holder keeps its highlight, and a drop shadow is parented to that
-  // holder rather than to the widget, so removing the widget leaves it in the room for
-  // every player. This takes all of that off again and touches nothing that is gone.
+  // the hovered holder keeps its highlight, a drop shadow is parented to that holder
+  // rather than to the widget, so removing the widget leaves it in the room for every
+  // player, and #enlarged is a single element the whole room shares, which only the
+  // widget's own touchend listener and moveEnd() ever hide again. This takes all of that
+  // off again and touches nothing that is gone.
   async abandonDrag() {
     for(const t of this.dropTargets || [])
       if(t.domElement)
@@ -3429,9 +3445,12 @@ export class Widget extends StateManaged {
       this.hoverTarget.domElement.classList.remove('droptarget');
     this.highlightStopDropLine(null);
     delete this.stopDropLines;
+    this.hideEnlarged();
 
     // hideShadowWidget() would write 'dropShadowWidget' back to the gone widget, so the
-    // shadow is taken out the way that method does but without that last step
+    // shadow is taken out the way that method does but without that last step - and
+    // without its preventRearrangeDuringPileDrop bracket, which only matters for a holder
+    // that is receiving a drop, while nothing is being dropped here
     const shadowWidget = liveWidget(this.get('dropShadowWidget'));
     if(shadowWidget) {
       shadowWidget.currentParent = liveWidget(shadowWidget.get('parent'));
@@ -4069,15 +4088,30 @@ export class Widget extends StateManaged {
           // limbo, from where the next update tried to pile them up again, forever. (#1402)
           if(pileId === null) {
             // the two cards stay where they are and stay within pileSnapRange, so every later update
-            // of either of them tries the same pile again - only the first attempt is worth reading
-            if(!reportedPileCreationFailures.has(thisOnPileCreationJSON)) {
-              reportedPileCreationFailures.add(thisOnPileCreationJSON);
+            // of either of them tries the same pile again - only the first attempt of this pair is
+            // worth reading, while a different pair failing the same way still gets its own message
+            const failureKey = `${thisOnPileCreationJSON} ${this.id} ${widgetID}`;
+            if(!reportedPileCreationFailures.has(failureKey)) {
+              reportedPileCreationFailures.add(failureKey);
               reportProblem(`Could not create a pile for '${this.id}' and '${widgetID}'. Check the onPileCreation property of '${this.id}'.`);
               for(const problem of pileProblems)
                 reportProblem(problem);
             }
             break;
           }
+
+          // Creating the pile ran every routine listening on 'id', and those are as free to delete
+          // the cards as the pile. A pile that gets only one of them stays in the room forever: a
+          // pile dissolves itself when a child is removed from it, and the card that is gone was
+          // never in it to be removed. So the empty pile goes again and the surviving card keeps its
+          // own position rather than handing it to a pile it is alone in.
+          if(liveWidget(this.id) !== this || liveWidget(widgetID) !== widget) {
+            const pileWidget = liveWidget(pileId);
+            if(pileWidget && !pileWidget.children().length)
+              await removeWidgetLocal(pileId);
+            break;
+          }
+
           await widget.set('parent', pileId);
           await this.bringToFront();
           await this.set('parent', pileId);

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -76,20 +76,31 @@ async function whileSuspended(promise) {
 // Problems found outside the routine interpreter - a pile that could not be created, a drop into a
 // holder that is gone. A caller that is an operation hands in the problems array of its own routine;
 // for the rest, a routine that happens to be running takes them over so that they appear in its log
-// next to its own problems, and a drag or a plain click has only the console to report to. (#1402, #1504)
+// next to its own problems, and a drag or a plain click becomes a note of its own in the routine
+// log - the panel a game author reads these in. (#1402, #1504)
 const problemsFromOutsideRoutines = [];
-function reportProblem(message, problems) {
+export function reportProblem(message, problems) {
   if(problems)
     problems.push(message);
   else if(routineDepth)
     problemsFromOutsideRoutines.push(message);
-  else
+  else {
     console.log(message);
+    if(jeRoutineLogging)
+      jeLoggingProblemNote(message);
+  }
 }
 
 // The onPileCreation values that already failed to produce a pile, so that the cards they belong to
 // do not report the same problem again on every single update.
 const reportedPileCreationFailures = new Set();
+
+// Opening the routine log starts a fresh set: without this, a failure that happened before anybody
+// was watching would keep the identical one from ever being reported again, and trying it once more
+// with the panel open - the obvious thing to do - would show nothing for the rest of the page.
+export function forgetReportedProblems() {
+  reportedPileCreationFailures.clear();
+}
 
 // wouldCreateParentCycle reads the parent of every widget it walks, which can come back into
 // getDefaultValue for a widget whose inherited parent is still being resolved. StateManaged's own
@@ -670,7 +681,7 @@ export class Widget extends StateManaged {
       // it was created instead of going into a widget that is gone. (#1504)
       const parentWidget = parent && widgets.has(parent) ? widgets.get(parent) : null;
       if(parent && !parentWidget)
-        reportProblem(`Widget ${parent} disappeared while ${this.get('id')} was being cloned into it.`, problems);
+        reportProblem(`Widget '${parent}' disappeared while '${this.get('id')}' was being cloned into it.`, problems);
 
       // use moveToHolder so that CLONE triggers onEnter and similar features
       cWidget.movedByButton = problems != null;
@@ -3108,7 +3119,9 @@ export class Widget extends StateManaged {
     // and every move it makes can run game logic that removes it in between - so by the time this
     // widget's turn comes there may be nothing left to move it into. (#1504)
     if(!holder || !widgets.has(holder.get('id'))) {
-      reportProblem(`Could not move ${this.id} into ${holder ? holder.get('id') : 'a holder'} because it does not exist.`, problems);
+      reportProblem(holder
+        ? `Could not move '${this.id}' into '${holder.get('id')}' because that holder no longer exists.`
+        : `Could not move '${this.id}' because the holder it should go into is gone.`, problems);
       return false;
     }
 
@@ -4006,7 +4019,8 @@ export class Widget extends StateManaged {
           }, this.get('onPileCreation'));
           if(thisOwner !== null)
             pile.owner = thisOwner;
-          const pileId = await addWidgetLocal(pile, false); // runtime path: keep random IDs
+          const pileProblems = [];
+          const pileId = await addWidgetLocal(pile, false, pileProblems); // runtime path: keep random IDs
           // An onPileCreation that does not describe a widget the client can build - "type": "card"
           // without a deck, for example - yields no pile. Handing the cards to it anyway put them in
           // limbo, from where the next update tried to pile them up again, forever. (#1402)
@@ -4015,7 +4029,9 @@ export class Widget extends StateManaged {
             // of either of them tries the same pile again - only the first attempt is worth reading
             if(!reportedPileCreationFailures.has(thisOnPileCreationJSON)) {
               reportedPileCreationFailures.add(thisOnPileCreationJSON);
-              reportProblem(`Could not create a pile for ${this.id} and ${widgetID}. Check the onPileCreation property of ${this.id}.`);
+              reportProblem(`Could not create a pile for '${this.id}' and '${widgetID}'. Check the onPileCreation property of '${this.id}'.`);
+              for(const problem of pileProblems)
+                reportProblem(problem);
             }
             break;
           }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -2,7 +2,7 @@ import { $, removeFromDOM, asArray, escapeID, mapAssetURLs, mod, stringifyForDis
 import { expressionCondition, expressionNames, expressionNumber } from '../expression.js';
 import { StateManaged } from '../statemanaged.js';
 import { playerName, playerColor, activePlayers, activeColors, mouseCoords } from '../overlays/players.js';
-import { batchStart, batchEnd, widgetFilter, widgets, flushDelta, runInput } from '../serverstate.js';
+import { batchStart, batchEnd, widgetFilter, widgets, liveWidget, flushDelta, runInput } from '../serverstate.js';
 import { showOverlay, shuffleWidgets, sortWidgets, exceedsDropLimit } from '../main.js';
 import { tracingEnabled } from '../tracing.js';
 import { toHex } from '../color.js';
@@ -672,14 +672,14 @@ export class Widget extends StateManaged {
     }
     delete clone.parent;
     delete clone.inheritFrom;
-    const newID = await addWidgetLocal(clone, false); // runtime path: keep random IDs
+    const newID = await addWidgetLocal(clone, false, problems); // runtime path: keep random IDs
     if(widgets.has(newID)) { // cloning can fail for example with invalid cardType
       const cWidget = widgets.get(newID);
 
       // The parent was there when this started, but creating the clone runs every routine that
       // listens on 'id' - one of those can have removed it by now, and the clone then stays where
       // it was created instead of going into a widget that is gone. (#1504)
-      const parentWidget = parent && widgets.has(parent) ? widgets.get(parent) : null;
+      const parentWidget = parent ? liveWidget(parent) : null;
       if(parent && !parentWidget)
         reportProblem(`Widget '${parent}' disappeared while '${this.get('id')}' was being cloned into it.`, problems);
 
@@ -3112,26 +3112,40 @@ export class Widget extends StateManaged {
   // Returns whether the widget was moved, so that a caller counting its moves does not count the
   // ones that were refused.
   async moveToHolder(holder, problems) {
-    if(this.inRemovalQueue)
-      return false;
-
     // A routine that moves several widgets one after another looks the holder up once per widget,
-    // and every move it makes can run game logic that removes it in between - so by the time this
-    // widget's turn comes there may be nothing left to move it into. (#1504)
-    if(!holder || !widgets.has(holder.get('id'))) {
+    // and every property written below runs whatever the game listens for - so the holder can be
+    // gone before this widget's turn comes, and either it or this widget can go in between any two
+    // of the steps. That is why the pair is checked after each of them and not once at the
+    // start; a holder that removeWidgetLocal() has only queued counts as gone. (#1504)
+    const cannotMove = ()=> {
+      if(this.inRemovalQueue || this.isBeingRemoved)
+        return true;
+      if(holder && liveWidget(holder.get('id')) === holder)
+        return false;
       reportProblem(holder
         ? `Could not move '${this.id}' into '${holder.get('id')}' because that holder no longer exists.`
         : `Could not move '${this.id}' because the holder it should go into is gone.`, problems);
+      return true;
+    };
+
+    if(cannotMove())
       return false;
-    }
 
     await this.bringToFront();
+    if(cannotMove())
+      return false;
+
     if(this.get('parent') && !this.currentParent)
       this.currentParent = widgets.get(this.get('parent'));
     if(this.currentParent != holder)
       await this.checkParent(true);
+    if(cannotMove())
+      return false;
 
     await this.set('owner',  null);
+    if(cannotMove())
+      return false;
+
     await this.set('parent', holder.get('id'));
     return true;
   }

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -661,7 +661,9 @@ export class Widget extends StateManaged {
     const clone = Object.assign(JSON.parse(JSON.stringify(this.state)), overrideProperties);
     const parent = clone.parent;
     const inheritFrom = clone.inheritFrom;
-    if(parent !== undefined && parent !== null && !widgets.has(parent))
+    // a parent that is already queued for removal is no place to put a clone, so nothing
+    // is created for it rather than creating one that then has nowhere to go
+    if(parent !== undefined && parent !== null && !liveWidget(parent))
       return null;
 
     clone.clonedFrom = this.get('id');
@@ -686,7 +688,7 @@ export class Widget extends StateManaged {
       // use moveToHolder so that CLONE triggers onEnter and similar features
       cWidget.movedByButton = problems != null;
       if(parentWidget)
-        await cWidget.moveToHolder(parentWidget);
+        await cWidget.moveToHolder(parentWidget, problems);
       if(inheritFrom)
         await cWidget.set('inheritFrom', inheritFrom);
 
@@ -3410,6 +3412,33 @@ export class Widget extends StateManaged {
 
     await this.updatePiles();
     delete this.pileUpdateFromDrag;
+  }
+
+  // Let go of a drag whose widget has left the room. Everything moveEnd() would still
+  // write to that widget is pointless, but the marks the drag left on other widgets
+  // outlive it: the drop targets keep the 'droppable' class, which move() takes as
+  // reason enough to drop the next dragged widget there whatever the holder accepts,
+  // the hovered holder keeps its highlight, and a drop shadow is parented to that
+  // holder rather than to the widget, so removing the widget leaves it in the room for
+  // every player. This takes all of that off again and touches nothing that is gone.
+  async abandonDrag() {
+    for(const t of this.dropTargets || [])
+      if(t.domElement)
+        t.domElement.classList.remove('droppable');
+    if(this.hoverTarget && this.hoverTarget.domElement)
+      this.hoverTarget.domElement.classList.remove('droptarget');
+    this.highlightStopDropLine(null);
+    delete this.stopDropLines;
+
+    // hideShadowWidget() would write 'dropShadowWidget' back to the gone widget, so the
+    // shadow is taken out the way that method does but without that last step
+    const shadowWidget = liveWidget(this.get('dropShadowWidget'));
+    if(shadowWidget) {
+      shadowWidget.currentParent = liveWidget(shadowWidget.get('parent'));
+      await shadowWidget.set('parent', null);
+      await shadowWidget.checkParent(true);
+      await removeWidgetLocal(shadowWidget.get('id'));
+    }
   }
 
   async hideShadowWidget() {

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -74,15 +74,22 @@ async function whileSuspended(promise) {
 }
 
 // Problems found outside the routine interpreter - a pile that could not be created, a drop into a
-// holder that is gone. A routine that is running takes them over so that they appear in its log
-// next to its own problems; a drag or a plain click has only the console to report to. (#1402, #1504)
+// holder that is gone. A caller that is an operation hands in the problems array of its own routine;
+// for the rest, a routine that happens to be running takes them over so that they appear in its log
+// next to its own problems, and a drag or a plain click has only the console to report to. (#1402, #1504)
 const problemsFromOutsideRoutines = [];
-function reportProblem(message) {
-  if(routineDepth)
+function reportProblem(message, problems) {
+  if(problems)
+    problems.push(message);
+  else if(routineDepth)
     problemsFromOutsideRoutines.push(message);
   else
     console.log(message);
 }
+
+// The onPileCreation values that already failed to produce a pile, so that the cards they belong to
+// do not report the same problem again on every single update.
+const reportedPileCreationFailures = new Set();
 
 // wouldCreateParentCycle reads the parent of every widget it walks, which can come back into
 // getDefaultValue for a widget whose inherited parent is still being resolved. StateManaged's own
@@ -663,7 +670,7 @@ export class Widget extends StateManaged {
       // it was created instead of going into a widget that is gone. (#1504)
       const parentWidget = parent && widgets.has(parent) ? widgets.get(parent) : null;
       if(parent && !parentWidget)
-        reportProblem(`Widget ${parent} disappeared while ${this.get('id')} was being cloned into it.`);
+        reportProblem(`Widget ${parent} disappeared while ${this.get('id')} was being cloned into it.`, problems);
 
       // use moveToHolder so that CLONE triggers onEnter and similar features
       cWidget.movedByButton = problems != null;
@@ -2148,19 +2155,21 @@ export class Widget extends StateManaged {
               if(target.get('hand') && target.get('player')) {
                 if(widgets.has(target.get('hand'))) {
                   const targetHand = widgets.get(target.get('hand'));
+                  let wasMoved = true;
                   await applyFlip();
                   if (targetHand == source) {
                     // cards are already in hand: only an owner update is needed
                     await c.set('owner', target.get('player'));
                   } else {
                     c.targetPlayer = target.get('player');
-                    await c.moveToHolder(targetHand);
+                    wasMoved = await c.moveToHolder(targetHand, problems);
                     delete c.targetPlayer;
                   }
                   await c.bringToFront();
                   if(targetHand.get('type') == 'holder')
                     await targetHand.updateAfterShuffle(); // this arranges the cards in the new owner's hand
-                  ++moved;
+                  if(wasMoved)
+                    ++moved;
                 } else {
                   problems.push(`Seat ${target.id} declares 'hand: ${target.get('hand')}' which does not exist.`);
                 }
@@ -2169,8 +2178,8 @@ export class Widget extends StateManaged {
               }
             } else {
               await applyFlip();
-              await c.moveToHolder(target);
-              ++moved;
+              if(await c.moveToHolder(target, problems))
+                ++moved;
             }
             delete c.movedByButton;
           }
@@ -2275,7 +2284,7 @@ export class Widget extends StateManaged {
                   if(c.get('_ancestor') == holder && !c.get('owner'))
                     await c.bringToFront();
                   else
-                    await c.moveToHolder(widgets.get(holder));
+                    await c.moveToHolder(widgets.get(holder), problems);
                 }
               }
             } else {
@@ -3089,16 +3098,18 @@ export class Widget extends StateManaged {
     );
   }
 
-  async moveToHolder(holder) {
+  // Returns whether the widget was moved, so that a caller counting its moves does not count the
+  // ones that were refused.
+  async moveToHolder(holder, problems) {
     if(this.inRemovalQueue)
-      return;
+      return false;
 
     // A routine that moves several widgets one after another looks the holder up once per widget,
     // and every move it makes can run game logic that removes it in between - so by the time this
     // widget's turn comes there may be nothing left to move it into. (#1504)
     if(!holder || !widgets.has(holder.get('id'))) {
-      reportProblem(`Could not move ${this.id} into ${holder ? holder.get('id') : 'a holder'} because it does not exist.`);
-      return;
+      reportProblem(`Could not move ${this.id} into ${holder ? holder.get('id') : 'a holder'} because it does not exist.`, problems);
+      return false;
     }
 
     await this.bringToFront();
@@ -3109,6 +3120,7 @@ export class Widget extends StateManaged {
 
     await this.set('owner',  null);
     await this.set('parent', holder.get('id'));
+    return true;
   }
 
   async moveStart() {
@@ -3999,7 +4011,12 @@ export class Widget extends StateManaged {
           // without a deck, for example - yields no pile. Handing the cards to it anyway put them in
           // limbo, from where the next update tried to pile them up again, forever. (#1402)
           if(pileId === null) {
-            reportProblem(`Could not create a pile for ${this.id} and ${widgetID}. Check the onPileCreation property of ${this.id}.`);
+            // the two cards stay where they are and stay within pileSnapRange, so every later update
+            // of either of them tries the same pile again - only the first attempt is worth reading
+            if(!reportedPileCreationFailures.has(thisOnPileCreationJSON)) {
+              reportedPileCreationFailures.add(thisOnPileCreationJSON);
+              reportProblem(`Could not create a pile for ${this.id} and ${widgetID}. Check the onPileCreation property of ${this.id}.`);
+            }
             break;
           }
           await widget.set('parent', pileId);

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -5660,3 +5660,34 @@ test('The JSON editor reports a parent that would create a loop while typing', a
     .expect(Selector('#jeCommands .error').exists).notOk();
   await t.expect(await ClientFunction(() => widgets.get('outer').get('x'))()).eql(123);
 });
+
+// A changed type is a remove of the widget followed by an add of the new one under the same id,
+// so a type the client cannot build - a card that names no deck - took the widget out and put
+// nothing back, on the server as well as here. The macro command runs over every widget in the
+// room, which is where one bad type would empty it.
+test('A macro giving every widget a type the client cannot build changes none of them', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    one: { id: 'one', type: 'basic', x: 200, y: 200, width: 100, height: 100 },
+    two: { id: 'two', type: 'basic', x: 400, y: 200, width: 100, height: 100 }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState({ modules: { JSON: 'editorModuleTopLeft' } });
+  await setName(t);
+
+  await t
+    .click('#editButton')
+    .expect(Selector('#editorModuleTopLeft.data_object').exists).ok()
+    .click('#w_one', { modifiers: { ctrl: true } })
+    .click('#je_callMacro')
+    .typeText('#jeText', `w.type = 'card';`, { replace: true, paste: true })
+    .click('#je_callMacro');
+
+  await t
+    .expect(jsonError()).contains('it names no deck')
+    .expect(widgetProperty('one', 'type')).eql('basic')
+    .expect(widgetProperty('two', 'type')).eql('basic')
+    .expect(Selector('#w_one').exists).ok()
+    .expect(Selector('#w_two').exists).ok();
+  await setEditorState(null);
+});

--- a/tests/testcafe/routines.js
+++ b/tests/testcafe/routines.js
@@ -823,3 +823,93 @@ test('a drag whose widget is deleted leaves no drop shadow behind', async t => {
   await t.click('#w_go');
   await expectEventually(t, markedWidgets, [ 'go' ]);
 });
+
+// Creating the pile runs every routine listening on 'id', and those are as free to delete one of
+// the two cards as the pile itself. The card that is left used to be handed to the pile anyway -
+// a pile with a single child, which nothing dissolves because the other card was never in it to
+// be removed from it, and which keeps the position of the card it swallowed. (#1402)
+test('a card deleted while its pile is being created leaves no pile behind', async t => {
+  await setRoomState({
+    deck: { id: 'deck', type: 'deck', cardTypes: { plain: {} }, x: 50, y: 400 },
+    card1: { id: 'card1', type: 'card', deck: 'deck', cardType: 'plain', x: 200, y: 100 },
+    card2: { id: 'card2', type: 'card', deck: 'deck', cardType: 'plain', x: 600, y: 100 },
+    watcher: { id: 'watcher', type: 'basic', x: 1200, y: 700, idGlobalUpdateRoutine: [
+      { func: 'SELECT', property: 'id', value: 'card2' },
+      { func: 'DELETE' }
+    ] },
+    go: markSelf
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+  await t.dragToElement('#w_card2', '#w_card1', { speed: 0.4 });
+
+  await expectEventually(t, async ()=>JSON.parse(await getState()).card2 || null, null);
+  // the pile the drag started to build is taken back out instead of staying behind with one card
+  await t.expect(Object.keys(JSON.parse(await getState())).filter(id=>id != '_meta').sort()).eql([ 'card1', 'deck', 'go', 'watcher' ]);
+  // and the card that is left keeps its own position rather than handing it to that pile
+  await t.expect(await widgetProperty('card1', 'parent')).eql(null);
+  await t.expect(await widgetProperty('card1', 'x')).eql(200);
+
+  // the client is still there and reacts to the next click
+  await t.click('#w_go');
+  await expectEventually(t, markedWidgets, [ 'go' ]);
+});
+
+// Taking the widget out of the holder it is in is itself a step that runs game logic, so the
+// holder it is on its way to can disappear while the widget is already detached. Its x and y are
+// the numbers it had inside its old holder, so leaving it on the top level would draw it somewhere
+// else entirely - it goes back where it came from instead. (#1504)
+test('a holder that disappears while the widget leaves its old one puts the widget back', async t => {
+  await setRoomState({
+    deck: { id: 'deck', type: 'deck', cardTypes: { plain: {} }, x: 50, y: 400 },
+    source: { id: 'source', type: 'holder', x: 50, y: 100, width: 700, height: 180, leaveRoutine: [
+      { func: 'SELECT', property: 'id', value: 'target' },
+      { func: 'DELETE' }
+    ] },
+    target: { id: 'target', type: 'holder', x: 50, y: 600, width: 700, height: 180 },
+    card1: { id: 'card1', type: 'card', deck: 'deck', cardType: 'plain', parent: 'source', x: 100, y: 20 },
+    card2: { id: 'card2', type: 'card', deck: 'deck', cardType: 'plain', parent: 'source', x: 300, y: 20 },
+    move: { id: 'move', type: 'button', text: 'move', x: 800, y: 400, clickRoutine: [
+      { func: 'MOVE', from: 'source', to: 'target', count: 2 }
+    ] }
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+  await t
+    .click('#editButton')
+    .click('#editorSidebar [icon=pest_control]')
+    .expect(Selector('#jeLog').exists).ok();
+
+  await ClientFunction(() => widgets.get('move').evaluateRoutine('clickRoutine', {}, {}).then(_=>true))();
+
+  await t.expect(Selector('#jeLog .jeLogProblems').innerText).contains('because that holder no longer exists');
+  // both cards are in the holder they started in - the one whose turn never came and the one that
+  // was already taken out of it when the target disappeared
+  await expectEventually(t, ()=>widgetProperty('card1', 'parent'), 'source');
+  await expectEventually(t, ()=>widgetProperty('card2', 'parent'), 'source');
+});
+
+// The guards in receiveDelta() are the last resort for a delta that names a widget this client
+// does not have: reading its state to build the undo entry, or moving it out of the way of a
+// parent change, both dereferenced a lookup that came back undefined and took the client down
+// before the delta was applied at all. (#2317)
+test('a delta naming a widget the client does not have is applied without taking it down', async t => {
+  await setRoomState({ go: markSelf });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+  await t.click('#editButton');
+
+  const undoProtocolMentionsGhost = await ClientFunction(() => {
+    sendRawDelta({ s: { ghost: { x: 42 } } });          // no state to undo back to
+    sendRawDelta({ s: { ghost: { parent: null } } });   // and nothing to move to the top level
+    return getUndoProtocol().some(entry=>entry.undoDelta.ghost !== undefined);
+  })();
+
+  await t.expect(undoProtocolMentionsGhost).notOk();
+  await t.expect(Selector('#clientErrorOverlay').visible).notOk();
+
+  // the client is still there and reacts to the next click
+  await t.click('#editorToolbar button[icon=close]');
+  await t.click('#w_go');
+  await expectEventually(t, markedWidgets, [ 'go' ]);
+});

--- a/tests/testcafe/routines.js
+++ b/tests/testcafe/routines.js
@@ -551,3 +551,129 @@ test('a routine finishing while another one is waiting keeps the client sending'
   await ClientFunction(() => widgets.get('go').set('marked', true).then(_=>true))();
   await expectEventually(t, markedWidgets, [ 'first', 'go', 'second' ]);
 });
+
+// Acting on a widget that is gone, or on one that was never created, is the other way the client
+// used to die: a lookup came back undefined at a moment when the code assumed a live widget, or an
+// ID was handed out for a widget that does not exist. (#1402, #1504, #2317)
+
+// "type": "card" without a deck describes nothing the client can create, so the pile was never
+// added - but its ID was handed back anyway, the cards were parented to it, and updating them
+// asked for the next pile, forever. (#1402)
+test('an onPileCreation that cannot create a pile leaves the cards where they are', async t => {
+  await setRoomState({
+    deck: { id: 'deck', type: 'deck', cardTypes: { plain: {} }, x: 50, y: 400 },
+    card1: { id: 'card1', type: 'card', deck: 'deck', cardType: 'plain', x: 200, y: 100, onPileCreation: { type: 'card' } },
+    card2: { id: 'card2', type: 'card', deck: 'deck', cardType: 'plain', x: 600, y: 100, onPileCreation: { type: 'card' } },
+    go: markSelf
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+  await t.dragToElement('#w_card2', '#w_card1', { speed: 0.4 });
+
+  // no pile was created and neither card was handed to one
+  await expectEventually(t, ()=>widgetProperty('card1', 'parent'), null);
+  await expectEventually(t, ()=>widgetProperty('card2', 'parent'), null);
+  await t.expect(Object.keys(JSON.parse(await getState())).filter(id=>id != '_meta').sort()).eql([ 'card1', 'card2', 'deck', 'go' ]);
+
+  // the client is still there and reacts to the next click
+  await t.click('#w_go');
+  await expectEventually(t, markedWidgets, [ 'go' ]);
+});
+
+// Creating the clone runs every routine listening on 'id', which can remove the holder the clone
+// was meant to go into between the check and the move. (#1504)
+test('a holder that disappears while a widget is cloned into it is reported', async t => {
+  await setRoomState({
+    holder: { id: 'holder', type: 'holder', x: 100, y: 400, width: 300, height: 300 },
+    source: { id: 'source', type: 'basic', x: 100, y: 100, width: 100, height: 100 },
+    watcher: { id: 'watcher', type: 'basic', x: 1200, y: 100, idGlobalUpdateRoutine: [
+      { func: 'SELECT', property: 'id', value: 'holder' },
+      { func: 'DELETE' },
+      { func: 'DELAY', milliseconds: 1 } // the removal reaches the room while CLONE is still running
+    ] },
+    clone: { id: 'clone', type: 'button', text: 'clone', x: 800, y: 400, clickRoutine: [
+      { func: 'SELECT', property: 'id', value: 'source' },
+      { func: 'CLONE', properties: { parent: 'holder' } },
+      { func: 'SELECT', property: 'id', value: 'go' },
+      { func: 'SET', property: 'marked', value: true }
+    ] },
+    go: markSelf
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+  await t
+    .click('#editButton')
+    .click('#editorSidebar [icon=pest_control]')
+    .expect(Selector('#jeLog').exists).ok();
+
+  await ClientFunction(() => widgets.get('clone').evaluateRoutine('clickRoutine', {}, {}).then(_=>true))();
+
+  // the holder being gone is a problem the game author can read, not an exception from a lookup
+  await t.expect(Selector('#jeLog .jeLogProblems').innerText).contains('disappeared while source was being cloned into it');
+  await t.expect(Selector('#jeLog .jeLogProblems').innerText).notContains('Exception:');
+  // the routine runs to its end and the clone stays on the table
+  await expectEventually(t, markedWidgets, [ 'go' ]);
+  await expectEventually(t, async ()=>Object.values(JSON.parse(await getState())).filter(w=>w.clonedFrom == 'source').length, 1);
+});
+
+// A drag holds on to the widget it moves, which is not necessarily the one that was pressed: a
+// press on a fixed child drags its movable ancestor. Game logic reacting to the move can remove
+// that ancestor, and everything the drag did afterwards wrote to a widget the room no longer had -
+// which took the client down in the undo protocol. (#2317)
+test('a widget removed while it is being dragged ends the drag instead of the client', async t => {
+  await setRoomState({
+    group: { id: 'group', type: 'basic', x: 100, y: 100, width: 300, height: 300, movable: true },
+    child: { id: 'child', type: 'basic', parent: 'group', x: 20, y: 20, width: 100, height: 100, movable: false },
+    watcher: { id: 'watcher', type: 'basic', x: 1200, y: 700, xGlobalUpdateRoutine: [
+      { func: 'IF', condition: '${widgetID} == "group"', thenRoutine: [
+        { func: 'SELECT', property: 'id', value: 'child' },
+        { func: 'SET', property: 'parent', value: null },
+        { func: 'SELECT', property: 'id', value: 'group' },
+        { func: 'DELETE' }
+      ] }
+    ] },
+    go: markSelf
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+  await t.drag('#w_child', 250, 150, { speed: 0.4 });
+
+  await expectEventually(t, async ()=>JSON.parse(await getState()).group || null, null);
+  await t.expect(Selector('#clientErrorOverlay').visible).notOk();
+
+  // the client is still there and reacts to the next click
+  await t.click('#w_go');
+  await expectEventually(t, markedWidgets, [ 'go' ]);
+});
+
+// A routine that moves several widgets one after another looks the holder up once per widget, and
+// every move it makes can run game logic that removes it in between. The widgets that are left
+// used to be handed to a holder that is gone, which put them in limbo. (#1504)
+test('moving into a holder that is gone leaves the widget where it is', async t => {
+  await setRoomState({
+    deck: { id: 'deck', type: 'deck', cardTypes: { plain: {} }, x: 50, y: 400 },
+    source: { id: 'source', type: 'holder', x: 50, y: 100, width: 700, height: 180 },
+    target: { id: 'target', type: 'holder', x: 50, y: 600, width: 700, height: 180, enterRoutine: [
+      { func: 'SELECT', property: 'id', value: 'target' },
+      { func: 'DELETE' },
+      { func: 'DELAY', milliseconds: 1 } // the removal reaches the room while MOVE is still running
+    ] },
+    card1: { id: 'card1', type: 'card', deck: 'deck', cardType: 'plain', parent: 'source' },
+    card2: { id: 'card2', type: 'card', deck: 'deck', cardType: 'plain', parent: 'source' },
+    move: { id: 'move', type: 'button', text: 'move', x: 800, y: 400, clickRoutine: [
+      { func: 'MOVE', from: 'source', to: 'target', count: 2 }
+    ] }
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+  await t
+    .click('#editButton')
+    .click('#editorSidebar [icon=pest_control]')
+    .expect(Selector('#jeLog').exists).ok();
+
+  await ClientFunction(() => widgets.get('move').evaluateRoutine('clickRoutine', {}, {}).then(_=>true))();
+
+  await t.expect(Selector('#jeLog .jeLogProblems').innerText).contains('because it does not exist');
+  // the card that is left stays in the holder it came from instead of getting an invalid parent
+  await expectEventually(t, ()=>widgetProperty('card1', 'parent'), 'source');
+});

--- a/tests/testcafe/routines.js
+++ b/tests/testcafe/routines.js
@@ -601,8 +601,7 @@ test('a holder that disappears while a widget is cloned into it is reported', as
     source: { id: 'source', type: 'basic', x: 100, y: 100, width: 100, height: 100 },
     watcher: { id: 'watcher', type: 'basic', x: 1200, y: 100, idGlobalUpdateRoutine: [
       { func: 'SELECT', property: 'id', value: 'holder' },
-      { func: 'DELETE' },
-      { func: 'DELAY', milliseconds: 1 } // the removal reaches the room while CLONE is still running
+      { func: 'DELETE' }
     ] },
     clone: { id: 'clone', type: 'button', text: 'clone', x: 800, y: 400, clickRoutine: [
       { func: 'SELECT', property: 'id', value: 'source' },
@@ -629,6 +628,41 @@ test('a holder that disappears while a widget is cloned into it is reported', as
   // the routine runs to its end and the clone stays on the table
   await expectEventually(t, markedWidgets, [ 'go' ]);
   await expectEventually(t, async ()=>Object.values(JSON.parse(await getState())).filter(w=>w.clonedFrom == 'source').length, 1);
+});
+
+// The routines listening on 'id' are told about the widget that was just created, and one of them
+// deleting it again is a legitimate thing for a game to do. Its ID kept naming a widget until that
+// removal was sent, so it was handed back to the caller, which parented into it. (#1504)
+test('a widget deleted by the routine reacting to its creation is not handed back', async t => {
+  await setRoomState({
+    source: { id: 'source', type: 'basic', x: 100, y: 100, width: 100, height: 100 },
+    holder: { id: 'holder', type: 'holder', x: 100, y: 400, width: 300, height: 300 },
+    watcher: { id: 'watcher', type: 'basic', x: 1200, y: 100, idGlobalUpdateRoutine: [
+      { func: 'SELECT', property: 'clonedFrom', value: 'source' },
+      { func: 'DELETE' }
+    ] },
+    clone: { id: 'clone', type: 'button', text: 'clone', x: 800, y: 400, clickRoutine: [
+      { func: 'SELECT', property: 'id', value: 'source' },
+      { func: 'CLONE', properties: { parent: 'holder' } },
+      { func: 'SELECT', property: 'id', value: 'go' },
+      { func: 'SET', property: 'marked', value: true }
+    ] },
+    go: markSelf
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+  await t
+    .click('#editButton')
+    .click('#editorSidebar [icon=pest_control]')
+    .expect(Selector('#jeLog').exists).ok();
+
+  await ClientFunction(() => widgets.get('clone').evaluateRoutine('clickRoutine', {}, {}).then(_=>true))();
+
+  await t.expect(Selector('#jeLog .jeLogProblems').innerText).contains('it was removed again while it was being created');
+  await t.expect(Selector('#jeLog .jeLogProblems').innerText).notContains('Exception:');
+  // the routine runs to its end and the room is left with exactly the widgets it started with
+  await expectEventually(t, markedWidgets, [ 'go' ]);
+  await t.expect(Object.keys(JSON.parse(await getState())).filter(id=>id != '_meta').sort()).eql([ 'clone', 'go', 'holder', 'source', 'watcher' ]);
 });
 
 // A drag holds on to the widget it moves, which is not necessarily the one that was pressed: a
@@ -697,8 +731,7 @@ test('moving into a holder that is gone leaves the widget where it is', async t 
     source: { id: 'source', type: 'holder', x: 50, y: 100, width: 700, height: 180 },
     target: { id: 'target', type: 'holder', x: 50, y: 600, width: 700, height: 180, enterRoutine: [
       { func: 'SELECT', property: 'id', value: 'target' },
-      { func: 'DELETE' },
-      { func: 'DELAY', milliseconds: 1 } // the removal reaches the room while MOVE is still running
+      { func: 'DELETE' }
     ] },
     card1: { id: 'card1', type: 'card', deck: 'deck', cardType: 'plain', parent: 'source' },
     card2: { id: 'card2', type: 'card', deck: 'deck', cardType: 'plain', parent: 'source' },

--- a/tests/testcafe/routines.js
+++ b/tests/testcafe/routines.js
@@ -178,6 +178,12 @@ const releaseDrag = ClientFunction(() => {
   document.body.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, button: 0, clientX: holder.x + holder.width/2, clientY: holder.y + holder.height/2 }));
 });
 
+// what a drag left on the widgets around it: the drop targets it offered and the one it hovered
+const dropStateClasses = ClientFunction(() => ({
+  droppable: document.querySelectorAll('.droppable').length,
+  droptarget: document.querySelectorAll('.droptarget').length
+}));
+
 async function widgetProperty(id, property) {
   const widget = JSON.parse(await getState())[id];
   return widget && widget[property] !== undefined ? widget[property] : null;
@@ -752,4 +758,68 @@ test('moving into a holder that is gone leaves the widget where it is', async t 
   await t.expect(Selector('#jeLog .jeLogProblems').visible).ok();
   // the card that is left stays in the holder it came from instead of getting an invalid parent
   await expectEventually(t, ()=>widgetProperty('card1', 'parent'), 'source');
+});
+
+// A drag that is abandoned because its widget is gone still has to take back what moveStart() put
+// on the widgets that stay: every drop target carries 'droppable' until the drop removes it again,
+// and the first hit test of the next drag takes any element with that class as its hover target
+// without asking whether the holder accepts what is being dragged. (#2317)
+test('a drag whose widget is deleted leaves no holder taking widgets it refuses', async t => {
+  await setRoomState({
+    deck: { id: 'deck', type: 'deck', cardTypes: { plain: {} }, x: 1300, y: 100 },
+    card1: { id: 'card1', type: 'card', deck: 'deck', cardType: 'plain', x: 100, y: 700 },
+    holder: { id: 'holder', type: 'holder', x: 500, y: 300, width: 500, height: 400, dropTarget: { type: 'basic' } },
+    group: { id: 'group', type: 'basic', x: 100, y: 100, width: 200, height: 200, movable: true },
+    child: { id: 'child', type: 'basic', parent: 'group', x: 20, y: 20, width: 100, height: 100, movable: false },
+    watcher: { id: 'watcher', type: 'basic', x: 1200, y: 700, xGlobalUpdateRoutine: [
+      { func: 'IF', condition: '${widgetID} == "group" and ${PROPERTY hoverTarget OF group} == "holder"', thenRoutine: [
+        { func: 'SELECT', property: 'id', value: 'child' },
+        { func: 'SET', property: 'parent', value: null },
+        { func: 'SELECT', property: 'id', value: 'group' },
+        { func: 'DELETE' }
+      ] }
+    ] }
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+  await t.drag('#w_child', 600, 400, { speed: 0.15 });
+
+  await expectEventually(t, async ()=>JSON.parse(await getState()).group || null, null);
+  await t.expect(dropStateClasses()).eql({ droppable: 0, droptarget: 0 });
+
+  // the holder takes basic widgets only, so a card dragged onto it stays where it is
+  await t.drag('#w_card1', 550, -250, { speed: 0.15 });
+  await expectEventually(t, ()=>widgetProperty('card1', 'parent'), null);
+});
+
+// The drop shadow a holder shows during a drag is a widget of its own, parented to the holder -
+// so removing the dragged widget does not take it along, and only the drop it never gets would
+// have removed it. It used to stay in the room for every player, marked as being dragged. (#2317)
+test('a drag whose widget is deleted leaves no drop shadow behind', async t => {
+  await setRoomState({
+    holder: { id: 'holder', type: 'holder', x: 500, y: 300, width: 500, height: 400, dropTarget: {}, dropShadow: true },
+    group: { id: 'group', type: 'basic', x: 100, y: 100, width: 200, height: 200, movable: true },
+    child: { id: 'child', type: 'basic', parent: 'group', x: 20, y: 20, width: 100, height: 100, movable: false },
+    watcher: { id: 'watcher', type: 'basic', x: 1200, y: 700, hoverTargetGlobalUpdateRoutine: [
+      { func: 'IF', condition: '${widgetID} == "group" and ${value} == "holder"', thenRoutine: [
+        { func: 'SELECT', property: 'id', value: 'child' },
+        { func: 'SET', property: 'parent', value: null },
+        { func: 'SELECT', property: 'id', value: 'group' },
+        { func: 'DELETE' }
+      ] }
+    ] },
+    go: markSelf
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+  await t.drag('#w_child', 600, 400, { speed: 0.15 });
+
+  await expectEventually(t, async ()=>JSON.parse(await getState()).group || null, null);
+  await expectEventually(t, async ()=>Object.values(JSON.parse(await getState())).filter(w=>w && w.dropShadowOwner).length, 0);
+  await t.expect(dropStateClasses()).eql({ droppable: 0, droptarget: 0 });
+  await t.expect(Selector('#clientErrorOverlay').visible).notOk();
+
+  // the client is still there and reacts to the next click
+  await t.click('#w_go');
+  await expectEventually(t, markedWidgets, [ 'go' ]);
 });

--- a/tests/testcafe/routines.js
+++ b/tests/testcafe/routines.js
@@ -582,6 +582,15 @@ test('an onPileCreation that cannot create a pile leaves the cards where they ar
   // the client is still there and reacts to the next click
   await t.click('#w_go');
   await expectEventually(t, markedWidgets, [ 'go' ]);
+
+  // opening the routine log is what an author does after nothing happened, so trying it again there
+  // has to say why - the message is not swallowed as a repeat of the one nobody was watching for
+  await t
+    .click('#editButton')
+    .click('#editorSidebar [icon=pest_control]')
+    .expect(Selector('#jeLog').exists).ok();
+  await ClientFunction(() => widgets.get('card2').updatePiles().then(_=>true))();
+  await t.expect(Selector('#jeLog .jeLogProblemNote').innerText).contains('Check the onPileCreation property of');
 });
 
 // Creating the clone runs every routine listening on 'id', which can remove the holder the clone
@@ -613,7 +622,9 @@ test('a holder that disappears while a widget is cloned into it is reported', as
   await ClientFunction(() => widgets.get('clone').evaluateRoutine('clickRoutine', {}, {}).then(_=>true))();
 
   // the holder being gone is a problem the game author can read, not an exception from a lookup
-  await t.expect(Selector('#jeLog .jeLogProblems').innerText).contains('disappeared while source was being cloned into it');
+  await t.expect(Selector('#jeLog .jeLogProblems').innerText).contains(`disappeared while 'source' was being cloned into it`);
+  // the operation that failed opens itself, so the explanation is readable without expanding it
+  await t.expect(Selector('#jeLog .jeLogProblems').visible).ok();
   await t.expect(Selector('#jeLog .jeLogProblems').innerText).notContains('Exception:');
   // the routine runs to its end and the clone stays on the table
   await expectEventually(t, markedWidgets, [ 'go' ]);
@@ -704,7 +715,8 @@ test('moving into a holder that is gone leaves the widget where it is', async t 
 
   await ClientFunction(() => widgets.get('move').evaluateRoutine('clickRoutine', {}, {}).then(_=>true))();
 
-  await t.expect(Selector('#jeLog .jeLogProblems').innerText).contains('because it does not exist');
+  await t.expect(Selector('#jeLog .jeLogProblems').innerText).contains('because that holder no longer exists');
+  await t.expect(Selector('#jeLog .jeLogProblems').visible).ok();
   // the card that is left stays in the holder it came from instead of getting an invalid parent
   await expectEventually(t, ()=>widgetProperty('card1', 'parent'), 'source');
 });

--- a/tests/testcafe/routines.js
+++ b/tests/testcafe/routines.js
@@ -575,6 +575,10 @@ test('an onPileCreation that cannot create a pile leaves the cards where they ar
   await expectEventually(t, ()=>widgetProperty('card2', 'parent'), null);
   await t.expect(Object.keys(JSON.parse(await getState())).filter(id=>id != '_meta').sort()).eql([ 'card1', 'card2', 'deck', 'go' ]);
 
+  // a drag has no routine to report to, so the reason ends up in the console
+  const consoleMessages = await t.getBrowserConsoleMessages();
+  await t.expect((consoleMessages.log || []).join('\n')).contains('Check the onPileCreation property of');
+
   // the client is still there and reacts to the next click
   await t.click('#w_go');
   await expectEventually(t, markedWidgets, [ 'go' ]);
@@ -639,6 +643,33 @@ test('a widget removed while it is being dragged ends the drag instead of the cl
   await t.drag('#w_child', 250, 150, { speed: 0.4 });
 
   await expectEventually(t, async ()=>JSON.parse(await getState()).group || null, null);
+  await t.expect(Selector('#clientErrorOverlay').visible).notOk();
+
+  // the client is still there and reacts to the next click
+  await t.click('#w_go');
+  await expectEventually(t, markedWidgets, [ 'go' ]);
+});
+
+// The same widget, removed while the drag is still starting: moveStart() sets 'dragging', the
+// routine reacting to that removes the widget, and the moves that arrived in the meantime used to
+// resume into it after the wait. (#2317)
+test('a widget removed while the drag is starting ends the drag instead of the client', async t => {
+  await setRoomState({
+    group: { id: 'group', type: 'basic', x: 100, y: 100, width: 300, height: 300, movable: true, draggingChangeRoutine: [
+      { func: 'SELECT', property: 'id', value: 'child' },
+      { func: 'SET', property: 'parent', value: null },
+      { func: 'SELECT', property: 'id', value: 'group' },
+      { func: 'DELETE' },
+      { func: 'DELAY', milliseconds: 300 } // moveStart waits here while further mousemoves are delivered
+    ] },
+    child: { id: 'child', type: 'basic', parent: 'group', x: 20, y: 20, width: 100, height: 100, movable: false },
+    go: markSelf
+  });
+  await ClientFunction(prepareClient)();
+  await setName(t);
+  await t.drag('#w_child', 250, 150, { speed: 0.2 });
+
+  await expectEventually(t, async ()=>JSON.parse(await getState()).group || null, null, undefined, 4000);
   await t.expect(Selector('#clientErrorOverlay').visible).notOk();
 
   // the client is still there and reacts to the next click


### PR DESCRIPTION
Implements **phase 2, group C** of the [client-crash issue report](https://agent.virtualtabletop.io/reports/crash-issues/) — *widget lifecycle races: acting on a widget that is gone or was never registered*.

The group's root cause is one sentence: a widget lookup is used at a moment when the code assumes a live widget, or an ID is handed out for a widget that does not exist. This PR closes both halves, so those situations end in a readable problem entry instead of a dead, frozen or silently corrupted client.

> **Based on #3075.** This branch targets `guard-widget-graph-cycles-and-routine-recursion` rather than `main`, so the diff shown here is phase 2 alone. It uses the problem-reporting plumbing phase 1 introduced. Please merge #3075 first; this can then be retargeted to `main`.

## Re-triage first

The report asks for the four issues in the group to be re-triaged before coding. Two of them are already gone:

* **#1504** (`client crash while CLONEing`) and **#403** (`pile cards → basic widget and back reloads VTT`) are **closed** — `clone()` checks `widgets.has(newID)`, `evaluateRoutine` catches a throwing operation and reports it as a problem, and the type changes behind #403 have been fixed since. Nothing here reopens them; the guards below simply remove the two remaining ways their shape can still be reached.
* **#1402**'s symptom has **changed for the worse**. The `TypeError: Cannot read properties of undefined (reading 'onChildAdd')` from the original report is gone — `onPropertyChange`'s parent branch is null-guarded on `main` already (one of the three sites the report names). What is left is an **endless loop**: `addWidgetLocal` still returns the ID of the pile it refused to create, the cards are parented to that ID and land in limbo, updating them asks for the next pile, and the client freezes while the console fills with `Refusing to add widget X with invalid parent Y`.
* **#2317**'s reported line (`inputHandler` reading `!n.passthroughMouse`) is guarded on `main` too, but the drag-state check the report asks for is missing, and it is still reachable — see below.

## What changed

* **An ID is only handed out for a widget that exists** (`serverstate.js`). `addWidgetLocal()` returns `null` when `addWidget()` did not create the widget, and refuses a `card` whose `deck` is missing or is not a deck up front — that is exactly the `onPileCreation: { "type": "card" }` of #1402, which `addWidget` would otherwise hold back forever waiting for a deck that is never coming. Automatic pile creation now leaves the cards where they are and reports it rather than handing them a parent that is not there, which is what ends the loop. Refusing a widget also skips the `sendPropertyUpdate()` below it, so it is no longer persisted for the other clients either — on `main` a card whose deck is missing was sent to the server and existed for every client but this one. A widget that did not survive its own creation is refused the same way: the routines listening on `id` are told about it and one of them deleting it again is a legitimate thing for a game to do, and its ID would otherwise still be handed back because the removal has not been sent yet.
* **A parent or holder that disappeared is aborted on, not dereferenced** (`widget.js`). Creating a clone runs every routine listening on `id`, and moving several widgets one after another runs game logic between each of them — either can remove the target in between. `clone()` and `moveToHolder()` treat that as "skip this one and say so" instead of calling `.get()` on `undefined`. A widget whose turn had not come keeps the parent it had; the one that was already mid-move goes back into the holder it came from, because the step that detaches it (`checkParent(true)`) is itself a step that runs game logic, and its `x`/`y` are the numbers it had *inside* that holder — left on the top level they would be read as the room's and draw it somewhere else entirely.
* **Automatic pile creation checks the cards, not only the pile** (`widget.js`). The routines that react to the new pile can delete either of the two cards it was built for. A pile that gets only one of them stays in the room for good — a pile dissolves itself when a child is *removed* from it, and the card that is gone was never in it to be removed — while the card that is left loses its own position to it. The still empty pile is taken back out instead.
* **Changing a widget's type in the editor no longer loses the widget** (`editmode.js`, `serverstate.js`, `jsonedit.js`). A type change is a remove of the old widget followed by an add of the new one under the same id, so a state the client refuses to build — `"type": "card"` on a widget with no deck — took the widget out and put nothing back, on the server as well as here. The refusals that only look at the state now live in `widgetAdditionProblem()`, which the type change asks *before* it removes anything and reports as an `alert()` like the failures around it. The macro command, which runs over every widget in the room, collects it per widget the way it already collects a bad parent instead of raising one dialog per widget.
* **"Gone" includes a widget that is only queued for removal** (`serverstate.js`, `widget.js`). `removeWidgetLocal()` marks a widget and records its `null` delta; the `widgets.delete()` happens when the surrounding batch is sent. So for the rest of that batch — the ordinary case, with no timer or `DELAY` involved — the room still has the ID, and asking for it finds a widget on its way out. The new `liveWidget()` is what the two guards above ask instead, and `moveToHolder()` asks it again after every step it takes rather than once at the start, because `bringToFront()`, `checkParent()` and `set('owner')` each run whatever the game listens for.
* **A drag lets go of a widget that leaves the room** (`mousehandling.js`). The widget a drag holds on to is not necessarily the one that was pressed — pressing a fixed child drags its movable ancestor — so the existing `if(!widget) return` in `handleInput` does not cover it. When that widget is removed mid-drag, every later move and the drop wrote to a widget the room no longer had. `dragTargetGone()` is the check `endDrag()` already made. It is now made before the drop as well, and inside the queued move chain once after every await: `moveStart()` sets `dragging`, which runs game logic that is free to remove the widget while the next mousemove is already being handled.
* **A drag that lets go still cleans up after itself** (`widget.js`, `mousehandling.js`). `moveStart()` does not only write on the dragged widget: it puts `droppable` on every holder the drag could end in, and a holder with `dropShadow` gets a shadow widget of its own, parented to the *holder*. Only `moveEnd()` takes those back, so simply skipping it for a widget that is gone left them behind — a holder kept `droppable`, which the first hit test of the next drag takes as reason enough to drop into it whatever it accepts, and the shadow stayed in the room for every player. `abandonDrag()` does that part of the drop on the widgets that are still there, and both places that let go of a drag call it.
* **A delta naming a widget the room does not have is skipped** (`serverstate.js`). The limbo pre-pass in `receiveDelta` and the undo protocol both dereferenced `widgets.get(widgetID)` unconditionally. This is the last-resort backstop the report asks for: it is what actually took the client down in #2317 (`TypeError: Cannot read properties of undefined (reading 'unalteredState')`), and it makes any future write to a removed widget a no-op rather than a crash.
* **The problems are visible, in the panel a game author actually reads.** These paths are not the routine interpreter, so they have no `problems` array of their own. `reportProblem()` takes the `problems` array of the operation that called it where there is one (`CLONE`, `MOVE`, `RECALL`), and hands the rest to whatever routine is running — they then appear in the Debug log next to its own problems. A drag or a plain click has no routine at all; those become a note of their own in the routine log, styled like the note the log already uses for messages about itself. That is the report's cross-cutting recommendation: a crash traded for "nothing happened and I don't know why" is not an improvement.
* **A failed operation shows why without another click.** The routine log marked a failed operation with a red `▶` and left the explanation collapsed underneath it — the Problems block was pre-expanded, but its parent was not. An operation with problems now opens itself. ([before/after of a failed `MOVE`](https://agent.virtualtabletop.io/reports/pr/1545283629469667399/ui-move-problem-expanded.png) · [a failed pile as a log note](https://agent.virtualtabletop.io/reports/pr/1545283629469667399/ui-pile-problem-note.png))
* **The messages name what to look at.** IDs are quoted, a card without a deck says it has no deck instead of printing `undefined`, and each refusal in `addWidgetLocal()` gives its reason. A rename whose re-add is refused says so in the editor — an `alert()`, which is what the JSON editor uses for the author-facing failures around it — rather than in the console. The set of already reported pile failures is cleared when the routine log is opened, so trying the same drag again while watching says why instead of staying silent until the page is reloaded.

## Verification

* Eleven new TestCafe tests in `tests/testcafe/routines.js` and one in `tests/testcafe/editor.js`, each of which fails without the corresponding guard: the pile loop hangs the client until the test times out, the two drags report the `unalteredState` crash and `TypeError: Cannot read properties of null (reading 'move')`, and the clone, the move and the widget deleted by the routine reacting to its creation all end with a widget parented to something the room does not have. None of the three uses a `DELAY` to get there — they delete inside the batch the operation is already running in, which is what a game does. Two cover what an abandoned drag leaves behind: without `abandonDrag()` a card is dropped into a holder that only takes basic widgets, and a drop shadow stays in the room state. The last four pin the guards above — a pile that keeps one card after the other was deleted, a widget left on the top level after the holder it was moving into disappeared, a delta naming a widget the client does not have, and a macro that gives every widget in the room a type the client cannot build.
* Local suite: jest 1657/1657; TestCafe `routines.js` 33/33, `card.js` + `interactions.js` + `holderevents.js` + `draglimit.js` 70/70, `editor.js` 96/97 — that one failure, *Edit mode: the deck browser says when a sort has nothing to sort by*, expects a server nobody has ever played a library game on and fails the same way with this branch stashed. No state hashes changed.
* Playable demo of every scenario, written as a tutorial: **[crash-guards-phase2.vtt](https://agent.virtualtabletop.io/reports/pr/1545283629469667399/crash-guards-phase2.vtt)** — *Xtras - Vanishing Widgets*, uploaded into this PR's own `pr-test-ai` test-server room, so it can just be opened and played there. It has three variants:
  * **Piles** — two pairs of cards, one with the default `onPileCreation` and one with `{"type": "card"}`. Drop each pair together. ([board](https://agent.virtualtabletop.io/reports/pr/1545283629469667399/vanishing-widgets-piles.png))
  * **Holders** — `MOVE` into a holder whose `enterRoutine` deletes it, and `CLONE` into a holder that an `idGlobalUpdateRoutine` deletes as the clone appears. ([board](https://agent.virtualtabletop.io/reports/pr/1545283629469667399/vanishing-widgets-holders.png))
  * **Dragging** — a "shredder" holder with `dropShadow` that deletes whatever hovers it, and a second holder that takes cards only, to show that an abandoned drag leaves nothing behind. ([board](https://agent.virtualtabletop.io/reports/pr/1545283629469667399/vanishing-widgets-dragging.png))

  Each variant passes `validator/validate_gamefile_node.js` and is walked end to end against a running server. Open the editor's Debug module to read the problem each refusal reports.

No widget property or routine-operation property was added, removed or renamed, so `validator/` and the `jeCommands` list need no changes. The demo tutorial follows `docs/tutorials.md` — band layout, semantic ids, `_meta.info` parity with `Properties - dragLimit` and `Types - Scoreboard`, and a square 530×530 SVG badge — but is deliberately **not** committed: nothing under `library/` is touched, and it can be added to `library/tutorials/` on request.

Closes #1402, closes #2317.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3165/pr-test (or any other room on that server)





