### PR TITLE
Record the DOM snapshot after the spinner has revealed its value

### DIFF
--- a/tests/testcafe/dom-snapshots/widget-gallery.chrome.json
+++ b/tests/testcafe/dom-snapshots/widget-gallery.chrome.json
@@ -1088,7 +1088,7 @@
       {
         "tag": "div",
         "id": "",
-        "classes": "hidden value",
+        "classes": "value",
         "box": [
           1280,
           50,
@@ -1103,7 +1103,7 @@
           "z-index": "auto",
           "background-color": "rgb(31, 92, 166)",
           "color": "rgb(255, 255, 255)",
-          "opacity": "0",
+          "opacity": "1",
           "background-image": "none",
           "font-style": "normal",
           "text-align": "center"

--- a/tests/testcafe/domsnapshot.js
+++ b/tests/testcafe/domsnapshot.js
@@ -87,10 +87,18 @@ async function openRoom(t, combo, state) {
 
 // A room that is still settling - a deferred layout, an asset that has not arrived - would
 // record a baseline nobody can reproduce, so read until two consecutive captures agree.
+//
+// The pause between two captures has to outlast the longest change the client makes on its own
+// once a widget is there, or "agree" only means the machine was fast enough to read the same
+// intermediate state twice: a spinner hides its value the moment angle and value arrive and
+// reveals it 1300 ms later, so with a shorter pause the tree that gets recorded - and compared
+// against the baseline - is whichever side of that timer this machine happened to land on.
+const SETTLE_PAUSE = 1600;
+
 async function settledSnapshot(t) {
   let previous = await captureSnapshot(STYLE_PROPERTIES);
-  for(let wait=100; wait<2000; wait*=2) {
-    await t.wait(wait);
+  for(let attempt=0; attempt<4; ++attempt) {
+    await t.wait(SETTLE_PAUSE);
     const snapshot = await captureSnapshot(STYLE_PROPERTIES);
     if(diff(previous, snapshot) === undefined)
       return snapshot;


### PR DESCRIPTION
`tests/testcafe/domsnapshot.js` decided that a room had finished rendering as soon as two DOM captures 100 ms apart agreed. That is shorter than a timer the fixture starts, so the recorded baseline pinned down a state that only exists for the first 1300 ms of the room's life — and whether a run sees it is a question about the machine, not about the code.

`Spinner.applyDeltaToDOM()` hides its value element whenever `angle` or `value` arrive and reveals it again from a `setTimeout(…, 1300)`. Those two properties are among the spinner's defaults, and `applyInitialDelta()` pushes the defaults through the DOM path, so the timer starts the moment the `widget-gallery` fixture's spinner is created. `tests/testcafe/dom-snapshots/widget-gallery.chrome.json` recorded that element mid-window, as `"classes": "hidden value"` with `"opacity": "0"`.

On a fast, idle runner the settle loop returns before the reveal and the baseline matches. On a busy machine a single `captureSnapshot()` call alone takes ~1.7 s, so the value element is long revealed by the time the first capture completes and the test reports

```
-        classes: "hidden value"
+        classes: "value"
-          opacity: "0"
+          opacity: "1"
```

with no source change at all — reproduced here on unmodified `main` with `npx testcafe chromium:headless tests/testcafe/domsnapshot.js`.

## The change

`settledSnapshot()` now pauses 1600 ms between the captures it compares instead of starting at 100 ms and doubling. A pause longer than the reveal makes "two captures agree" mean the room has actually stopped moving rather than that the machine was quick enough to read the same intermediate state twice: the timer starts before the first capture, so the second one is always taken after it has fired, on any machine. The baseline is re-recorded with the value element as it ends up — `"classes": "value"`, `"opacity": "1"` — which is also the state a player sees, so a real regression in that element still shows up as a diff.

The fixture itself, the widgets and the client are untouched; the whole diff is the settle interval and those two baseline values.

## Verification

- `npx testcafe "chromium:headless --no-sandbox" tests/testcafe/domsnapshot.js` on this branch: 3/3 pass, and they pass again with six busy CPU cores competing with the browser — the load that makes `main` fail here.
- The same command on `main` in the same environment fails on `widget-gallery` with exactly the diff above.
- The re-recording run (`WRITE_DOM_SNAPSHOTS=1`) rewrote all five baselines and only `widget-gallery.chrome.json` changed, in only those two values — the other four fixtures' trees are byte-identical to what was checked in.
- `tests/testcafe/pixelsnapshot.js` (the other half of Layer F, which shares the fixtures) passes on this branch, 4/4.
- `npm test`: 56 suites, 1664 tests, all pass.

Split out of #3174: this flake is on `main` today, in a file that PR does not touch.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3176/pr-test (or any other room on that server)