### PR TITLE
Retry the TestCafe REST helpers so a dropped connection does not fail a job

### DIFF
--- a/tests/fetch-retry.test.js
+++ b/tests/fetch-retry.test.js
@@ -52,10 +52,15 @@ test('retries a connection that drops during the body read', async () => {
   expect(calls.length).toBe(2);
 });
 
-test('rethrows once the attempts are used up', async () => {
+test('rethrows once the attempts are used up, naming the request and the attempts', async () => {
   const calls = stub(networkError(), networkError(), networkError());
-  await expect(fetchTextWithRetry('/state')).rejects.toThrow('fetch failed');
+  await expect(fetchTextWithRetry('/state')).rejects.toThrow('fetch failed (GET /state, 3 attempts)');
   expect(calls.length).toBe(3);
+});
+
+test('names the method of a failed request that is not a GET', async () => {
+  stub(networkError());
+  await expect(fetchTextWithRetry('/state', { method: 'PUT' }, 1)).rejects.toThrow('(PUT /state, 1 attempts)');
 });
 
 test('passes an HTTP error status through instead of retrying it', async () => {

--- a/tests/fetch-retry.test.js
+++ b/tests/fetch-retry.test.js
@@ -1,0 +1,71 @@
+import { fetchTextWithRetry } from './testcafe/fetch-retry.js';
+
+// The TestCafe REST helpers all go through this wrapper, so what it retries - and what it
+// must not retry - decides whether a dropped connection ends up as a red CI run.
+
+const originalFetch = globalThis.fetch;
+
+function response(text, status=200) {
+  return { status, text: async () => text };
+}
+
+// undici reports every network-level problem this way, both for the request and for the body read
+function networkError() {
+  return Object.assign(new TypeError('fetch failed'), { cause: new Error('other side closed') });
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// returns the number of calls the stub received alongside the wrapper's result
+function stub(...outcomes) {
+  const calls = [];
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, options });
+    const outcome = outcomes[calls.length-1];
+    if(typeof outcome == 'function')
+      return outcome();
+    throw outcome;
+  };
+  return calls;
+}
+
+test('returns the response body without retrying a healthy request', async () => {
+  const calls = stub(() => response('{"a":1}'));
+  expect(await fetchTextWithRetry('/state')).toBe('{"a":1}');
+  expect(calls.length).toBe(1);
+});
+
+test('retries a request rejected before it was sent', async () => {
+  const calls = stub(networkError(), () => response('state'));
+  expect(await fetchTextWithRetry('/state')).toBe('state');
+  expect(calls.length).toBe(2);
+});
+
+test('retries a connection that drops during the body read', async () => {
+  const calls = stub(
+    () => ({ status: 200, text: async () => { throw networkError(); } }),
+    () => response('state')
+  );
+  expect(await fetchTextWithRetry('/state')).toBe('state');
+  expect(calls.length).toBe(2);
+});
+
+test('rethrows once the attempts are used up', async () => {
+  const calls = stub(networkError(), networkError(), networkError());
+  await expect(fetchTextWithRetry('/state')).rejects.toThrow('fetch failed');
+  expect(calls.length).toBe(3);
+});
+
+test('passes an HTTP error status through instead of retrying it', async () => {
+  const calls = stub(() => response('room not found', 404));
+  expect(await fetchTextWithRetry('/state')).toBe('room not found');
+  expect(calls.length).toBe(1);
+});
+
+test('repeats the request unchanged, so a PUT body survives the retry', async () => {
+  const calls = stub(networkError(), () => response(''));
+  await fetchTextWithRetry('/state', { method: 'PUT', body: '{"widgets":{}}' });
+  expect(calls.map(call => call.options.body)).toEqual([ '{"widgets":{}}', '{"widgets":{}}' ]);
+});

--- a/tests/testcafe/fetch-retry.js
+++ b/tests/testcafe/fetch-retry.js
@@ -5,15 +5,19 @@
 // just kills whichever test runs next, most often in the beforeEach hook, so the operation is retried with
 // a short backoff. An HTTP error status is passed through untouched: that one is a real failure the tests
 // have to see. The callers only ever want the response body, so retrying the read is free of side effects -
-// a partial body is discarded and both endpoints are GETs of room state.
+// a partial body is discarded and both endpoints are GETs of room state. The error that survives the last
+// attempt names the request and how often it was tried, because on its own 'TypeError: fetch failed' tells
+// a CI log neither which request died nor that anything retried it.
 export async function fetchTextWithRetry(url, options, attempts=3) {
   for(let attempt=1; ; attempt++) {
     try {
       const response = await fetch(url, options);
       return await response.text();
     } catch(e) {
-      if(attempt == attempts)
+      if(attempt == attempts) {
+        e.message += ` (${options && options.method || 'GET'} ${url}, ${attempts} attempts)`;
         throw e;
+      }
       await new Promise(resolve => setTimeout(resolve, 100 * attempt));
     }
   }

--- a/tests/testcafe/fetch-retry.js
+++ b/tests/testcafe/fetch-retry.js
@@ -1,0 +1,20 @@
+// Node reuses the connection to the server between requests, and one that the server has closed in the
+// meantime makes the next fetch() reject with a network-level 'TypeError: fetch failed' before the request
+// is ever sent. A connection that drops after the response headers rejects the same way, in the body read
+// instead of the request - so both happen inside the retried operation here. Neither is a test failure, it
+// just kills whichever test runs next, most often in the beforeEach hook, so the operation is retried with
+// a short backoff. An HTTP error status is passed through untouched: that one is a real failure the tests
+// have to see. The callers only ever want the response body, so retrying the read is free of side effects -
+// a partial body is discarded and both endpoints are GETs of room state.
+export async function fetchTextWithRetry(url, options, attempts=3) {
+  for(let attempt=1; ; attempt++) {
+    try {
+      const response = await fetch(url, options);
+      return await response.text();
+    } catch(e) {
+      if(attempt == attempts)
+        throw e;
+      await new Promise(resolve => setTimeout(resolve, 100 * attempt));
+    }
+  }
+}

--- a/tests/testcafe/test-util.js
+++ b/tests/testcafe/test-util.js
@@ -8,6 +8,8 @@ import { diffString, diff } from 'json-diff';
 
 import { fullLegacyCombination, legacyModeCombinations } from '../../client/js/legacymoderegistry.js';
 
+import { fetchTextWithRetry } from './fetch-retry.js';
+
 const referenceDir = path.resolve() + '/save/testcafe-references';
 fs.mkdirSync(referenceDir, { recursive: true });
 let server = null;
@@ -80,25 +82,8 @@ export async function setName(t, name, color) {
     .click('#activeGameButton');
 }
 
-// Node reuses the connection to the server between requests, and one that the server has closed in
-// the meantime makes the next fetch() reject with a network-level 'TypeError: fetch failed' before the
-// request is ever sent. That is not a test failure - it just kills whichever test runs next, most
-// often in the beforeEach hook - so a rejected request is retried with a short backoff. An HTTP error
-// status is passed through untouched: that one is a real failure the tests have to see.
-async function fetchWithRetry(url, options, attempts=3) {
-  for(let attempt=1; ; attempt++) {
-    try {
-      return await fetch(url, options);
-    } catch(e) {
-      if(attempt == attempts)
-        throw e;
-      await new Promise(resolve => setTimeout(resolve, 100 * attempt));
-    }
-  }
-}
-
 export async function setRoomState(state) {
-  await fetchWithRetry(`${server}/state/testcafe-testing`, {
+  await fetchTextWithRetry(`${server}/state/testcafe-testing`, {
     method: 'PUT',
     headers: {
       'Content-Type':'application/json'
@@ -108,7 +93,7 @@ export async function setRoomState(state) {
 }
 
 export async function setLegacyMode(name, value) {
-  await fetchWithRetry(`${server}/setLegacyMode/testcafe-testing/${name}/${value === true ? 'true' : 'false'}`, {
+  await fetchTextWithRetry(`${server}/setLegacyMode/testcafe-testing/${name}/${value === true ? 'true' : 'false'}`, {
     method: 'PUT'
   });
 }
@@ -128,8 +113,7 @@ export async function applyLegacy(combo) {
 }
 
 export async function getState() {
-  const response = await fetchWithRetry(`${server}/state/testcafe-testing/false`);
-  return await response.text();
+  return await fetchTextWithRetry(`${server}/state/testcafe-testing/false`);
 }
 
 export async function getStateObject() {
@@ -152,8 +136,7 @@ export async function expectEventually(t, get, expected, message, timeout=1000) 
 
 // getState leaves _meta out - this is the version and the game settings the room is on
 export async function getMeta() {
-  const response = await fetchWithRetry(`${server}/state/testcafe-testing`);
-  return JSON.parse(await response.text())._meta;
+  return JSON.parse(await fetchTextWithRetry(`${server}/state/testcafe-testing`))._meta;
 }
 
 // Wait until the room state stops changing, i.e. until every routine triggered by

--- a/tests/testcafe/test-util.js
+++ b/tests/testcafe/test-util.js
@@ -80,8 +80,25 @@ export async function setName(t, name, color) {
     .click('#activeGameButton');
 }
 
+// Node reuses the connection to the server between requests, and one that the server has closed in
+// the meantime makes the next fetch() reject with a network-level 'TypeError: fetch failed' before the
+// request is ever sent. That is not a test failure - it just kills whichever test runs next, most
+// often in the beforeEach hook - so a rejected request is retried with a short backoff. An HTTP error
+// status is passed through untouched: that one is a real failure the tests have to see.
+async function fetchWithRetry(url, options, attempts=3) {
+  for(let attempt=1; ; attempt++) {
+    try {
+      return await fetch(url, options);
+    } catch(e) {
+      if(attempt == attempts)
+        throw e;
+      await new Promise(resolve => setTimeout(resolve, 100 * attempt));
+    }
+  }
+}
+
 export async function setRoomState(state) {
-  await fetch(`${server}/state/testcafe-testing`, {
+  await fetchWithRetry(`${server}/state/testcafe-testing`, {
     method: 'PUT',
     headers: {
       'Content-Type':'application/json'
@@ -91,7 +108,7 @@ export async function setRoomState(state) {
 }
 
 export async function setLegacyMode(name, value) {
-  await fetch(`${server}/setLegacyMode/testcafe-testing/${name}/${value === true ? 'true' : 'false'}`, {
+  await fetchWithRetry(`${server}/setLegacyMode/testcafe-testing/${name}/${value === true ? 'true' : 'false'}`, {
     method: 'PUT'
   });
 }
@@ -111,7 +128,7 @@ export async function applyLegacy(combo) {
 }
 
 export async function getState() {
-  const response = await fetch(`${server}/state/testcafe-testing/false`);
+  const response = await fetchWithRetry(`${server}/state/testcafe-testing/false`);
   return await response.text();
 }
 
@@ -135,7 +152,7 @@ export async function expectEventually(t, get, expected, message, timeout=1000) 
 
 // getState leaves _meta out - this is the version and the game settings the room is on
 export async function getMeta() {
-  const response = await fetch(`${server}/state/testcafe-testing`);
+  const response = await fetchWithRetry(`${server}/state/testcafe-testing`);
   return JSON.parse(await response.text())._meta;
 }
 


### PR DESCRIPTION
The TestCafe helpers that talk to the test server over REST now retry a request that fails at the network level, so a dropped connection no longer fails a test - and with it the whole CI job.

`tests/testcafe/test-util.js` reaches the server with plain `fetch()` calls, and Node's undici keeps those connections alive between requests. When the server closes such a connection between two tests, the next request rejects with `TypeError: fetch failed` before it is ever sent. The test that happens to run at that moment fails, even though nothing is wrong with the client or the code under test. Most of the time that is `resetRoom()` in the `beforeEach` hook, which is why the failure reads as `- Error in fixture.beforeEach hook - TypeError: fetch failed`.

It is not tied to one test. Recent examples:

* on `main`, `card.js` / 'A write object bound to a property of the card widget itself is not editable' (run 33988424952)
* on a PR branch, `editor.js` twice in a row on two different tests, 'A deck that overrides the pile template says so while the pile mirrors into it' and 'Deck editor: a sheet of fronts with a matching sheet of backs in the new deck wizard' (run 34037005001, jobs 101496797566 and 101501530153)

The change is a small `fetchTextWithRetry()` wrapper in the new `tests/testcafe/fetch-retry.js`: it performs the request *and* the body read as one operation, retries it up to three attempts with a 100 ms / 200 ms backoff and rethrows the original error if all of them fail. A connection that drops after the response headers rejects the body read with the same `TypeError: fetch failed`, so retrying only the request would leave that case open. An HTTP error status is deliberately not retried - a 4xx/5xx is a real failure the tests have to see. The error that survives the last attempt gets the method, the URL and the attempt count appended to its message, so a red CI job reads `TypeError: fetch failed (PUT http://localhost:8272/state/testcafe-testing, 3 attempts)` rather than a bare `TypeError: fetch failed` that says neither which request died nor that anything retried it. `setRoomState`, `setLegacyMode`, `getState` and `getMeta` (and therefore `getStateObject`, `resetRoom`, `applyLegacy`, `waitForStableState` and `compareState`) go through it; those are all four `fetch()` calls in the suite. Retrying is safe for each of them: both `PUT`s are idempotent and re-send a plain string body, both `GET`s read room state and discard a partial body.

Split out of #3171, which is about the trace viewer and the editor bundle: this flake predates that branch, happens on `main` as well and hits every PR's CI, so it does not belong in that diff.

## Verification

* `tests/fetch-retry.test.js` covers the wrapper in jest: a healthy request, a rejected request, a connection dropped during the body read, the rethrow after the last attempt and the context in its message, an HTTP error status that is not retried, and a `PUT` body that survives the retry unchanged.
* Against real servers on Node 22: a server that destroys the connection mid-body is retried and answers on the second attempt (187 ms); a port nothing listens on rethrows `TypeError: fetch failed (PUT http://localhost:8341/state/testcafe-testing, 3 attempts)` after ~455 ms.
* `npm test` - 1661 passing.
* TestCafe `draglimit.js` (and earlier `connection.js`, `toolbar.js`, `card.js`) pass locally against a real server, so the helpers still behave the same on the happy path.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3172/pr-test (or any other room on that server)

