### PR TITLE
Drop null-valued properties when a delta creates a widget

### DIFF
--- a/server/room.mjs
+++ b/server/room.mjs
@@ -801,9 +801,12 @@ export default class Room {
     for(const widgetID in delta.s) {
       if(delta.s[widgetID] === null) {
         delete this.state[widgetID];
-      } else if(this.state[widgetID] === undefined) {
-        this.state[widgetID] = delta.s[widgetID];
       } else {
+        // a delta can create a widget and reset one of its properties to the
+        // default in one go - null means "remove the property", also for a
+        // widget that only starts existing with this delta
+        if(this.state[widgetID] === undefined)
+          this.state[widgetID] = {};
         for(const property in delta.s[widgetID]) {
           if(delta.s[widgetID][property] === null) {
             delete this.state[widgetID][property];

--- a/tests/server/room.test.js
+++ b/tests/server/room.test.js
@@ -217,10 +217,14 @@ describe('server/room.mjs', function() {
 
   test('receiveDelta does not store null properties of a widget it creates', function() {
     const room = roomReceivingDeltas({ _meta: {} });
+    const delta = { s: { card1: { id: 'card1', type: 'card', x: null, y: null, z: 3 } } };
 
-    room.receiveDelta(player, { s: { card1: { id: 'card1', type: 'card', x: null, y: null, z: 3 } } });
+    room.receiveDelta(player, delta);
 
     expect(room.state.card1).toEqual({ id: 'card1', type: 'card', z: 3 });
+    // the delta is kept by the other players to detect conflicts, so later property
+    // writes to the room state must not reach through into it
+    expect(room.state.card1).not.toBe(delta.s.card1);
   });
 
   test('receiveDelta removes null properties of a widget that already exists', function() {

--- a/tests/server/room.test.js
+++ b/tests/server/room.test.js
@@ -32,6 +32,15 @@ function roomLoadingStates(states) {
   return room;
 }
 
+// a room that applies deltas and talks to nobody
+function roomReceivingDeltas(state) {
+  const room = Object.create(Room.prototype);
+  room.state = state;
+  room.deltaID = 0;
+  room.broadcast = ()=>{};
+  return room;
+}
+
 function writeVariantFiles(stateID, count) {
   for(let i=0; i<count; ++i)
     fs.writeFileSync(path.join(directory, `${stateID}-${i}.json`), `{"variant":${i}}`);
@@ -141,5 +150,21 @@ describe('server/room.mjs', function() {
     expect(states.empty).toBeUndefined();
     expect(states.filled).toBeDefined();
     expect(states['PL:games/Empty']).toBeDefined();
+  });
+
+  test('receiveDelta does not store null properties of a widget it creates', function() {
+    const room = roomReceivingDeltas({ _meta: {} });
+
+    room.receiveDelta(player, { s: { card1: { id: 'card1', type: 'card', x: null, y: null, z: 3 } } });
+
+    expect(room.state.card1).toEqual({ id: 'card1', type: 'card', z: 3 });
+  });
+
+  test('receiveDelta removes null properties of a widget that already exists', function() {
+    const room = roomReceivingDeltas({ _meta: {}, card1: { id: 'card1', type: 'card', x: 10, z: 3 } });
+
+    room.receiveDelta(player, { s: { card1: { x: null, z: 4 } } });
+
+    expect(room.state.card1).toEqual({ id: 'card1', type: 'card', z: 4 });
   });
 });

--- a/tests/testcafe/editor.js
+++ b/tests/testcafe/editor.js
@@ -1401,7 +1401,7 @@ test('Create game using edit mode', async t => {
     .click('#buttonInputGo')
     .rightClick('#w_dice2')
     .click('#w_dice2');
-  await compareState(t, '3878b15bd31f8ad1d0972a20b69d7ea5');
+  await compareState(t, 'eae7a01f31d1075d7e458b4abf5af3d6');
 });
 
 test('Deck editor: add card type, dynamic object, delete face, undo', async t => {

--- a/tests/testcafe/publiclibrary-2.js
+++ b/tests/testcafe/publiclibrary-2.js
@@ -13,7 +13,7 @@ publicLibraryButtons('Reversi',            0, '35e0017570f9ecd206a2317c1528be36'
          { from: 'zpiece19', to: 'sq35', sticks: true  },
          { from: 'zpiece08', to: 'sq53', sticks: true  }
        ]);
-publicLibraryButtons('Reward',             0, '5290d9113f42a3c0e458a788b5a1ea99', [
+publicLibraryButtons('Reward',             0, '5acf6ceee560f871fac038af6d1196d1', [
   'gmex', 'kprc', 'oksq', 'j1wz', 'vfhn', 'seat1', 'next'
 ]);
 publicLibraryButtons('Rummy Tiles',        0, '2625ca4661785ca9a75cdf93d6379427', [ 'startMix', 'draw14' ]);


### PR DESCRIPTION
## What this changes

`Room.receiveDelta` in `server/room.mjs` stored a newly created widget's delta object
verbatim (`this.state[widgetID] = delta.s[widgetID]`). Null-valued properties were only
deleted on the branch that updates a widget which already exists. A client that creates a
widget **and** resets one of its properties to the default in the same delta — `set()` sends
a default-valued write as `null` — therefore left literal nulls in the saved room state,
e.g. `"x": null, "y": null`.

Both branches now share the property loop, so a created widget is stored exactly the way an
updated one is: `null` means "this property is not set", whether or not the widget existed
before the delta.

## Why

Games downloaded from such a room fail the library validator with
`<id>[x]: number expected`, which is how this surfaced — a save flagged by *Check Library*
while reviewing #3117. The same leftover nulls are baked into games that are already in the
library: `library/games/Bhukhar/0.json`, `Great Greece/0.json`, `Green Streams/0.json`,
`Herd Hero/0.json`, `No Monkey/0.json` and 42 more files, 1374 such properties in total.

This PR fixes the cause and deliberately touches **no** library game. Cleaning the existing
files up was proposed as a separate change and declined, so it is out of scope here and no
follow-up is pending for it:

> A human (lawdawg96) has declined the spin-off PR you asked for.
> You asked for: Strip leftover null-valued widget properties from the public-library games

That leaves those games exactly as they are, which costs nothing at play time: every client
`delete`s a null-valued property the moment it loads the state, so the nulls only ever show
up as false `[x]: number expected` errors when the *file* is validated — by the Check Library
CI job or `validator/validate_gamefile_node.js`. They are invisible in the app itself: edit
mode's Debug ⇒ Validation panel validates each widget's `unalteredState`, from which the
client has already deleted every null, so it reports no problems for these games. They also
stay there: loading a game assigns the parsed file to `this.state` verbatim
and saving writes `this.state` back out unchanged, so a leftover null only disappears once a
client rewrites that particular property in a room running this fix.

Split out of #3117: this is pre-existing server behavior, unrelated to holder layouts.

## It also stops the room state from aliasing the delta

Storing `delta.s[widgetID]` by reference made the room state and the broadcast delta the same
object. Every other player retains that delta in `possiblyConflictingDeltas`
(`server/player.mjs`) to detect conflicts with late deltas, so a later delta touching the same
widget wrote straight through into that retained conflict record and could make a conflict be
reported or missed against values that were never broadcast. Building a fresh object and
copying the properties into it ends that aliasing; the new test pins it.

## The client needs no counterpart

`client/js/serverstate.js` already drops these properties on every client: `addWidget()`
ends in `applyInitialDelta()`, which calls `StateManaged.applyDelta()`, and that `delete`s
any key whose value is `null`. The clients therefore never held the nulls — only the
server's copy of the state did, which is the copy that gets saved and downloaded. No client
change is needed for all clients to hold identical state.

## Reproduced before and after

On a local server, with a routine that clones a card into a pile — `CLONE` creates the
widget and `moveToHolder` then resets its `x`/`y` to the pile's `0`/`0` default inside the
same delta:

* **before** — the room state and the `/dl/<room>/<stateID>` download carry
  `"x": null, "y": null` on the clone, and `node validator/validate_gamefile_node.js`
  reports `<id>[x]: number expected` / `<id>[y]: number expected`;
* **after** — the clone has no `x`/`y` at all and the validator reports neither error.

## Tests

* **jest** (`npm test`): 1656 pass, including two new cases in `tests/server/room.test.js`
  pinning both branches of `receiveDelta` — the widget a delta creates and one that already
  exists.
* **TestCafe** (Chromium, local): `routines.js`, `editor.js`, `publiclibrary-1..4`,
  `corpusreplay.js`, `card.js`, `interactions.js`, `holderevents.js`, `legacymatrix.js`,
  `boardsize.js`, `canvas.js`, `connection.js`, `domsnapshot.js`, `draglimit.js`,
  `gamelink.js`, `gameshelf.js`, `inheritfrom.js`, `keyboardzoom.js`, `pixelsnapshot.js`,
  `scoreboard.js`, `toolbar.js`.

**Two recorded hashes changed and were regenerated**, both because the recorded reference
state contained such leftover nulls:

| test | old → new | state diff against the recorded reference |
|---|---|---|
| `editor.js` — *Create game using edit mode* | `3878b15b…` → `eae7a01f…` | exactly one removed line: `"parent": null` on `xxcf`, the pile that splitting a pile creates |
| `publiclibrary-2.js` — *Reward* | `5290d911…` → `5acf6cee…` | none — the state is **deeply equal** to the recorded one. A cloned card's `x`/`y` are no longer written as nulls first and overwritten later, so they serialize at the end of the widget instead of in their old slot. Same values, different key order, different md5. |

No other value changed in either.

The only other failures in those local runs are pre-existing and reproduce with this
branch’s `server/room.mjs` reverted: the `boardsize.js` re-layout case and the
`domsnapshot.js` snapshots (a headless window-size / fade-in timing artifact), plus
`multiclient.js`, which this sandbox cannot run at all (“Native Automation mode does not
support the use of multiple browser windows”).

---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3170/pr-test (or any other room on that server)



