### PR TITLE
Honor counts and drop limits in dragging-filtered holders

### DIFF
--- a/client/js/main.js
+++ b/client/js/main.js
@@ -25,15 +25,21 @@ export const clientPointer = $('#clientPointer');
 export function compareDropTarget(widget, t, existingChild=false){
   for(const dropTargetObject of asArray(t.get('dropTarget'))) {
     let isValidObject = true;
+    let hasPersistentCondition = false;
     for(const key in dropTargetObject) {
       // dragging is cleared on release, after the holder has accepted the child
       if(existingChild && key == 'dragging')
         continue;
+      hasPersistentCondition = true;
       if(dropTargetObject[key] != widget.get(key) && (existingChild || (key != 'type' || widget.get(key) != 'deck' || dropTargetObject[key] != 'card'))) {
         isValidObject = false;
         break;
       }
     }
+    // A dragging-only filter still uses the holder's default card membership,
+    // keeping fixed controls and deck definitions out of children().
+    if(existingChild && !hasPersistentCondition && 'dragging' in dropTargetObject && widget.get('type') != 'card')
+      isValidObject = false;
     if(isValidObject) {
       return true;
     }

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -22,11 +22,14 @@ export const dropTargets = new Map();
 
 export const clientPointer = $('#clientPointer');
 
-export function compareDropTarget(widget, t, exclude){
+export function compareDropTarget(widget, t, existingChild=false){
   for(const dropTargetObject of asArray(t.get('dropTarget'))) {
     let isValidObject = true;
     for(const key in dropTargetObject) {
-      if(dropTargetObject[key] != widget.get(key) && (exclude == true || (key != 'type' || widget.get(key) != 'deck' || dropTargetObject[key] != 'card'))) {
+      // dragging is cleared on release, after the holder has accepted the child
+      if(existingChild && key == 'dragging')
+        continue;
+      if(dropTargetObject[key] != widget.get(key) && (existingChild || (key != 'type' || widget.get(key) != 'deck' || dropTargetObject[key] != 'card'))) {
         isValidObject = false;
         break;
       }

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -22,7 +22,7 @@ export const dropTargets = new Map();
 
 export const clientPointer = $('#clientPointer');
 
-export function compareDropTarget(widget, t, existingChild=false){
+export function compareDropTarget(widget, t, existingChild=false, dragged=widget){
   for(const dropTargetObject of asArray(t.get('dropTarget'))) {
     let isValidObject = true;
     let hasPersistentCondition = false;
@@ -31,7 +31,10 @@ export function compareDropTarget(widget, t, existingChild=false){
       if(existingChild && key == 'dragging')
         continue;
       hasPersistentCondition = true;
-      if(dropTargetObject[key] != widget.get(key) && (existingChild || (key != 'type' || widget.get(key) != 'deck' || dropTargetObject[key] != 'card'))) {
+      // Pile targeting can match card properties through its first card, but
+      // the live drag state belongs to the pile being moved.
+      const propertyWidget = key == 'dragging' ? dragged : widget;
+      if(dropTargetObject[key] != propertyWidget.get(key) && (existingChild || (key != 'type' || widget.get(key) != 'deck' || dropTargetObject[key] != 'card'))) {
         isValidObject = false;
         break;
       }
@@ -67,12 +70,14 @@ function getValidDropTargets(widget, dragged = widget) {
     if(!t.isVisible())
       continue;
 
-    // if the holder has a drop limit and it's reached, skip the holder -
-    // unless the dragged widget is already its child and just goes back in
-    if(exceedsDropLimit(t) && t.children().indexOf(widget) == -1)
+    // A pile contributes its cards to a holder or pile, while a line takes the
+    // whole pile as one stop. Something already in the target can go back even
+    // when the target is full.
+    const dropCount = dragged.get('type') == 'pile' && [ 'holder', 'pile' ].includes(t.get('type')) ? dragged.children().length : 1;
+    if(exceedsDropLimit(t, dropCount) && t.children().indexOf(widget) == -1 && dragged.get('_ancestor') != t.get('id'))
       continue;
 
-    let isValid = compareDropTarget(widget, t);
+    let isValid = compareDropTarget(widget, t, false, dragged);
 
     let tt = t;
     while(isValid) {

--- a/tests/testcafe/holderevents.js
+++ b/tests/testcafe/holderevents.js
@@ -184,6 +184,29 @@ test('A card dragged onto a full holder is refused and stays on the table', asyn
   await t.expect(String((after.log||{}).trace||'')).eql('', 'no holder event fired');
 });
 
+test('A dragging-based drop target counts accepted cards and applies its drop limit', async t => {
+  const state = fixtureState({
+    handB: { dropTarget: { dragging: 'TestCafe' }, dropLimit: 1 },
+    go: { clickRoutine: [
+      { func: 'COUNT', holder: 'handB', variable: 'count' },
+      { func: 'SET', collection: 'thisButton', property: 'count', value: '${count}' }
+    ] }
+  });
+  state.card2 = { id: 'card2', type: 'card', deck: 'deck', cardType: 'plain', x: 900, y: 60 };
+  await openRoom(t, 'modern', state);
+  await setName(t, 'TestCafe');
+
+  await dragPath(t, CARD, [ { onto: 'handB' } ]);
+  await clickGo(t);
+  const counted = await stateWhen(s=>s.go && s.go.count !== undefined);
+  await t.expect(counted.go.count).eql(1, 'COUNT sees the accepted card after dragging is cleared');
+
+  await dragPath(t, 'card2', [ { onto: 'handB' } ]);
+  await t.wait(500);
+  const after = await getStateObject();
+  await t.expect(after.card2.parent).eql(undefined, 'the second card stayed on the table');
+});
+
 // ---------------------------------------------------------------------------------------------
 // The properties that change what an event does
 // ---------------------------------------------------------------------------------------------

--- a/tests/testcafe/holderevents.js
+++ b/tests/testcafe/holderevents.js
@@ -221,6 +221,42 @@ test('A dragging-based drop target applies its drop limit', async t => {
   await t.expect(after.card2.parent).eql(undefined, 'the second card stayed on the table');
 });
 
+test('A dragging-based drop target accepts an incoming pile that exactly fits its drop limit', async t => {
+  const state = fixtureState({ handB: { dropTarget: { dragging: 'TestCafe' }, dropLimit: 4 } });
+  state.card1.parent = 'pile1';
+  state.card2 = { id: 'card2', type: 'card', deck: 'deck', cardType: 'plain', parent: 'pile1' };
+  state.card3 = { id: 'card3', type: 'card', deck: 'deck', cardType: 'plain', parent: 'pile1' };
+  state.pile1 = { id: 'pile1', type: 'pile', x: 700, y: 60 };
+  state.held = { id: 'held', type: 'card', deck: 'deck', cardType: 'plain', parent: 'handB', x: 4, y: 4 };
+  await openRoom(t, 'modern', state);
+  await setName(t, 'TestCafe');
+
+  await dragPath(t, 'pile1', [ { onto: 'handB' } ]);
+  await t.wait(500);
+  const after = await getStateObject();
+  await t.expect(after.pile1.parent).eql('handB', 'the three-card pile was accepted into the holder with one card');
+});
+
+test('A dragging-based drop target counts every card in an incoming pile against its drop limit', async t => {
+  const state = fixtureState({ handB: { dropTarget: { dragging: 'TestCafe' }, dropLimit: 4 } });
+  state.card1.parent = 'pile1';
+  state.card2 = { id: 'card2', type: 'card', deck: 'deck', cardType: 'plain', parent: 'pile1' };
+  state.card3 = { id: 'card3', type: 'card', deck: 'deck', cardType: 'plain', parent: 'pile1' };
+  state.pile1 = { id: 'pile1', type: 'pile', x: 700, y: 60 };
+  state.held1 = { id: 'held1', type: 'card', deck: 'deck', cardType: 'plain', parent: 'handB', x: 4, y: 4 };
+  state.held2 = { id: 'held2', type: 'card', deck: 'deck', cardType: 'plain', parent: 'handB', x: 4, y: 4 };
+  await openRoom(t, 'modern', state);
+  await setName(t, 'TestCafe');
+
+  await dragPath(t, 'pile1', [ { onto: 'handB' } ]);
+  await t.wait(500);
+  const after = await getStateObject();
+  await t.expect(after.pile1.parent).eql(undefined, 'the three-card pile stayed on the table because only two slots were free');
+  await t.expect(after.card1.parent).eql('pile1', 'the refused pile kept its cards');
+  await t.expect(after.card2.parent).eql('pile1', 'the refused pile kept its cards');
+  await t.expect(after.card3.parent).eql('pile1', 'the refused pile kept its cards');
+});
+
 // ---------------------------------------------------------------------------------------------
 // The properties that change what an event does
 // ---------------------------------------------------------------------------------------------

--- a/tests/testcafe/holderevents.js
+++ b/tests/testcafe/holderevents.js
@@ -184,22 +184,36 @@ test('A card dragged onto a full holder is refused and stays on the table', asyn
   await t.expect(String((after.log||{}).trace||'')).eql('', 'no holder event fired');
 });
 
-test('A dragging-based drop target counts accepted cards and applies its drop limit', async t => {
+test('A dragging-only drop target excludes a deck holder\'s structural children from COUNT', async t => {
   const state = fixtureState({
-    handB: { dropTarget: { dragging: 'TestCafe' }, dropLimit: 1 },
-    go: { clickRoutine: [
+    handB: { dropTarget: { dragging: 'TestCafe' }, enterRoutine: [
       { func: 'COUNT', holder: 'handB', variable: 'count' },
-      { func: 'SET', collection: 'thisButton', property: 'count', value: '${count}' }
+      { func: 'SELECT', property: 'id', value: 'log', collection: 'log' },
+      { func: 'SET', collection: 'log', property: 'count', value: '${count}' }
     ] }
   });
+  state.deck.parent = 'handB';
+  state.recall = { id: 'recall', type: 'button', parent: 'handB', fixedParent: true, text: 'Recall & Shuffle' };
+  await openRoom(t, 'modern', state);
+  await setName(t, 'TestCafe');
+
+  await dragPath(t, CARD, [ { onto: 'handB' } ]);
+  const counted = await stateWhen(s=>s.log && s.log.count !== undefined);
+  await t.expect(counted.card1.parent).eql('handB', 'the card was accepted');
+  await t.expect(counted.log.count).eql(1, 'enterRoutine counts the card but not the deck definition or fixed control');
+});
+
+test('A dragging-based drop target applies its drop limit', async t => {
+  const state = fixtureState({ handB: { dropTarget: { dragging: 'TestCafe' }, dropLimit: 1 } });
+  state.deck.parent = 'handB';
+  state.recall = { id: 'recall', type: 'button', parent: 'handB', fixedParent: true, text: 'Recall & Shuffle' };
   state.card2 = { id: 'card2', type: 'card', deck: 'deck', cardType: 'plain', x: 900, y: 60 };
   await openRoom(t, 'modern', state);
   await setName(t, 'TestCafe');
 
   await dragPath(t, CARD, [ { onto: 'handB' } ]);
-  await clickGo(t);
-  const counted = await stateWhen(s=>s.go && s.go.count !== undefined);
-  await t.expect(counted.go.count).eql(1, 'COUNT sees the accepted card after dragging is cleared');
+  const accepted = await stateWhen(s=>s.card1 && s.card1.parent == 'handB');
+  await t.expect(accepted.card1.parent).eql('handB', 'structural children do not make the holder full');
 
   await dragPath(t, 'card2', [ { onto: 'handB' } ]);
   await t.wait(500);


### PR DESCRIPTION
## Problem

A holder can use the temporary `dragging` property in `dropTarget` to accept cards only from a particular player. The holder correctly accepts a matching drag, but release clears `dragging` before the card becomes its child. Rechecking that transient condition then hides the accepted card from `holder.children()`: `COUNT` reports zero, and `dropLimit` sees an empty holder and accepts too many cards.

Simply ignoring `dragging` after release exposed another case in standard deck holders. Their deck definition and fixed Recall button share the holder with its cards; a filter containing only `dragging` then matched all three direct children, so the first card's `enterRoutine` counted 3 instead of 1 and structural widgets could consume `dropLimit` slots.

Pile drags exposed an admission-time counterpart: holder targeting checks a pile's first card so normal `{ "type": "card" }` filters accept it, but the player-name `dragging` value exists on the pile itself. As a result, a dragging-filtered holder did not recognize the pile. Capacity checks also treated every dragged pile as one widget instead of charging each card it carries.

This addresses the following Discord report ([source](https://discord.com/channels/770758631146782780/1545427860871708762/1548202011659341916)):

> Moshek: So, I'm trying something out... I have a holder for cards, where I've set "dropTarget": { "dragging": "<playername>" }... For another purpose, I'm trying to count cards in that holder... but now with that dropTarget on there, the count always comes back as 0... Am I missing something?
>
> Moshek: It also seems to cause the dropLimit to be ignored
>
> LawDawg: Confirmed. Both of those things do not behave as they should. Will look into it.

## Fix

`dragging` remains an admission-time condition for live drops, but holder membership no longer rechecks it after release. When it is the only condition, existing children use the holder's normal card-membership rule, keeping deck definitions and fixed controls out of `children()`. Additional persistent `dropTarget` conditions continue to filter holder children as written, including the exact card-versus-deck distinction used by holders.

When a pile is dragged, its first card still supplies ordinary target properties while the pile supplies the live `dragging` value. Holder and pile capacity checks count every card in that incoming pile; line capacity remains based on the single stop being added. A pile already belonging to a full target can still be returned to it.

As a result, cards and piles accepted through `{ "dragging": "player name" }` remain visible to `COUNT` and contribute their actual card counts to the holder's `dropLimit`, while structural children do neither.

No widget property, mode, routine parameter, validator rule, editor control, or library file changes; this repairs the existing properties' behavior.

## Testing

- `npm test -- --runInBand` — 56 suites, 1,664 tests passed
- Chromium TestCafe: all 26 tests in `tests/testcafe/holderevents.js` passed
- Added browser regressions for structural children, first-card `enterRoutine` count, single-card capacity, and three-card pile drops that exactly fit or exceed the remaining capacity


---

PR-SERVER-BOT: You can play around with it here: https://test.virtualtabletop.io/PR-3179/pr-test (or any other room on that server)
