### PR TITLE
Compress zip entries with zlib so downloaded games can be opened again

### DIFF
--- a/client/js/editor/sidebar/properties.js
+++ b/client/js/editor/sidebar/properties.js
@@ -5475,8 +5475,18 @@ class PropertiesModule extends SidebarModule {
     idInput.title = options.title || 'Rename widget';
     idInput.setAttribute('aria-label', options.ariaLabel || 'Widget id');
 
+    // the rename replaces the widget object, so the id the field stands for is
+    // kept here instead of read back from the widget it was created for - and
+    // a browser may commit the same edit twice (a change event on Enter and
+    // another one when the field loses focus), which must not start a second
+    // rename that then finds the new id taken by the first one
+    let currentID = widget.id;
+    let renaming = false;
+
     idInput.onchange = async () => {
-      const oldID = widget.id;
+      if(renaming)
+        return;
+      const oldID = currentID;
       const newID = idInput.value.trim();
       if(newID == oldID) {
         idInput.value = oldID;
@@ -5493,13 +5503,15 @@ class PropertiesModule extends SidebarModule {
         return;
       }
 
+      renaming = true;
       idInput.disabled = true;
       batchStart();
       try {
         setDeltaCause(`${getPlayerDetails().playerName} renamed widget ${oldID} to ${newID} in editor`);
-        const state = JSON.parse(JSON.stringify(widget.state));
+        const state = JSON.parse(JSON.stringify((widgets.get(oldID) || widget).state));
         state.id = newID;
         await updateWidgetId(state, oldID);
+        currentID = newID;
         const renamedWidget = widgets.get(newID);
         if(renamedWidget && options.onRenamed)
           options.onRenamed(renamedWidget);
@@ -5507,6 +5519,7 @@ class PropertiesModule extends SidebarModule {
         alert(`Could not rename widget: ${error}`);
         idInput.value = oldID;
       } finally {
+        renaming = false;
         batchEnd();
         idInput.disabled = false;
       }
@@ -5514,7 +5527,7 @@ class PropertiesModule extends SidebarModule {
 
     idInput.onkeydown = event => {
       if(event.key == 'Escape') {
-        idInput.value = widget.id;
+        idInput.value = currentID;
         idInput.blur();
       }
     };

--- a/server/zip.mjs
+++ b/server/zip.mjs
@@ -1,7 +1,9 @@
 // setImmediate is a node global, but the tests run this module in a jsdom environment
 import { setImmediate } from 'timers';
+import util from 'util';
+import zlib from 'zlib';
 
-import { strFromU8, strToU8, unzip, unzipSync, Zip as ZipStream, ZipDeflate, ZipPassThrough } from 'fflate';
+import { strFromU8, strToU8, unzip, unzipSync, Zip as ZipStream, ZipPassThrough } from 'fflate';
 
 // fflate is a plain (de)compressor without a file object model: it turns a zip into a
 // { name: Uint8Array } map in one go. These helpers add the things the importers need on
@@ -10,11 +12,29 @@ import { strFromU8, strToU8, unzip, unzipSync, Zip as ZipStream, ZipDeflate, Zip
 // without keeping the event loop busy for seconds on a big game, which would stall every
 // room on the server and not just the one that is being downloaded or imported.
 
-// how much data is handed to the compressor before the event loop gets a turn again
+// how much data is hashed into an entry's CRC before the event loop gets a turn again
 const chunkSize = 1048576;
+
+const deflateRaw = util.promisify(zlib.deflateRaw);
 
 function toU8(buffer) {
   return buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+}
+
+// a zip entry whose deflate stream was produced elsewhere: the caller pushes the original
+// bytes so that fflate computes the CRC and the size, but the compressed bytes are what
+// ends up in the archive
+class ZipDeflated extends ZipPassThrough {
+  constructor(filename, deflated) {
+    super(filename);
+    this.compression = 8;
+    this.deflated = deflated;
+  }
+
+  process(chunk, final) {
+    if(final)
+      this.ondata(null, this.deflated, true);
+  }
 }
 
 // { filename: uncompressed size }, directory entries included (their names end in a slash)
@@ -39,6 +59,9 @@ async function readString(buffer, name) {
 
 // entries are streamed into the zip one chunk at a time so that the event loop keeps
 // running while a big collection or a game with many assets is packed
+// the deflating itself is left to zlib: fflate's streaming deflate emits back references
+// that reach in front of the start of the stream, which yields entries that no inflater
+// accepts ("invalid distance"), and zlib compresses in the libuv thread pool anyway
 function create(files, compress) {
   return new Promise((resolve, reject)=>{
     const chunks = [];
@@ -53,7 +76,7 @@ function create(files, compress) {
     (async ()=>{
       for(const [ name, content ] of Object.entries(files)) {
         const data = typeof content == 'string' ? strToU8(content) : toU8(content);
-        const entry = compress ? new ZipDeflate(name, { level: 6 }) : new ZipPassThrough(name);
+        const entry = compress ? new ZipDeflated(name, await deflateRaw(data)) : new ZipPassThrough(name);
         zip.add(entry);
         for(let offset=0; offset<data.length || !offset; offset+=chunkSize) {
           entry.push(data.subarray(offset, offset+chunkSize), offset+chunkSize >= data.length);

--- a/tests/server/zip.test.js
+++ b/tests/server/zip.test.js
@@ -61,6 +61,17 @@ describe('server/zip.mjs', function() {
     }
   });
 
+  // the shortest input for which fflate's streaming deflate emits a back reference that
+  // points in front of the start of the stream, making the entry impossible to inflate
+  const brokenByFflate = Buffer.from([ 1, 0, 0, 0, 1, 0, 0, 191, 0, 1, 0, 0, 0 ]);
+
+  test('deflates entries into a stream that can be inflated again', async function() {
+    const zip = await Zip.create({ 'assets/1_13': brokenByFflate }, true);
+    const entry = (await Zip.read(zip, [ 'assets/1_13' ]))['assets/1_13'];
+
+    expect(Buffer.compare(Buffer.from(entry), brokenByFflate)).toEqual(0);
+  });
+
   test('keeps the event loop running while packing', async function() {
     let ticks = 0;
     const ticker = setInterval(()=>++ticks, 1);

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -427,6 +427,43 @@ test('Renaming a widget keeps its color controls clear and it movable', async t 
   await t.expect(result.y).notEql(200);
 });
 
+test('A rename that the browser commits twice does not claim the new id is taken', async t => {
+  await t.resizeWindow(1280, 800);
+  await setRoomState({
+    old: { id: 'old', type: 'basic', x: 200, y: 200 }
+  });
+  await ClientFunction(prepareClient)();
+  await setEditorState(propertiesModuleOpen);
+  await setName(t);
+  await t
+    .click('#editButton')
+    .expect(propertiesModule.exists).ok()
+    .click('#w_old')
+    .expect(Selector('[aria-label="Widget id"]').exists).ok();
+
+  // Chrome commits an edited field with a change event, and depending on how
+  // the field loses focus it can send a second one for the same edit, so a
+  // rename must survive being asked for twice.
+  const result = await ClientFunction(() => {
+    const input = document.querySelector('[aria-label="Widget id"]');
+    const alerts = [];
+    const originalAlert = window.alert;
+    window.alert = message => alerts.push(message);
+    input.value = 'new';
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    return new Promise(resolve => setTimeout(() => {
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+      setTimeout(() => {
+        window.alert = originalAlert;
+        resolve({ alerts, renamed: widgets.has('new'), gone: !widgets.has('old') });
+      }, 200);
+    }, 500));
+  })();
+
+  await t.expect(result).eql({ alerts: [], renamed: true, gone: true });
+});
+
 test('Dice faces have their own icon, image scale and CSS controls', async t => {
   // Keep this at the narrow layout from the review so the controls remain
   // useful in the smallest supported properties sidebar.


### PR DESCRIPTION
Downloading a game whose assets happen to trigger an fflate bug produced a `.vtt` that can never be opened again. `Room.download()` compresses every `.vtt`/`.vttc` with `Zip.create(files, true)`, and fflate's streaming deflate can emit a back reference that points in front of the start of the stream: the entry lists correctly in the zip index, but every inflater rejects it — fflate's own with `invalid distance`, node's zlib with `invalid distance too far back`. The entries are now deflated with node's `zlib` instead, and only the finished deflate stream is handed to fflate, which still writes the zip around it.

Split out of #3167, which ran into it while packing a demo room; it is a pre-existing data-corruption bug in the download path and unrelated to that PR.

## Who is affected

Round-tripping all 7343 files in `library/` through `Zip.create(…, true)` + `Zip.read()` before the fix produced 6 unreadable entries — 4 distinct assets, in 5 public-library games:

| asset | games |
| --- | --- |
| `assets/527842758_40444` | Agra, Naval Warfare |
| `assets/-853299197_555264` | No Cheese No Coin |
| `assets/-166120722_44088` | Perfect Draw_ |
| `assets/1684093304_42704` | Perfect Draw_ |
| `assets/1227252222_45304` | Road Race |

Downloading any of those five games today yields a `.vtt` that the server itself refuses to import again (`ERROR LOADING FILE: Error: invalid distance`). After the fix all 7343 round-trip cleanly, and downloading Agra from a running server and re-uploading it works.

## It is not the chunk size

`create()` pushes 1 MiB at a time, so the obvious suspect was the size of the pushes — but that is not the cause. The bug is in fflate's match search: when it re-seeks the hash chain to the rarest 2-byte sequence inside a match, the running distance loses its relation to the position it was derived from and can grow past the number of bytes emitted so far, while the bound it is checked against (`Math.min(32767, i)`) counts the 32768-byte lookback area that fflate prepends to its buffer. So the distance is accepted although it reaches in front of the stream.

That needs no large push at all — 13 bytes in a single push are enough:

```js
node -e "import('./server/zip.mjs').then(async m=>{const d=Buffer.from([1,0,0,0,1,0,0,191,0,1,0,0,0]);const z=await m.default.create({a:d},true);try{await m.default.read(z,['a']);console.log('ok')}catch(e){console.log('FAIL',e.message)}})"
```

Pushing the same library corpus through fflate in 16 KiB chunks still corrupts 4 of the 6 entries, so shrinking `chunkSize` would only have hidden the bug for some inputs. Levels 0–3 do not reach the code path, which is why only 6 (level `create()` uses) and 9 are affected.

## The change

- `server/zip.mjs`: `ZipDeflate` is replaced by a small `ZipPassThrough` subclass that reports compression method 8 and emits an already-deflated stream. The original bytes are still pushed through it in chunks so that fflate computes the CRC and the size and the event loop keeps getting a turn; `zlib.deflateRaw` runs in the libuv thread pool, so compression no longer occupies the event loop at all.
- Compression level and output stay equivalent (zlib defaults to level 6, the level `create()` asked fflate for) and the archives get slightly smaller — 19938 instead of 20177 bytes for the Agra asset.
- Reading, listing and the uncompressed path are untouched, as is the client's use of fflate: `client/js/overlays/states.js` uses the one-shot `zipSync`, which does not have this bug.

## Verification

- `npm test` — 1651 tests pass; `tests/server/zip.test.js` gains a regression test that deflates the 13-byte payload above and reads it back.
- Full `library/` corpus round-trip: 0 of 7343 files corrupt (6 before).
- End to end on a running server: uploaded Agra, downloaded it via `/dl/…`, verified all 16 entries inflate to their listed size, and re-imported the download successfully.

## Also here: the widget rename field, which broke CI for every PR

Since GitHub's runners moved to Chrome 152, the TestCafe case *"Renaming a widget keeps its color controls clear and it movable"* fails on every branch, so `TestCafe Chrome` and `Production Environment` are red on every open PR (see the comment above for the evidence that it predates this branch). Splitting the fix into its own PR was declined, so it rides along here.

`createWidgetIdInput()` in `client/js/editor/sidebar/properties.js` read the id it was renaming from the widget object the field was created for. The rename replaces that object, so the captured one keeps the old id — and a browser that commits the same edit twice (a `change` event on Enter and a second one when the field loses focus, which is what Chrome 152 does) starts a second rename from the old id to the new one and alerts `A widget with the id "x" already exists.` over a rename that in fact worked.

The field now tracks the id it stands for, updates it once the rename went through, and ignores a change event that arrives while a rename is still running. `tests/testcafe/editor.js` gains a case that sends the second change event itself, so the regression is caught in any browser: it reproduces the alert without the fix and passes with it. The full `editor.js` suite (96 tests) passes locally.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3168/pr-test (or any other room on that server)
