### PR TITLE
Place a line's stops on the path when the room state is loaded

### DIFF
--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -138,6 +138,8 @@ export function addWidget(widget, instance, allowMissingParent) {
     if(!widgets.has(c.id))
       addWidget(c);
   delete deferredChildren[widget.id];
+
+  w.onAddedToRoom();
 }
 
 // useTypeBasedID is false on runtime engine paths (CLONE, automatic pile

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -618,7 +618,13 @@ function receiveStateFromServer(args) {
   triggerGameStartRoutineOnNextStateLoad = false;
 
   (async function() {
-    await finishLoadingWidgets();
+    // the game start routines are what the loaded room does next, so they run
+    // whether or not the widgets managed to finish loading
+    try {
+      await finishLoadingWidgets();
+    } catch(e) {
+      console.error(`Could not finish loading the room!`, e);
+    }
 
     if(runGameStartRoutines) {
       batchStart();

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -25,6 +25,11 @@ let triggerGameStartRoutineOnNextStateLoad = false;
 
 let undoProtocol = [];
 
+// the undo entry a state load pushes - and the cause of what the widgets write
+// while they finish loading, so it merges into that entry instead of coming
+// between the player and their own last action
+const stateLoadCause = 'received complete room state';
+
 function normalizeRoomID(roomID) {
   if(!config.roomNamesCaseSensitive)
     roomID = roomID.toLowerCase();
@@ -138,8 +143,6 @@ export function addWidget(widget, instance, allowMissingParent) {
     if(!widgets.has(c.id))
       addWidget(c);
   delete deferredChildren[widget.id];
-
-  w.onAddedToRoom();
 }
 
 // useTypeBasedID is false on runtime engine paths (CLONE, automatic pile
@@ -467,7 +470,7 @@ function addStateEntryToUndoProtocol(state) {
     }
   }
 
-  undoProtocol.push({ delta: {s:redoDelta,c:'received complete room state'}, undoDelta });
+  undoProtocol.push({ delta: {s:redoDelta,c:stateLoadCause}, undoDelta });
 }
 
 function getUndoProtocol() {
@@ -601,16 +604,33 @@ function receiveStateFromServer(args) {
 
   cancelInputOverlay();
 
-  if(triggerGameStartRoutineOnNextStateLoad) {
-    triggerGameStartRoutineOnNextStateLoad = false;
-    (async function() {
+  const runGameStartRoutines = triggerGameStartRoutineOnNextStateLoad;
+  triggerGameStartRoutineOnNextStateLoad = false;
+
+  (async function() {
+    // The widgets of a state are added one by one, so a widget that needs the
+    // others - a line placing its stops on its path, for example - can only do
+    // its part once they are all there. One batch for all of them, and before
+    // the game start routines, which expect a room that is done loading.
+    batchStart();
+    setDeltaCause(stateLoadCause);
+    for(const w of [ ...widgets.values() ]) {
+      try {
+        await w.onStateLoaded();
+      } catch(e) {
+        console.error(`Could not finish loading widget!`, w.id, e);
+      }
+    }
+    batchEnd();
+
+    if(runGameStartRoutines) {
       batchStart();
       for(const [ id, w ] of widgets)
         if(w.get('gameStartRoutine'))
           await w.evaluateRoutine('gameStartRoutine', { widgetID: id }, { widget: [ w ] });
       batchEnd();
-    })();
-  }
+    }
+  })();
 }
 
 function cancelInputOverlay() {

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -30,6 +30,16 @@ let undoProtocol = [];
 // between the player and their own last action
 const stateLoadCause = 'received complete room state';
 
+// set() dispatches the change and global-update routines a game defines. While
+// the widgets of an arriving state finish loading it does not: what they write
+// there is the engine making the state render the way it was saved, not the game
+// changing anything. Every client loads the same state, so a stop's
+// xChangeRoutine would otherwise run once per client just because somebody
+// opened the room - and an INPUT or DELAY in it would hold the load batch, and
+// with it the game start routines, open until that client answers it.
+// applyInitialDelta leaves them out for the state itself for the same reason.
+export let dispatchChangeRoutines = true;
+
 function normalizeRoomID(roomID) {
   if(!config.roomNamesCaseSensitive)
     roomID = roomID.toLowerCase();
@@ -608,20 +618,7 @@ function receiveStateFromServer(args) {
   triggerGameStartRoutineOnNextStateLoad = false;
 
   (async function() {
-    // The widgets of a state are added one by one, so a widget that needs the
-    // others - a line placing its stops on its path, for example - can only do
-    // its part once they are all there. One batch for all of them, and before
-    // the game start routines, which expect a room that is done loading.
-    batchStart();
-    setDeltaCause(stateLoadCause);
-    for(const w of [ ...widgets.values() ]) {
-      try {
-        await w.onStateLoaded();
-      } catch(e) {
-        console.error(`Could not finish loading widget!`, w.id, e);
-      }
-    }
-    batchEnd();
+    await finishLoadingWidgets();
 
     if(runGameStartRoutines) {
       batchStart();
@@ -631,6 +628,29 @@ function receiveStateFromServer(args) {
       batchEnd();
     }
   })();
+}
+
+// The widgets of a state are added one by one, so a widget that needs the others
+// - a line placing its stops on its path, for example - can only do its part
+// once they are all there. One batch for all of them, and before the game start
+// routines, which expect a room that is done loading.
+export async function finishLoadingWidgets() {
+  batchStart();
+  setDeltaCause(stateLoadCause);
+  const dispatchAfterwards = dispatchChangeRoutines;
+  dispatchChangeRoutines = false;
+  try {
+    for(const w of [ ...widgets.values() ]) {
+      try {
+        await w.onStateLoaded();
+      } catch(e) {
+        console.error(`Could not finish loading widget!`, w.id, e);
+      }
+    }
+  } finally {
+    dispatchChangeRoutines = dispatchAfterwards;
+    batchEnd();
+  }
 }
 
 function cancelInputOverlay() {

--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -45,6 +45,11 @@ export class StateManaged {
     this.applyDelta(delta);
   }
 
+  // the widget is part of the room now - the hook for everything that needs the
+  // other widgets of the state, which are only complete once the whole batch of
+  // additions is through
+  onAddedToRoom() {}
+
   getDefaultValue(key) {
     if(this.inheritedProperties)
       for(const [ id, properties ] of Object.entries(this.inheritFrom()))

--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -1,5 +1,5 @@
 import { dropTargets } from './main.js';
-import { sendPropertyUpdate } from './serverstate.js';
+import { dispatchChangeRoutines, sendPropertyUpdate } from './serverstate.js';
 import { tracingEnabled } from './tracing.js';
 
 export class StateManaged {
@@ -51,6 +51,8 @@ export class StateManaged {
   // implementation has to finish without an observable delay: anything that
   // waits for a network round trip or for something to be rendered would
   // rearrange the board under the player's cursor after it looked ready.
+  // What it writes is persisted and rendered like any other change, but it
+  // dispatches no change or global-update routine of the game (see set()).
   async onStateLoaded() {}
 
   getDefaultValue(key) {
@@ -135,6 +137,11 @@ export class StateManaged {
       this.state[property] = JSON.parse(JSONvalue);
     sendPropertyUpdate(this.get('id'), property, value);
     await this.onPropertyChange(property, oldValue, value);
+
+    // a write the engine does while a state is loading is not a change the game
+    // made, so it does not dispatch what the game listens for
+    if(!dispatchChangeRoutines)
+      return;
 
     if(Array.isArray(this.get(`${property}ChangeRoutine`)))
       await this.evaluateRoutine(`${property}ChangeRoutine`, { oldValue, value }, {});

--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -45,8 +45,12 @@ export class StateManaged {
     this.applyDelta(delta);
   }
 
-  // the whole state is in the room now - the hook for everything that needs the
-  // other widgets of a state, which do not exist yet while it is being added
+  // The whole state is in the room now - the hook for everything that needs the
+  // other widgets of a state, which do not exist yet while it is being added.
+  // The room already presents itself as loaded when this runs, so an
+  // implementation has to finish without an observable delay: anything that
+  // waits for a network round trip or for something to be rendered would
+  // rearrange the board under the player's cursor after it looked ready.
   async onStateLoaded() {}
 
   getDefaultValue(key) {

--- a/client/js/statemanaged.js
+++ b/client/js/statemanaged.js
@@ -45,10 +45,9 @@ export class StateManaged {
     this.applyDelta(delta);
   }
 
-  // the widget is part of the room now - the hook for everything that needs the
-  // other widgets of the state, which are only complete once the whole batch of
-  // additions is through
-  onAddedToRoom() {}
+  // the whole state is in the room now - the hook for everything that needs the
+  // other widgets of a state, which do not exist yet while it is being added
+  async onStateLoaded() {}
 
   getDefaultValue(key) {
     if(this.inheritedProperties)

--- a/client/js/widgets/line.js
+++ b/client/js/widgets/line.js
@@ -57,6 +57,42 @@ export class Line extends Widget {
     }
   }
 
+  // A state whose stops carry no coordinates - or coordinates that stopped
+  // matching the path, e.g. because the line was reshaped after the save - would
+  // otherwise render them all in the line's top left corner until a player or
+  // the editor touches something. The widgets of a state arrive one by one, so
+  // the stops usually do not exist yet when the line does: place them once the
+  // whole batch of additions is through. A state whose stops already sit on the
+  // path is left exactly as it was loaded.
+  onAddedToRoom() {
+    if(this.initialStopLayout)
+      return;
+    this.initialStopLayout = setTimeout(async ()=>{
+      this.initialStopLayout = null;
+      // the widget can be gone again - or replaced by a newer state - by now
+      if(widgets.get(this.id) !== this || this.isBeingRemoved || !this.stopsOffPath())
+        return;
+      batchStart();
+      setDeltaCause(`line ${this.id} placed its stops`);
+      try {
+        await this.layoutStops();
+      } finally {
+        batchEnd();
+      }
+    });
+  }
+
+  // whether any stop sits somewhere other than where the line puts it - the same
+  // coordinates positionAttachedWidgets writes, compared instead of assigned
+  stopsOffPath() {
+    return this.stopList().some(entry=>{
+      const stop = widgets.get(entry.widget);
+      const point = this.stopCoordInParentFrame(stop, this.pointAtPosition(entry.position));
+      return Math.round(point.x - stop.get('width')/2) != stop.get('x')
+          || Math.round(point.y - stop.get('height')/2) != stop.get('y');
+    });
+  }
+
   isEllipse() {
     return this.get('lineShape') == 'ellipse';
   }

--- a/client/js/widgets/line.js
+++ b/client/js/widgets/line.js
@@ -60,30 +60,40 @@ export class Line extends Widget {
   // A state whose stops carry no coordinates - or coordinates that stopped
   // matching the path, e.g. because the line was reshaped after the save - would
   // otherwise render them all in the line's top left corner until a player or
-  // the editor touches something. The widgets of a state arrive one by one, so
-  // the stops usually do not exist yet when the line does: place them once the
-  // whole batch of additions is through. A state whose stops already sit on the
-  // path is left exactly as it was loaded.
-  onAddedToRoom() {
-    if(this.initialStopLayout)
+  // the editor touches something. The room is complete here, which the line
+  // itself being added is not: its stops usually arrive after it.
+  async onStateLoaded() {
+    // A stop the state does not contain is dropped by stopList, so laying the
+    // line out would write that shortened list back and lose the entry for good.
+    // Nobody asked for a layout here, so leave a save that names one alone.
+    if(this.stopsMissingFromRoom())
       return;
-    this.initialStopLayout = setTimeout(async ()=>{
-      this.initialStopLayout = null;
-      // the widget can be gone again - or replaced by a newer state - by now
-      if(widgets.get(this.id) !== this || this.isBeingRemoved || !this.stopsOffPath())
-        return;
-      batchStart();
-      setDeltaCause(`line ${this.id} placed its stops`);
-      try {
-        await this.layoutStops();
-      } finally {
-        batchEnd();
-      }
-    });
+
+    // A stop that is not a child of the line is placed through the CSS
+    // transforms of its frame and of the line's, read out of the DOM - and a
+    // line inside an owner / onlyVisibleForSeat / display:false chain is not
+    // rendered at all on part of the clients, which all run this. Placing those
+    // would let whoever happens to load the room decide where they end up for
+    // everybody, so they stay with the interactions that position them.
+    if(this.hasExternalStops())
+      return;
+
+    if(!this.stopsOffPath())
+      return;
+
+    await this.layoutStops();
   }
 
-  // whether any stop sits somewhere other than where the line puts it - the same
-  // coordinates positionAttachedWidgets writes, compared instead of assigned
+  // an entry of the stops list whose widget is not part of the room
+  stopsMissingFromRoom() {
+    const stops = this.get('stops');
+    return Array.isArray(stops) && stops.some(entry=>entry && typeof entry == 'object' && !widgets.has(entry.widget));
+  }
+
+  // Whether any stop sits somewhere other than where the line puts it - the same
+  // coordinates positionAttachedWidgets writes, compared instead of assigned.
+  // Rotation is left out: it is only meaningful together with the
+  // lineOriginalRotation the line stores when it takes a stop's rotation over.
   stopsOffPath() {
     return this.stopList().some(entry=>{
       const stop = widgets.get(entry.widget);

--- a/client/js/widgets/line.js
+++ b/client/js/widgets/line.js
@@ -92,16 +92,27 @@ export class Line extends Widget {
   }
 
   // Whether any stop sits somewhere other than where the line puts it - the same
-  // coordinates positionAttachedWidgets writes, compared instead of assigned.
-  // Rotation is left out: it is only meaningful together with the
-  // lineOriginalRotation the line stores when it takes a stop's rotation over.
+  // coordinates and rotation positionAttachedWidgets writes, compared instead of
+  // assigned.
   stopsOffPath() {
     return this.stopList().some(entry=>{
       const stop = widgets.get(entry.widget);
       const point = this.stopCoordInParentFrame(stop, this.pointAtPosition(entry.position));
       return Math.round(point.x - stop.get('width')/2) != stop.get('x')
-          || Math.round(point.y - stop.get('height')/2) != stop.get('y');
+          || Math.round(point.y - stop.get('height')/2) != stop.get('y')
+          || this.stopRotationOffPath(stop, entry.position);
     });
+  }
+
+  // A stop the line turns onto the path is off it while it carries any other
+  // rotation - a save that only stores where a stop sits would otherwise load it
+  // unrotated and snap it onto the tangent on the first interaction. A stop the
+  // line does not turn is off it while the line still holds the rotation it took
+  // over earlier, which a layout hands back.
+  stopRotationOffPath(stop, position) {
+    if(this.shouldRotateStops())
+      return (+stop.get('rotation') || 0) != this.stopRotationOnPath(stop, position);
+    return stop.get('lineOriginalRotation') !== null;
   }
 
   isEllipse() {

--- a/tests/client/line-widget.test.js
+++ b/tests/client/line-widget.test.js
@@ -736,3 +736,80 @@ describe('dragging a widget onto a line to make it a stop', () => {
     });
   });
 });
+
+describe('a line places its stops when a state is loaded', () => {
+  const stopIDs = [ 'load-a', 'load-b', 'load-c' ];
+
+  // what happens when a state arrives: every widget is added, and only once the
+  // whole batch is through does anything scheduled during it get a turn
+  async function loadState(lineState, stopStates) {
+    const line = createLine(lineState);
+    const stops = stopStates.map(state => {
+      const stop = new Widget(state.id);
+      addWidget({ type: 'basic', parent: line.id, width: 40, height: 40, ...state }, stop);
+      return stop;
+    });
+    await new Promise(resolve => setTimeout(resolve));
+    return { line, stops };
+  }
+
+  function unload(line, stops) {
+    for(const stop of stops)
+      removeWidget(stop.id);
+    removeWidget(line.id);
+  }
+
+  // 300 long, offset from the line's own origin so a placed stop cannot be
+  // confused with one that was never placed at all
+  const geometry = { x: 100, y: 100, lineStart: { x: 20, y: 70 }, lineEnd: { x: 320, y: 70 }, rotateStops: false };
+  const coordinates = stops => stops.map(stop => [ stop.get('x'), stop.get('y') ]);
+
+  test('stops that carry no coordinates end up on the path instead of in the corner', async () => {
+    const { line, stops } = await loadState(
+      { ...geometry, id: 'load-line', autoSpaceStops: false, stops: stopIDs.map((widget, i) => ({ widget, position: i/2 })) },
+      stopIDs.map(id => ({ id }))
+    );
+
+    expect(coordinates(stops)).toEqual([ [ 0, 50 ], [ 150, 50 ], [ 300, 50 ] ]);
+    unload(line, stops);
+  });
+
+  test('autoSpaceStops re-spaces stops whose stored positions do not match the line anymore', async () => {
+    const { line, stops } = await loadState(
+      { ...geometry, id: 'load-line', autoSpaceStops: true, stops: stopIDs.map((widget, i) => ({ widget, position: i/10 })) },
+      stopIDs.map(id => ({ id }))
+    );
+
+    expect(line.stopList().map(entry => entry.position)).toEqual([ 0, 0.5, 1 ]);
+    expect(coordinates(stops)).toEqual([ [ 0, 50 ], [ 150, 50 ], [ 300, 50 ] ]);
+    unload(line, stops);
+  });
+
+  test('stops that sit on the path keep the positions they were saved with', async () => {
+    // uneven positions the line would re-space away from if it laid them out
+    // again: a state that renders correctly is a deliberate one
+    const { line, stops } = await loadState(
+      { ...geometry, id: 'load-line', autoSpaceStops: true, stops: stopIDs.map((widget, i) => ({ widget, position: i/10 })) },
+      stopIDs.map((id, i) => ({ id, x: i*30, y: 50 }))
+    );
+
+    expect(line.stopList().map(entry => entry.position)).toEqual([ 0, 0.1, 0.2 ]);
+    expect(coordinates(stops)).toEqual([ [ 0, 50 ], [ 30, 50 ], [ 60, 50 ] ]);
+    unload(line, stops);
+  });
+
+  test('a save whose stops already sit on the path is not written to again', async () => {
+    const lineState = { ...geometry, id: 'saved-line', autoSpaceStops: true, stops: stopIDs.map((widget, i) => ({ widget, position: i/2 })) };
+    const saved = await loadState(lineState, stopIDs.map(id => ({ id })));
+    const savedLine = JSON.parse(JSON.stringify(saved.line.state));
+    const savedStops = saved.stops.map(stop => JSON.parse(JSON.stringify(stop.state)));
+    unload(saved.line, saved.stops);
+
+    const { line, stops } = await loadState(savedLine, savedStops);
+    // set() writes to state only, so a widget nothing has written to still
+    // equals the state it was loaded with - down to the last property
+    for(const widget of [ line, ...stops ])
+      expect(widget.state).toEqual(widget.unalteredState);
+    unload(line, stops);
+  });
+});

--- a/tests/client/line-widget.test.js
+++ b/tests/client/line-widget.test.js
@@ -1,4 +1,4 @@
-import { widgets, addWidget, batchStart, batchEnd, widgetFilter, flushDelta } from '../../client/js/serverstate.js';
+import { widgets, addWidget, batchStart, batchEnd, widgetFilter, flushDelta, finishLoadingWidgets } from '../../client/js/serverstate.js';
 import { Widget } from '../../client/js/widgets/widget.js';
 import { compareDropTarget, exceedsDropLimit } from '../../client/js/main.js';
 
@@ -749,8 +749,7 @@ describe('a line places its stops when a state is loaded', () => {
       addWidget({ type: 'basic', parent: line.id, width: 40, height: 40, ...state }, stop);
       return stop;
     });
-    for(const widget of [ line, ...stops ])
-      await widget.onStateLoaded();
+    await finishLoadingWidgets();
     return { line, stops };
   }
 
@@ -836,11 +835,37 @@ describe('a line places its stops when a state is loaded', () => {
     const stop = new Widget('load-a');
     addWidget({ id: 'load-a', type: 'basic', x: 7, y: 7, width: 40, height: 40 }, stop);
 
-    for(const widget of [ line, stop ])
-      await widget.onStateLoaded();
+    await finishLoadingWidgets();
 
     expect(line.hasExternalStops()).toBe(true);
     expect([ stop.get('x'), stop.get('y') ]).toEqual([ 7, 7 ]);
+    unload(line, [ stop ]);
+  });
+
+  test('placing the stops runs none of the routines the game listens with', async () => {
+    // every client loads the same state, so a routine running here would run
+    // once per client on nothing but the room being opened - and an INPUT in it
+    // would hold the load batch open until that one client answers it
+    const line = createLine({ ...geometry, id: 'load-line', autoSpaceStops: false, stops: [ { widget: 'load-a', position: 0.5 } ] });
+    const stop = new Widget('load-a');
+    addWidget({ id: 'load-a', type: 'basic', parent: 'load-line', width: 40, height: 40, xChangeRoutine: [ { func: 'INPUT' } ] }, stop);
+    const listener = new Widget('load-listener');
+    addWidget({ id: 'load-listener', type: 'basic', xGlobalUpdateRoutine: [ { func: 'INPUT' } ] }, listener);
+
+    const evaluated = [];
+    for(const widget of [ line, stop, listener ])
+      widget.evaluateRoutine = async routine => { evaluated.push([ widget.id, routine ]); };
+
+    await finishLoadingWidgets();
+
+    expect(evaluated).toEqual([]);
+    expect([ stop.get('x'), stop.get('y') ]).toEqual([ 150, 50 ]);
+
+    // and the game gets its routines back for what happens after the load
+    await stop.set('x', 42);
+    expect(evaluated).toEqual([ [ 'load-a', 'xChangeRoutine' ], [ 'load-listener', 'xGlobalUpdateRoutine' ] ]);
+
+    removeWidget('load-listener');
     unload(line, [ stop ]);
   });
 });

--- a/tests/client/line-widget.test.js
+++ b/tests/client/line-widget.test.js
@@ -741,7 +741,7 @@ describe('a line places its stops when a state is loaded', () => {
   const stopIDs = [ 'load-a', 'load-b', 'load-c' ];
 
   // what happens when a state arrives: every widget is added, and only once the
-  // whole batch is through does anything scheduled during it get a turn
+  // whole state is in the room does each of them get its onStateLoaded turn
   async function loadState(lineState, stopStates) {
     const line = createLine(lineState);
     const stops = stopStates.map(state => {
@@ -749,7 +749,8 @@ describe('a line places its stops when a state is loaded', () => {
       addWidget({ type: 'basic', parent: line.id, width: 40, height: 40, ...state }, stop);
       return stop;
     });
-    await new Promise(resolve => setTimeout(resolve));
+    for(const widget of [ line, ...stops ])
+      await widget.onStateLoaded();
     return { line, stops };
   }
 
@@ -811,5 +812,35 @@ describe('a line places its stops when a state is loaded', () => {
     for(const widget of [ line, ...stops ])
       expect(widget.state).toEqual(widget.unalteredState);
     unload(line, stops);
+  });
+
+  test('a stops list naming a widget the state does not contain is left as it is', async () => {
+    // laying the line out would write the list back without the missing entry,
+    // so the save would lose it - and it is what a routine adding a line and its
+    // stops one at a time looks like while it is still adding them
+    const { line, stops } = await loadState(
+      { ...geometry, id: 'load-line', autoSpaceStops: true, stops: [ ...stopIDs, 'load-later' ].map((widget, i) => ({ widget, position: i/10 })) },
+      stopIDs.map(id => ({ id }))
+    );
+
+    expect(line.get('stops').map(entry => entry.widget)).toEqual([ ...stopIDs, 'load-later' ]);
+    expect(coordinates(stops)).toEqual([ [ 0, 0 ], [ 0, 0 ], [ 0, 0 ] ]);
+    unload(line, stops);
+  });
+
+  test('a stop that is not a child of the line is left where the state put it', async () => {
+    // an external stop is placed through the CSS transforms of two frames, which
+    // read differently on a client that does not render the line at all - so
+    // every client agreeing on where it goes is not a given
+    const line = createLine({ ...geometry, id: 'external-line', autoSpaceStops: false, stops: [ { widget: 'load-a', position: 0.5 } ] });
+    const stop = new Widget('load-a');
+    addWidget({ id: 'load-a', type: 'basic', x: 7, y: 7, width: 40, height: 40 }, stop);
+
+    for(const widget of [ line, stop ])
+      await widget.onStateLoaded();
+
+    expect(line.hasExternalStops()).toBe(true);
+    expect([ stop.get('x'), stop.get('y') ]).toEqual([ 7, 7 ]);
+    unload(line, [ stop ]);
   });
 });

--- a/tests/client/line-widget.test.js
+++ b/tests/client/line-widget.test.js
@@ -1014,6 +1014,24 @@ describe('a line places its stops when a state is loaded', () => {
     unload(line, stops);
   });
 
+  test('a stop that sits on the path but is not turned onto it is rotated', async () => {
+    // a state that stores where a stop sits but not how it is turned renders it
+    // unrotated and snaps it onto the tangent on the first interaction - the
+    // same before/after split as a stop with no coordinates at all
+    const curve = { ...geometry, id: 'load-line', rotateStops: true, autoSpaceStops: false, controlStart: { x: 20, y: -80 }, controlEnd: { x: 320, y: 220 }, stops: [ { widget: 'load-a', position: 0.5 } ] };
+    const stopState = { id: 'load-a', width: 60, height: 40 };
+
+    const placed = await loadState(curve, [ stopState ]);
+    const [ x, y ] = coordinates(placed.stops)[0];
+    const rotation = placed.stops[0].get('rotation');
+    unload(placed.line, placed.stops);
+    expect(rotation).not.toBe(0);
+
+    const { line, stops } = await loadState(curve, [ { ...stopState, x, y } ]);
+    expect(stops[0].get('rotation')).toBe(rotation);
+    unload(line, stops);
+  });
+
   test('a save whose stops already sit on the path is not written to again', async () => {
     const lineState = { ...geometry, id: 'saved-line', autoSpaceStops: true, stops: stopIDs.map((widget, i) => ({ widget, position: i/2 })) };
     const saved = await loadState(lineState, stopIDs.map(id => ({ id })));


### PR DESCRIPTION
A line widget only laid its stops out when something triggered it: a geometry or property change, a drop, or a call to `distributeAttachedWidgetsEvenly()` / `updateAttachedWidgets()`. Loading a game triggered nothing. A saved state whose stop widgets carry no `x`/`y` — hand-written JSON, a game file edited outside the app, a save made before the line was reshaped — therefore rendered every stop at its parent's origin, piled on top of each other, and stayed that way until a player or the editor touched something. The room looked broken on load even though its `stops` list was perfectly correct.

| on load, before | on load, with this PR |
| --- | --- |
| ![before](https://agent.virtualtabletop.io/reports/pr/1546242043964301384/line-stops-on-load-before.png) | ![after](https://agent.virtualtabletop.io/reports/pr/1546242043964301384/line-stops-on-load-after.png) |

The same holds for a stop's rotation: a state that stores where a stop sits but not how `rotateStops` turns it loaded it unrotated and snapped it onto the tangent on the first interaction. That is live content — the `Types - Line` tutorial has eleven such stops:

| `Types - Line` on load, before | with this PR |
| --- | --- |
| ![before](https://agent.virtualtabletop.io/reports/pr/1546242043964301384/line-stops-rotation-before.png) | ![after](https://agent.virtualtabletop.io/reports/pr/1546242043964301384/line-stops-rotation-after.png) |

## The change

`receiveStateFromServer()` gets a completion pass: once every widget of a state is in the room, each of them is given an `onStateLoaded()` turn — in one batch, before the game start routines run. The base implementation in `StateManaged` does nothing; `Line` uses it to put its stops where the line says they belong, reusing `layoutStops()` so `autoSpaceStops` decides whether they are re-spaced or placed at their own stored positions, exactly as everywhere else.

The full state load is the point where this is safe. The widgets of a state arrive one by one, so a line's stops usually do not exist yet while the line itself is being added, and laying out too early would prune them out of the `stops` list for good — `stopList()` drops entries whose widget is missing, and re-spacing writes that filtered list back.

The line writes only when there is something to fix, and stays out of it whenever it cannot be sure:

- **A save that already renders correctly is left alone.** The stops are laid out only when at least one of them sits somewhere other than where the line puts it, or is turned differently from how the line would turn it (`stopsOffPath()`, the same comparison `positionAttachedWidgets()` writes). Otherwise there is no delta, no undo entry and no state-hash movement — verified on the `Types - Line` tutorial: once its stops have been placed, loading it again writes nothing.
- **A `stops` entry naming a widget the state does not contain** means a layout would write the shortened list back and lose that entry. Nobody asked for a layout here, so such a line is skipped.
- **A stop that is not a child of the line** is placed through the CSS transforms of two frames, read out of the DOM — and a line under an `owner` / `onlyVisibleForSeat` / `display: false` chain is not rendered on every client, while every client runs this pass. Placing those automatically would let whoever happens to load the room decide where they end up for everybody, so they stay with the interactions that position them explicitly. This guard is why the widget's biggest user in the library is out of scope by design: all 309 stops of **All Aboard** are external, so each of its 101 lines returns here and the game is untouched.
- **Undo:** what the pass writes carries the same delta cause as the state load itself, so it merges into that one undo entry instead of costing the player their first Ctrl+Z.
- **The game does not hear it.** `set()` normally dispatches `${property}ChangeRoutine`, `changeRoutine` and every matching global-update routine. The load pass turns that off for its duration: what it writes is persisted, sent and rendered like any other change, but silent towards the routines a game listens with — the same distinction `applyInitialDelta()` already draws for the state itself. Otherwise a stop's `xChangeRoutine` would run once on every client that opened the room, and an `INPUT` or `DELAY` in it would hold the load batch, and with it the game start routines, open until that one client answered it.

The room removes its loading indicator before the pass runs, so `StateManaged.onStateLoaded()` documents what an implementation may do: finish without an observable delay. `Line`'s is pure arithmetic on `pointAtPosition()` and the stop's `width`/`height`, but a future hook that waited for a network round trip or a rendered image would rearrange a board that already presented itself as ready. The game start routines run whether or not the pass got through, so a throw in it cannot skip them.

## Why this is its own PR

It is a pre-existing bug on `main` and has nothing to do with #3173, which only changes how the distances between stops are computed. It was found because a demo room shipped with that PR happened to be hand-written JSON without stop coordinates. Fixing it means changing *when* a line writes widget positions during room load, which is a different risk profile from that PR's arithmetic and deserves its own review. Split out of #3173.

## Verification

- `npm test` — all 56 jest suites (1672 tests) pass. Eight cases in `tests/client/line-widget.test.js` cover the pass: stops without coordinates end up on the path, `autoSpaceStops` re-spaces stops whose stored positions no longer match, stops that already sit on the path keep the positions they were saved with, a stop that sits on the path but is not turned onto it is rotated, a save that is reloaded is not written to again (its `state` still equals the `unalteredState` it was loaded with), a `stops` list naming a widget the state does not contain is left as it is, a stop that is not a child of the line is left where the state put it, and placing the stops runs neither a stop's `xChangeRoutine` nor a listener's `xGlobalUpdateRoutine` while the same write right afterwards runs both. The first three fail without the change, the last three fail without their guards.
- TestCafe `editor.js` passes in full (96/96), including `Line widget in edit mode` and `Line stops that are not children of the line`, as do `interactions.js` and `holderevents.js` (54/54 — the ones that exercise change and global-update routines through `set()` on the normal, non-loading path).
- Verified in a real browser against a running server: a state with three coordinate-less child stops renders them in the line's corner on `main` and on the path with this change, and the placement is persisted to the server; the `Types - Line` tutorial loads with its eleven unturned stops laid along their curves instead of axis-aligned, and loading the repaired state again writes nothing; a line whose `stops` names a missing widget keeps that entry and is not laid out; an external stop keeps the coordinates the state gave it; and after loading such a room the first Ctrl+Z undoes the player's own last action, not the placement. With an `xChangeRoutine` and a matching `xGlobalUpdateRoutine` added to that state, both fire on load without the guard and neither fires with it, while the stops are placed either way — checked against the minified bundle as well, since the flag is read across two files the client bundle concatenates into one scope.

## Demo room

**Line stops on load** is uploaded into the `pr-test-ai` room of this PR's own test server (the link is at the bottom of this description; replace `pr-test` with `pr-test-ai`) ([download](https://agent.virtualtabletop.io/reports/pr/1546242043964301384/Line%20stops%20on%20load.vtt)): a hand-written state whose stops carry neither coordinates nor rotations at all. It is authored to tutorial quality — title / overview / example row / captions — and shows three captioned examples side by side: a straight line, a curved line with `controlStart` / `controlEnd`, and a closed `lineShape: ellipse` whose positions wrap around. All three ship the positions they end up with, so the file and the JSON editor agree, and all three are turned onto their paths by the load pass. Two numbered steps below them make the point interactive: **1. Pile the stops up** moves every stop into the corner of its line — what such a state renders like — and **2. Reload the page (F5)** shows the lines placing them again. The room lives on the test server only and is deliberately **not** added to `library/tutorials/`; say the word and it can be moved there.

| on load | after "Pile the stops up" |
| --- | --- |
| ![demo room](https://agent.virtualtabletop.io/reports/pr/1546242043964301384/line-stops-demo-room.png) | ![piled up](https://agent.virtualtabletop.io/reports/pr/1546242043964301384/line-stops-demo-piled.png) |


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3174/pr-test (or any other room on that server)
