### PR TITLE
Drop the values a deleted widget handed down to the ones inheriting from it

### DIFF
--- a/client/js/editmode.js
+++ b/client/js/editmode.js
@@ -1609,7 +1609,7 @@ async function updateWidget(currentState, oldState, applyChangesFromUI) {
   if(widget.id !== previousState.id) {
     await updateWidgetId(widget, previousState.id);
   } else if (widget.type !== previousState.type) {
-    await removeWidgetLocal(previousState.id, true);
+    await removeWidgetLocal(previousState.id, true, true);
     const id = await addWidgetLocal(widget);
 
     // Handle special case where type is removed

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -634,8 +634,12 @@ function removeWidget(widgetID) {
   dropTargets.delete(widgetID);
   // only with the widget out of the room does re-reading an inherited property give
   // the value the inheritor falls back to instead of the one that is going away
-  if(widget)
-    widget.revertInheritedValues();
+  try {
+    if(widget)
+      widget.revertInheritedValues();
+  } catch(e) {
+    console.error(`Could not revert inherited values!`, widgetID, e);
+  }
 }
 
 async function removeWidgetLocal(widgetID, keepChildren, isBeingReplaced) {

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -624,13 +624,18 @@ function cancelInputOverlay() {
 }
 
 function removeWidget(widgetID) {
+  const widget = widgets.get(widgetID);
   try {
-    widgets.get(widgetID).applyRemove();
+    widget.applyRemove();
   } catch(e) {
     console.error(`Could not remove widget!`, widgetID, e);
   }
   widgets.delete(widgetID);
   dropTargets.delete(widgetID);
+  // only with the widget out of the room does re-reading an inherited property give
+  // the value the inheritor falls back to instead of the one that is going away
+  if(widget)
+    widget.revertInheritedValues();
 }
 
 async function removeWidgetLocal(widgetID, keepChildren) {
@@ -648,13 +653,30 @@ async function removeWidgetLocal(widgetID, keepChildren) {
   if(widgets.get(widgetID).inRemovalQueue)
     return;
 
-  for(const w of getWidgetsToRemove(widgetID)) {
+  const removing = getWidgetsToRemove(widgetID);
+  // A widget that inherits from one of these falls back to its own defaults once it is
+  // gone, so it can end up a different size than the one a line placed it by. Only
+  // collected for the games that have a line at all - the flush below is not worth it
+  // otherwise.
+  const inheriting = widgetFilter(w=>w.get('type') == 'line').length
+    ? [ ...new Set(removing.flatMap(w=>w.inheritingWidgets())) ].filter(w=>!removing.includes(w))
+    : [];
+
+  for(const w of removing) {
     w.isBeingRemoved = true;
     // don't actually set deck and parent to null (only pretend to) because when "receiving" the delta, the applyRemove has to find the parent
     await w.onPropertyChange('deck', w.get('deck'), null);
     if(!w.isLimbo)
       await w.onPropertyChange('parent', w.get('parent'), null);
     sendPropertyUpdate(w.id, null);
+  }
+
+  // the removal only takes effect once the delta is applied, so the new sizes
+  // are only there to lay out by after it has been
+  if(inheriting.length) {
+    flushDelta();
+    for(const w of inheriting)
+      await w.updateLinesForStopLayout();
   }
 }
 

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -655,14 +655,16 @@ async function removeWidgetLocal(widgetID, keepChildren, isBeingReplaced) {
 
   const removing = getWidgetsToRemove(widgetID);
   // A widget that inherits from one of these falls back to its own defaults once it is
-  // gone, so it can end up a different size than the one a line placed it by. A rename
-  // or a type change takes the widget out only to add it straight back, which hands the
-  // same values down again - there is nothing to lay out for those. Only collected for
-  // the games that have a line at all, since the flush below is not worth it otherwise.
+  // gone, so it can end up somewhere else or a different size than a line placed it by
+  // and glued its end points to. A rename or a type change takes the widget out only to
+  // add it straight back, which hands the same values down again - there is nothing to
+  // lay out for those. Only collected for the games that have a line at all, since the
+  // flush below is not worth it otherwise.
+  const lines = widgetFilter(w=>w.get('type') == 'line');
   const inheritors = new Set();
-  if(!isBeingReplaced && widgetFilter(w=>w.get('type') == 'line').length)
+  if(!isBeingReplaced && lines.length)
     for(const w of removing)
-      w.stopLayoutInheritors(inheritors);
+      w.lineLayoutInheritors(lines, inheritors);
   const inheriting = [ ...inheritors ].filter(w=>!removing.includes(w));
 
   for(const w of removing) {
@@ -674,12 +676,14 @@ async function removeWidgetLocal(widgetID, keepChildren, isBeingReplaced) {
     sendPropertyUpdate(w.id, null);
   }
 
-  // the removal only takes effect once the delta is applied, so the new sizes
-  // are only there to lay out by after it has been
+  // the removal only takes effect once the delta is applied, so the values that are
+  // fallen back to are only there to lay out by after it has been
   if(inheriting.length) {
     flushDelta();
-    for(const w of inheriting)
+    for(const w of inheriting) {
+      await w.updateConnectedLineEndpoints();
       await w.updateLinesForStopLayout();
+    }
   }
 }
 

--- a/client/js/serverstate.js
+++ b/client/js/serverstate.js
@@ -190,7 +190,7 @@ async function updateWidgetId(widget, oldID) {
     sendPropertyUpdate(child.get('id'), 'parent', null);
   for(const card of cards)
     sendPropertyUpdate(card.get('id'), 'deck', null);
-  await removeWidgetLocal(oldID, true);
+  await removeWidgetLocal(oldID, true, true);
 
   const id = await addWidgetLocal(widget);
 
@@ -638,7 +638,7 @@ function removeWidget(widgetID) {
     widget.revertInheritedValues();
 }
 
-async function removeWidgetLocal(widgetID, keepChildren) {
+async function removeWidgetLocal(widgetID, keepChildren, isBeingReplaced) {
   function getWidgetsToRemove(widgetID) {
     const children = [];
     if(!keepChildren)
@@ -655,12 +655,15 @@ async function removeWidgetLocal(widgetID, keepChildren) {
 
   const removing = getWidgetsToRemove(widgetID);
   // A widget that inherits from one of these falls back to its own defaults once it is
-  // gone, so it can end up a different size than the one a line placed it by. Only
-  // collected for the games that have a line at all - the flush below is not worth it
-  // otherwise.
-  const inheriting = widgetFilter(w=>w.get('type') == 'line').length
-    ? [ ...new Set(removing.flatMap(w=>w.inheritingWidgets())) ].filter(w=>!removing.includes(w))
-    : [];
+  // gone, so it can end up a different size than the one a line placed it by. A rename
+  // or a type change takes the widget out only to add it straight back, which hands the
+  // same values down again - there is nothing to lay out for those. Only collected for
+  // the games that have a line at all, since the flush below is not worth it otherwise.
+  const inheritors = new Set();
+  if(!isBeingReplaced && widgetFilter(w=>w.get('type') == 'line').length)
+    for(const w of removing)
+      w.stopLayoutInheritors(inheritors);
+  const inheriting = [ ...inheritors ].filter(w=>!removing.includes(w));
 
   for(const w of removing) {
     w.isBeingRemoved = true;

--- a/client/js/widgets/spinner.js
+++ b/client/js/widgets/spinner.js
@@ -27,7 +27,7 @@ class Spinner extends Widget {
       this.createChildNodes();
 
     if(delta.angle !== undefined && this.spinner || delta.value !== undefined && this.value) {
-      this.spinner.style.transform = `rotate(${delta.angle}deg)`;
+      this.spinner.style.transform = `rotate(${this.get('angle')}deg)`;
       this.value.classList.add('hidden');
       if(this.timeout)
         clearTimeout(this.timeout);

--- a/client/js/widgets/spinner.js
+++ b/client/js/widgets/spinner.js
@@ -1,4 +1,4 @@
-class Spinner extends Widget {
+export class Spinner extends Widget {
   constructor(id) {
     super(id);
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -404,6 +404,36 @@ export class Widget extends StateManaged {
     this.applyInheritedDeltaToDOM(delta);
   }
 
+  // The widgets that take their unset properties from this one.
+  inheritingWidgets() {
+    return (StateManaged.inheritFromMapping[this.id] || []).slice();
+  }
+
+  // A widget inheriting from this one falls back to its remaining sources - or to its
+  // own defaults - the moment this one is gone, which is what get() reports from then
+  // on. Hand it that fallback, or it keeps rendering the values it inherited: a stop
+  // that inherits its size from a deleted widget would sit on the line by one size and
+  // be drawn at another. Only makes sense once this widget has left the room, since
+  // that is what makes re-reading the values give the fallback rather than this widget.
+  revertInheritedValues() {
+    for(const inheriting of this.inheritingWidgets()) {
+      const properties = inheriting.inheritFrom()[this.id] || [];
+      const reverted = {};
+      for(const key of new Set([ ...Object.keys(this.state), ...Object.keys(this.inheritedProperties || {}) ]))
+        if(this.inheritFromIsValid(properties, key) && inheriting.state[key] === undefined)
+          reverted[key] = null;
+      if(!Object.keys(reverted).length)
+        continue;
+      inheriting.applyInheritedDeltaToDOM(reverted);
+      // the same property can come from more than one source, so whatever the others
+      // still provide goes back on after the blanket revert
+      const remaining = { ...inheriting.inheritFrom() };
+      delete remaining[this.id];
+      if(Object.keys(remaining).length)
+        inheriting.applyInheritedValuesToDOM(remaining);
+    }
+  }
+
   applyInitialDelta(delta) {
     super.applyInitialDelta(delta);
     this.activateAnimation = true;
@@ -3299,6 +3329,13 @@ export class Widget extends StateManaged {
         inheriting.widgetsInheritingProperty(property, result);
     }
     return result;
+  }
+
+  // Ask every line carrying this widget as a stop to place it again. Used when the
+  // size it is laid out by changed without a property of its own changing.
+  async updateLinesForStopLayout() {
+    for(const line of linesWithStop(this.id))
+      await line.onStopPropertyChange(this);
   }
 
   // Connections are expressed against a target's global transform. A change

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -3331,15 +3331,25 @@ export class Widget extends StateManaged {
     return result;
   }
 
-  // The stops a line would place differently because of this widget: everything that
-  // takes one of the properties a stop is laid out by from here, through however many
-  // levels of inheritance, and that some line lists as a stop.
-  stopLayoutInheritors(result = new Set) {
-    for(const property of stopLayoutProperties)
+  // The widgets a line would draw differently because of this one: everything that takes
+  // one of the properties a line reacts to from here, through however many levels of
+  // inheritance, and that some line either lays out as a stop or glues an end point to.
+  lineLayoutInheritors(lines, result = new Set) {
+    const connected = lines.filter(line=>line.get('connectStart') || line.get('connectEnd'));
+    for(const property of lineRelevantProperties)
       for(const widget of this.widgetsInheritingProperty(property))
-        if(linesWithStop(widget.id).length)
+        if(linesWithStop(widget.id).length || widget.hasConnectedEndPoint(connected))
           result.add(widget);
     return result;
+  }
+
+  // Whether one of the lines glues an end point to this widget or to something inside
+  // it - either way that end point moves when the transform of this widget changes.
+  hasConnectedEndPoint(lines) {
+    return lines.some(line=>[ line.get('connectStart'), line.get('connectEnd') ].some(connection=>{
+      const target = connection && widgets.get(connection.line);
+      return target && (target == this || target.isDescendantOf(this));
+    }));
   }
 
   // Ask every line carrying this widget as a stop to place it again. Used when the

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -3337,9 +3337,12 @@ export class Widget extends StateManaged {
   lineLayoutInheritors(lines, result = new Set) {
     const connected = lines.filter(line=>line.get('connectStart') || line.get('connectEnd'));
     for(const property of lineRelevantProperties)
-      for(const widget of this.widgetsInheritingProperty(property))
-        if(linesWithStop(widget.id).length || widget.hasConnectedEndPoint(connected))
+      for(const widget of this.widgetsInheritingProperty(property)) {
+        if(result.has(widget))
+          continue;
+        if(lines.some(line=>lineListsStop(line, widget.id)) || widget.hasConnectedEndPoint(connected))
           result.add(widget);
+      }
     return result;
   }
 

--- a/client/js/widgets/widget.js
+++ b/client/js/widgets/widget.js
@@ -3331,6 +3331,17 @@ export class Widget extends StateManaged {
     return result;
   }
 
+  // The stops a line would place differently because of this widget: everything that
+  // takes one of the properties a stop is laid out by from here, through however many
+  // levels of inheritance, and that some line lists as a stop.
+  stopLayoutInheritors(result = new Set) {
+    for(const property of stopLayoutProperties)
+      for(const widget of this.widgetsInheritingProperty(property))
+        if(linesWithStop(widget.id).length)
+          result.add(widget);
+    return result;
+  }
+
   // Ask every line carrying this widget as a stop to place it again. Used when the
   // size it is laid out by changed without a property of its own changing.
   async updateLinesForStopLayout() {

--- a/tests/client/client-util.js
+++ b/tests/client/client-util.js
@@ -18,8 +18,10 @@ export function addLabel(id) {
 
 //start: copied from serverstate.js due to circular imports
 export function removeWidget(widgetID) {
-  widgets.get(widgetID).applyRemove();
+  const widget = widgets.get(widgetID);
+  widget.applyRemove();
   widgets.delete(widgetID);
   dropTargets.delete(widgetID);
+  widget.revertInheritedValues();
 }
 //end: copied from serverstate.js

--- a/tests/client/line-widget.test.js
+++ b/tests/client/line-widget.test.js
@@ -270,7 +270,7 @@ describe('Line widget geometry', () => {
     expect(stop.get('x') + stop.get('width')/2).toBe(50);
 
     // what the removal collects beforehand to place again once the widget is gone
-    const inheritors = [ ...source.stopLayoutInheritors() ];
+    const inheritors = [ ...source.lineLayoutInheritors(widgetFilter(w=>w.get('type') == 'line')) ];
     expect(inheritors).toContain(stop);
 
     removeWidget(source.id);
@@ -751,6 +751,34 @@ describe('Line widget connections', () => {
     const depEndGlobal = { x: dep.get('x') + dep.pointProperty('lineEnd').x, y: dep.get('y') + dep.pointProperty('lineEnd').y };
     const targetStartGlobal = { x: target.get('x') + target.pointProperty('lineStart').x, y: target.get('y') + target.pointProperty('lineStart').y };
     expect(depEndGlobal).toEqual(targetStartGlobal);
+  });
+
+  test('an end point follows a target whose inherited geometry is gone', async () => {
+    const source = new Widget('connect-source');
+    addWidget({ id: 'connect-source', type: 'basic', x: 400, y: 300, width: 100, height: 40 }, source);
+    const target = new Widget('connect-target');
+    addWidget({ id: 'connect-target', type: 'basic', inheritFrom: source.id }, target);
+    target.coordGlobalFromCoordLocal = coord => ({ x: target.get('x') + coord.x, y: target.get('y') + coord.y });
+    const dep = createLine({ id: 'dep', x: 0, y: 0, lineStart: { x: 0, y: 0 }, lineEnd: { x: 100, y: 0 },
+      connectStart: { line: target.id, position: 0.5 } });
+
+    const startGlobal = () => dep.coordGlobalFromCoordLocal(dep.pointProperty('lineStart'));
+    const targetCenter = () => target.coordGlobalFromCoordLocal({ x: target.get('width')/2, y: target.get('height')/2 });
+    await dep.applyConnections();
+    expect(startGlobal()).toEqual(targetCenter());
+
+    // what the removal collects beforehand to update once the widget is gone
+    const inheritors = [ ...source.lineLayoutInheritors(widgetFilter(w=>w.get('type') == 'line')) ];
+    expect(inheritors).toContain(target);
+
+    removeWidget(source.id);
+    for(const w of inheritors)
+      await w.updateConnectedLineEndpoints();
+
+    expect(target.get('x')).toBe(target.defaults.x);
+    expect(startGlobal()).toEqual(targetCenter());
+
+    removeWidget(target.id);
   });
 
   test('a curved connected line keeps its shape (control points follow the ends) when the target moves', async () => {

--- a/tests/client/line-widget.test.js
+++ b/tests/client/line-widget.test.js
@@ -233,6 +233,28 @@ describe('Line widget geometry', () => {
     removeWidget(line.id);
   });
 
+  test('removing the widget a stop inherits its size from places it by the size it falls back to', async () => {
+    const line = createLine({ id: 'orphan-line', x: 0, y: 0, lineStart: { x: 0, y: 0 }, lineEnd: { x: 100, y: 0 }, rotateStops: false, autoSpaceStops: false,
+      stops: [ { widget: 'orphaned-stop', position: 0.25 } ] });
+    const source = new Widget('orphan-source');
+    addWidget({ id: 'orphan-source', type: 'basic', width: 20, height: 20 }, source);
+    const stop = new Widget('orphaned-stop');
+    addWidget({ id: 'orphaned-stop', type: 'basic', parent: line.id, inheritFrom: source.id }, stop);
+
+    await line.setStopPosition(stop.id, 0.5);
+    expect(stop.get('x') + stop.get('width')/2).toBe(50);
+
+    // the stop is now a different size than the one it was placed by
+    removeWidget(source.id);
+    await stop.updateLinesForStopLayout();
+
+    expect(stop.get('width')).toBe(stop.defaults.width);
+    expect(stop.get('x') + stop.get('width')/2).toBe(50);
+
+    removeWidget(stop.id);
+    removeWidget(line.id);
+  });
+
   test('renaming a stop keeps a single entry in place, at its own position', async () => {
     const line = createLine({ id: 'rename-line', x: 0, y: 0, lineStart: { x: 0, y: 0 }, lineEnd: { x: 300, y: 0 }, autoSpaceStops: true,
       stops: [ 'rename-a', 'rename-b', 'rename-c' ].map((widget, i) => ({ widget, position: i / 2 })) });

--- a/tests/client/line-widget.test.js
+++ b/tests/client/line-widget.test.js
@@ -255,6 +255,36 @@ describe('Line widget geometry', () => {
     removeWidget(line.id);
   });
 
+  test('a stop that inherits its size through another widget is collected for re-layout', async () => {
+    const line = createLine({ id: 'chain-line', x: 0, y: 0, lineStart: { x: 0, y: 0 }, lineEnd: { x: 100, y: 0 }, rotateStops: false, autoSpaceStops: false,
+      stops: [ { widget: 'chained-stop', position: 0.25 } ] });
+    const source = new Widget('chain-source');
+    addWidget({ id: 'chain-source', type: 'basic', width: 20, height: 20 }, source);
+    const middle = new Widget('chain-middle');
+    addWidget({ id: 'chain-middle', type: 'basic', inheritFrom: source.id }, middle);
+    const stop = new Widget('chained-stop');
+    addWidget({ id: 'chained-stop', type: 'basic', parent: line.id, inheritFrom: middle.id }, stop);
+
+    await line.setStopPosition(stop.id, 0.5);
+    expect(stop.get('width')).toBe(20);
+    expect(stop.get('x') + stop.get('width')/2).toBe(50);
+
+    // what the removal collects beforehand to place again once the widget is gone
+    const inheritors = [ ...source.stopLayoutInheritors() ];
+    expect(inheritors).toContain(stop);
+
+    removeWidget(source.id);
+    for(const w of inheritors)
+      await w.updateLinesForStopLayout();
+
+    expect(stop.get('width')).toBe(stop.defaults.width);
+    expect(stop.get('x') + stop.get('width')/2).toBe(50);
+
+    removeWidget(middle.id);
+    removeWidget(stop.id);
+    removeWidget(line.id);
+  });
+
   test('renaming a stop keeps a single entry in place, at its own position', async () => {
     const line = createLine({ id: 'rename-line', x: 0, y: 0, lineStart: { x: 0, y: 0 }, lineEnd: { x: 300, y: 0 }, autoSpaceStops: true,
       stops: [ 'rename-a', 'rename-b', 'rename-c' ].map((widget, i) => ({ widget, position: i / 2 })) });

--- a/tests/client/widget-inheritance.test.js
+++ b/tests/client/widget-inheritance.test.js
@@ -1,11 +1,18 @@
-import { widgets } from '../../client/js/serverstate.js';
+import { addWidget, widgets } from '../../client/js/serverstate.js';
+import { asArray, mapAssetURLs } from '../../client/js/domhelpers.js';
+import { Widget } from '../../client/js/widgets/widget.js';
 
 import { createWidget, removeWidget } from './client-util.js';
 
-// getDefaultValue() resolves inheritance through the concatenated global scope of the
-// shipped bundle rather than through an import, so expose the widget map it reads.
-beforeAll(() => {
+// Inheritance and spinner.js read these names from the concatenated global scope
+// of the shipped bundle, so expose them before importing the spinner class.
+let Spinner;
+beforeAll(async () => {
   globalThis.widgets = widgets;
+  globalThis.Widget = Widget;
+  globalThis.asArray = asArray;
+  globalThis.mapAssetURLs = mapAssetURLs;
+  ({ Spinner } = await import('../../client/js/widgets/spinner.js'));
 });
 
 // A widget with inheritFrom takes every property it does not set itself from another widget.
@@ -62,5 +69,18 @@ describe('Removing a widget that other widgets inherit from', () => {
 
     expect(inheritor.get('height')).toBe(55);
     expect(inheritor.domElement.style.height).toBe('55px');
+  });
+
+  test('a spinner renders the angle it falls back to', () => {
+    createWidget({ id: 'angleSource', type: 'basic', angle: 720 });
+    const spinner = new Spinner('inheritsAngle');
+    addWidget({ id: spinner.id, type: 'spinner', inheritFrom: { angleSource: [ 'angle' ] } }, spinner);
+    expect(spinner.get('angle')).toBe(720);
+    expect(spinner.spinner.style.transform).toBe('rotate(720deg)');
+
+    removeWidget('angleSource');
+
+    expect(spinner.get('angle')).toBe(0);
+    expect(spinner.spinner.style.transform).toBe('rotate(0deg)');
   });
 });

--- a/tests/client/widget-inheritance.test.js
+++ b/tests/client/widget-inheritance.test.js
@@ -1,0 +1,54 @@
+import { widgets } from '../../client/js/serverstate.js';
+
+import { createWidget, removeWidget } from './client-util.js';
+
+// getDefaultValue() resolves inheritance through the concatenated global scope of the
+// shipped bundle rather than through an import, so expose the widget map it reads.
+beforeAll(() => {
+  globalThis.widgets = widgets;
+});
+
+// A widget with inheritFrom takes every property it does not set itself from another widget.
+// Once that widget is gone it falls back to its remaining sources or to its own defaults,
+// which is what get() reports from then on - so what it is drawn with has to follow, or a
+// line places a stop by one size and draws it at another.
+describe('Removing a widget that other widgets inherit from', () => {
+  afterEach(() => {
+    for(const id of [ ...widgets.keys() ])
+      removeWidget(id);
+  });
+
+  test('the inheritor falls back to its own default and is drawn with it', () => {
+    createWidget({ id: 'sizeSource', type: 'basic', width: 40, height: 40 });
+    const inheritor = createWidget({ id: 'inheritsSize', type: 'basic', inheritFrom: 'sizeSource' });
+    expect(inheritor.get('height')).toBe(40);
+    expect(inheritor.domElement.style.height).toBe('40px');
+
+    removeWidget('sizeSource');
+
+    expect(inheritor.get('height')).toBe(inheritor.defaults.height);
+    expect(inheritor.domElement.style.height).toBe(`${inheritor.defaults.height}px`);
+  });
+
+  test('a property the inheritor sets itself keeps its value', () => {
+    createWidget({ id: 'sizeSource', type: 'basic', width: 40, height: 40 });
+    const inheritor = createWidget({ id: 'inheritsWidth', type: 'basic', inheritFrom: 'sizeSource', height: 70 });
+
+    removeWidget('sizeSource');
+
+    expect(inheritor.get('height')).toBe(70);
+    expect(inheritor.get('width')).toBe(inheritor.defaults.width);
+  });
+
+  test('a second source takes over the properties the removed one provided', () => {
+    createWidget({ id: 'firstSource', type: 'basic', height: 40 });
+    createWidget({ id: 'secondSource', type: 'basic', height: 55 });
+    const inheritor = createWidget({ id: 'inheritsFromTwo', type: 'basic', inheritFrom: { firstSource: '*', secondSource: '*' } });
+    expect(inheritor.get('height')).toBe(40);
+
+    removeWidget('firstSource');
+
+    expect(inheritor.get('height')).toBe(55);
+    expect(inheritor.domElement.style.height).toBe('55px');
+  });
+});

--- a/tests/client/widget-inheritance.test.js
+++ b/tests/client/widget-inheritance.test.js
@@ -40,6 +40,18 @@ describe('Removing a widget that other widgets inherit from', () => {
     expect(inheritor.get('width')).toBe(inheritor.defaults.width);
   });
 
+  test('the inheritor can be moved again once an inherited lock is gone', () => {
+    createWidget({ id: 'lockedSource', type: 'basic', movable: false });
+    const inheritor = createWidget({ id: 'inheritsMovable', type: 'basic', inheritFrom: 'lockedSource' });
+    expect(inheritor.get('movable')).toBe(false);
+    expect(inheritor.domElement.className).not.toContain('movable');
+
+    removeWidget('lockedSource');
+
+    expect(inheritor.get('movable')).toBe(true);
+    expect(inheritor.domElement.className).toContain('movable');
+  });
+
   test('a second source takes over the properties the removed one provided', () => {
     createWidget({ id: 'firstSource', type: 'basic', height: 40 });
     createWidget({ id: 'secondSource', type: 'basic', height: 55 });

--- a/tests/testcafe/inheritfrom.js
+++ b/tests/testcafe/inheritfrom.js
@@ -113,7 +113,7 @@ test('A change to the source reaches the bottom of the chain', async t => {
   await t.expect((await observed(t)).text).eql('changed', 'and so does what a routine reads');
 });
 
-test('Removing the source leaves the inherited value behind', async t => {
+test('Deleting the source drops the value it handed down', async t => {
   await openRoom(t, 'modern', chain({
     leaf: { inheritFrom: { base: [ 'text' ] } },
     remove: { type: 'button', x: 700, y: 500, width: 100, height: 60, text: 'remove', clickRoutine: [
@@ -124,13 +124,11 @@ test('Removing the source leaves the inherited value behind', async t => {
   await t.click('#w_remove');
   await t.expect(Selector('#w_base').exists).notOk('the source is gone');
 
-  // #2854, and worse than the issue says: the two halves of the widget disagree. The DOM keeps
-  // whatever applyInheritedDeltaToDOM() last wrote, because nothing tells the inheriting widget
-  // that its source is gone - while get() resolves through widgets.has(id) and so returns the
-  // widget's own default from the moment of the deletion. So the player reads 'from base' off
-  // the table and a routine reading the same property gets ''.
-  await t.expect(Selector('#w_leaf textarea').value).contains('from base', 'the leaf still renders it');
-  await t.expect((await observed(t)).text).eql('', 'while a routine already sees it gone');
+  // get() resolves inheritance through widgets.has(id), so the leaf falls back to its own
+  // default the moment the source is deleted - and what it is drawn with has to say the same,
+  // or the player reads one value off the table while a routine reading it gets another.
+  await t.expect(Selector('#w_leaf textarea').value).eql('', 'the leaf stops rendering it');
+  await t.expect((await observed(t)).text).eql('', 'and a routine reads the same');
 });
 
 test('An inherited property is not part of the widget\'s own state', async t => {


### PR DESCRIPTION
A widget with `inheritFrom` takes every property it does not set itself from another widget. When that widget was **deleted**, the widgets inheriting from it kept being *drawn* with the values it had handed down, while `get()` — which resolves inheritance through `widgets.has(id)` — returned their own default (or a remaining source's value) from the moment of the deletion. The two halves of the widget then disagreed: a routine read one value while the player saw another.

`removeWidget()` now hands every inheritor the values it falls back to — from its remaining sources, or from its own defaults — once the deleted widget is out of the room, so that re-reading those properties gives the fallback rather than the widget that is going away. `removeWidgetLocal()` then refreshes what a line draws from those values: every line that carries one of those widgets as a stop — directly or through a chain of inheritance — places it again by the size the stop actually ends up with, and every line that glues an end point to one of them (or to something inside it) re-glues to where it actually ends up. A rename and an editor type change take the widget out only to add it straight back under the same inheritance, so that pass is skipped for them: it would place the stops by the size they fall back to for the instant the source is gone and leave them off the path.

The spinner renders the angle it resolves to rather than the raw value out of the delta, which is `null` for a property that is no longer inherited — so a spinner that inherited its `angle` turns to the angle it has left instead of keeping the one it lost.

## What it looks like

`library/tutorials/Types - Line` shows it: every stop of `line3` inherits its 40×40 from the first stop, so deleting that first stop leaves the other four reported as the 111×168 holder default while they are still drawn 40×40. The line places them by the size it reads, so the moment anything lays them out again — the next room load, for instance — they sit about 70 px off the path.

Deleting `line3S0` and reloading the room, on `main` and on this branch (the path is drawn in red here; the tutorial has it at `lineWidth: 0`):

| before | after |
| --- | --- |
| ![before](https://agent.virtualtabletop.io/reports/pr/1546744441207914539/line3-stops-off-path-before.png) | ![after](https://agent.virtualtabletop.io/reports/pr/1546744441207914539/line3-stops-off-path-after.png) |

Measured in the browser against the running server, the drawn centres of the four remaining stops move by 71, 72, 72 and 71 px between the deletion and the next load on `main`, and by 0 px on this branch.

## Not part of this change

Issue #2854 is about taking a property **out of** an `inheritFrom` list, which still does not update the widget. That half is deliberately untouched — this PR only covers the source widget being deleted, which is the half that leaves the widget and the state disagreeing.

## Why it is a PR of its own

It was found while reviewing #3173 (line stop spacing), but it is an inheritance/deletion bug in the engine that reproduces on `main` independently of any line change. [@96LawDawg asked there](https://github.com/ArnoldSmith86/virtualtabletop/pull/3173#issuecomment-5563872343) that it be moved out:

> This last change needs to be its own PR. Move it out of here and send the message in Discord asking to start a different PR.

## Verification

- `npm test` — 1671 tests in 57 suites pass. The new cases in `tests/client/widget-inheritance.test.js` and `tests/client/line-widget.test.js` fail without the change (the inheritor keeps the 40 px it was given where its own default is 100, a second source does not take over, an inherited `movable: false` never lets go of the widget, a stop inheriting through an intermediate widget is not collected for the re-layout, and a target of a connected end point is not collected at all).
- The TestCafe fixture `inheritfrom.js` covers the same thing in a browser: `Deleting the source drops the value it handed down` used to assert the broken state (the leaf renders `from base` while a routine already reads `''`) and now asserts that both read the same. `inheritfrom.js` and `editor.js` pass locally, 105 tests in all.
- Walked through in a browser against the running server: renaming the size source, changing its type in the editor, deleting it, deleting it with a stop that inherits through an intermediate widget, deleting a source of `movable`, deleting the source a connected line's target inherits its geometry from, and deleting the source a spinner inherits its `angle` from. The stops stay on the path, the end point stays on the target and the spinner shows the angle it reports, in every case.

## Demo room

**Inherited values on delete** is uploaded into this PR's test-server room, https://test.virtualtabletop.io/PR-3177/pr-test-ai. It is written to tutorial quality but is a demo only and deliberately **not** added to `library/tutorials/` — say the word and it can be moved there. Two variants:

- **Line stops** ([download](https://agent.virtualtabletop.io/reports/pr/1546744441207914539/Inherited%20values%20on%20delete.vtt)) — five stops on an arch, of which four take their size from the first one, and a **Delete stop 0** button. Press it and the four fall back to the default holder size, drawn with it and placed on the path by it; reload the room and they stay where they are.
- **Connections and angles** ([download](https://agent.virtualtabletop.io/reports/pr/1546744441207914539/Inherited%20values%20on%20delete%201.vtt)) — a line with its end point glued to the middle of a widget that inherits its size, and two spinners of which the right one inherits `angle` from the left. Delete either source and the end point moves to the target's new middle, and the spinner turns to the angle it falls back to.

| line stops, after loading | line stops, after deleting stop 0 |
| --- | --- |
| ![demo room](https://agent.virtualtabletop.io/reports/pr/1546744441207914539/demo-room.png) | ![after the deletion](https://agent.virtualtabletop.io/reports/pr/1546744441207914539/demo-room-deleted.png) |

| connections and angles, after loading | after deleting both sources |
| --- | --- |
| ![demo room variant](https://agent.virtualtabletop.io/reports/pr/1546744441207914539/demo-room-variant1.png) | ![after the deletions](https://agent.virtualtabletop.io/reports/pr/1546744441207914539/demo-room-variant1-deleted.png) |

No widget property, routine operation or parameter is added or renamed, so there is no new validator, `jeCommands` or visual-editor surface to go with it.


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3177/pr-test (or any other room on that server)
