### PR TITLE
Open the trace file before anything traces into a room with tracing enabled

### DIFF
--- a/server/room.mjs
+++ b/server/room.mjs
@@ -569,6 +569,7 @@ export default class Room {
       Logging.log(`loading room ${this.id}`);
       this.state = FileUpdater(JSON.parse(fs.readFileSync(this.roomFilename())));
       this.state._meta.states = Object.assign(this.state._meta.states, this.getPublicLibraryGames());
+      this.traceIsEnabled(Config.get('forceTracing') || this.traceIsEnabled());
 
       this.migrateOldPublicLibraryLinks();
       this.migrateBrokenSaveWithoutVersion();
@@ -576,7 +577,6 @@ export default class Room {
       this.removeInvalidPublicLibraryLinks(player);
       this.removeStatesWithoutVariants(player);
 
-      this.traceIsEnabled(Config.get('forceTracing') || this.traceIsEnabled());
       this.normalizeGameSettings(this.state._meta.gameSettings);
       this.broadcast('state', this.state);
     } else {
@@ -1385,6 +1385,12 @@ export default class Room {
     this.sendMetaUpdate();
   }
 
+  openTraceFile() {
+    this.tracingFilename = `${Config.directory('save')}/${this.id}-${+new Date}.trace`;
+    fs.writeFileSync(this.tracingFilename, '[\n');
+    Logging.log(`tracing enabled for room ${this.id} to file ${this.tracingFilename}`);
+  }
+
   trace(source, payload) {
     if(!this.traceIsEnabled() && source == 'client' && payload.type == 'enable') {
       this.traceIsEnabled(true);
@@ -1392,6 +1398,10 @@ export default class Room {
     }
 
     if(this.traceIsEnabled()) {
+      // a saved room comes back with tracing already enabled, so the room state can ask for tracing
+      // before load() opened a file for it - whatever is traced until then opens the file itself
+      if(!this.tracingFilename)
+        this.openTraceFile();
       payload.servertime = +new Date;
       payload.source = source;
       payload.serverDeltaID = this.deltaID;
@@ -1404,10 +1414,8 @@ export default class Room {
     if(setEnabled && this.state && this.state._meta) {
       this.state._meta.tracingEnabled = true;
 
-      this.tracingFilename = `${Config.directory('save')}/${this.id}-${+new Date}.trace`;
+      this.openTraceFile();
       this.broadcast('tracing', 'enable');
-      fs.writeFileSync(this.tracingFilename, '[\n');
-      Logging.log(`tracing enabled for room ${this.id} to file ${this.tracingFilename}`);
     }
     return this.state && this.state._meta && this.state._meta.tracingEnabled;
   }

--- a/server/room.mjs
+++ b/server/room.mjs
@@ -14,6 +14,7 @@ export default class Room {
   players = [];
   state = {};
   deltaID = 0;
+  isLoading = false;
   lastStatisticsDeltaID = 0;
   lastMouseState = new Map();
 
@@ -21,10 +22,21 @@ export default class Room {
     this.id = id;
     this.unloadCallback = unloadCallback;
     this.publicLibraryUpdatedCallback = publicLibraryUpdatedCallback;
+    this.startUnloadTimeout();
+  }
+
+  // loading a room can take a while because linked states are fetched over the network - unloading
+  // it in the middle of that would write a half loaded room to disk, so wait for the load to finish
+  startUnloadTimeout() {
+    clearTimeout(this.unloadTimeout);
     this.unloadTimeout = setTimeout(_=>{
       if(this.players.length == 0) {
-        Logging.log(`unloading room ${this.id} after 5s without player connection`);
-        this.unload();
+        if(this.isLoading) {
+          this.startUnloadTimeout();
+        } else {
+          Logging.log(`unloading room ${this.id} after 5s without player connection`);
+          this.unload();
+        }
       }
     }, 5000);
   }
@@ -550,63 +562,65 @@ export default class Room {
   }
 
   async load(fileOrLink, player, delayForGameStartRoutine) {
-    const emptyState = {
-      _meta: {
-        version: 1,
-        metaVersion: 1,
-        players: {},
-        states: {},
-        starred: {}
-      }
-    };
+    this.isLoading = true;
+    try {
+      const emptyState = {
+        _meta: {
+          version: 1,
+          metaVersion: 1,
+          players: {},
+          states: {},
+          starred: {}
+        }
+      };
 
-    if(!fileOrLink && !fs.existsSync(this.roomFilename())) {
-      Logging.log(`creating room ${this.id}`);
-      this.state = FileUpdater(emptyState);
-      this.state._meta.states = Object.assign(this.state._meta.states, this.getPublicLibraryGames());
-      this.traceIsEnabled(Config.get('forceTracing'));
-    } else if(!fileOrLink) {
-      Logging.log(`loading room ${this.id}`);
-      this.state = FileUpdater(JSON.parse(fs.readFileSync(this.roomFilename())));
-      this.state._meta.states = Object.assign(this.state._meta.states, this.getPublicLibraryGames());
-      this.traceIsEnabled(Config.get('forceTracing') || this.traceIsEnabled());
+      if(!fileOrLink && !fs.existsSync(this.roomFilename())) {
+        Logging.log(`creating room ${this.id}`);
+        this.state = FileUpdater(emptyState);
+        this.state._meta.states = Object.assign(this.state._meta.states, this.getPublicLibraryGames());
+        this.traceIsEnabled(Config.get('forceTracing'));
+      } else if(!fileOrLink) {
+        Logging.log(`loading room ${this.id}`);
+        this.state = FileUpdater(JSON.parse(fs.readFileSync(this.roomFilename())));
+        this.state._meta.states = Object.assign(this.state._meta.states, this.getPublicLibraryGames());
+        this.traceIsEnabled(Config.get('forceTracing') || this.traceIsEnabled());
 
-      this.migrateOldPublicLibraryLinks();
-      this.migrateBrokenSaveWithoutVersion();
-      await this.updateLinkedStates();
-      this.removeInvalidPublicLibraryLinks(player);
-      this.removeStatesWithoutVariants(player);
+        this.migrateOldPublicLibraryLinks();
+        this.migrateBrokenSaveWithoutVersion();
+        await this.updateLinkedStates();
+        this.removeInvalidPublicLibraryLinks(player);
+        this.removeStatesWithoutVariants(player);
 
-      this.normalizeGameSettings(this.state._meta.gameSettings);
-      this.broadcast('state', this.state);
-    } else {
-      let newState = emptyState;
-      let errorMessage = 'Error loading state.';
-      try {
-        if(fileOrLink.match(/^http/))
-          newState = await FileLoader.readVariantFromLink(fileOrLink);
-        else
-          newState = JSON.parse(fs.readFileSync(fileOrLink));
-      } catch(e) {
-        errorMessage = `Error loading state:\n${e.toString()}`;
-        newState = null;
-      }
-      if(newState) {
-        Logging.log(`loading room ${this.id} from ${fileOrLink}`);
-        this.setState(newState, player, delayForGameStartRoutine);
+        this.normalizeGameSettings(this.state._meta.gameSettings);
+        this.broadcast('state', this.state);
       } else {
-        Logging.log(`loading room ${this.id} from ${fileOrLink} FAILED: ${errorMessage}`);
-        this.setState(emptyState, player, false);
-        if(player)
-          player.send('error', errorMessage);
+        let newState = emptyState;
+        let errorMessage = 'Error loading state.';
+        try {
+          if(fileOrLink.match(/^http/))
+            newState = await FileLoader.readVariantFromLink(fileOrLink);
+          else
+            newState = JSON.parse(fs.readFileSync(fileOrLink));
+        } catch(e) {
+          errorMessage = `Error loading state:\n${e.toString()}`;
+          newState = null;
+        }
+        if(newState) {
+          Logging.log(`loading room ${this.id} from ${fileOrLink}`);
+          this.setState(newState, player, delayForGameStartRoutine);
+        } else {
+          Logging.log(`loading room ${this.id} from ${fileOrLink} FAILED: ${errorMessage}`);
+          this.setState(emptyState, player, false);
+          if(player)
+            player.send('error', errorMessage);
+        }
       }
+
+      if(!this.state._meta || typeof this.state._meta.version !== 'number')
+        throw Error('Room state has invalid meta information.');
+    } finally {
+      this.isLoading = false;
     }
-
-    if(!this.state._meta || typeof this.state._meta.version !== 'number')
-      throw Error('Room state has invalid meta information.');
-
-    if(!fileOrLink)
-      this.trace('init', { initialState: this.state });
   }
 
   async loadState(player, stateID, variantID, linkSourceStateID, delayForGameStartRoutine) {
@@ -1385,10 +1399,13 @@ export default class Room {
     this.sendMetaUpdate();
   }
 
+  // the trace viewer replays a trace on top of the initialState of its first record, so a trace
+  // file always starts with the room state at the moment the file was opened
   openTraceFile() {
     this.tracingFilename = `${Config.directory('save')}/${this.id}-${+new Date}.trace`;
     fs.writeFileSync(this.tracingFilename, '[\n');
     Logging.log(`tracing enabled for room ${this.id} to file ${this.tracingFilename}`);
+    this.trace('init', { initialState: this.state });
   }
 
   trace(source, payload) {

--- a/tests/server/room.test.js
+++ b/tests/server/room.test.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { jest } from '@jest/globals'; // the ES module build has no globals of its own
 
 import Room from '../../server/room.mjs';
 import { VERSION } from '../../server/fileupdater.mjs';
@@ -172,8 +173,8 @@ describe('server/room.mjs', function() {
     room.trace('unload', {});
 
     const trace = readTraceFile();
-    expect(trace.length).toEqual(1);
-    expect(trace[0].source).toEqual('unload');
+    expect(trace.map(entry=>entry.source)).toEqual([ 'init', 'unload' ]);
+    expect(trace[0].initialState).toEqual(room.state);
   });
 
   test('trace writes into the file that was opened when tracing was switched on', function() {
@@ -182,6 +183,26 @@ describe('server/room.mjs', function() {
     room.traceIsEnabled(true);
     room.trace('unload', {});
 
-    expect(readTraceFile().map(entry=>entry.source)).toEqual([ 'broadcast', 'unload' ]);
+    const trace = readTraceFile();
+    expect(trace.map(entry=>entry.source)).toEqual([ 'init', 'broadcast', 'unload' ]);
+    expect(trace[0].initialState).toEqual(room.state);
+  });
+
+  test('the unload timeout waits for a room that is still loading', function() {
+    jest.useFakeTimers();
+    const room = Object.create(Room.prototype);
+    room.id = 'room';
+    room.players = [];
+    room.isLoading = true;
+    room.unload = jest.fn();
+
+    room.startUnloadTimeout();
+    jest.advanceTimersByTime(20000);
+    expect(room.unload).not.toHaveBeenCalled();
+
+    room.isLoading = false;
+    jest.advanceTimersByTime(5000);
+    expect(room.unload).toHaveBeenCalled();
+    jest.useRealTimers();
   });
 });

--- a/tests/server/room.test.js
+++ b/tests/server/room.test.js
@@ -7,6 +7,7 @@ import { VERSION } from '../../server/fileupdater.mjs';
 
 let directory = null;
 let source = null;
+let saveDirectory = null;
 
 const moveFile = (from, to)=>Room.prototype.moveFile.call(null, from, to);
 
@@ -32,6 +33,22 @@ function roomLoadingStates(states) {
   return room;
 }
 
+// a room that traces into the temporary directory and talks to nobody
+function tracingRoom(meta) {
+  const room = Object.create(Room.prototype);
+  room.id = 'room';
+  room.deltaID = 0;
+  room.players = [];
+  room.state = { _meta: meta };
+  return room;
+}
+
+function readTraceFile() {
+  const files = fs.readdirSync(directory).filter(f=>f.match(/\.trace$/));
+  expect(files.length).toEqual(1);
+  return JSON.parse(fs.readFileSync(path.join(directory, files[0]), 'utf8'));
+}
+
 function writeVariantFiles(stateID, count) {
   for(let i=0; i<count; ++i)
     fs.writeFileSync(path.join(directory, `${stateID}-${i}.json`), `{"variant":${i}}`);
@@ -41,9 +58,15 @@ beforeEach(function() {
   directory = fs.mkdtempSync(path.join(os.tmpdir(), 'vtt-room-'));
   source = path.join(directory, '0.json');
   fs.writeFileSync(source, '{"a":1}');
+  saveDirectory = process.env.VTT_SAVE_DIR;
+  process.env.VTT_SAVE_DIR = directory;
 });
 
 afterEach(function() {
+  if(saveDirectory === undefined)
+    delete process.env.VTT_SAVE_DIR;
+  else
+    process.env.VTT_SAVE_DIR = saveDirectory;
   fs.rmSync(directory, { recursive: true, force: true });
 });
 
@@ -141,5 +164,24 @@ describe('server/room.mjs', function() {
     expect(states.empty).toBeUndefined();
     expect(states.filled).toBeDefined();
     expect(states['PL:games/Empty']).toBeDefined();
+  });
+
+  test('trace opens a trace file for a room that was loaded with tracing already enabled', function() {
+    const room = tracingRoom({ tracingEnabled: true });
+
+    room.trace('unload', {});
+
+    const trace = readTraceFile();
+    expect(trace.length).toEqual(1);
+    expect(trace[0].source).toEqual('unload');
+  });
+
+  test('trace writes into the file that was opened when tracing was switched on', function() {
+    const room = tracingRoom({});
+
+    room.traceIsEnabled(true);
+    room.trace('unload', {});
+
+    expect(readTraceFile().map(entry=>entry.source)).toEqual([ 'broadcast', 'unload' ]);
   });
 });


### PR DESCRIPTION
Fixes a server crash on loading a room that has tracing enabled. The room save file keeps `_meta.tracingEnabled`, so such a room comes back from disk with tracing already on while `Room.tracingFilename` is still `undefined` — `load()` only assigns it a few statements later. Anything that traces in that window ends up in `fs.appendFileSync(undefined, …)`:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string or an instance of Buffer or URL. Received undefined
    at Object.appendFileSync (node:fs:2512:6)
    at Room.trace (server/room.mjs:1399:10)
    at Room.unload (server/room.mjs:1439:10)
    at Timeout._onTimeout (server/room.mjs:27:14)
```

Two ways into that window:

* `removeInvalidPublicLibraryLinks()` / `removeStatesWithoutVariants()` repair the loaded room and call `sendMetaUpdate()` → `broadcast()` → `trace()`, all before tracing is set up.
* The 5s "no player connected" unload timer from the constructor fires while `load()` is still awaiting `updateLinkedStates()` (which fetches linked games over HTTP). `unload()` → `trace('unload', …)` then crashes in a timer callback, i.e. uncaught, taking the server down.

## What changed

* The trace file is opened by a small `openTraceFile()` helper, and `trace()` calls it when the room asks for tracing but no file is open yet — so no trace record can ever hit an undefined filename, whatever the ordering.
* `openTraceFile()` also writes the `init` record with the room state, so every trace file starts with the record `loadStateAtIndex()` in the trace viewer replays on top of (`loadedTrace[0].initialState`). A room that was loaded from disk with tracing already enabled used to start its trace file with the state broadcast instead, i.e. its traces could never be opened. The now-redundant `trace('init', …)` at the end of `load()` is gone, so there is still exactly one anchor record per file.
* `load()` now enables tracing right after the room state is read, before the migration/repair steps, so a whole room load lands in one trace file instead of the repairs opening a second one.
* The unload timer waits for a room that is still loading: it moved into `startUnloadTimeout()`, `load()` marks itself with `isLoading`, and a timeout that fires mid-load re-arms itself. That closes the race behind the stack trace above — a room can no longer write a half-loaded state to disk, close its trace file with `]` and call its unload callback while `load()` is still running, only to be registered in `activeRooms` afterwards.

No behavior change for rooms without tracing.

## Verification

* `npm test` — 1654 passing, including three new regression tests in `tests/server/room.test.js`.
* TestCafe `connection.js` and `gameshelf.js` pass locally against a server built from this branch.
* Manually: a room save containing `"tracingEnabled": true` plus a game with a dead public-library link. On `main` loading it crashes; with this change the room loads, gets repaired, and unloads cleanly, leaving a single well-formed trace file starting with the `init` record.
* In a browser against this branch: enable tracing with F9, file a user report, disconnect and let the room unload — the trace file is `init, broadcast/tracing, client/enable, client/user report, removePlayer, broadcast/meta, unload` and replays cleanly with the arithmetic of `loadStateAtIndex()`.

Note for reviewers: `Ctrl+F9` (opening a trace file) is broken on `main` for an unrelated reason — `client/js/traceviewer.js` sits in the editor bundle, does not export `loadTraceFile`, and misses several names in the handover in `client/js/main.js`. That is a separate client-side fix and is not part of this PR.

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3169/pr-test (or any other room on that server)
